### PR TITLE
Add unit tests for `update_inuse_status.py` and `connect_crd.py`

### DIFF
--- a/lablink-client-base/lablink-client-service/lablink_client_service/connect_crd.py
+++ b/lablink-client-base/lablink-client-service/lablink_client_service/connect_crd.py
@@ -50,7 +50,7 @@ def construct_command(args):
     return command
 
 
-def reconstruct_command(command: str = None):
+def reconstruct_command(command: str = None) -> str:
     """Reconstructs the Chrome Remote Desktop command.
 
     Args:

--- a/lablink-client-base/lablink-client-service/lablink_client_service/connect_crd.py
+++ b/lablink-client-base/lablink-client-service/lablink_client_service/connect_crd.py
@@ -59,10 +59,7 @@ def reconstruct_command(command: str) -> str:
     Returns:
         str: Reconstructed command to connect to the machine.
     """
-    if command is None:
-        arg_to_parse = None
-    else:
-        arg_to_parse = command.split()
+    arg_to_parse = command.split()
 
     # Parse the command line arguments
     parser = create_parser()

--- a/lablink-client-base/lablink-client-service/lablink_client_service/connect_crd.py
+++ b/lablink-client-base/lablink-client-service/lablink_client_service/connect_crd.py
@@ -50,11 +50,11 @@ def construct_command(args):
     return command
 
 
-def reconstruct_command(command: str = None) -> str:
+def reconstruct_command(command: str) -> str:
     """Reconstructs the Chrome Remote Desktop command.
 
     Args:
-        command (str, optional): CRD command to connect to the machine. Defaults to None.
+        command (str): CRD command to connect to the machine.
 
     Returns:
         str: Reconstructed command to connect to the machine.
@@ -77,7 +77,7 @@ def reconstruct_command(command: str = None) -> str:
     return command
 
 
-def connect_to_crd(command=None, pin=None):
+def connect_to_crd(command, pin):
     # Parse the command line arguments
     command = reconstruct_command(command)
 

--- a/lablink-client-base/lablink-client-service/lablink_client_service/connect_crd.py
+++ b/lablink-client-base/lablink-client-service/lablink_client_service/connect_crd.py
@@ -39,6 +39,9 @@ def construct_command(args):
     redirect_url = "'https://remotedesktop.google.com/_/oauthredirect'"
     name = os.getenv("VM_NAME", "$(hostname)")
 
+    if args.code is None:
+        raise ValueError("Code must be provided to construct the command.")
+
     command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host"
     command += f" --code={args.code}"
     command += f" --redirect-url={redirect_url}"

--- a/lablink-client-base/lablink-client-service/tests/test_connect_crd.py
+++ b/lablink-client-base/lablink-client-service/tests/test_connect_crd.py
@@ -10,6 +10,8 @@ from lablink_client_service.connect_crd import (
     connect_to_crd,
 )
 
+CRD_COMMAND_WITH_CODE = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
+
 
 def test_construct_command_with_code():
     args = argparse.Namespace(code="test_code")
@@ -65,7 +67,7 @@ def test_reconstruct_command(mock_create_parser, mock_construct_command):
 
 
 def test_whole_reconstruction():
-    crd_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name='$(hostname)'"
+    crd_command = CRD_COMMAND_WITH_CODE
     command = reconstruct_command(crd_command)
     expected = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
     assert command == expected
@@ -74,8 +76,8 @@ def test_whole_reconstruction():
 @patch("lablink_client_service.connect_crd.subprocess.run")
 @patch("lablink_client_service.connect_crd.reconstruct_command")
 def test_connect_to_crd(mock_reconstruct_command, mock_subprocess_run):
-    input_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
-    reconstructed_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
+    input_command = CRD_COMMAND_WITH_CODE
+    reconstructed_command = CRD_COMMAND_WITH_CODE
 
     mock_reconstruct_command.return_value = reconstructed_command
     pin = "123456"
@@ -100,7 +102,7 @@ def test_connect_to_crd(mock_reconstruct_command, mock_subprocess_run):
 
 @patch("lablink_client_service.connect_crd.subprocess.run")
 def test_whole_connection_workflow(mock_subprocess_run):
-    input_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
+    input_command = CRD_COMMAND_WITH_CODE
     pin = "123456"
 
     with patch.dict(os.environ, {"VM_NAME": "test_vm"}):

--- a/lablink-client-base/lablink-client-service/tests/test_connect_crd.py
+++ b/lablink-client-base/lablink-client-service/tests/test_connect_crd.py
@@ -1,0 +1,71 @@
+import argparse
+import os
+
+import pytest
+from unittest.mock import patch, MagicMock
+
+from lablink_client_service.connect_crd import (
+    construct_command,
+    reconstruct_command,
+    connect_to_crd,
+)
+
+
+def test_construct_command_with_code():
+    args = argparse.Namespace(code="test_code")
+    with patch.dict(os.environ, {"VM_NAME": "test_vm"}):
+        command = construct_command(args)
+
+    expected = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code=test_code --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=test_vm"
+    assert command == expected
+
+
+def test_construct_command_without_vm_name():
+    args = argparse.Namespace(code="test_code")
+    with patch.dict(os.environ, {}, clear=True):
+        command = construct_command(args)
+
+    expected = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code=test_code --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
+    assert command == expected
+
+
+def test_construct_command_without_code():
+    args = argparse.Namespace(code=None)
+    with pytest.raises(
+        ValueError, match="Code must be provided to construct the command."
+    ):
+        construct_command(args)
+
+
+@patch("lablink_client_service.connect_crd.construct_command")
+@patch("lablink_client_service.connect_crd.create_parser")
+def test_reconstruct_command(mock_create_parser, mock_construct_command):
+    mock_parser = MagicMock()
+    mock_args = argparse.Namespace(code="test_code")
+    mock_parser.parse_known_args.return_value = (mock_args, [])
+    mock_create_parser.return_value = mock_parser
+    mock_construct_command.return_value = "test_command"
+
+    result = reconstruct_command(
+        "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code=test_code --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=test_vm"
+    )
+
+    mock_create_parser.assert_called_once()
+    mock_parser.parse_known_args.assert_called_once_with(
+        args=[
+            "DISPLAY=",
+            "/opt/google/chrome-remote-desktop/start-host",
+            "--code=test_code",
+            "--redirect-url='https://remotedesktop.google.com/_/oauthredirect'",
+            "--name=test_vm",
+        ]
+    )
+    mock_construct_command.assert_called_once_with(mock_args)
+    assert result == "test_command"
+
+
+def test_whole_reconstruction():
+    crd_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name='$(hostname)'"
+    command = reconstruct_command(crd_command)
+    expected = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
+    assert command == expected

--- a/lablink-client-base/lablink-client-service/tests/test_connect_crd.py
+++ b/lablink-client-base/lablink-client-service/tests/test_connect_crd.py
@@ -96,3 +96,21 @@ def test_connect_to_crd(mock_reconstruct_command, mock_subprocess_run):
         capture_output=True,
         text=True,
     )
+
+
+@patch("lablink_client_service.connect_crd.subprocess.run")
+def test_whole_connection_workflow(mock_subprocess_run):
+    input_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
+    pin = "123456"
+
+    with patch.dict(os.environ, {"VM_NAME": "test_vm"}):
+        connect_to_crd(input_command, pin)
+
+    expected_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=test_vm"
+    mock_subprocess_run.assert_called_once_with(
+        expected_command,
+        input="123456\n123456\n",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )

--- a/lablink-client-base/lablink-client-service/tests/test_connect_crd.py
+++ b/lablink-client-base/lablink-client-service/tests/test_connect_crd.py
@@ -69,3 +69,30 @@ def test_whole_reconstruction():
     command = reconstruct_command(crd_command)
     expected = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
     assert command == expected
+
+
+@patch("lablink_client_service.connect_crd.subprocess.run")
+@patch("lablink_client_service.connect_crd.reconstruct_command")
+def test_connect_to_crd(mock_reconstruct_command, mock_subprocess_run):
+    input_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
+    reconstructed_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
+
+    mock_reconstruct_command.return_value = reconstructed_command
+    pin = "123456"
+    mock_result = MagicMock()
+    mock_result.stdout = "Connection successful"
+    mock_result.stderr = ""
+    mock_subprocess_run.return_value = mock_result
+
+    connect_to_crd(input_command, pin)
+
+    mock_reconstruct_command.assert_called_once_with(
+        "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)"
+    )
+    mock_subprocess_run.assert_called_once_with(
+        "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code='hidden_code' --redirect-url='https://remotedesktop.google.com/_/oauthredirect' --name=$(hostname)",
+        input="123456\n123456\n",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )

--- a/lablink-client-base/lablink-client-service/tests/test_update_inuse.py
+++ b/lablink-client-base/lablink-client-service/tests/test_update_inuse.py
@@ -1,0 +1,56 @@
+import pytest
+from unittest.mock import patch, MagicMock
+import requests
+
+from lablink_client_service.update_inuse_status import (
+    is_process_running,
+    listen_for_process,
+    call_api,
+)
+
+
+def test_is_process_running(monkeypatch):
+    # Mock psutil.process_iter to return a list of mock processes
+    mock_process = MagicMock()
+    mock_process.cmdline.return_value = ["python", "myproc"]
+    monkeypatch.setattr("psutil.process_iter", lambda: [mock_process])
+    assert is_process_running("myproc") is True
+
+
+def test_is_process_running_no_process(monkeypatch):
+    # Mock psutil.process_iter to return an empty list
+    monkeypatch.setattr("psutil.process_iter", lambda: [])
+    assert is_process_running("myproc") is False
+
+
+def test_listen_for_process_triggers_callback(monkeypatch):
+    monkeypatch.setattr("time.sleep", lambda _: None)
+    states = [False, True]
+
+    def fake_proc_iter():
+        val = states.pop(0)
+        proc = MagicMock()
+        proc.cmdline.return_value = ["myproc"] if val else ["other"]
+        return [proc]
+
+    monkeypatch.setattr("psutil.process_iter", fake_proc_iter)
+    called = []
+
+    # Define a callback function that appends to the called list and raises StopIteration because we want to stop
+    # listening after the first call
+    def stop_callback():
+        called.append(True)
+        raise StopIteration
+
+    with pytest.raises(StopIteration):
+        listen_for_process("myproc", interval=0, callback_func=stop_callback)
+
+    assert called
+
+
+@patch("requests.post")
+def test_call_api_success(mock_post):
+    mock_post.return_value.json.return_value = {"ok": True}
+    mock_post.return_value.raise_for_status = lambda: None
+    call_api("myproc", "http://fake.url")
+    mock_post.assert_called_once()


### PR DESCRIPTION
This PR fixes #138 and fixes #140.

This pull request introduces enhancements to the `connect_crd.py` functionalities and adds comprehensive unit tests for both `connect_crd.py` and `update_inuse_status.py`. Key changes include stricter input validation, improved type annotations, and the addition of test coverage for critical workflows.

### Enhancements to `connect_crd.py`:

* Added input validation in `construct_command` to ensure the `code` argument is provided, raising a `ValueError` if missing.
* Updated type annotations and removed default `None` values for `command` and `pin` parameters in `reconstruct_command` and `connect_to_crd` functions, ensuring stricter type enforcement. [[1]](diffhunk://#diff-7a1691fc2b8b856f4e84464cf108b1b2ec5d47cd78d70e467fab5e7d5675eedeL50-L61) [[2]](diffhunk://#diff-7a1691fc2b8b856f4e84464cf108b1b2ec5d47cd78d70e467fab5e7d5675eedeL77-R77)

### Unit tests for `connect_crd.py`:

* Added tests for `construct_command` to validate behavior with and without environment variables and to ensure proper error handling when `code` is not provided.
* Added tests for `reconstruct_command` to verify command reconstruction logic and integration with mocked dependencies.
* Added tests for `connect_to_crd` to validate the end-to-end connection workflow using mocked subprocess calls.

### Unit tests for `update_inuse_status.py`:

* Added tests for `is_process_running` to confirm detection of running processes using mocked `psutil.process_iter`.
* Added tests for `listen_for_process` to verify callback functionality when a target process starts, utilizing a mocked time delay.
* Added tests for `call_api` to ensure successful API calls with mocked `requests.post`.