### PR TITLE
chore: Update client package Python requirement and version

### DIFF
--- a/packages/client/pyproject.toml
+++ b/packages/client/pyproject.toml
@@ -21,8 +21,8 @@ description = "Lablink Client Service that will be installed in the lablink-clie
 keywords = ["vm", "docker", "postgres", "tutorial", "AWS"]
 name = "lablink-client-service"
 readme = "README.md"
-requires-python = ">=3.9"
-version = "0.0.8a0"
+requires-python = ">=3.8"
+version = "0.0.8a1"
 
 [project.optional-dependencies]
 dev = ["twine", "build", "pytest", "ruff", "pytest-cov"]


### PR DESCRIPTION
## Summary
- Lower Python requirement from `>=3.9` to `>=3.8` for broader compatibility
- Bump version from `0.0.8a0` to `0.0.8a1`

## Test plan
- [ ] Verify CI/CD passes
- [ ] Confirm package builds successfully with Python 3.8+

🤖 Generated with [Claude Code](https://claude.com/claude-code)