### PR TITLE
Create Additional VMs

### DIFF
--- a/lablink-allocator/lablink-allocator-service/main.py
+++ b/lablink-allocator/lablink-allocator-service/main.py
@@ -226,7 +226,7 @@ def submit_vm_details():
 @app.route("/api/launch", methods=["POST"])
 @auth.login_required
 def launch():
-    num_vms = request.form.get("num_vms")
+    num_vms = int(request.form.get("num_vms"))
     terraform_dir = Path("terraform")
     runtime_file = terraform_dir / "terraform.runtime.tfvars"
 

--- a/lablink-allocator/lablink-allocator-service/main.py
+++ b/lablink-allocator/lablink-allocator-service/main.py
@@ -242,6 +242,9 @@ def launch():
         )
 
     try:
+        # Calculate the number of VMs to launch
+        total_vms = num_vms + database.get_row_count()
+
         # Init Terraform (optional if already initialized)
         subprocess.run(["terraform", "init"], cwd=terraform_dir, check=True)
 
@@ -276,7 +279,7 @@ def launch():
             "-auto-approve",
             "-var-file=terraform.runtime.tfvars",
             "-var-file=terraform.credentials.tfvars",
-            f"-var=instance_count={num_vms}",
+            f"-var=instance_count={total_vms}",
         ]
 
         logger.debug(f"Running command: {' '.join(apply_cmd)}")


### PR DESCRIPTION
This PR fixes #115. Previously, the admin should enter the total number of VMs to create when additional VMs are required. This PR modifies the UX so that the admin enters number of additional VMs needed to scale up the tutorial session. 