### PR TITLE
Fix AMI

### DIFF
--- a/lablink-allocator/lablink-allocator-service/main.py
+++ b/lablink-allocator/lablink-allocator-service/main.py
@@ -695,7 +695,15 @@ if __name__ == "__main__":
     terraform_dir = Path("terraform")
     if not (terraform_dir / "terraform.runtime.tfvars").exists():
         logger.info("Initializing Terraform...")
-        subprocess.run(["terraform", "init",
-                        f"-backend-config=backend-client-{ENVIRONMENT}.hcl"],
-                        cwd=terraform_dir, check=True)
+        if ENVIRONMENT not in ["prod", "test"]:
+            Path.unlink(terraform_dir / "backend.tf")
+            subprocess.run(
+                ["terraform", "init"],
+                cwd=terraform_dir,
+                check=True,
+            )
+        else:
+            subprocess.run(["terraform", "init",
+                            f"-backend-config=backend-client-{ENVIRONMENT}.hcl"],
+                            cwd=terraform_dir, check=True)
     app.run(host="0.0.0.0", port=5000, threaded=True)

--- a/lablink-allocator/main.tf
+++ b/lablink-allocator/main.tf
@@ -91,7 +91,7 @@ variable "allocator_image_tag" {
 }
 
 resource "aws_instance" "lablink_allocator_server" {
-  ami                  = "ami-0e096562a04af2d8b"
+  ami                  = "ami-0bd08c9d4aa9f0bc6"
   instance_type        = local.allocator_instance_type
   security_groups      = [aws_security_group.allow_http.name]
   key_name             = aws_key_pair.lablink_key_pair.key_name


### PR DESCRIPTION
This pull request introduces improvements to the Terraform initialization logic and updates the Amazon Machine Image (AMI) used for the lablink allocator server. The main changes focus on better handling of environment-specific initialization steps and updating the infrastructure configuration.

Terraform initialization improvements:

* In `main.py`, the Terraform initialization process now conditionally unlinks `backend.tf` and runs a standard `terraform init` for non-production and non-test environments, while retaining the custom backend configuration for production and test.

Infrastructure configuration update:

* In `main.tf`, the AMI for the `lablink_allocator_server` resource has been updated to a newer version, ensuring the server uses the latest image.