### PR TITLE
fix: Add safety check for leading dots in hostname and bump version

### DIFF
--- a/packages/allocator/pyproject.toml
+++ b/packages/allocator/pyproject.toml
@@ -24,7 +24,7 @@ description = "VM Allocator Service Package for Lablink"
 name = "lablink-allocator-service"
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.0.3a0"
+version = "0.0.3a1"
 
 [project.optional-dependencies]
 dev = ["twine", "build", "pytest", "ruff", "pytest-cov"]

--- a/packages/allocator/src/lablink_allocator_service/utils/config_helpers.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/config_helpers.py
@@ -65,6 +65,10 @@ def get_allocator_url(cfg, allocator_ip: str) -> Tuple[str, str]:
         else:
             # Default to just the domain
             host = cfg.dns.domain
+
+        # Just to be safe
+        if host.startswith("."):
+            host = host[1:]
     else:
         # Use IP address
         host = allocator_ip


### PR DESCRIPTION
## Summary
- Added an additional safety check to strip leading dots from hostnames
- Bumped allocator version from 0.0.3a0 to 0.0.3a1

## Changes
- After building the hostname from DNS configuration, check if it starts with a dot and strip it if present
- Version bump in pyproject.toml

## Test plan
- [ ] Verify hostnames are correctly generated without leading dots
- [ ] Test with various DNS configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)