### PR TITLE
fix: correct COPY paths in production client Dockerfile

### DIFF
--- a/lablink-client-base/lablink-client-base-image/Dockerfile
+++ b/lablink-client-base/lablink-client-base-image/Dockerfile
@@ -123,7 +123,7 @@ USER ${USERNAME}
 WORKDIR /home/${USERNAME}
 
 # Create scripts directory with miniforge, uv, and nvm installation scripts
-COPY install_miniforge.sh  install_nvm.sh /scripts/
+COPY lablink-client-base-image/install_miniforge.sh lablink-client-base-image/install_nvm.sh /scripts/
 
 # Make scripts executable and run them
 RUN sudo chmod +x /scripts/*.sh && \
@@ -141,7 +141,7 @@ RUN uv venv /home/${USERNAME}/.venv && \
     uv pip install --python=/home/${USERNAME}/.venv/bin/python lablink-client-service==${PACKAGE_VERSION}
 
 # Copy the startup script
-COPY start.sh /home/${USERNAME}/start.sh
+COPY lablink-client-base-image/start.sh /home/${USERNAME}/start.sh
 RUN sudo chmod +x /home/${USERNAME}/start.sh
 
 # Run the startup script


### PR DESCRIPTION
## Problem

The production client Dockerfile build was failing on main branch with:
```
ERROR: "/start.sh": not found
ERROR: "/install_miniforge.sh": not found
```

## Root Cause

The build context for the client image is `./lablink-client-base`, but the Dockerfile was using incorrect relative paths in COPY commands:
- ❌ `COPY start.sh` (looks for `./lablink-client-base/start.sh`)
- ❌ `COPY install_miniforge.sh` (looks for `./lablink-client-base/install_miniforge.sh`)

But the files are actually in the subdirectory:
- ✅ `./lablink-client-base/lablink-client-base-image/start.sh`
- ✅ `./lablink-client-base/lablink-client-base-image/install_miniforge.sh`

## Solution

Updated production Dockerfile to use correct paths relative to build context:
```dockerfile
COPY lablink-client-base-image/install_miniforge.sh lablink-client-base-image/install_nvm.sh /scripts/
COPY lablink-client-base-image/start.sh /home/${USERNAME}/start.sh
```

## Why This Wasn't Caught Earlier

- Dev Dockerfile already had correct paths
- PR builds use dev Dockerfiles (passed ✅)
- Production Dockerfiles only used when merging to main
- This is why main branch build failed

## Verification

- [x] Reviewed all COPY commands in production client Dockerfile
- [x] Verified allocator Dockerfile paths are correct (context is repo root)
- [x] Dev Dockerfile already uses correct paths

Fixes the main branch build failure in run #18232926778

🤖 Generated with [Claude Code](https://claude.com/claude-code)