### PR TITLE
fix: update module path in Dockerfile to lablink_allocator_service

### DIFF
--- a/packages/allocator/Dockerfile
+++ b/packages/allocator/Dockerfile
@@ -33,7 +33,7 @@ RUN uv venv /app/.venv && \
     uv pip install --python=/app/.venv/bin/python lablink-allocator-service==${PACKAGE_VERSION}
 
 # Ensure terraform directory has write permissions for state files
-RUN chmod -R 777 /app/.venv/lib/python*/site-packages/lablink_allocator/terraform/
+RUN chmod -R 777 /app/.venv/lib/python*/site-packages/lablink_allocator_service/terraform/
 
 # Expose ports for Flask
 EXPOSE 5000


### PR DESCRIPTION
Fixes the chmod path in allocator Dockerfile to use the correct module name `lablink_allocator_service` (with `-service` suffix) instead of the old `lablink_allocator` name.

This was causing Docker builds to fail when building production images with PyPI packages.