### PR TITLE
fix: Add comprehensive URL sanitization for prepended dots

### DIFF
--- a/packages/allocator/pyproject.toml
+++ b/packages/allocator/pyproject.toml
@@ -24,7 +24,7 @@ description = "VM Allocator Service Package for Lablink"
 name = "lablink-allocator-service"
 readme = "README.md"
 requires-python = ">=3.9"
-version = "0.0.3a1"
+version = "0.0.3a2"
 
 [project.optional-dependencies]
 dev = ["twine", "build", "pytest", "ruff", "pytest-cov"]

--- a/packages/allocator/src/lablink_allocator_service/utils/config_helpers.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/config_helpers.py
@@ -74,6 +74,10 @@ def get_allocator_url(cfg, allocator_ip: str) -> Tuple[str, str]:
         host = allocator_ip
 
     base_url = f"{protocol}://{host}"
+
+    # Sanitize URL to remove prepended dots
+    base_url = base_url.replace("://.", "://")
+
     return base_url, protocol
 
 

--- a/packages/client/pyproject.toml
+++ b/packages/client/pyproject.toml
@@ -22,7 +22,7 @@ keywords = ["vm", "docker", "postgres", "tutorial", "AWS"]
 name = "lablink-client-service"
 readme = "README.md"
 requires-python = ">=3.8"
-version = "0.0.8a2"
+version = "0.0.8a3"
 
 [project.optional-dependencies]
 dev = ["twine", "build", "pytest", "ruff", "pytest-cov"]

--- a/packages/client/src/lablink_client_service/check_gpu.py
+++ b/packages/client/src/lablink_client_service/check_gpu.py
@@ -22,7 +22,8 @@ def check_gpu_health(allocator_url: str, interval: int = 20):
     """
     logger.debug("Starting GPU health check...")
     last_status = None
-    base_url = allocator_url.rstrip('/')
+    base_url = allocator_url.rstrip("/")
+    base_url = base_url.replace("://.", "://")
 
     while True:
         curr_status = None
@@ -104,6 +105,8 @@ def main(cfg: Config) -> None:
         allocator_url = allocator_url_env
     else:
         allocator_url = f"http://{cfg.allocator.host}:{cfg.allocator.port}"
+
+    allocator_url_env = allocator_url_env.replace("://.", "://")
 
     check_gpu_health(allocator_url=allocator_url)
 

--- a/packages/client/src/lablink_client_service/update_inuse_status.py
+++ b/packages/client/src/lablink_client_service/update_inuse_status.py
@@ -113,10 +113,12 @@ def main(cfg: Config) -> None:
     # otherwise use host:port with HTTP
     allocator_url = os.getenv("ALLOCATOR_URL")
     if allocator_url:
-        base_url = allocator_url.rstrip('/')
+        base_url = allocator_url.rstrip("/")
     else:
         base_url = f"http://{cfg.allocator.host}:{cfg.allocator.port}"
     url = f"{base_url}/api/update_inuse_status"
+
+    url = url.replace("://.", "://")
 
     # Start listening for the process
     listen_for_process(


### PR DESCRIPTION
## Summary
- Add URL sanitization to remove prepended dots (`:://.`) in allocator's `get_allocator_url` helper
- Add URL sanitization in client's `check_gpu.py` for both environment variable and constructed URLs
- Add URL sanitization in client's `update_inuse_status.py` for the final API endpoint URL
- Bump allocator version to 0.0.3a2
- Bump client version to 0.0.8a3

## Problem
Previous fixes (#196, #197, #198) addressed URL sanitization in specific locations, but edge cases remained where prepended dots could still appear in URLs, particularly when URLs are constructed from environment variables or config values.

## Solution
This PR adds comprehensive URL sanitization across all URL construction points:

1. **Allocator** (`config_helpers.py`): Sanitize the base URL after protocol/host construction
2. **Client** (`check_gpu.py`): Sanitize both the environment variable URL and the final base URL
3. **Client** (`update_inuse_status.py`): Sanitize the final API endpoint URL after construction

All sanitization uses the same pattern: `url.replace("://.", "://")`

## Test plan
- [ ] Verify allocator URL construction handles edge cases with leading dots
- [ ] Test client GPU health checks with various ALLOCATOR_URL formats
- [ ] Test client status updates with sanitized URLs
- [ ] Verify no broken URLs in logs or API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)