### PR TITLE
Make Region Configurable for the Backend

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -791,6 +791,7 @@ def main():
                     "init",
                     f"-backend-config=backend-client-{ENVIRONMENT}.hcl",
                     f"-backend-config=bucket={bucket_name}",
+                    f"-backend-config=region={cfg.app.region}",
                 ],
                 cwd=TERRAFORM_DIR,
                 check=True,

--- a/packages/allocator/src/lablink_allocator_service/terraform/backend-client-ci-test.hcl
+++ b/packages/allocator/src/lablink_allocator_service/terraform/backend-client-ci-test.hcl
@@ -1,6 +1,5 @@
 # Backend config for client VM terraform state (ci-test environment)
 # Bucket name will be passed via -backend-config="bucket=..." at runtime
 key            = "ci-test/client/terraform.tfstate"
-region         = "us-west-2"
 dynamodb_table = "lock-table"
 encrypt        = true

--- a/packages/allocator/src/lablink_allocator_service/terraform/backend-client-prod.hcl
+++ b/packages/allocator/src/lablink_allocator_service/terraform/backend-client-prod.hcl
@@ -1,6 +1,5 @@
 # Backend config for client VM terraform state (prod environment)
 # Bucket name will be passed via -backend-config="bucket=..." at runtime
 key            = "prod/client/terraform.tfstate"
-region         = "us-west-2"
 dynamodb_table = "lock-table"
 encrypt        = true

--- a/packages/allocator/src/lablink_allocator_service/terraform/backend-client-test.hcl
+++ b/packages/allocator/src/lablink_allocator_service/terraform/backend-client-test.hcl
@@ -1,6 +1,5 @@
 # Backend config for client VM terraform state (test environment)
 # Bucket name will be passed via -backend-config="bucket=..." at runtime
 key            = "test/client/terraform.tfstate"
-region         = "us-west-2"
 dynamodb_table = "lock-table"
 encrypt        = true


### PR DESCRIPTION
This PR fixes #209. Previously, the Terraform initialization of the allocator was fixed to "us-west-2". However, the PR makes it configurable, making the Terraform initialization based on the `cfg.app.region` instead of fixing the value. 