### PR TITLE
fix: remove automated Docker trigger from publish workflow

### DIFF
--- a/.github/workflows/publish-pip.yml
+++ b/.github/workflows/publish-pip.yml
@@ -196,25 +196,17 @@ jobs:
           echo "Publishing ${{ matrix.package }} to PyPI..."
           uv publish
           echo "✅ Published successfully!"
+          echo ""
+          echo "📦 Package published to PyPI"
 
-          # Extract version for triggering Docker build
+          # Extract version for reference
           VERSION=$(grep '^version = ' pyproject.toml | cut -d'"' -f2)
           echo "version=${VERSION}" >> $GITHUB_OUTPUT
+          echo "Version: ${VERSION}"
+          echo ""
+          echo "ℹ️  To build production Docker images with this version:"
+          echo "   gh workflow run lablink-images.yml -f environment=prod -f package_version=${VERSION}"
         working-directory: ${{ matrix.dir }}
-
-      # Trigger Docker image rebuild with new package version
-      - name: Trigger Docker image build
-        if: steps.publish.outcome == 'success'
-        uses: peter-evans/repository-dispatch@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          repository: ${{ github.repository }}
-          event-type: package-published
-          client-payload: |
-            {
-              "package": "${{ matrix.package }}",
-              "version": "${{ steps.publish.outputs.version }}"
-            }
 
       # Dry run summary
       - name: Dry run summary


### PR DESCRIPTION
## Summary

Removes the failing automated Docker build trigger from the publish workflow to prevent workflow failures after successful PyPI publishes.

## Problem

The `publish-pip.yml` workflow was failing on the "Trigger Docker image build" step with error:
```
Resource not accessible by integration
```

This happens because `GITHUB_TOKEN` doesn't have permission to trigger `repository_dispatch` events, which requires a PAT with `repo` scope.

## Solution

- ✅ Removed the failing "Trigger Docker image build" step
- ✅ Added helpful message in publish output showing how to manually trigger Docker builds
- ✅ Workflow now completes successfully after PyPI publish

## Manual Docker Build Trigger

After publishing to PyPI, trigger production Docker builds with:
```bash
gh workflow run lablink-images.yml -f environment=prod -f package_version=<version>
```

For example:
```bash
gh workflow run lablink-images.yml -f environment=prod -f package_version=0.0.2a0
```

## Testing

- [x] Workflow syntax is valid
- [x] Removed step references are cleaned up
- [x] Helpful instructions added to workflow output

🤖 Generated with [Claude Code](https://claude.com/claude-code)