### PR TITLE
Add Unset AWS Credentials Functionality for Admin Users

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -223,7 +223,7 @@ def admin():
         return render_template("admin.html", error=error)
 
 
-@app.route("/api/admin/unset-aws-credentials", methods=["DELETE"])
+@app.route("/api/admin/unset-aws-credentials", methods=["POST"])
 @auth.login_required
 def unset_aws_credentials():
     # Remove AWS credentials from environment variables

--- a/packages/allocator/src/lablink_allocator_service/templates/admin.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/admin.html
@@ -120,7 +120,7 @@
         {{ message }}
       </div>
       <form>
-        <input type="submit" value="Unset AWS Credentials" formaction="/api/admin/unset-aws-credentials" formmethod="delete" />
+        <input type="submit" value="Unset AWS Credentials" formaction="/api/admin/unset-aws-credentials" formmethod="post" />
       </form>
     {% endif %}
     {% if error %}

--- a/packages/allocator/tests/test_admin_auth.py
+++ b/packages/allocator/tests/test_admin_auth.py
@@ -186,7 +186,7 @@ def test_admin_unset_aws_credentials(client, admin_headers, monkeypatch):
     monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "test_secret_key")
     monkeypatch.setenv("AWS_SESSION_TOKEN", "test_session_token")
 
-    client.delete(
+    client.post(
         "/api/admin/unset-aws-credentials",
         headers=admin_headers,
     )


### PR DESCRIPTION
This PR adds a new feature where the admin can unset the AWS Credentials when the admin enters the wrong AWS credentials in the admin panel. This PR fixes #190. 