### PR TITLE
Add ci-test backend for terraform in allocator

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/terraform/backend-client-ci-test.hcl
+++ b/packages/allocator/src/lablink_allocator_service/terraform/backend-client-ci-test.hcl
@@ -1,0 +1,6 @@
+# Backend config for client VM terraform state (ci-test environment)
+# Bucket name will be passed via -backend-config="bucket=..." at runtime
+key            = "ci-test/client/terraform.tfstate"
+region         = "us-west-2"
+dynamodb_table = "lock-table"
+encrypt        = true


### PR DESCRIPTION
## Problem

Related to  #213 but we could still add a validation step in the future for state creation.

When creating client VMs for the `ci-test` environment, Terraform successfully provisions all AWS resources (EC2 instances, security groups, IAM roles, etc.) but the state file in S3 remains empty. This causes:
- Orphaned AWS resources that cannot be destroyed via Terraform
- `terraform destroy` reports "0 resources destroyed" 
- Manual cleanup required for all orphaned resources

## Root Cause

The allocator was missing the `backend-client-ci-test.hcl` backend configuration file. When VMs are created for the ci-test environment:

1. Terraform runs `terraform init` but has no backend config for ci-test
2. Terraform defaults to **local state** instead of S3 backend
3. VMs are created successfully and state is written to local `terraform.tfstate` file **inside the container**
4. State is never uploaded to S3 (no backend configured)
5. When destroy runs, it looks in S3 and finds no state → "0 resources to destroy"
6. Actual resources remain orphaned in AWS

## Evidence

Verified by SSHing into running allocator container:
```bash
$ ls terraform/backend-client-*.hcl
backend-client-dev.hcl
backend-client-prod.hcl
backend-client-test.hcl
# ❌ backend-client-ci-test.hcl missing!

$ ls terraform/terraform.tfstate
terraform.tfstate  # ✓ Exists locally but not in S3
```

## Solution

Added `backend-client-ci-test.hcl` with proper S3 backend configuration:
- Key: `ci-test/client/terraform.tfstate`
- Region: `us-west-2`
- DynamoDB table: `lock-table`
- Encryption: `true`

Now when VMs are created for ci-test, Terraform will properly configure the S3 backend and upload state files.

## Testing

After this fix:
1. Deploy allocator with updated code
2. Create client VMs via allocator UI for ci-test environment
3. Verify state file exists in S3: `s3://[bucket]/ci-test/client/terraform.tfstate`
4. Verify state file contains resources (not empty)
5. Run terraform destroy and verify resources are properly cleaned up

## Additional Notes

This issue only affected the `ci-test` environment. The `dev`, `test`, and `prod` environments already had backend config files and were working correctly.