### PR TITLE
Add Configuration for the Image and Repository to Clone in Allocator

### DIFF
--- a/lablink-allocator/lablink-allocator-service/conf/config.yaml
+++ b/lablink-allocator/lablink-allocator-service/conf/config.yaml
@@ -9,6 +9,8 @@ db:
 
 machine:
   machine_type: "g4dn.xlarge"
+  repository: "https://github.com/talmolab/cosyne-tutorial-data.git"
+  image: "ghcr.io/talmolab/lablink-sleap-client-image:linux-amd64-test"
 
 app:
   admin_user: "admin"

--- a/lablink-allocator/lablink-allocator-service/conf/structured_config.py
+++ b/lablink-allocator/lablink-allocator-service/conf/structured_config.py
@@ -25,6 +25,8 @@ class AppConfig:
 @dataclass
 class MachineConfig:
     machine_type: str = field(default="g4dn.xlarge")
+    repository: str = field(default="")
+    image: str = field(default="ghcr.io/talmolab/lablink-client-base-image:latest")
 
 
 @dataclass

--- a/lablink-allocator/lablink-allocator-service/main.py
+++ b/lablink-allocator/lablink-allocator-service/main.py
@@ -215,6 +215,7 @@ def launch():
         with open(os.path.join(terraform_dir, "terraform.runtime.tfvars"), "w") as f:
             f.write(f'allocator_ip = "{allocator_ip}"\n')
             f.write(f'machine_type = "{cfg.machine.machine_type}"\n')
+            f.write(f'image_name = "{cfg.machine.image}"\n')
 
         # Apply with the new number of instances
         apply_cmd = [

--- a/lablink-allocator/lablink-allocator-service/terraform/main.tf
+++ b/lablink-allocator/lablink-allocator-service/terraform/main.tf
@@ -40,6 +40,11 @@ variable "machine_type" {
   default     = "t2.medium"
 }
 
+variable "image_name" {
+  type        = string
+  description = "VM Image Name to be used as client base image"
+}
+
 resource "aws_security_group" "lablink_sg_" {
   name        = "lablink_sg_"
   description = "Allow SSH and Docker ports"
@@ -103,7 +108,7 @@ resource "aws_instance" "lablink_vm" {
 
               nvidia-smi || echo "nvidia-smi failed, GPU may not be present"
 
-              docker pull ghcr.io/talmolab/lablink-client-base-image:latest
+              docker pull ${var.image_name}
               if [ $? -ne 0 ]; then
                   echo "Docker image pull failed!" >&2
                   exit 1
@@ -111,7 +116,7 @@ resource "aws_instance" "lablink_vm" {
                   echo "Docker image pulled successfully."
               fi
 
-              docker run -dit --gpus all -e ALLOCATOR_HOST=${var.allocator_ip} ghcr.io/talmolab/lablink-client-base-image:latest
+              docker run -dit --gpus all -e ALLOCATOR_HOST=${var.allocator_ip} ${var.image_name}
               if [ $? -ne 0 ]; then
                   echo "Docker run failed!" >&2
                   exit 1


### PR DESCRIPTION
This PR introduces new configurations for the allocator web app: `machine.image` and `machine.repository`. 
- `machine.image`: Image of VM instance for the client
- `machine.repository`: Repository to clone in the client's VM instances