### PR TITLE
fix: Handle empty subdomains in get_allocator_url

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,3 +224,5 @@ outputs
 
 # Ignore lambda zip files
 lambda_package.zip
+.claude/settings.local.json
+uv.lock

--- a/packages/allocator/src/lablink_allocator_service/utils/config_helpers.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/config_helpers.py
@@ -50,11 +50,18 @@ def get_allocator_url(cfg, allocator_ip: str) -> Tuple[str, str]:
     if hasattr(cfg, "dns") and cfg.dns.enabled:
         # Use DNS hostname
         if cfg.dns.pattern == "custom":
-            host = f"{cfg.dns.custom_subdomain}.{cfg.dns.domain}"
+            # Only add subdomain if it's non-empty
+            if cfg.dns.custom_subdomain:
+                host = f"{cfg.dns.custom_subdomain}.{cfg.dns.domain}"
+            else:
+                host = cfg.dns.domain
         elif cfg.dns.pattern == "auto":
             # For auto pattern, would need environment/resource_suffix
             # For now, fall back to custom_subdomain if available
-            host = f"{cfg.dns.custom_subdomain}.{cfg.dns.domain}"
+            if cfg.dns.custom_subdomain:
+                host = f"{cfg.dns.custom_subdomain}.{cfg.dns.domain}"
+            else:
+                host = cfg.dns.domain
         else:
             # Default to just the domain
             host = cfg.dns.domain


### PR DESCRIPTION
## Summary
- Fixed `get_allocator_url()` to properly handle empty `custom_subdomain` values
- Prevents malformed URLs like `https://.lablink.sleap.ai`
- Now falls back to just the domain when subdomain is not specified

## Changes
- Added conditional checks for non-empty `custom_subdomain` in both `custom` and `auto` DNS patterns
- Ensures URLs are properly formed as `https://lablink.sleap.ai` instead of `https://.lablink.sleap.ai`

## Test plan
- [ ] Verify URLs are correctly generated when `custom_subdomain` is empty
- [ ] Verify URLs are correctly generated when `custom_subdomain` is set
- [ ] Test with both `custom` and `auto` DNS patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)