### PR TITLE
Add Destruction Workflow for the Allocator

### DIFF
--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -1,0 +1,48 @@
+name: Terraform Destroy
+
+on:
+  workflow_dispatch:
+    inputs:
+      confirm_destroy:
+        description: "Type 'yes' to confirm destruction"
+        required: true
+        default: "no"
+
+permissions:
+  id-token: write # Required for OIDC
+  contents: read
+
+jobs:
+  destroy:
+    if: github.event.inputs.confirm_destroy == 'yes'
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Configure AWS credentials via OIDC
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          role-to-assume: arn:aws:iam::711387140753:role/github_lablink_repository-AE68499B37C7
+          aws-region: us-west-2
+
+      - name: Setup Terraform
+        uses: hashicorp/setup-terraform@v2
+        with:
+          terraform_version: 1.6.6
+
+      - name: Store private key for EC2
+        run: echo "${{ secrets.EC2_PRIVATE_KEY }}" > ~/ec2-key.pem
+        shell: bash
+
+      - name: Set permissions for the private key
+        run: chmod 600 ~/ec2-key.pem
+
+      - name: Terraform Init
+        run: terraform init
+        working-directory: lablink-allocator
+
+      - name: Terraform Destroy
+        run: terraform destroy -auto-approve
+        working-directory: lablink-allocator

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -7,7 +7,9 @@ on:
         description: "Type 'yes' to confirm destruction"
         required: true
         default: "no"
-
+  pull_request:
+    branches:
+      - main
 permissions:
   id-token: write # Required for OIDC
   contents: read

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -1,11 +1,6 @@
 name: Terraform Destroy
 
 on:
-  workflow_run:
-    workflows: ["Terraform Deploy"]
-    types:
-      - completed
-
   workflow_dispatch:
     inputs:
       confirm_destroy:
@@ -38,12 +33,6 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.6.6
-
-      - name: Download Terraform State
-        uses: actions/download-artifact@v4
-        with:
-          name: terraform-state
-          path: lablink-allocator/
 
       - name: Store private key for EC2
         run: echo "${{ secrets.EC2_PRIVATE_KEY }}" > ~/ec2-key.pem

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -1,6 +1,13 @@
 name: Terraform Destroy
 
 on:
+  workflow_run:
+    workflows: ["Terraform Deploy"]
+    types:
+      - completed
+    branches:
+      - "**" # Runs on all branches
+
   workflow_dispatch:
     inputs:
       confirm_destroy:
@@ -44,12 +51,6 @@ jobs:
       - name: Terraform Init
         run: terraform init
         working-directory: lablink-allocator
-
-      - name: Download Terraform State
-        uses: actions/download-artifact@v4
-        with:
-          name: terraform-state
-          path: lablink-allocator
 
       - name: Terraform Destroy
         run: terraform destroy -auto-approve

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -46,7 +46,7 @@ jobs:
         working-directory: lablink-allocator
 
       - name: Download Terraform State
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: terraform-state
           path: lablink-allocator/terraform.tfstate

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -7,9 +7,8 @@ on:
         description: "Type 'yes' to confirm destruction"
         required: true
         default: "no"
-  pull_request:
-    branches:
-      - main
+        type: string
+
 permissions:
   id-token: write # Required for OIDC
   contents: read

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -5,8 +5,6 @@ on:
     workflows: ["Terraform Deploy"]
     types:
       - completed
-    branches:
-      - "**" # Runs on all branches
 
   workflow_dispatch:
     inputs:
@@ -40,6 +38,12 @@ jobs:
         uses: hashicorp/setup-terraform@v2
         with:
           terraform_version: 1.6.6
+
+      - name: Download Terraform State
+        uses: actions/download-artifact@v3
+        with:
+          name: terraform-state
+          path: lablink-allocator/
 
       - name: Store private key for EC2
         run: echo "${{ secrets.EC2_PRIVATE_KEY }}" > ~/ec2-key.pem

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -40,7 +40,7 @@ jobs:
           terraform_version: 1.6.6
 
       - name: Download Terraform State
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: terraform-state
           path: lablink-allocator/

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -45,6 +45,12 @@ jobs:
         run: terraform init
         working-directory: lablink-allocator
 
+      - name: Download Terraform State
+        uses: actions/download-artifact@v3
+        with:
+          name: terraform-state
+          path: lablink-allocator/terraform.tfstate
+
       - name: Terraform Destroy
         run: terraform destroy -auto-approve
         working-directory: lablink-allocator

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -49,7 +49,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: terraform-state
-          path: lablink-allocator/terraform.tfstate
+          path: lablink-allocator
 
       - name: Terraform Destroy
         run: terraform destroy -auto-approve

--- a/.github/workflows/lablink-allocator-terraform.yml
+++ b/.github/workflows/lablink-allocator-terraform.yml
@@ -55,6 +55,14 @@ jobs:
         working-directory: lablink-allocator
         continue-on-error: true # Allow failure to move on to cleanup
 
+      - name: Upload Terraform State
+        uses: actions/upload-artifact@v4
+        with:
+          name: terraform-state
+          path: |
+            lablink-allocator/terraform.tfstate
+            lablink-allocator/.terraform/terraform.tfstate
+
       - name: Get EC2 Public IP and write to config
         id: get_ip
         run: |

--- a/.github/workflows/lablink-allocator-terraform.yml
+++ b/.github/workflows/lablink-allocator-terraform.yml
@@ -55,14 +55,6 @@ jobs:
         working-directory: lablink-allocator
         continue-on-error: true # Allow failure to move on to cleanup
 
-      - name: Upload Terraform State
-        uses: actions/upload-artifact@v4
-        with:
-          name: terraform-state
-          path: |
-            lablink-allocator/terraform.tfstate
-            lablink-allocator/.terraform/terraform.tfstate
-
       - name: Get EC2 Public IP and write to config
         id: get_ip
         run: |

--- a/.github/workflows/lablink-allocator-terraform.yml
+++ b/.github/workflows/lablink-allocator-terraform.yml
@@ -55,6 +55,11 @@ jobs:
         working-directory: lablink-allocator
         continue-on-error: true # Allow failure to move on to cleanup
 
+      - name: Upload Terraform State
+        uses: actions/upload-artifact@v3
+        with:
+          name: terraform-state
+          path: lablink-allocator/terraform.tfstate
       - name: Get EC2 Public IP and write to config
         id: get_ip
         run: |

--- a/.github/workflows/lablink-allocator-terraform.yml
+++ b/.github/workflows/lablink-allocator-terraform.yml
@@ -38,6 +38,13 @@ jobs:
         run: terraform init
         working-directory: lablink-allocator
 
+      - name: Terraform Format
+        run: terraform fmt -check
+        working-directory: lablink-allocator
+      - name: Terraform Validate
+        run: terraform validate
+        working-directory: lablink-allocator
+
       - name: Terraform Plan
         run: terraform plan
         working-directory: lablink-allocator

--- a/.github/workflows/lablink-allocator-terraform.yml
+++ b/.github/workflows/lablink-allocator-terraform.yml
@@ -56,7 +56,7 @@ jobs:
         continue-on-error: true # Allow failure to move on to cleanup
 
       - name: Upload Terraform State
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: terraform-state
           path: lablink-allocator/terraform.tfstate

--- a/.github/workflows/lablink-allocator-terraform.yml
+++ b/.github/workflows/lablink-allocator-terraform.yml
@@ -55,11 +55,6 @@ jobs:
         working-directory: lablink-allocator
         continue-on-error: true # Allow failure to move on to cleanup
 
-      - name: Upload Terraform State
-        uses: actions/upload-artifact@v4
-        with:
-          name: terraform-state
-          path: lablink-allocator/terraform.tfstate
       - name: Get EC2 Public IP and write to config
         id: get_ip
         run: |

--- a/lablink-allocator/backend_config.tf
+++ b/lablink-allocator/backend_config.tf
@@ -2,7 +2,7 @@ terraform {
   backend "s3" {
     bucket         = "tf-state-bucket"
     key            = "lablink/terraform.tfstate"
-    region         = "us-west-2"
+    region         = "us-west-1"
     dynamodb_table = "lock-table"
     encrypt        = true
   }

--- a/lablink-allocator/backend_config.tf
+++ b/lablink-allocator/backend_config.tf
@@ -1,8 +1,8 @@
 terraform {
   backend "s3" {
-    bucket         = "tf-state-bucket"
-    key            = "lablink/terraform.tfstate"
-    region         = "us-west-1"
+    bucket         = "tf-state-lablink-allocator-bucket"
+    key            = "terraform.tfstate"
+    region         = "us-west-2"
     dynamodb_table = "lock-table"
     encrypt        = true
   }

--- a/lablink-allocator/backend_config.tf
+++ b/lablink-allocator/backend_config.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "tf-state-bucket"
+    key            = "lablink/terraform.tfstate"
+    region         = "us-west-2"
+    dynamodb_table = "lock-table"
+    encrypt        = true
+  }
+}

--- a/lablink-allocator/main.tf
+++ b/lablink-allocator/main.tf
@@ -31,10 +31,6 @@ resource "aws_security_group" "allow_http" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
-
-  lifecycle {
-    prevent_destroy = true
-  }
 }
 
 resource "aws_instance" "lablink_allocator_server" {


### PR DESCRIPTION
This PR adds a new Github Actions Workflow that destroys resources created for the allocator side of Lablink. 

Related Issue: 
- #44 