### PR TITLE
Add Startup Script on `lablink-client-base-image`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,4 +216,4 @@ terraform/service-account-*.json
 .DS_Store
 
 # ignore output for Hydra
-lablink-client-base/lablink-client-service/outputs
+outputs

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -108,5 +108,12 @@ RUN sudo chmod +x /scripts/*.sh && \
 # Activate conda environment and install client service package
 RUN /home/${USERNAME}/miniforge3/bin/conda run -n base pip install lablink-client-service
 
+# Copy the startup script
+COPY start.sh /home/${USERNAME}/start.sh
+RUN chmod +x /home/${USERNAME}/start.sh
+
 # Entrypoint included since opening terminal is needed to authorize connect of the remote computer to your Google Chrome account. 
-ENTRYPOINT [ "/bin/bash" ]
+# ENTRYPOINT [ "/bin/bash" ]
+
+# Run the startup script
+CMD ["/home/client/start.sh"]

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -110,7 +110,7 @@ RUN /home/${USERNAME}/miniforge3/bin/conda run -n base pip install lablink-clien
 
 # Copy the startup script
 COPY start.sh /home/${USERNAME}/start.sh
-RUN chmod +x /home/${USERNAME}/start.sh
+RUN sudo chmod +x /home/${USERNAME}/start.sh
 
 # Entrypoint included since opening terminal is needed to authorize connect of the remote computer to your Google Chrome account. 
 # ENTRYPOINT [ "/bin/bash" ]

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -105,7 +105,7 @@ RUN sudo chmod +x /scripts/*.sh && \
     /scripts/install_uv.sh && \
     /scripts/install_nvm.sh
 
-# Activate conda environment and install additional packages
+# Activate conda environment and install client service package
 RUN /home/${USERNAME}/miniforge3/bin/conda run -n base pip install lablink-client-service
 
 # Entrypoint included since opening terminal is needed to authorize connect of the remote computer to your Google Chrome account. 

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -112,8 +112,5 @@ RUN /home/${USERNAME}/miniforge3/bin/conda run -n base pip install lablink-clien
 COPY start.sh /home/${USERNAME}/start.sh
 RUN sudo chmod +x /home/${USERNAME}/start.sh
 
-# Entrypoint included since opening terminal is needed to authorize connect of the remote computer to your Google Chrome account. 
-# ENTRYPOINT [ "/bin/bash" ]
-
 # Run the startup script
 CMD ["/home/client/start.sh"]

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -105,5 +105,9 @@ RUN sudo chmod +x /scripts/*.sh && \
     /scripts/install_uv.sh && \
     /scripts/install_nvm.sh
 
+# Activate conda environment and install additional packages
+RUN /home/${USERNAME}/miniforge3/bin/conda run -n base pip install --extra-index-url https://test.pypi.org/simple/ lablink-client-service
+
+
 # Entrypoint included since opening terminal is needed to authorize connect of the remote computer to your Google Chrome account. 
 ENTRYPOINT [ "/bin/bash" ]

--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -106,8 +106,7 @@ RUN sudo chmod +x /scripts/*.sh && \
     /scripts/install_nvm.sh
 
 # Activate conda environment and install additional packages
-RUN /home/${USERNAME}/miniforge3/bin/conda run -n base pip install --extra-index-url https://test.pypi.org/simple/ lablink-client-service
-
+RUN /home/${USERNAME}/miniforge3/bin/conda run -n base pip install lablink-client-service
 
 # Entrypoint included since opening terminal is needed to authorize connect of the remote computer to your Google Chrome account. 
 ENTRYPOINT [ "/bin/bash" ]

--- a/lablink-client-base/lablink-client-base-image/README.md
+++ b/lablink-client-base/lablink-client-base-image/README.md
@@ -106,11 +106,11 @@ docker pull ghcr.io/talmolab/lablink-client-base-image:linux-amd64-test
 then
 
 ```bash
-docker run --gpus all -it ghcr.io/talmolab/lablink-client-base-image:linux-amd64-test
+docker run --gpus all -e DB_HOST=<db-host> -it ghcr.io/talmolab/lablink-client-base-image:linux-amd64-test
 ```
 
 To build locally for testing you can use the command:
 ```bash
-docker build --no-cache -t sleap-crd ./lablink-client-base/lablink-client-base-image
-docker run --gpus all -it --rm --name sleap-crd sleap-crd
+docker build --no-cache -t client-base-crd ./lablink-client-base/lablink-client-base-image
+docker run --gpus all -it --rm --name client-base-crd client-base-crd
 ```

--- a/lablink-client-base/lablink-client-base-image/start.sh
+++ b/lablink-client-base/lablink-client-base-image/start.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+# Activate the conda environment and run the subscribe script
+/home/client/miniforge3/bin/conda run -n base subscribe

--- a/lablink-client-base/lablink-client-base-image/start.sh
+++ b/lablink-client-base/lablink-client-base-image/start.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
 
+echo "Running subscribe script..."
 # Activate the conda environment and run the subscribe script
-/home/client/miniforge3/bin/conda run -n base subscribe
+/home/client/miniforge3/bin/conda run -n base subscribe db.host=$DB_HOST

--- a/lablink-client-base/lablink-client-service/lablink_client_service/database.py
+++ b/lablink-client-base/lablink-client-service/lablink_client_service/database.py
@@ -152,7 +152,7 @@ class PostgresqlDatabase:
                             )
                             
                             print("Chrome Remote Desktop connected successfully. Exiting listener loop.")
-                            return
+                            break
 
                         except json.JSONDecodeError as e:
                             print(f"Error decoding JSON payload: {e}")

--- a/lablink-client-base/lablink-client-service/lablink_client_service/database.py
+++ b/lablink-client-base/lablink-client-service/lablink_client_service/database.py
@@ -150,6 +150,9 @@ class PostgresqlDatabase:
                                 pin=pin,
                                 command=command,
                             )
+                            
+                            print("Chrome Remote Desktop connected successfully. Exiting listener loop.")
+                            return
 
                         except json.JSONDecodeError as e:
                             print(f"Error decoding JSON payload: {e}")


### PR DESCRIPTION
This PR adds a new startup script `startup.sh` so that it can listen to any changes in the database when starting up the VM and start enter CRD command automatically. 