### PR TITLE
Clears the Database when Admin Destroys All Resources

### DIFF
--- a/lablink-allocator/lablink-allocator-service/database.py
+++ b/lablink-allocator/lablink-allocator-service/database.py
@@ -323,6 +323,17 @@ class PostgresqlDatabase:
         row = self.cursor.fetchone()
         return row[0] if row else None
 
+    def clear_database(self) -> None:
+        """Delete all VMs from the table."""
+        query = f"DELETE FROM {self.table_name};"
+        try:
+            self.cursor.execute(query)
+            self.conn.commit()
+            logger.debug("All VMs deleted from the table.")
+        except Exception as e:
+            logger.error(f"Error deleting VMs: {e}")
+            self.conn.rollback()
+
     @classmethod
     def load_database(cls, dbname, user, password, host, port, table_name):
         """Loads an existing database from PostgreSQL.

--- a/lablink-allocator/lablink-allocator-service/main.py
+++ b/lablink-allocator/lablink-allocator-service/main.py
@@ -245,6 +245,11 @@ def destroy():
             apply_cmd, cwd=terraform_dir, check=True, capture_output=True, text=True
         )
 
+        # Clear the database
+        logger.debug("Clearing the database...")
+        database.clear_database()
+        logger.debug("Database cl   eared successfully.")
+
         return render_template("dashboard.html", output=result.stdout)
     except subprocess.CalledProcessError as e:
         return render_template("dashboard.html", error=e.stderr or e.stdout)

--- a/lablink-allocator/lablink-allocator-service/main.py
+++ b/lablink-allocator/lablink-allocator-service/main.py
@@ -248,7 +248,7 @@ def destroy():
         # Clear the database
         logger.debug("Clearing the database...")
         database.clear_database()
-        logger.debug("Database cl   eared successfully.")
+        logger.debug("Database cleared successfully.")
 
         return render_template("dashboard.html", output=result.stdout)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
This PR introduces functionality to clear all VMs from the database and integrates this feature into the application's destruction process. The changes include adding a new method to handle database clearing and updating the `destroy` function to use this method.

Related Issue:
- https://github.com/talmolab/lablink/issues/55