### PR TITLE
Add Master Destroy Feature to the Workflow

### DIFF
--- a/.github/workflows/client-vm-infrastructure-test.yml
+++ b/.github/workflows/client-vm-infrastructure-test.yml
@@ -42,6 +42,10 @@ jobs:
         run: |
           uv sync --all-extras
 
+      - name: Remove backend config
+        run: |
+          rm -f lablink-allocator/lablink-allocator-service/terraform/backend.tf
+
       - name: Run tests
         working-directory: lablink-allocator/lablink-allocator-service/terraform
         run: |

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -63,7 +63,7 @@ jobs:
       - name: Terraform Destroy Client VMs
         working-directory: lablink-allocator/lablink-allocator-service/terraform
         run: |
-          terraform destroy -auto-approve
+          echo "Destroying client VMs..."
 
       - name: Terraform Init
         working-directory: lablink-allocator

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -60,10 +60,18 @@ jobs:
         run: |
           terraform init -backend-config=backend-client-${{ github.event.inputs.environment }}.hcl
 
+      - name: Extract Variable File
+        working-directory: lablink-allocator/lablink-allocator-service/terraform
+        run: |
+          if [ "${{ github.event.inputs.environment }}" = "dev" ]; then
+            cp variables-dev.tfvars variables.tfvars
+          else
+            aws s3 cp s3://tf-state-lablink-allocator-bucket/${{ github.event.inputs.environment }}/client/terraform.runtime.tfvars variables.tfvars
+          fi
       - name: Terraform Destroy Client VMs
         working-directory: lablink-allocator/lablink-allocator-service/terraform
         run: |
-          echo "Destroying client VMs..."
+          terraform destroy -auto-approve -var-file=variables.tfvars
 
       - name: Terraform Init
         working-directory: lablink-allocator

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -55,6 +55,16 @@ jobs:
             echo "tag=linux-amd64-latest-test" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Terraform Init Client VMs
+        working-directory: lablink-allocator/lablink-allocator-service/terraform
+        run: |
+          terraform init -backend-config=backend-client-${{ github.event.inputs.environment }}.hcl
+
+      - name: Terraform Destroy Client VMs
+        working-directory: lablink-allocator/lablink-allocator-service/terraform
+        run: |
+          terraform destroy -auto-approve
+
       - name: Terraform Init
         working-directory: lablink-allocator
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -221,3 +221,6 @@ outputs
 
 # Ignore VS Code workspace settings
 .vscode/
+
+# Ignore lambda zip files
+lambda_package.zip

--- a/lablink-allocator/lablink-allocator-service/conf/config.yaml
+++ b/lablink-allocator/lablink-allocator-service/conf/config.yaml
@@ -18,3 +18,5 @@ app:
   admin_user: "admin"
   admin_password: "IwanttoSLEAP"
   region: "us-west-2"
+
+bucket_name: "tf-state-lablink-allocator-bucket"

--- a/lablink-allocator/lablink-allocator-service/conf/structured_config.py
+++ b/lablink-allocator/lablink-allocator-service/conf/structured_config.py
@@ -75,6 +75,7 @@ class Config:
     db: DatabaseConfig = field(default_factory=DatabaseConfig)
     machine: MachineConfig = field(default_factory=MachineConfig)
     app: AppConfig = field(default_factory=AppConfig)
+    bucket_name: str = field(default="tf-state-lablink-allocator-bucket")
 
 
 cs = ConfigStore.instance()

--- a/lablink-allocator/lablink-allocator-service/main.py
+++ b/lablink-allocator/lablink-allocator-service/main.py
@@ -349,11 +349,11 @@ def launch():
         clean_output = ANSI_ESCAPE.sub("", result.stdout)
 
         # Upload the runtime file to S3
-        s3_bucket = "tf-state-lablink-allocator-bucket"
+        logger.debug(f"Uploading runtime file to S3 bucket: {cfg.bucket_name}...")
         upload_to_s3(
             local_path=runtime_file,
             env=ENVIRONMENT,
-            bucket_name=s3_bucket,
+            bucket_name=cfg.bucket_name,
             region=cfg.app.region,
         )
 

--- a/lablink-allocator/lablink-allocator-service/templates/instance-logs.html
+++ b/lablink-allocator/lablink-allocator-service/templates/instance-logs.html
@@ -267,7 +267,7 @@
                 const logBox = document.getElementById("logBox");
                 const shouldFollowTail = document.getElementById("followTail").checked;
                 
-                const res = await fetch(`/api/vm-logs/${hostname}`);
+                const res = await fetch(`/api/vm-logs/${hostname}`, { credentials : 'include' });
                 if (res.ok) {
                     const data = await res.json();
                     const logs = data.logs || "No logs available.";

--- a/lablink-allocator/lablink-allocator-service/terraform/backend-client-dev.hcl
+++ b/lablink-allocator/lablink-allocator-service/terraform/backend-client-dev.hcl
@@ -1,0 +1,3 @@
+# Intentionally left blank to fall back to local backend
+# Run: terraform init
+# This will use ./terraform.tfstate in the current directory

--- a/lablink-allocator/lablink-allocator-service/terraform/backend-client-prod.hcl
+++ b/lablink-allocator/lablink-allocator-service/terraform/backend-client-prod.hcl
@@ -1,0 +1,5 @@
+bucket         = "tf-state-lablink-allocator-bucket"
+key            = "prod/client/terraform.tfstate"
+region         = "us-west-2"
+dynamodb_table = "lock-table"
+encrypt        = true

--- a/lablink-allocator/lablink-allocator-service/terraform/backend-client-test.hcl
+++ b/lablink-allocator/lablink-allocator-service/terraform/backend-client-test.hcl
@@ -1,0 +1,5 @@
+bucket         = "tf-state-lablink-allocator-bucket"
+key            = "test/client/terraform.tfstate"
+region         = "us-west-2"
+dynamodb_table = "lock-table"
+encrypt        = true

--- a/lablink-allocator/lablink-allocator-service/terraform/backend.tf
+++ b/lablink-allocator/lablink-allocator-service/terraform/backend.tf
@@ -1,0 +1,3 @@
+terraform {
+  backend "s3" {}
+}

--- a/lablink-allocator/lablink-allocator-service/terraform/tests/test_plan.py
+++ b/lablink-allocator/lablink-allocator-service/terraform/tests/test_plan.py
@@ -1,8 +1,8 @@
-import os
 import json
 import pytest
 import re
 import subprocess
+from pathlib import Path
 
 
 @pytest.fixture(scope="module")
@@ -11,13 +11,17 @@ def plan(fixture_dir):
     Fixture to validate the Terraform plan using the provided fixtures.
     """
     # Find the Terraform directory relative to this test file
-    base_dir = os.path.join(os.path.dirname(__file__), "..")
-    var_path = os.path.join(fixture_dir, "plan.auto.tfvars")
+    base_dir = Path(__file__).parent.parent
+    var_path = fixture_dir / "plan.auto.tfvars"
 
     # Initialize and create the plan
-    subprocess.run(["terraform", "init", "-input=false", "-no-color"], cwd=base_dir)
+    subprocess.run(
+        ["terraform", "init", "-input=false", "-no-color"],
+        cwd=base_dir,
+        check=True
+    )
     subprocess.run(["terraform", "plan", f"-var-file={var_path}", "-out=plan.tfplan",
-                    "-no-color"], cwd=base_dir)
+                    "-no-color"], cwd=base_dir, check=True)
     result = subprocess.run(["terraform", "show", "-json", "plan.tfplan"],
                             cwd=base_dir, check=True, capture_output=True)
     tfplan = json.loads(result.stdout)

--- a/lablink-allocator/lablink-allocator-service/terraform/tests/test_plan.py
+++ b/lablink-allocator/lablink-allocator-service/terraform/tests/test_plan.py
@@ -16,7 +16,7 @@ def plan(fixture_dir):
 
     # Initialize and create the plan
     subprocess.run(
-        ["terraform", "init", "-input=false", "-no-color"],
+        ["terraform", "init", "-input=false", "-no-color", "-backend=false", "-reconfigure"],
         cwd=base_dir,
         check=True
     )

--- a/lablink-allocator/lablink-allocator-service/terraform/tests/test_plan.py
+++ b/lablink-allocator/lablink-allocator-service/terraform/tests/test_plan.py
@@ -16,8 +16,7 @@ def plan(fixture_dir):
 
     # Initialize and create the plan
     subprocess.run(
-        ["terraform", "init", "-input=false", "-no-color",
-         "-backend=false", "-reconfigure"],
+        ["terraform", "init", "-input=false", "-no-color"],
         cwd=base_dir,
         check=True
     )

--- a/lablink-allocator/lablink-allocator-service/terraform/tests/test_plan.py
+++ b/lablink-allocator/lablink-allocator-service/terraform/tests/test_plan.py
@@ -12,11 +12,12 @@ def plan(fixture_dir):
     """
     # Find the Terraform directory relative to this test file
     base_dir = Path(__file__).parent.parent
-    var_path = fixture_dir / "plan.auto.tfvars"
+    var_path = (Path(fixture_dir) / "plan.auto.tfvars").resolve()
 
     # Initialize and create the plan
     subprocess.run(
-        ["terraform", "init", "-input=false", "-no-color", "-backend=false", "-reconfigure"],
+        ["terraform", "init", "-input=false", "-no-color",
+         "-backend=false", "-reconfigure"],
         cwd=base_dir,
         check=True
     )

--- a/lablink-allocator/lablink-allocator-service/tests/conftest.py
+++ b/lablink-allocator/lablink-allocator-service/tests/conftest.py
@@ -30,6 +30,7 @@ def omega_config():
                 "admin_password": "test_pass",
                 "region": "us-west-2",
             },
+            "bucket_name": "test-bucket",
         }
     )
 

--- a/lablink-allocator/lablink-allocator-service/tests/test_terraform_api.py
+++ b/lablink-allocator/lablink-allocator-service/tests/test_terraform_api.py
@@ -68,7 +68,7 @@ def test_launch_vm_success(
 
     # Assert upload to s3 called once with correct args
     mock_upload_to_s3.assert_called_once_with(
-        bucket_name="tf-state-lablink-allocator-bucket",
+        bucket_name="test-bucket",
         region="us-west-2",
         local_path=Path("terraform") / "terraform.runtime.tfvars",
         env="test",

--- a/lablink-allocator/lablink-allocator-service/tests/test_terraform_api.py
+++ b/lablink-allocator/lablink-allocator-service/tests/test_terraform_api.py
@@ -6,11 +6,13 @@ POST_ENDPOINT = "/api/launch"
 DESTROY_ENDPOINT = "/destroy"
 
 
+@patch("main.upload_to_s3")
 @patch("main.check_support_nvidia", return_value=True)
 @patch("main.subprocess.run")
 def test_launch_vm_success(
     mock_run,
     mock_check_support_nvidia,
+    mock_upload_to_s3,
     client,
     admin_headers,
     monkeypatch,
@@ -63,6 +65,15 @@ def test_launch_vm_success(
     tfvars = (Path("terraform") / "terraform.runtime.tfvars").read_text()
     missing = [line for line in expected_lines if line not in tfvars]
     assert not missing, f"Missing lines in tfvars: {missing}"
+
+    # Assert upload to s3 called once with correct args
+    mock_upload_to_s3.assert_called_once_with(
+        bucket_name="tf-state-lablink-allocator-bucket",
+        region="us-west-2",
+        local_path=Path("terraform") / "terraform.runtime.tfvars",
+        env="test",
+    )
+
 
 
 @patch("main.subprocess.run")

--- a/lablink-allocator/lablink-allocator-service/tests/utils/test_aws_utils.py
+++ b/lablink-allocator/lablink-allocator-service/tests/utils/test_aws_utils.py
@@ -2,7 +2,6 @@ from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 from botocore.exceptions import ClientError
 import utils.aws_utils as aws_utils
-from pathlib import Path
 
 
 @patch("utils.aws_utils.boto3.client")

--- a/lablink-allocator/lablink-allocator-service/tests/utils/test_aws_utils.py
+++ b/lablink-allocator/lablink-allocator-service/tests/utils/test_aws_utils.py
@@ -1,6 +1,8 @@
+from types import SimpleNamespace
 from unittest.mock import patch, MagicMock
 from botocore.exceptions import ClientError
 import utils.aws_utils as aws_utils
+from pathlib import Path
 
 
 @patch("utils.aws_utils.boto3.client")
@@ -108,3 +110,35 @@ def test_check_support_nvidia_no_gpuinfo(mock_boto_client):
     mock_boto_client.return_value = mock_ec2
 
     assert aws_utils.check_support_nvidia("t2.micro") is False
+
+
+def test_upload_to_s3_success(monkeypatch, tmp_path):
+    # Prepare a real file so Path handling is realistic
+    local_file = tmp_path / "vars.auto.tfvars"
+    local_file.write_text('foo="bar"\n')
+
+    # Mock the S3 client and its upload_file method
+    mock_s3 = SimpleNamespace(upload_file=MagicMock(name="upload_file"))
+    client_mock = MagicMock(return_value=mock_s3)
+    monkeypatch.setattr(
+            aws_utils, "boto3", SimpleNamespace(client=client_mock), raising=True
+        )
+
+    bucket = "tf-state-lablink-allocator-bucket"
+
+    aws_utils.upload_to_s3(
+        bucket_name=bucket,
+        region="us-west-2",
+        local_path=local_file,
+        env="test",
+    )
+
+    # Assert: region passed to boto3.client
+    client_mock.assert_called_once_with("s3", region_name="us-west-2")
+
+    # Assert: upload_file args and ExtraArgs
+    expected_key = f'test/client/{local_file.name}'
+    mock_s3.upload_file.assert_called_once()
+    args, kwargs = mock_s3.upload_file.call_args
+    assert args == (local_file, bucket, expected_key)
+    assert kwargs["ExtraArgs"] == {"ContentType": "text/plain"}

--- a/lablink-allocator/lablink-allocator-service/utils/aws_utils.py
+++ b/lablink-allocator/lablink-allocator-service/utils/aws_utils.py
@@ -121,7 +121,7 @@ def upload_to_s3(
         env (str): The environment (e.g., dev, test, prod) for the upload.
         bucket_name (str): The name of the S3 bucket to upload to.
         region (str): The AWS region where the S3 bucket is located.
-        kms_key_id (Optional[str], optional): The KMS key ID for server-side encryption. 
+        kms_key_id (Optional[str], optional): The KMS key ID for server-side encryption.
             Defaults to None.
     """
     s3 = boto3.client("s3", region_name=region)

--- a/lablink-allocator/lablink-allocator-service/utils/aws_utils.py
+++ b/lablink-allocator/lablink-allocator-service/utils/aws_utils.py
@@ -1,6 +1,7 @@
 import os
 import logging
 from pathlib import Path
+from typing import Optional
 
 import boto3
 from botocore.exceptions import ClientError
@@ -111,8 +112,18 @@ def upload_to_s3(
         env: str,
         bucket_name: str,
         region: str,
-        kms_key_id: str|None=None
+        kms_key_id: Optional[str] = None,
     ) -> None:
+    """Uploads a file to an S3 bucket.
+
+    Args:
+        local_path (Path): The local file path to upload.
+        env (str): The environment (e.g., dev, test, prod) for the upload.
+        bucket_name (str): The name of the S3 bucket to upload to.
+        region (str): The AWS region where the S3 bucket is located.
+        kms_key_id (Optional[str], optional): The KMS key ID for server-side encryption. 
+            Defaults to None.
+    """
     s3 = boto3.client("s3", region_name=region)
     key = f"{env}/client/{local_path.name}"
     extra = {"ContentType": "text/plain"}

--- a/lablink-allocator/main.tf
+++ b/lablink-allocator/main.tf
@@ -11,6 +11,31 @@ provider "aws" {
 # Get the current AWS account ID
 data "aws_caller_identity" "current" {}
 
+data "aws_iam_policy_document" "s3_backend_doc" {
+  # List the bucket (optionally scope with prefix condition)
+  statement {
+    effect    = "Allow"
+    actions   = ["s3:ListBucket"]
+    resources = ["arn:aws:s3:::mybucket"]
+
+    condition {
+      test     = "StringLike"
+      variable = "s3:prefix"
+      values   = ["path/to/my/*"]
+    }
+  }
+
+  # Read/Write/Delete objects under the prefix
+  statement {
+    effect  = "Allow"
+    actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
+    resources = [
+      "arn:aws:s3:::mybucket/path/to/my/*"
+    ]
+  }
+}
+
+
 # Zip the Lambda function code
 # To package the Lambda function into a zip file
 data "archive_file" "lambda_zip" {
@@ -67,10 +92,11 @@ variable "allocator_image_tag" {
 }
 
 resource "aws_instance" "lablink_allocator_server" {
-  ami             = "ami-0e096562a04af2d8b"
-  instance_type   = local.allocator_instance_type
-  security_groups = [aws_security_group.allow_http.name]
-  key_name        = aws_key_pair.lablink_key_pair.key_name
+  ami                  = "ami-0e096562a04af2d8b"
+  instance_type        = local.allocator_instance_type
+  security_groups      = [aws_security_group.allow_http.name]
+  key_name             = aws_key_pair.lablink_key_pair.key_name
+  iam_instance_profile = aws_iam_instance_profile.allocator_instance_profile.name
 
   user_data = templatefile("${path.module}/user_data.sh", {
     ALLOCATOR_IMAGE_TAG  = var.allocator_image_tag
@@ -124,12 +150,43 @@ resource "aws_iam_role" "lambda_exec" {
   name = "lablink_lambda_exec_${var.resource_suffix}"
   assume_role_policy = jsonencode({
     Version = "2012-10-17"
+    Statement = [
+      {
+        Effect    = "Allow"
+        Principal = { Service = "lambda.amazonaws.com" }
+        Action    = "sts:AssumeRole"
+      },
+    ]
+  })
+}
+
+
+resource "aws_iam_policy" "s3_backend_policy" {
+  name   = "lablink_s3_backend_${var.resource_suffix}"
+  policy = data.aws_iam_policy_document.s3_backend_doc.json
+}
+
+resource "aws_iam_role" "instance_role" {
+  name = "lablink_instance_role_${var.resource_suffix}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
     Statement = [{
-      Effect    = "Allow"
-      Principal = { Service = "lambda.amazonaws.com" }
+      Effect    = "Allow",
+      Principal = { Service = "ec2.amazonaws.com" },
       Action    = "sts:AssumeRole"
     }]
   })
+}
+
+resource "aws_iam_role_policy_attachment" "attach_s3_backend" {
+  role       = aws_iam_role.instance_role.name
+  policy_arn = aws_iam_policy.s3_backend_policy.arn
+}
+
+resource "aws_iam_instance_profile" "allocator_instance_profile" {
+  name = "lablink_instance_profile_${var.resource_suffix}"
+  role = aws_iam_role.instance_role.name
 }
 
 # Subscription filter to send CloudWatch logs to Lambda

--- a/lablink-allocator/main.tf
+++ b/lablink-allocator/main.tf
@@ -16,12 +16,12 @@ data "aws_iam_policy_document" "s3_backend_doc" {
   statement {
     effect    = "Allow"
     actions   = ["s3:ListBucket"]
-    resources = ["arn:aws:s3:::mybucket"]
+    resources = ["arn:aws:s3:::tf-state-lablink-allocator-bucket"]
 
     condition {
       test     = "StringLike"
       variable = "s3:prefix"
-      values   = ["path/to/my/*"]
+      values   = ["${var.resource_suffix}/*"]
     }
   }
 
@@ -30,7 +30,7 @@ data "aws_iam_policy_document" "s3_backend_doc" {
     effect  = "Allow"
     actions = ["s3:GetObject", "s3:PutObject", "s3:DeleteObject"]
     resources = [
-      "arn:aws:s3:::mybucket/path/to/my/*"
+      "arn:aws:s3:::tf-state-lablink-allocator-bucket/${var.resource_suffix}/*"
     ]
   }
 }

--- a/lablink-allocator/main.tf
+++ b/lablink-allocator/main.tf
@@ -12,7 +12,6 @@ provider "aws" {
 data "aws_caller_identity" "current" {}
 
 data "aws_iam_policy_document" "s3_backend_doc" {
-  # List the bucket (optionally scope with prefix condition)
   statement {
     effect    = "Allow"
     actions   = ["s3:ListBucket"]

--- a/lablink-allocator/main.tf
+++ b/lablink-allocator/main.tf
@@ -67,11 +67,10 @@ variable "allocator_image_tag" {
 }
 
 resource "aws_instance" "lablink_allocator_server" {
-  ami                  = "ami-0e096562a04af2d8b"
-  instance_type        = local.allocator_instance_type
-  security_groups      = [aws_security_group.allow_http.name]
-  key_name             = aws_key_pair.lablink_key_pair.key_name
-  iam_instance_profile = aws_iam_instance_profile.allocator_instance_profile.name
+  ami             = "ami-0e096562a04af2d8b"
+  instance_type   = local.allocator_instance_type
+  security_groups = [aws_security_group.allow_http.name]
+  key_name        = aws_key_pair.lablink_key_pair.key_name
 
   user_data = templatefile("${path.module}/user_data.sh", {
     ALLOCATOR_IMAGE_TAG  = var.allocator_image_tag
@@ -131,29 +130,6 @@ resource "aws_iam_role" "lambda_exec" {
       Action    = "sts:AssumeRole"
     }]
   })
-}
-
-resource "aws_iam_role" "allocator_instance_role" {
-  name = "lablink-allocator-instance-role-${var.resource_suffix}"
-  assume_role_policy = jsonencode({
-    Version = "2012-10-17",
-    Statement = [{
-      Effect    = "Allow",
-      Principal = { Service = "ec2.amazonaws.com" },
-      Action    = "sts:AssumeRole"
-    }]
-  })
-}
-
-# SSM core permissions (RunCommand, inventory, etc.)
-resource "aws_iam_role_policy_attachment" "allocator_ssm_core" {
-  role       = aws_iam_role.allocator_instance_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
-}
-
-resource "aws_iam_instance_profile" "allocator_instance_profile" {
-  name = "lablink-allocator-instance-profile-${var.resource_suffix}"
-  role = aws_iam_role.allocator_instance_role.name
 }
 
 # Subscription filter to send CloudWatch logs to Lambda

--- a/lablink-allocator/user_data.sh
+++ b/lablink-allocator/user_data.sh
@@ -1,4 +1,10 @@
 #!/bin/bash
+
+# Install AWS SSM Agent
+sudo apt-get update -y
+sudo apt-get install -y amazon-ssm-agent
+sudo systemctl enable --now amazon-ssm-agent
+
 IMAGE="ghcr.io/talmolab/lablink-allocator-image:${ALLOCATOR_IMAGE_TAG}"
 docker pull $IMAGE
 docker run -d -p 80:5000 \

--- a/lablink-allocator/user_data.sh
+++ b/lablink-allocator/user_data.sh
@@ -1,10 +1,5 @@
 #!/bin/bash
 
-# Install AWS SSM Agent
-sudo apt-get update -y
-sudo apt-get install -y amazon-ssm-agent
-sudo systemctl enable --now amazon-ssm-agent
-
 IMAGE="ghcr.io/talmolab/lablink-allocator-image:${ALLOCATOR_IMAGE_TAG}"
 docker pull $IMAGE
 docker run -d -p 80:5000 \


### PR DESCRIPTION
This PR introduces a "master destroy" feature to the CI/CD workflow, allowing for the complete teardown of all virtual machines (VMs) created by the allocator service. It also includes several related enhancements and fixes.

### Summary

The primary goal of this PR is to address the limitation of the previous destroy workflow, which only terminated the allocator server itself, leaving client VMs running. This new functionality provides a mechanism to destroy all resources, ensuring a clean environment after testing or use.

The key changes include:

- **Enhanced Destroy Workflow:** The `lablink-allocator-destroy.yml` GitHub Actions workflow has been updated to include a manually triggered "master destroy" job. This job leverages Terraform to destroy all client VMs across different environments (dev, test, prod).
- **Remote State Management:** The Terraform configuration has been updated to use an S3 backend for remote state management. This ensures that the state of the infrastructure is consistent and accessible to the destroy workflow.
- **IAM Role for S3 Access:** The allocator server is now assigned an IAM role that grants it the necessary permissions to read and write to the S3 bucket where the Terraform state is stored.
- **S3 Upload of Runtime Variables:** The allocator service now uploads the `terraform.runtime.tfvars` file to the S3 bucket. This file contains the runtime variables for the client VMs, which are required by the destroy workflow.
- **Frontend Fix:** A fix has been implemented in the `instance-logs.html` template to include credentials in the `fetch` request, addressing a potential authentication issue when retrieving VM logs.

### API Changes

There are no direct API changes in this PR. However, the introduction of the "master destroy" feature in the CI/CD workflow represents a significant change in the operational capabilities of the system.

### Example Usage

To trigger the master destroy workflow:

1.  Go to the "Actions" tab in the GitHub repository.
2.  Select the "lablink-allocator-destroy" workflow.
3.  Click the "Run workflow" button.
4.  Choose the environment (dev, test, or prod) from which to destroy the VMs.
5.  Click the "Run workflow" button.

### Other Notes

- The decision to use an S3 backend for Terraform state was made to ensure that the state is persistent and accessible to the destroy workflow, which runs in a separate environment from the allocator service.
- The `terraform.runtime.tfvars` file is uploaded to S3 to provide the destroy workflow with the necessary information to identify and destroy the correct resources.
- The frontend fix was necessary to ensure that the browser sends the necessary authentication cookies when making requests to the backend.

This PR significantly improves the manageability of the LabLink infrastructure by providing a reliable and automated way to tear down all resources.