### PR TITLE
Add 53 Route and Elastic IP 

### DIFF
--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -88,3 +88,4 @@ jobs:
           terraform destroy -auto-approve \
             -var="resource_suffix=${{ github.event.inputs.environment }}" \
             -var="allocator_image_tag=${{ steps.resolve_image_tag.outputs.tag }}"
+            -var-file="terraform.tfvars"

--- a/.github/workflows/lablink-allocator-destroy.yml
+++ b/.github/workflows/lablink-allocator-destroy.yml
@@ -87,5 +87,5 @@ jobs:
         run: |
           terraform destroy -auto-approve \
             -var="resource_suffix=${{ github.event.inputs.environment }}" \
-            -var="allocator_image_tag=${{ steps.resolve_image_tag.outputs.tag }}"
+            -var="allocator_image_tag=${{ steps.resolve_image_tag.outputs.tag }}" \
             -var-file="terraform.tfvars"

--- a/.github/workflows/lablink-allocator-terraform.yml
+++ b/.github/workflows/lablink-allocator-terraform.yml
@@ -129,7 +129,7 @@ jobs:
         run: |
           terraform apply -auto-approve \
             -var="resource_suffix=${{ steps.setenv.outputs.env }}" \
-            -var="allocator_image_tag=${{ steps.getimagetag.outputs.tag }}"
+            -var="allocator_image_tag=${{ steps.getimagetag.outputs.tag }}" \
             -var-file="terraform.tfvars"
         continue-on-error: true
 

--- a/.github/workflows/lablink-allocator-terraform.yml
+++ b/.github/workflows/lablink-allocator-terraform.yml
@@ -130,6 +130,7 @@ jobs:
           terraform apply -auto-approve \
             -var="resource_suffix=${{ steps.setenv.outputs.env }}" \
             -var="allocator_image_tag=${{ steps.getimagetag.outputs.tag }}"
+            -var-file="terraform.tfvars"
         continue-on-error: true
 
       - name: Save PEM Key to Artifact

--- a/lablink-allocator/main.tf
+++ b/lablink-allocator/main.tf
@@ -5,7 +5,7 @@ variable "resource_suffix" {
 }
 
 variable "dns_name" {
-  description = "DNS Name for 53 Route"
+  description = "DNS Name for Route 53"
   type        = string
 }
 
@@ -123,7 +123,7 @@ resource "aws_eip" "lablink_allocator_eip" {
   }
 }
 
-# Find the Route 53 Host zone by name
+# Find the Route 53 hosted zone by name
 data "aws_route53_zone" "selected" {
   name         = var.dns_name
   private_zone = false

--- a/lablink-allocator/terraform.tfvars
+++ b/lablink-allocator/terraform.tfvars
@@ -1,0 +1,1 @@
+dns_name = "lablink.sleap.ai"


### PR DESCRIPTION
This pull request updates the Terraform configuration for the Lablink Allocator to improve Elastic IP management and automate DNS setup with Route 53. The main changes are the switch from a data source to a managed resource for Elastic IPs, and the addition of logic to create or select the appropriate Route 53 hosted zone and DNS records.

**Elastic IP Management:**
* Replaced the `data.aws_eip.lablink_allocator_ip` data source with a managed `aws_eip.lablink_allocator_eip` resource, ensuring the Elastic IP is created and tagged as needed. All references to the Elastic IP now use the resource instead of the data source. [[1]](diffhunk://#diff-5c7ae460966e6e17c3e70e4a76e3ac03280ea2221ed1998f2b5de68c6521e0ceL103-R108) [[2]](diffhunk://#diff-5c7ae460966e6e17c3e70e4a76e3ac03280ea2221ed1998f2b5de68c6521e0ceL114-R160) [[3]](diffhunk://#diff-5c7ae460966e6e17c3e70e4a76e3ac03280ea2221ed1998f2b5de68c6521e0ceL235-R270)

**DNS and Route 53 Automation:**
* Added a new `dns_name` variable to configure the DNS name for the Route 53 zone.
* Implemented logic to find an existing Route 53 hosted zone by name, or create one if it does not exist, using `data.aws_route53_zone.selected` and `aws_route53_zone.lablink_main`.
* Created a new Route 53 A record for the allocator app, pointing to the managed Elastic IP.

These changes make the infrastructure setup more robust and automated, especially for DNS management and IP assignment.