### PR TITLE
Add `lablink-client-base-image`

### DIFF
--- a/.github/workflows/lablink-client-base-image-production.yml
+++ b/.github/workflows/lablink-client-base-image-production.yml
@@ -61,5 +61,6 @@ jobs:
           tags: |
             ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:latest
             ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}
-            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.6.1-cudnn8-runtime-ubuntu20.04
             ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-ubuntu20.04-nvm-0.40.2-uv-0.6.8-miniforge3-24.11.3

--- a/.github/workflows/lablink-client-base-image-production.yml
+++ b/.github/workflows/lablink-client-base-image-production.yml
@@ -1,0 +1,65 @@
+name: Build and Push lablink-client-base-image (Production Workflow)
+
+# Run on push to main branch after testing is complete
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - lablink-client-base-image/** # Only run on changes to lablink-client-base-image
+      - .github/workflows/lablink-client-base-image_production.yml # Only run on changes to this workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # Only build on Ubuntu for now since Docker is not available on macOS runners
+    strategy:
+      matrix:
+        platform: [linux/amd64] # Only build amd64 for now
+      max-parallel: 2 # Build both architectures in parallel (if more than one)
+    outputs:
+      git_sha: ${{ steps.get_sha.outputs.sha }}
+      sanitized_platform: ${{ steps.sanitize_platform.outputs.sanitized_platform }}
+    steps:
+      - name: Checkout code
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v4
+
+      - name: Get Git SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Debug Git SHA
+        run: echo "Git SHA ${{ steps.get_sha.outputs.sha }}"
+
+      # Generate a sanitized platform string with slashes replaced by dashes
+      - name: Sanitize platform name
+        id: sanitize_platform
+        run: |
+          sanitized_platform="${{ matrix.platform }}" # Copy platform value
+          sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
+          echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
+
+      # Step 4: Set up Docker Buildx for multi-architecture builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container # Use a container driver for Buildx (default)
+
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push Docker image
+        # https://github.com/docker/build-push-action
+        uses: docker/build-push-action@v6
+        with:
+          context: ./lablink-client-base/lablink-client-base-image # Build context wrt the root of the repository
+          file: ./lablink-client-base/lablink-client-base-image/Dockerfile # Path to Dockerfile wrt the root of the repository
+          platforms: ${{ matrix.platform }}
+          push: true # Push the image to Docker Hub
+          # Tags for the production images, including the "latest" tag
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:latest
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}

--- a/.github/workflows/lablink-client-base-image-test.yml
+++ b/.github/workflows/lablink-client-base-image-test.yml
@@ -1,0 +1,64 @@
+name: Build and Push lablink-client-base-image (Test Workflow)
+
+# Run on push to branches other than main for lablink-client-base
+on:
+  push:
+    branches-ignore:
+      - main
+    paths:
+      - lablink-client-base/lablink-client-base-image/** # Only run on changes to lablink-client-base
+      - .github/workflows/lablink-client-base-image-test.yml # Only run on changes to this workflow
+
+jobs:
+  build:
+    runs-on: ubuntu-latest # Only build on Ubuntu for now since Docker is not available on macOS runners
+    strategy:
+      matrix:
+        platform: [linux/amd64] # Only build amd64 for now
+      max-parallel: 2 # Build both architectures in parallel (if more than one)
+    outputs:
+      git_sha: ${{ steps.get_sha.outputs.sha }}
+      sanitized_platform: ${{ steps.sanitize_platform.outputs.sanitized_platform }}
+    steps:
+      - name: Checkout code
+        # https://github.com/actions/checkout
+        uses: actions/checkout@v4
+
+      - name: Get Git SHA
+        id: get_sha
+        run: echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
+      - name: Debug Git SHA
+        run: echo "Git SHA ${{ steps.get_sha.outputs.sha }}"
+
+      # Generate a sanitized platform string with slashes replaced by dashes
+      - name: Sanitize platform name
+        id: sanitize_platform
+        run: |
+          sanitized_platform="${{ matrix.platform }}" # Copy platform value
+          sanitized_platform="${sanitized_platform/\//-}" # Replace / with -
+          echo "sanitized_platform=$sanitized_platform" >> $GITHUB_OUTPUT
+
+      # Step 4: Set up Docker Buildx for multi-architecture builds
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          driver: docker-container # Use a container driver for Buildx (default)
+
+      # Step 5: Authenticate to GitHub Container Registry
+      - name: Authenticate to GitHub Container Registry
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+
+      - name: Build and push Docker image
+        # https://github.com/docker/build-push-action
+        uses: docker/build-push-action@v6
+        with:
+          context: ./lablink-client-base/lablink-client-base-image # Build context wrt the root of the repository
+          file: ./lablink-client-base/lablink-client-base-image/Dockerfile # Path to Dockerfile wrt the root of the repository
+          platforms: ${{ matrix.platform }}
+          push: true # Push the image to Docker Hub
+          # Tags all include "-test" to differentiate from production images
+          tags: |
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test

--- a/.github/workflows/lablink-client-base-image-test.yml
+++ b/.github/workflows/lablink-client-base-image-test.yml
@@ -60,5 +60,6 @@ jobs:
           # Tags all include "-test" to differentiate from production images
           tags: |
             ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-test
-            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.3.1-cudnn8-runtime-ubuntu20.04-test
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-nvidia-cuda-11.6.1-cudnn8-runtime-ubuntu20.04-test
             ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-${{ steps.get_sha.outputs.sha }}-test
+            ghcr.io/${{ github.repository_owner }}/lablink-client-base-image:${{ steps.sanitize_platform.outputs.sanitized_platform }}-ubuntu20.04-nvm-0.40.2-uv-0.6.8-miniforge3-24.11.3-test

--- a/lablink-client-base/lablink-client-base-image/.devcontainer/devcontainer.json
+++ b/lablink-client-base/lablink-client-base-image/.devcontainer/devcontainer.json
@@ -15,6 +15,6 @@
       }
     },
     "postCreateCommand": "echo 'Devcontainer ready for use!'",
-    "remoteUser": "root"
+    "remoteUser": "client"
   }
   

--- a/lablink-client-base/lablink-client-base-image/.devcontainer/devcontainer.json
+++ b/lablink-client-base/lablink-client-base-image/.devcontainer/devcontainer.json
@@ -1,4 +1,4 @@
-{
+ {
     "name": "Lablink Client Base",
     "build": {
       "context": "..",

--- a/lablink-client-base/lablink-client-base-image/.devcontainer/devcontainer.json
+++ b/lablink-client-base/lablink-client-base-image/.devcontainer/devcontainer.json
@@ -1,0 +1,20 @@
+{
+    "name": "Lablink Client Base",
+    "build": {
+      "context": "..",
+      "dockerfile": "../Dockerfile"
+    },
+    "runArgs": [
+      "--gpus=all"
+    ],
+    "customizations": {
+      "vscode": {
+        "settings": {
+          "terminal.integrated.defaultProfile.linux": "bash"
+        }
+      }
+    },
+    "postCreateCommand": "echo 'Devcontainer ready for use!'",
+    "remoteUser": "root"
+  }
+  

--- a/lablink-client-base/lablink-client-base-image/.dockerignore
+++ b/lablink-client-base/lablink-client-base-image/.dockerignore
@@ -18,3 +18,5 @@ README.md
 .gitignore
 terraform/*
 .devcontainer/*
+
+scripts/*

--- a/lablink-client-base/lablink-client-base-image/.dockerignore
+++ b/lablink-client-base/lablink-client-base-image/.dockerignore
@@ -1,0 +1,20 @@
+# Ignore Python cache
+__pycache__/
+*.pyc
+*.pyo
+
+# Ignore virtual environments
+env/
+venv/
+
+# Ignore version control and logs
+.git/
+*.log
+
+# Ignore Docker build artifacts
+docker/*.tmp
+
+README.md
+.gitignore
+terraform/*
+.devcontainer/*

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -54,3 +54,12 @@ RUN chmod +x /scripts/install_miniforge.sh
 
 # Run script during build to install Miniforge
 RUN bash /scripts/install_miniforge.sh
+
+# Copy install script into container
+COPY install_uv.sh /scripts/install_uv.sh
+
+# Make script executable
+RUN chmod +x /scripts/install_uv.sh
+
+# Run script during build to install Miniforge
+RUN bash /scripts/install_uv.sh

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -1,6 +1,10 @@
 # Base image with GPU support
 FROM nvidia/cuda:11.6.1-cudnn8-devel-ubuntu20.04
 
+# https://askubuntu.com/questions/1402167/must-specify-the-user-name-option-when-running-as-root-chrome-remote-desktop
+# Must be a non-root user to run Chrome Remote Desktop
+ARG USERNAME="client"
+
 # Set non-interactive mode
 ENV DEBIAN_FRONTEND=noninteractive
 
@@ -72,3 +76,34 @@ RUN chmod +x /scripts/install_nvm.sh
 
 # Run script during build to install nvm
 RUN bash /scripts/install_nvm.sh
+
+# Install Chrome Remote Desktop
+RUN  curl https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/trusted.gpg.d/chrome-remote-desktop.gpg && \
+    # Add the Chrome Remote Desktop repository
+    echo "deb [arch=amd64] https://dl.google.com/linux/chrome-remote-desktop/deb stable main" > /etc/apt/sources.list.d/chrome-remote-desktop.list && \
+    # Update package lists and install Chrome Remote Desktop
+    apt-get update && apt-get install --assume-yes chrome-remote-desktop && \
+    # Clean up to reduce image size
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Configure Chrome Remote Desktop to use Xfce by default
+RUN echo "exec /etc/X11/Xsession /usr/bin/xfce4-session" > /etc/chrome-remote-desktop-session
+
+# Because there is no display connected to your instance, disable the display manager service on your instance
+RUN systemctl disable lightdm.service
+
+# Create the user USERNAME
+RUN useradd -m -s /bin/bash ${USERNAME} && echo "${USERNAME}:password" | chpasswd && \
+    echo "${USERNAME} ALL=(ALL) NOPASSWD:ALL" >> /etc/sudoers.d/${USERNAME} && \
+    chmod 0440 /etc/sudoers.d/${USERNAME} && \
+    chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
+
+# Add USERNAME to the chrome-remote-desktop group
+RUN usermod -aG chrome-remote-desktop ${USERNAME}
+
+# Switch to non-root user for Google Chrome Remote Desktop to work.
+USER ${USERNAME}
+WORKDIR /home/${USERNAME}
+
+# Entrypoint included since opening terminal is needed to authorize connect of the remote computer to your Google Chrome account. 
+ENTRYPOINT [ "/bin/bash" ]

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -1,0 +1,56 @@
+# Base image with GPU support
+FROM nvidia/cuda:11.6.1-cudnn8-devel-ubuntu20.04
+
+# Set non-interactive mode
+ENV DEBIAN_FRONTEND=noninteractive
+
+# Set user
+ENV USER=root
+
+# Set NVIDIA driver capabilities
+ENV NVIDIA_DRIVER_CAPABILITIES=all
+
+# Install dependencies
+# opencv requires opengl https://github.com/conda-forge/opencv-feedstock/issues/401
+# Default python3 is 3.8 in ubuntu 20.04 https://wiki.ubuntu.com/FocalFossa/ReleaseNotes#Python3_by_default
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    libfontconfig1 \
+    libgssapi-krb5-2 \
+    libdbus-1-3 \
+    libx11-xcb1 \
+    libxkbcommon-x11-0 \
+    curl \
+    # Base packages for compatibility with GCC-10 and other software
+    gcc-10-base \
+    libgcc-s1 \
+    # XFCE4 desktop environment for lightweight graphical interface
+    xfce4 \
+    desktop-base \
+    # Required for session and screen management
+    dbus-x11 \
+    xscreensaver \
+    xbase-clients \
+    xvfb \
+    # Miscellaneous dependencies
+    # Provides process management utilities
+    psmisc \
+    # Dummy X server for headless environments
+    xserver-xorg-video-dummy \
+    # Supports session management and terminal multiplexers
+    libutempter0 \  
+    # Enables secure communication and package verification
+    gnupg2 \             
+    # Allows running commands as root
+    sudo && \               
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
+
+# Copy install script into container
+COPY install_miniforge.sh /scripts/install_miniforge.sh
+
+# Make script executable
+RUN chmod +x /scripts/install_miniforge.sh
+
+# Run script during build to install Miniforge
+RUN bash /scripts/install_miniforge.sh

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -19,6 +19,12 @@ ENV NVIDIA_DRIVER_CAPABILITIES=all
 # Default python3 is 3.8 in ubuntu 20.04 https://wiki.ubuntu.com/FocalFossa/ReleaseNotes#Python3_by_default
 RUN apt-get update && apt-get install -y --no-install-recommends \
     build-essential \
+    libgl1-mesa-glx \
+    libglapi-mesa \
+    libegl-mesa0 \
+    libegl1 \
+    libopengl0 \
+    libglib2.0-0 \
     libfontconfig1 \
     libgssapi-krb5-2 \
     libdbus-1-3 \
@@ -34,7 +40,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Required for session and screen management
     dbus-x11 \
     xscreensaver \
-    xbase-clients \
     xvfb \
     # Miscellaneous dependencies
     # Provides process management utilities
@@ -46,7 +51,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Enables secure communication and package verification
     gnupg2 \             
     # Allows running commands as root
-    sudo && \               
+    sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
@@ -86,7 +91,7 @@ RUN  curl https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /
     # Clean up to reduce image size
     apt-get clean && rm -rf /var/lib/apt/lists/*
 
-# Configure Chrome Remote Desktop to use Xfce by default
+# Configure Chrome Remote Desktop to use Gnome by default
 RUN echo "exec /etc/X11/Xsession /usr/bin/xfce4-session" > /etc/chrome-remote-desktop-session
 
 # Because there is no display connected to your instance, disable the display manager service on your instance

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -37,6 +37,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # XFCE4 desktop environment for lightweight graphical interface
     xfce4 \
     desktop-base \
+    xfce4-terminal \
+    xfce4-goodies \
     # Required for session and screen management
     dbus-x11 \
     xscreensaver \

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -51,38 +51,26 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Supports session management and terminal multiplexers
     libutempter0 \  
     # Enables secure communication and package verification
-    gnupg2 \             
+    gnupg2 \
+    # For Chrome Browser
+    fonts-liberation \
+    libasound2 \
+    wget \
+    xdg-utils \
     # Allows running commands as root
     sudo && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
-# Copy install script into container
-COPY install_miniforge.sh /scripts/install_miniforge.sh
 
-# Make script executable
-RUN chmod +x /scripts/install_miniforge.sh
+# Create scripts directory with miniforge, uv, and nvm installation scripts
+COPY install_miniforge.sh install_uv.sh install_nvm.sh /scripts/
 
-# Run script during build to install Miniforge
-RUN bash /scripts/install_miniforge.sh
-
-# Copy install script into container
-COPY install_uv.sh /scripts/install_uv.sh
-
-# Make script executable
-RUN chmod +x /scripts/install_uv.sh
-
-# Run script during build to install Miniforge
-RUN bash /scripts/install_uv.sh
-
-# Install Node Version Manager (nvm)
-COPY install_nvm.sh /scripts/install_nvm.sh
-
-# Make script executable
-RUN chmod +x /scripts/install_nvm.sh
-
-# Run script during build to install nvm
-RUN bash /scripts/install_nvm.sh
+# Make scripts executable and run them
+RUN chmod +x /scripts/*.sh && \
+    /scripts/install_miniforge.sh && \
+    /scripts/install_uv.sh && \
+    /scripts/install_nvm.sh
 
 # Install Chrome Remote Desktop
 RUN  curl https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/trusted.gpg.d/chrome-remote-desktop.gpg && \
@@ -98,6 +86,11 @@ RUN echo "exec /etc/X11/Xsession /usr/bin/xfce4-session" > /etc/chrome-remote-de
 
 # Because there is no display connected to your instance, disable the display manager service on your instance
 RUN systemctl disable lightdm.service
+
+# Install Chrome browser
+RUN curl -L -o google-chrome-stable_current_amd64.deb \
+    https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb && \
+    apt install --assume-yes --fix-broken ./google-chrome-stable_current_amd64.deb
 
 # Create the user USERNAME
 RUN useradd -m -s /bin/bash ${USERNAME} && echo "${USERNAME}:password" | chpasswd && \

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -63,3 +63,12 @@ RUN chmod +x /scripts/install_uv.sh
 
 # Run script during build to install Miniforge
 RUN bash /scripts/install_uv.sh
+
+# Install Node Version Manager (nvm)
+COPY install_nvm.sh /scripts/install_nvm.sh
+
+# Make script executable
+RUN chmod +x /scripts/install_nvm.sh
+
+# Run script during build to install nvm
+RUN bash /scripts/install_nvm.sh

--- a/lablink-client-base/lablink-client-base-image/README.md
+++ b/lablink-client-base/lablink-client-base-image/README.md
@@ -42,9 +42,9 @@ nvidia-smi
 This guide explains how to connect to the Chrome Remote Desktop server running in the container to access the desktop environment.
 
 ### Prerequisites
-1. Google Account: You need a Google account to use Chrome Remote Desktop.
-2. Chrome Browser: You need to have the Chrome browser installed on your local machine.
-3. Docker Setup:
+1. **Google Account**: You need a Google account to use Chrome Remote Desktop.
+2. **Chrome Browser**: You need to have the Chrome browser installed on your local machine.
+3. **Docker Setup**:
    - Ensure Docker is installed and running on your system.
 
 ### Steps to Connect

--- a/lablink-client-base/lablink-client-base-image/README.md
+++ b/lablink-client-base/lablink-client-base-image/README.md
@@ -32,9 +32,9 @@ nvidia-smi
 
 **Notes:**
 
-- -it ensures that you get an interactive terminal. The i stands for interactive, and t allocates a pseudo-TTY, which is what allows you to interact with the bash shell inside the container.
-- The -v or --volume option mounts the specified directory with the same level of access as the directory has on the host.
-- The --rm flag in a docker run command automatically removes the container when it stops. This is useful for running temporary or one-time containers without cluttering your Docker environment with stopped containers.
+- `-it` ensures that you get an interactive terminal. The `i` stands for interactive, and `t` allocates a pseudo-TTY, which is what allows you to interact with the bash shell inside the container.
+- The `-v` or `--volume` option mounts the specified directory with the same level of access as the directory has on the host.
+- The `--rm` flag in a docker run command automatically removes the container when it stops. This is useful for running temporary or one-time containers without cluttering your Docker environment with stopped containers.
 
 
 ## Connecting to Chrome Remote Desktop

--- a/lablink-client-base/lablink-client-base-image/README.md
+++ b/lablink-client-base/lablink-client-base-image/README.md
@@ -1,23 +1,116 @@
-# sleap-chrome-remote-desktop
+# lablink-client-base-image
 
 ## Description
-This folder of the repo contains a DockerFile for a lightweight container (~9.75 GB) with the PyPI installation of SLEAP and all of its dependencies and a Chrome Remote Desktop server.
+This folder contains the Dockerfile (with the size of 10.1 GB) and configuration files for the base image used in the LabLink client. The image is designed to run on a Linux system with NVIDIA GPU support, specifically for use with Chrome Remote Desktop. This is the base image for the client side (VM instance) of the LabLink infrastructure. 
 
 The base image used is [nvidia/cuda:11.6.1-cudnn8-devel-ubuntu20.04](https://hub.docker.com/layers/nvidia/cuda/11.3.1-cudnn8-runtime-ubuntu20.04/images/sha256-025a321d3131b688f4ac09d80e9af6221f2d1568b4f9ea6e45a698beebb439c0).
 
 - The repo has CI set up in `.github/workflows` for building and pushing the image when making changes.
   - The workflow uses the linux/amd64 platform to build. 
-- `./sleap_chrome_remote_desktop/.devcontainer/devcontainer.json` is convenient for developing inside a container made with the DockerFile using Visual Studio Code.
+- `./lablink-client-base/lablink-client-base-image/.devcontainer/devcontainer.json` is convenient for developing inside a container made with the DockerFile using Visual Studio Code.
 
 ## Installation
 
 **Make sure to have Docker Daemon running first**
 
-
 You can pull the image if you don't have it built locally, or need to update the latest, with
 
 ```bash
-docker pull ghcr.io/talmolab/lablink-client-base-image:linux-amd64
+docker pull ghcr.io/talmolab/lablink-client-base-image:latest
 ```
 
 ## Usage
+Then, to run the image with GPU interactively, 
+```bash
+docker run --gpus all -it ghcr.io/talmolab/lablink-client-base-image:latest
+```
+
+In the container, you can run GPU commands like
+```bash
+nvidia-smi
+```
+
+**Notes:**
+
+- -it ensures that you get an interactive terminal. The i stands for interactive, and t allocates a pseudo-TTY, which is what allows you to interact with the bash shell inside the container.
+- The -v or --volume option mounts the specified directory with the same level of access as the directory has on the host.
+- The --rm flag in a docker run command automatically removes the container when it stops. This is useful for running temporary or one-time containers without cluttering your Docker environment with stopped containers.
+
+
+## Connecting to Chrome Remote Desktop
+
+This guide explains how to connect to the Chrome Remote Desktop server running in the container to access the desktop environment.
+
+### Prerequisites
+1. Google Account: You need a Google account to use Chrome Remote Desktop.
+2. Chrome Browser: You need to have the Chrome browser installed on your local machine.
+3. Docker Setup:
+   - Ensure Docker is installed and running on your system.
+
+### Steps to Connect
+
+### 1. Start the Docker Container
+
+Start the Docker container with the Chrome Remote Desktop server running in it.
+
+```bash
+docker run --rm -it --gpus=all <your-container-name>
+```
+
+### 2. Connect to the Chrome Remote Desktop
+
+1. On your local machine, go to [https://remotedesktop.google.com/access](https://remotedesktop.google.com/access) in your Chrome browser.
+
+2. Sign in with your Google account.
+
+3. Then, click "Set up via SSH" on the left and follow the provided steps.
+- This will provide the command in this form: 
+  ```bash
+  DISPLAY= /opt/google/chrome-remote-desktop/start-host \
+    --code="4/xxxxxxxxxxxxxxxxxxxxxxxx" \
+    --redirect-url="https://remotedesktop.google.com/_/oauthredirect" \
+    --name=$(hostname)
+  ```
+
+1. Run the provided command in your remote machine's terminal with Docker container running. Make sure to refresh the website. 
+
+2. When prompted, enter 6-digit PIN. This number will be used for additional authorization when you connect later.
+
+### 3. Run Chrome Remote Desktop
+
+1. Go to [https://remotedesktop.google.com/access](https://remotedesktop.google.com/access) in your Chrome browser.
+
+2. Sign in with your Google account.
+
+3. Then, click "Remote Access" to check the status of your remote desktop (make sure to refresh the page).
+
+4. If you see the status as "Online", click on the remote desktop to connect and enter the 6-digit PIN you set earlier.
+
+### 4. Access the GUI
+
+Once connected to the remote machine, open a terminal and type the Nvidia commands like `nvidia-smi`. The GUI should be displayed in your chrome remote desktop display environment on your local machine.
+
+## Build
+To build and push via automated CI, just push changes to a branch.
+
+- Pushes to `main` result in an image with the tag `latest`.
+- Pushes to other branches have tags with `-test` appended.
+- See `.github/workflows` for testing and production workflows.
+
+To test `test` images locally use after pushing the `test` images via CI:
+
+```bash
+docker pull ghcr.io/talmolab/lablink-client-base-image:linux-amd64-test
+```
+
+then
+
+```bash
+docker run --gpus all -it ghcr.io/talmolab/lablink-client-base-image:linux-amd64-test
+```
+
+To build locally for testing you can use the command:
+```bash
+docker build --no-cache -t sleap-crd ./lablink-client-base/lablink-client-base-image
+docker run --gpus all -it --rm --name sleap-crd sleap-crd
+```

--- a/lablink-client-base/lablink-client-base-image/README.md
+++ b/lablink-client-base/lablink-client-base-image/README.md
@@ -1,0 +1,23 @@
+# sleap-chrome-remote-desktop
+
+## Description
+This folder of the repo contains a DockerFile for a lightweight container (~9.75 GB) with the PyPI installation of SLEAP and all of its dependencies and a Chrome Remote Desktop server.
+
+The base image used is [nvidia/cuda:11.6.1-cudnn8-devel-ubuntu20.04](https://hub.docker.com/layers/nvidia/cuda/11.3.1-cudnn8-runtime-ubuntu20.04/images/sha256-025a321d3131b688f4ac09d80e9af6221f2d1568b4f9ea6e45a698beebb439c0).
+
+- The repo has CI set up in `.github/workflows` for building and pushing the image when making changes.
+  - The workflow uses the linux/amd64 platform to build. 
+- `./sleap_chrome_remote_desktop/.devcontainer/devcontainer.json` is convenient for developing inside a container made with the DockerFile using Visual Studio Code.
+
+## Installation
+
+**Make sure to have Docker Daemon running first**
+
+
+You can pull the image if you don't have it built locally, or need to update the latest, with
+
+```bash
+docker pull ghcr.io/talmolab/lablink-client-base-image:linux-amd64
+```
+
+## Usage

--- a/lablink-client-base/lablink-client-base-image/install_miniforge.sh
+++ b/lablink-client-base/lablink-client-base-image/install_miniforge.sh
@@ -26,8 +26,11 @@ source "$HOME/.bashrc" || source "$HOME/.profile"
 echo "Disabling auto-activation of base environment..."
 conda config --set auto_activate_base false
 
-# Cleanup installer file
-rm -f "${INSTALLER}"
+# Verify Miniforge installation
+echo "Verifying Miniforge installation..."
+which conda && conda --version || echo "ERROR: Miniforge is not found in PATH"
+echo "PATH is set to: $PATH"
+conda env list
 
 echo "Miniforge and Mamba are set up successfully!"
 exec "$@"

--- a/lablink-client-base/lablink-client-base-image/install_miniforge.sh
+++ b/lablink-client-base/lablink-client-base-image/install_miniforge.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e  # Exit on error
 
 # Define Miniforge installer filename manually to avoid `uname` inconsistencies
 INSTALLER="Miniforge3-Linux-x86_64.sh"

--- a/lablink-client-base/lablink-client-base-image/install_miniforge.sh
+++ b/lablink-client-base/lablink-client-base-image/install_miniforge.sh
@@ -1,0 +1,33 @@
+#!/bin/bash
+set -e  # Exit on error
+
+# Define Miniforge installer filename manually to avoid `uname` inconsistencies
+INSTALLER="Miniforge3-Linux-x86_64.sh"
+
+# Download the Miniforge installer script
+echo "Downloading Miniforge installer..."
+curl -L -O "https://github.com/conda-forge/miniforge/releases/latest/download/${INSTALLER}"
+
+# Run the installer script non-interactively in a standard location
+echo "Installing Miniforge..."
+bash "${INSTALLER}" -b -p "$HOME/miniforge3"
+
+# Ensure the installation directory is correctly exported
+export PATH="$HOME/miniforge3/bin:$PATH"
+
+# Initialize conda for the current shell
+echo "Initializing Conda..."
+conda init bash
+
+# Source the profile file to apply conda init changes immediately
+source "$HOME/.bashrc" || source "$HOME/.profile"
+
+# Disable automatic activation of the base environment
+echo "Disabling auto-activation of base environment..."
+conda config --set auto_activate_base false
+
+# Cleanup installer file
+rm -f "${INSTALLER}"
+
+echo "Miniforge and Mamba are set up successfully!"
+exec "$@"

--- a/lablink-client-base/lablink-client-base-image/install_nvm.sh
+++ b/lablink-client-base/lablink-client-base-image/install_nvm.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Install nvm
+echo "Installing nvm..."
+curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.2/install.sh | bash
+
+echo "nvm installed successfully"
+
+# Check nvm version
+echo "Checking nvm version..."
+echo "The directory for NVM: $NVM_DIR"
+echo "The version of NVM: $(nvm --version)"

--- a/lablink-client-base/lablink-client-base-image/install_uv.sh
+++ b/lablink-client-base/lablink-client-base-image/install_uv.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Download UV installer
+echo "Downloading UV installer..."
+curl -LsSf https://astral.sh/uv/install.sh | bash
+
+# Ensure UV is in the PATH
+export PATH="$HOME/.local/bin:$PATH"
+
+# Verify UV installation
+which uv && uv --version || echo "ERROR: UV is not found in PATH"
+echo "PATH is set to: $PATH"
+
+# Self update
+echo "Self updating UV..."
+uv self update


### PR DESCRIPTION
The `lablink-client-base-image` is the base image for the VM instances for participants to use during a tutorial session of a subject software. Developers can base off this image in order to create their own VM images specifically for their subject software.

Installed the following in the image: 

- Chrome Remote Desktop
- Chrome Browser
- UV Package Manager
- Miniforge
- Node Version Manager
- Xfce Desktop Environment

Related Issue: 
- #4 