### PR TITLE
Extract Client's Analytics from Each Client's VM Instances

### DIFF
--- a/lablink-allocator/lablink-allocator-service/terraform/main.tf
+++ b/lablink-allocator/lablink-allocator-service/terraform/main.tf
@@ -93,7 +93,7 @@ resource "tls_private_key" "lablink_key" {
 }
 
 resource "aws_key_pair" "lablink_key_pair" {
-  key_name   = "sleap-lablink"
+  key_name   = "lablink_key_pair_client"
   public_key = tls_private_key.lablink_key.public_key_openssh
 }
 

--- a/lablink-allocator/lablink-allocator-service/utils/analytics_utils.py
+++ b/lablink-allocator/lablink-allocator-service/utils/analytics_utils.py
@@ -1,0 +1,59 @@
+import os
+import subprocess
+import json
+from pathlib import Path
+
+
+def get_instance_ips(terraform_dir: str) -> list:
+    """Get the public IP addresses of the instances created by Terraform.
+
+    Args:
+        terraform_dir (str): The directory where the Terraform configuration is located.
+
+    Raises:
+        RuntimeError: Error running terraform output command.
+        RuntimeError: Error decoding JSON output.
+        ValueError: Expected output to be a list of IP addresses.
+
+    Returns:
+        list: A list of public IP addresses of the instances.
+    """
+    result = subprocess.run(
+        ["terraform", "output", "-json", "lablink_vm_public_ips"],
+        cwd=terraform_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(f"Error running terraform output: {result.stderr}")
+    try:
+        output = json.loads(result.stdout)
+    except json.JSONDecodeError as e:
+        raise RuntimeError(f"Error decoding JSON output: {e}")
+    if not isinstance(output, list):
+        raise ValueError("Expected output to be a list of IP addresses")
+    return output
+
+
+def get_ssh_key_pairs(terraform_dir: str) -> str:
+    """Get the SSH private key used for connecting to the instances.
+
+    Args:
+        terraform_dir (str): The directory where the Terraform configuration is located.
+
+    Returns:
+        str: The path to the SSH private key file.
+    """
+    result = subprocess.run(
+        ["terraform", "output", "-json", "lablink_private_key_pem"],
+        cwd=terraform_dir,
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    key_path = "/tmp/lablink_key.pem"
+    with open(key_path, "w") as f:
+        f.write(result.stdout)
+    os.chmod(key_path, 0o400)
+    return key_path


### PR DESCRIPTION
This PR introduces a new functionality in Lablink's Allocator: Extract all `.slp` files from each VM instance to the local directory. 