### PR TITLE
Publish lablink-client-service 0.0.4

### DIFF
--- a/lablink-client-base/lablink-client-service/pyproject.toml
+++ b/lablink-client-base/lablink-client-service/pyproject.toml
@@ -18,7 +18,7 @@ description = "Lablink Client Service that will be installed in the lablink-clie
 keywords = ["vm", "docker", "postgres", "tutorial"]
 name = "lablink-client-service"
 readme = "README.md"
-version = "0.0.4a1"
+version = "0.0.4"
 
 [project.optional-dependencies]
 dev = ["toml", "twine", "build", "pytest", "black", "python-dotenv"]


### PR DESCRIPTION
This pull request includes a small change to the `pyproject.toml` file for the `lablink-client-service` project. The version has been updated from a pre-release (`0.0.4a1`) to a stable release (`0.0.4`).