### PR TITLE
fix: clear VM assignment on auto-reboot so VMs become available for reassignment

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -1290,6 +1290,17 @@ class PostgresqlDatabase:
         across reboots. If reboot attempts are exhausted, the
         assignment is explicitly released via `release_assignment`.
 
+        Note: setting `crdcommand = NULL` fires the Postgres trigger
+        `trigger_crd_command_insert_or_update`, which emits a NOTIFY
+        with a NULL-valued CrdCommand payload. The LISTEN loop in
+        `listen_for_notifications` discards such payloads (see the
+        `hostname is None or pin is None or command is None` guard),
+        but each reboot still produces a spurious "Invalid notification
+        payload" warning in any client currently listening. The proper
+        fix is to add a `WHEN (NEW.CrdCommand IS NOT NULL)` guard to
+        the trigger definition; tracked for PR 4 of the failed-VM
+        recovery roadmap.
+
         Args:
             hostname: The hostname of the VM being rebooted.
         """
@@ -1325,6 +1336,12 @@ class PostgresqlDatabase:
         status to 'error' so the pool reflects the VM as unassignable
         until an admin intervenes. reboot_count is preserved for
         diagnostics.
+
+        Note: like `record_reboot`, setting `crdcommand = NULL` fires
+        the Postgres NOTIFY trigger with a NULL payload, producing a
+        discarded notification and a spurious warning log in any
+        listening client. The trigger-level fix is tracked for PR 4 of
+        the failed-VM recovery roadmap.
 
         Args:
             hostname: The hostname of the VM whose assignment is being released.

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -446,12 +446,23 @@ class PostgresqlDatabase:
         Used by /api/request_vm to decide between reassignment (same
         hostname, new CRD) and fresh assignment (new hostname).
 
+        Re-raises on DB error rather than swallowing: "lookup failed"
+        and "no assignment exists" are semantically different states.
+        Treating them identically (by returning None in both cases)
+        would silently route a student with an existing assignment to
+        the fresh-assignment path under a transient DB blip, producing
+        a dual-assignment. The caller's outer try/except handles the
+        raised exception and renders the generic error page.
+
         Args:
             email: The student's email address.
 
         Returns:
             A dict with hostname, status, reboot_count if an assignment
             exists, or None if the email has no VM.
+
+        Raises:
+            Exception: on DB connection or query failure.
         """
         query = f"""
             SELECT hostname, status, COALESCE(reboot_count, 0)
@@ -474,7 +485,7 @@ class PostgresqlDatabase:
             logger.error(
                 f"Failed to look up assigned VM for '{email}': {e}"
             )
-            return None
+            raise
 
     def assign_vm(self, email, crd_command, pin) -> None:
         """Assign a VM to a user.
@@ -513,8 +524,12 @@ class PostgresqlDatabase:
                 raise
 
     def reassign_crd(
-        self, hostname: str, crd_command: str, pin: str
-    ) -> None:
+        self,
+        hostname: str,
+        crd_command: str,
+        pin: str,
+        expected_email: str,
+    ) -> bool:
         """Reassign a new CRD command and PIN to an already-assigned VM.
 
         Used when a student whose VM failed and was rebooted resubmits
@@ -523,23 +538,50 @@ class PostgresqlDatabase:
         pg_notify, which wakes the client's /vm_startup LISTEN loop
         (or is picked up on the next /vm_startup call after reboot).
 
+        The UPDATE is conditional on `useremail = expected_email` to
+        close the race where the auto-reboot service's
+        `release_assignment` fires between the caller's
+        `get_assigned_vm_for_email` and this call. If the row's
+        useremail no longer matches (e.g., released and reassigned to
+        a different student), the UPDATE writes zero rows and the
+        method returns False so the caller can surface a retry-page
+        to the student.
+
         Args:
             hostname: The VM whose CRD is being reassigned.
             crd_command: The newly-generated CRD enrollment command.
             pin: The PIN to pair with the command.
+            expected_email: The email this row is expected to be
+                assigned to at the time of the UPDATE. Serves as an
+                optimistic-concurrency guard.
+
+        Returns:
+            True if the row was updated, False if the assignment has
+            changed (row no longer owned by expected_email).
         """
         query = f"""
             UPDATE {self.table_name}
             SET crdcommand = %s, pin = %s
-            WHERE hostname = %s;
+            WHERE hostname = %s AND useremail = %s;
         """
         with self._cursor as cursor:
             try:
-                cursor.execute(query, (crd_command, pin, hostname))
-                self.conn.commit()
-                logger.info(
-                    f"Reassigned CRD for VM '{hostname}'"
+                cursor.execute(
+                    query, (crd_command, pin, hostname, expected_email)
                 )
+                updated = cursor.rowcount > 0
+                self.conn.commit()
+                if updated:
+                    logger.info(
+                        f"Reassigned CRD for VM '{hostname}'"
+                    )
+                else:
+                    logger.warning(
+                        f"Could not reassign CRD for VM '{hostname}': "
+                        f"row no longer owned by '{expected_email}' "
+                        f"(concurrent release or reassignment)"
+                    )
+                return updated
             except Exception as e:
                 logger.error(
                     f"Failed to reassign CRD for '{hostname}': {e}"

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -1209,8 +1209,10 @@ class PostgresqlDatabase:
     def record_reboot(self, hostname: str) -> None:
         """Record a reboot attempt for a VM.
 
-        Sets status to 'rebooting', increments reboot_count, and updates
-        last_reboot_time.
+        Sets status to 'rebooting', increments reboot_count, updates
+        last_reboot_time, and clears assignment fields (useremail,
+        crdcommand, pin) so the VM becomes available for reassignment
+        after it comes back online.
 
         Args:
             hostname: The hostname of the VM being rebooted.
@@ -1219,7 +1221,10 @@ class PostgresqlDatabase:
             UPDATE {self.table_name}
             SET status = 'rebooting',
                 reboot_count = COALESCE(reboot_count, 0) + 1,
-                last_reboot_time = NOW()
+                last_reboot_time = NOW(),
+                useremail = NULL,
+                crdcommand = NULL,
+                pin = NULL
             WHERE hostname = %s;
         """
         with self._cursor as cursor:

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -1246,6 +1246,40 @@ class PostgresqlDatabase:
                 self.conn.rollback()
                 raise
 
+    def release_assignment(self, hostname: str) -> None:
+        """Release a VM's student assignment when it is deemed unrecoverable.
+
+        Called by the auto-reboot service when reboot_count exceeds
+        max_attempts. Clears useremail, crdcommand, pin and sets
+        status to 'error' so the pool reflects the VM as unassignable
+        until an admin intervenes. reboot_count is preserved for
+        diagnostics.
+
+        Args:
+            hostname: The hostname of the VM whose assignment is being released.
+        """
+        query = f"""
+            UPDATE {self.table_name}
+            SET useremail = NULL,
+                crdcommand = NULL,
+                pin = NULL,
+                status = 'error'
+            WHERE hostname = %s;
+        """
+        with self._cursor as cursor:
+            try:
+                cursor.execute(query, (hostname,))
+                self.conn.commit()
+                logger.info(
+                    f"Released assignment for unrecoverable VM '{hostname}'"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Failed to release assignment for '{hostname}': {e}"
+                )
+                self.conn.rollback()
+                raise
+
     def get_reboot_info(self, hostname: str) -> Optional[dict]:
         """Get reboot tracking info for a VM.
 

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -1210,9 +1210,14 @@ class PostgresqlDatabase:
         """Record a reboot attempt for a VM.
 
         Sets status to 'rebooting', increments reboot_count, updates
-        last_reboot_time, and clears assignment fields (useremail,
-        crdcommand, pin) so the VM becomes available for reassignment
-        after it comes back online.
+        last_reboot_time, and clears the CRD session fields
+        (crdcommand, pin) — the Chrome Remote Desktop enrollment
+        token is one-shot and is invalidated by the reboot, so it must
+        be reissued when the student reconnects.
+
+        `useremail` is preserved so the student keeps their VM slot
+        across reboots. If reboot attempts are exhausted, the
+        assignment is explicitly released via `release_assignment`.
 
         Args:
             hostname: The hostname of the VM being rebooted.
@@ -1222,7 +1227,6 @@ class PostgresqlDatabase:
             SET status = 'rebooting',
                 reboot_count = COALESCE(reboot_count, 0) + 1,
                 last_reboot_time = NOW(),
-                useremail = NULL,
                 crdcommand = NULL,
                 pin = NULL
             WHERE hostname = %s;

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -440,6 +440,42 @@ class PostgresqlDatabase:
                 f"No VM found for email in the database: {email}"
             )
 
+    def get_assigned_vm_for_email(self, email: str) -> Optional[dict]:
+        """Look up whether an email already has a VM assigned.
+
+        Used by /api/request_vm to decide between reassignment (same
+        hostname, new CRD) and fresh assignment (new hostname).
+
+        Args:
+            email: The student's email address.
+
+        Returns:
+            A dict with hostname, status, reboot_count if an assignment
+            exists, or None if the email has no VM.
+        """
+        query = f"""
+            SELECT hostname, status, COALESCE(reboot_count, 0)
+            FROM {self.table_name}
+            WHERE useremail = %s
+            LIMIT 1;
+        """
+        try:
+            with self._cursor as cursor:
+                cursor.execute(query, (email,))
+                row = cursor.fetchone()
+            if row is None:
+                return None
+            return {
+                "hostname": row[0],
+                "status": row[1],
+                "reboot_count": row[2],
+            }
+        except Exception as e:
+            logger.error(
+                f"Failed to look up assigned VM for '{email}': {e}"
+            )
+            return None
+
     def assign_vm(self, email, crd_command, pin) -> None:
         """Assign a VM to a user.
 

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -512,6 +512,41 @@ class PostgresqlDatabase:
                 self.conn.rollback()
                 raise
 
+    def reassign_crd(
+        self, hostname: str, crd_command: str, pin: str
+    ) -> None:
+        """Reassign a new CRD command and PIN to an already-assigned VM.
+
+        Used when a student whose VM failed and was rebooted resubmits
+        /api/request_vm with a newly-generated CRD enrollment code.
+        The existing Postgres trigger on UPDATE OF CrdCommand fires
+        pg_notify, which wakes the client's /vm_startup LISTEN loop
+        (or is picked up on the next /vm_startup call after reboot).
+
+        Args:
+            hostname: The VM whose CRD is being reassigned.
+            crd_command: The newly-generated CRD enrollment command.
+            pin: The PIN to pair with the command.
+        """
+        query = f"""
+            UPDATE {self.table_name}
+            SET crdcommand = %s, pin = %s
+            WHERE hostname = %s;
+        """
+        with self._cursor as cursor:
+            try:
+                cursor.execute(query, (crd_command, pin, hostname))
+                self.conn.commit()
+                logger.info(
+                    f"Reassigned CRD for VM '{hostname}'"
+                )
+            except Exception as e:
+                logger.error(
+                    f"Failed to reassign CRD for '{hostname}': {e}"
+                )
+                self.conn.rollback()
+                raise
+
     def get_first_available_vm(self) -> str:
         """Get the first available VM that is not assigned.
 

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -332,9 +332,9 @@ def submit_vm_details():
                 )
                 return render_template(
                     "index.html",
-                    error="Your previous VM encountered a problem and "
-                    "could not be recovered. Please try again in a "
-                    "moment — a fresh VM will be assigned.",
+                    error="Your previous VM could not be recovered. "
+                    "Please wait up to 60 seconds and try again — a "
+                    "fresh VM will be assigned.",
                 )
 
             # Any other status: log and fall through to fresh assignment

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -293,11 +293,24 @@ def submit_vm_details():
             status = existing["status"]
 
             if status == "running":
-                database.reassign_crd(
+                reassigned = database.reassign_crd(
                     hostname=hostname,
                     crd_command=crd_command,
                     pin=PIN,
+                    expected_email=email,
                 )
+                if not reassigned:
+                    # Race: the row was released/reassigned between
+                    # get_assigned_vm_for_email and this UPDATE.
+                    logger.warning(
+                        f"Reassign race for '{email}' on '{hostname}'; "
+                        f"asking student to retry"
+                    )
+                    return render_template(
+                        "index.html",
+                        error="Your VM assignment changed. Please try "
+                        "again — a fresh VM will be assigned.",
+                    )
                 logger.info(
                     f"Reassigned CRD for '{email}' on existing VM "
                     f"'{hostname}'"
@@ -310,11 +323,22 @@ def submit_vm_details():
                 # Queue the CRD on the row. When the client's
                 # /vm_startup call lands after recovery, the existing
                 # race-condition path returns it immediately.
-                database.reassign_crd(
+                reassigned = database.reassign_crd(
                     hostname=hostname,
                     crd_command=crd_command,
                     pin=PIN,
+                    expected_email=email,
                 )
+                if not reassigned:
+                    logger.warning(
+                        f"Reassign race for '{email}' on recovering "
+                        f"VM '{hostname}'; asking student to retry"
+                    )
+                    return render_template(
+                        "index.html",
+                        error="Your VM assignment changed. Please try "
+                        "again — a fresh VM will be assigned.",
+                    )
                 logger.info(
                     f"Queued CRD for '{email}' on recovering VM "
                     f"'{hostname}' (status={status})"

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -285,21 +285,79 @@ def submit_vm_details():
                 "Please ask your instructor for help.",
             )
 
-        # Check if there are any available VMs
+        # If this email already owns a VM, reassign the new CRD to it
+        # in place instead of picking a new VM.
+        existing = database.get_assigned_vm_for_email(email=email)
+        if existing is not None:
+            hostname = existing["hostname"]
+            status = existing["status"]
+
+            if status == "running":
+                database.reassign_crd(
+                    hostname=hostname,
+                    crd_command=crd_command,
+                    pin=PIN,
+                )
+                logger.info(
+                    f"Reassigned CRD for '{email}' on existing VM "
+                    f"'{hostname}'"
+                )
+                return render_template(
+                    "success.html", host=hostname, pin=PIN
+                )
+
+            if status in ("rebooting", "initializing"):
+                # Queue the CRD on the row. When the client's
+                # /vm_startup call lands after recovery, the existing
+                # race-condition path returns it immediately.
+                database.reassign_crd(
+                    hostname=hostname,
+                    crd_command=crd_command,
+                    pin=PIN,
+                )
+                logger.info(
+                    f"Queued CRD for '{email}' on recovering VM "
+                    f"'{hostname}' (status={status})"
+                )
+                return render_template(
+                    "recovery.html", host=hostname, status=status
+                )
+
+            if status == "error":
+                # Reboot-service will release the assignment on its
+                # next tick. Ask the student to retry then.
+                logger.warning(
+                    f"VM '{hostname}' is in error state; asking "
+                    f"'{email}' to retry"
+                )
+                return render_template(
+                    "index.html",
+                    error="Your previous VM encountered a problem and "
+                    "could not be recovered. Please try again in a "
+                    "moment — a fresh VM will be assigned.",
+                )
+
+            # Any other status: log and fall through to fresh assignment
+            logger.warning(
+                f"Unexpected status '{status}' for '{email}' on "
+                f"'{hostname}'; falling through to fresh assignment"
+            )
+
+        # No existing assignment: assign a fresh VM from the pool
         if len(database.get_unassigned_vms()) == 0:
             logger.error("No available VMs found.")
             return render_template(
                 "index.html",
-                error="No available VMs. Please try again later. Please ask your "
-                "instructor for help",
+                error="No available VMs. Please try again later. Please "
+                "ask your instructor for help",
             )
 
-        # Assign the VM
         database.assign_vm(email=email, crd_command=crd_command, pin=PIN)
 
-        # Display success message
         assigned_vm = database.get_vm_details(email=email)
-        return render_template("success.html", host=assigned_vm[0], pin=assigned_vm[1])
+        return render_template(
+            "success.html", host=assigned_vm[0], pin=assigned_vm[1]
+        )
     except Exception as e:
         logger.error(f"Error in submit_vm_details: {e}")
         return render_template(

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -292,25 +292,31 @@ def submit_vm_details():
             hostname = existing["hostname"]
             status = existing["status"]
 
-            if status == "running":
-                reassigned = database.reassign_crd(
+            def _attempt_reassign():
+                """Try to reassign CRD; return True on success, or render
+                a retry-page response if the row was released under us."""
+                if database.reassign_crd(
                     hostname=hostname,
                     crd_command=crd_command,
                     pin=PIN,
                     expected_email=email,
+                ):
+                    return None  # success; caller continues
+                # Race: release_assignment fired between lookup and UPDATE.
+                logger.warning(
+                    f"Reassign race for '{email}' on '{hostname}' "
+                    f"(status={status}); asking student to retry"
                 )
-                if not reassigned:
-                    # Race: the row was released/reassigned between
-                    # get_assigned_vm_for_email and this UPDATE.
-                    logger.warning(
-                        f"Reassign race for '{email}' on '{hostname}'; "
-                        f"asking student to retry"
-                    )
-                    return render_template(
-                        "index.html",
-                        error="Your VM assignment changed. Please try "
-                        "again — a fresh VM will be assigned.",
-                    )
+                return render_template(
+                    "index.html",
+                    error="Your VM assignment changed. Please try "
+                    "again — a fresh VM will be assigned.",
+                )
+
+            if status == "running":
+                race_response = _attempt_reassign()
+                if race_response is not None:
+                    return race_response
                 logger.info(
                     f"Reassigned CRD for '{email}' on existing VM "
                     f"'{hostname}'"
@@ -323,22 +329,9 @@ def submit_vm_details():
                 # Queue the CRD on the row. When the client's
                 # /vm_startup call lands after recovery, the existing
                 # race-condition path returns it immediately.
-                reassigned = database.reassign_crd(
-                    hostname=hostname,
-                    crd_command=crd_command,
-                    pin=PIN,
-                    expected_email=email,
-                )
-                if not reassigned:
-                    logger.warning(
-                        f"Reassign race for '{email}' on recovering "
-                        f"VM '{hostname}'; asking student to retry"
-                    )
-                    return render_template(
-                        "index.html",
-                        error="Your VM assignment changed. Please try "
-                        "again — a fresh VM will be assigned.",
-                    )
+                race_response = _attempt_reassign()
+                if race_response is not None:
+                    return race_response
                 logger.info(
                     f"Queued CRD for '{email}' on recovering VM "
                     f"'{hostname}' (status={status})"

--- a/packages/allocator/src/lablink_allocator_service/reboot.py
+++ b/packages/allocator/src/lablink_allocator_service/reboot.py
@@ -89,12 +89,21 @@ class AutoRebootService:
         for vm in failed_vms:
             hostname = vm["hostname"]
 
-            # Check max attempts
+            # Max attempts exhausted: release the student's assignment
+            # so they can be re-routed to a fresh VM. The VM is marked
+            # 'error' and will not be retried until admin intervention.
             if vm["reboot_count"] >= self.max_attempts:
-                logger.debug(
-                    f"VM '{hostname}' has reached max reboot attempts "
-                    f"({self.max_attempts}), skipping"
+                logger.warning(
+                    f"VM '{hostname}' exhausted reboot attempts "
+                    f"({self.max_attempts}), releasing assignment"
                 )
+                try:
+                    self.database.release_assignment(hostname)
+                except Exception as e:
+                    logger.error(
+                        f"Failed to release assignment for "
+                        f"'{hostname}': {e}"
+                    )
                 continue
 
             # Check cooldown

--- a/packages/allocator/src/lablink_allocator_service/templates/recovery.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/recovery.html
@@ -29,7 +29,7 @@
     <p class="mb-3">Current status: <strong>{{ status }}</strong></p>
     <p class="mb-4">
       Your new Chrome Remote Desktop command has been queued. Once the
-      VM finishes recovering, it will connect automatically. This
+      VM finishes recovering, it should connect automatically. This
       usually takes a minute or two. If it still hasn't connected
       after five minutes, please ask your instructor for help.
     </p>

--- a/packages/allocator/src/lablink_allocator_service/templates/recovery.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/recovery.html
@@ -1,0 +1,39 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>VM Recovering</title>
+  <link
+    href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
+    rel="stylesheet">
+  <style>
+    body {
+      background-color: #f8f9fa;
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      height: 100vh;
+    }
+    .card {
+      padding: 30px;
+      border-radius: 12px;
+      box-shadow: 0 0 10px rgba(0, 0, 0, 0.1);
+      max-width: 520px;
+    }
+  </style>
+</head>
+<body>
+  <div class="card text-center">
+    <h1 class="text-warning mb-3">Your VM Is Recovering</h1>
+    <p class="mb-2">Assigned Hostname: <strong>{{ host }}</strong></p>
+    <p class="mb-3">Current status: <strong>{{ status }}</strong></p>
+    <p class="mb-4">
+      Your new Chrome Remote Desktop command has been queued. Once the
+      VM finishes recovering, it will connect automatically. This
+      usually takes a minute or two. If it still hasn't connected
+      after five minutes, please ask your instructor for help.
+    </p>
+    <a href="/" class="btn btn-primary">Back to Home</a>
+  </div>
+</body>
+</html>

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -1326,3 +1326,40 @@ def test_cancel_scheduled_destruction(db_instance):
         (schedule_id,),
     )
     db_instance.conn.commit.assert_called_once()
+
+
+def test_get_assigned_vm_for_email_found(db_instance):
+    """Test looking up an email that already owns a VM."""
+    db_instance.cursor.fetchone.return_value = ("vm-7", "running", 0)
+
+    result = db_instance.get_assigned_vm_for_email("student@test.edu")
+
+    assert result == {
+        "hostname": "vm-7",
+        "status": "running",
+        "reboot_count": 0,
+    }
+    # Query should filter on useremail and bind the email parameter
+    query = db_instance.cursor.execute.call_args[0][0]
+    args = db_instance.cursor.execute.call_args[0][1]
+    assert "useremail" in query
+    assert args == ("student@test.edu",)
+
+
+def test_get_assigned_vm_for_email_not_found(db_instance):
+    """Test looking up an email with no existing VM."""
+    db_instance.cursor.fetchone.return_value = None
+
+    result = db_instance.get_assigned_vm_for_email("unknown@test.edu")
+
+    assert result is None
+
+
+def test_get_assigned_vm_for_email_error(db_instance, caplog):
+    """Test error handling in get_assigned_vm_for_email."""
+    db_instance.cursor.execute.side_effect = Exception("DB error")
+
+    result = db_instance.get_assigned_vm_for_email("student@test.edu")
+
+    assert result is None
+    assert "Failed to look up assigned VM" in caplog.text

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -1356,46 +1356,77 @@ def test_get_assigned_vm_for_email_not_found(db_instance):
 
 
 def test_get_assigned_vm_for_email_error(db_instance, caplog):
-    """Test error handling in get_assigned_vm_for_email."""
+    """Test that get_assigned_vm_for_email re-raises DB errors.
+
+    Re-raising is deliberate: the caller must not conflate "lookup
+    failed" with "no assignment exists" (see method docstring).
+    """
     db_instance.cursor.execute.side_effect = Exception("DB error")
 
-    result = db_instance.get_assigned_vm_for_email("student@test.edu")
-
-    assert result is None
+    with pytest.raises(Exception, match="DB error"):
+        db_instance.get_assigned_vm_for_email("student@test.edu")
     assert "Failed to look up assigned VM" in caplog.text
 
 
-def test_reassign_crd(db_instance):
-    """Test reassigning a new CRD command to an existing VM."""
-    db_instance.reassign_crd(
+def test_reassign_crd_succeeds_when_row_still_owned(db_instance):
+    """Test reassigning a new CRD command when the row is still owned."""
+    db_instance.cursor.rowcount = 1
+
+    result = db_instance.reassign_crd(
         hostname="vm-7",
         crd_command=(
             "DISPLAY= /opt/google/chrome-remote-desktop/start-host "
             "--code='4/abc' --redirect-url='...'"
         ),
         pin="987654",
+        expected_email="student@test.edu",
     )
 
+    assert result is True
     db_instance.cursor.execute.assert_called_once()
     query = db_instance.cursor.execute.call_args[0][0]
     args = db_instance.cursor.execute.call_args[0][1]
 
-    # Query targets the right columns and the given hostname
+    # Query targets the right columns and guards on useremail
     assert "crdcommand" in query.lower()
     assert "pin" in query.lower()
     assert "WHERE hostname" in query
-    # Parameter order: (crd_command, pin, hostname)
-    assert args[2] == "vm-7"
+    assert "useremail" in query.lower()
+    # Parameter order: (crd_command, pin, hostname, expected_email)
     assert "4/abc" in args[0]
     assert args[1] == "987654"
+    assert args[2] == "vm-7"
+    assert args[3] == "student@test.edu"
 
     db_instance.conn.commit.assert_called_once()
+
+
+def test_reassign_crd_returns_false_when_row_released(db_instance, caplog):
+    """Test that reassign_crd returns False when useremail no longer matches.
+
+    Simulates the race where the auto-reboot service's release_assignment
+    fires between the caller's get_assigned_vm_for_email and reassign_crd.
+    """
+    db_instance.cursor.rowcount = 0
+
+    result = db_instance.reassign_crd(
+        hostname="vm-7",
+        crd_command="cmd",
+        pin="987654",
+        expected_email="student@test.edu",
+    )
+
+    assert result is False
+    db_instance.conn.commit.assert_called_once()
+    assert "row no longer owned by 'student@test.edu'" in caplog.text
 
 
 def test_reassign_crd_error(db_instance, caplog):
     """Test error handling in reassign_crd."""
     db_instance.cursor.execute.side_effect = Exception("DB error")
     with pytest.raises(Exception, match="DB error"):
-        db_instance.reassign_crd("vm-7", "cmd", "000000")
+        db_instance.reassign_crd(
+            "vm-7", "cmd", "000000", "student@test.edu"
+        )
     db_instance.conn.rollback.assert_called_once()
     assert "Failed to reassign CRD" in caplog.text

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -1363,3 +1363,39 @@ def test_get_assigned_vm_for_email_error(db_instance, caplog):
 
     assert result is None
     assert "Failed to look up assigned VM" in caplog.text
+
+
+def test_reassign_crd(db_instance):
+    """Test reassigning a new CRD command to an existing VM."""
+    db_instance.reassign_crd(
+        hostname="vm-7",
+        crd_command=(
+            "DISPLAY= /opt/google/chrome-remote-desktop/start-host "
+            "--code='4/abc' --redirect-url='...'"
+        ),
+        pin="987654",
+    )
+
+    db_instance.cursor.execute.assert_called_once()
+    query = db_instance.cursor.execute.call_args[0][0]
+    args = db_instance.cursor.execute.call_args[0][1]
+
+    # Query targets the right columns and the given hostname
+    assert "crdcommand" in query.lower()
+    assert "pin" in query.lower()
+    assert "WHERE hostname" in query
+    # Parameter order: (crd_command, pin, hostname)
+    assert args[2] == "vm-7"
+    assert "4/abc" in args[0]
+    assert args[1] == "987654"
+
+    db_instance.conn.commit.assert_called_once()
+
+
+def test_reassign_crd_error(db_instance, caplog):
+    """Test error handling in reassign_crd."""
+    db_instance.cursor.execute.side_effect = Exception("DB error")
+    with pytest.raises(Exception, match="DB error"):
+        db_instance.reassign_crd("vm-7", "cmd", "000000")
+    db_instance.conn.rollback.assert_called_once()
+    assert "Failed to reassign CRD" in caplog.text

--- a/packages/allocator/tests/test_reassignment_flow.py
+++ b/packages/allocator/tests/test_reassignment_flow.py
@@ -141,3 +141,34 @@ def test_request_vm_no_existing_assignment_picks_fresh_vm(
     fake_db.assign_vm.assert_called_once()
     fake_db.reassign_crd.assert_not_called()
     assert b"vm-free-1" in resp.data
+
+
+def test_request_vm_unexpected_status_falls_through_to_fresh_assignment(
+    client, monkeypatch
+):
+    """Unknown status on existing row falls through to fresh assignment."""
+    from lablink_allocator_service import main
+
+    fake_db = MagicMock()
+    fake_db.get_assigned_vm_for_email.return_value = {
+        "hostname": "vm-unknown-state",
+        "status": "stopped",  # not handled explicitly
+        "reboot_count": 0,
+    }
+    fake_db.get_unassigned_vms.return_value = ["vm-free-2"]
+    fake_db.get_vm_details.return_value = ["vm-free-2", "123456", "cmd"]
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    resp = client.post(
+        REQUEST_VM_ENDPOINT,
+        data={
+            "email": "student@test.edu",
+            "crd_command": VALID_CRD_COMMAND,
+        },
+    )
+
+    assert resp.status_code == 200
+    # Fell through to fresh-assignment path
+    fake_db.reassign_crd.assert_not_called()
+    fake_db.assign_vm.assert_called_once()
+    assert b"vm-free-2" in resp.data

--- a/packages/allocator/tests/test_reassignment_flow.py
+++ b/packages/allocator/tests/test_reassignment_flow.py
@@ -1,0 +1,143 @@
+"""Tests for /api/request_vm reassignment branching.
+
+Covers the four cases of the request-flow change in PR 1:
+1. Email has no existing assignment -> fresh assignment (regression).
+2. Email has an existing running VM -> reassign_crd, success page.
+3. Email has an existing rebooting/initializing VM -> reassign_crd,
+   recovery page.
+4. Email has an existing error VM -> retry-shortly message.
+"""
+
+from unittest.mock import MagicMock
+
+
+REQUEST_VM_ENDPOINT = "/api/request_vm"
+
+VALID_CRD_COMMAND = (
+    "DISPLAY= /opt/google/chrome-remote-desktop/start-host "
+    "--code='4/abc123' --redirect-url='https://example.com' "
+    "--name='vm-1'"
+)
+
+
+def test_request_vm_existing_running_reassigns_same_host(
+    client, monkeypatch
+):
+    """Email already owns a running VM: reassign CRD on same host."""
+    from lablink_allocator_service import main
+
+    fake_db = MagicMock()
+    fake_db.get_assigned_vm_for_email.return_value = {
+        "hostname": "vm-7",
+        "status": "running",
+        "reboot_count": 0,
+    }
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    resp = client.post(
+        REQUEST_VM_ENDPOINT,
+        data={
+            "email": "student@test.edu",
+            "crd_command": VALID_CRD_COMMAND,
+        },
+    )
+
+    assert resp.status_code == 200
+    fake_db.reassign_crd.assert_called_once()
+    # Args may be positional or keyword — accept either
+    call_args = fake_db.reassign_crd.call_args
+    hostname_arg = (
+        call_args.kwargs.get("hostname")
+        if "hostname" in call_args.kwargs
+        else call_args.args[0]
+    )
+    assert hostname_arg == "vm-7"
+    # Fresh assignment path is NOT taken
+    fake_db.assign_vm.assert_not_called()
+    fake_db.get_unassigned_vms.assert_not_called()
+    # Response body mentions the hostname
+    assert b"vm-7" in resp.data
+
+
+def test_request_vm_existing_rebooting_renders_recovery_page(
+    client, monkeypatch
+):
+    """Email's VM is mid-reboot: queue CRD, render recovery page."""
+    from lablink_allocator_service import main
+
+    fake_db = MagicMock()
+    fake_db.get_assigned_vm_for_email.return_value = {
+        "hostname": "vm-3",
+        "status": "rebooting",
+        "reboot_count": 1,
+    }
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    resp = client.post(
+        REQUEST_VM_ENDPOINT,
+        data={
+            "email": "student@test.edu",
+            "crd_command": VALID_CRD_COMMAND,
+        },
+    )
+
+    assert resp.status_code == 200
+    fake_db.reassign_crd.assert_called_once()
+    fake_db.assign_vm.assert_not_called()
+    # Recovery page mentions the hostname
+    assert b"vm-3" in resp.data
+    assert b"Recovering" in resp.data
+
+
+def test_request_vm_existing_error_renders_retry_message(
+    client, monkeypatch
+):
+    """Email's VM is in error state: do not reassign; ask to retry."""
+    from lablink_allocator_service import main
+
+    fake_db = MagicMock()
+    fake_db.get_assigned_vm_for_email.return_value = {
+        "hostname": "vm-9",
+        "status": "error",
+        "reboot_count": 3,
+    }
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    resp = client.post(
+        REQUEST_VM_ENDPOINT,
+        data={
+            "email": "student@test.edu",
+            "crd_command": VALID_CRD_COMMAND,
+        },
+    )
+
+    assert resp.status_code == 200
+    fake_db.reassign_crd.assert_not_called()
+    fake_db.assign_vm.assert_not_called()
+    assert b"try again" in resp.data.lower()
+
+
+def test_request_vm_no_existing_assignment_picks_fresh_vm(
+    client, monkeypatch
+):
+    """Regression: email with no VM gets a fresh assignment."""
+    from lablink_allocator_service import main
+
+    fake_db = MagicMock()
+    fake_db.get_assigned_vm_for_email.return_value = None
+    fake_db.get_unassigned_vms.return_value = ["vm-free-1"]
+    fake_db.get_vm_details.return_value = ["vm-free-1", "123456", "cmd"]
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    resp = client.post(
+        REQUEST_VM_ENDPOINT,
+        data={
+            "email": "new@test.edu",
+            "crd_command": VALID_CRD_COMMAND,
+        },
+    )
+
+    assert resp.status_code == 200
+    fake_db.assign_vm.assert_called_once()
+    fake_db.reassign_crd.assert_not_called()
+    assert b"vm-free-1" in resp.data

--- a/packages/allocator/tests/test_reassignment_flow.py
+++ b/packages/allocator/tests/test_reassignment_flow.py
@@ -1,11 +1,13 @@
 """Tests for /api/request_vm reassignment branching.
 
-Covers the four cases of the request-flow change in PR 1:
+Covers the cases of the request-flow change in PR 1:
 1. Email has no existing assignment -> fresh assignment (regression).
 2. Email has an existing running VM -> reassign_crd, success page.
 3. Email has an existing rebooting/initializing VM -> reassign_crd,
    recovery page.
 4. Email has an existing error VM -> retry-shortly message.
+5. Reassign race -> reassign_crd returns False -> retry page.
+6. Unknown status -> fall through to fresh assignment.
 """
 
 from unittest.mock import MagicMock
@@ -32,6 +34,7 @@ def test_request_vm_existing_running_reassigns_same_host(
         "status": "running",
         "reboot_count": 0,
     }
+    fake_db.reassign_crd.return_value = True
     monkeypatch.setattr(main, "database", fake_db, raising=False)
 
     resp = client.post(
@@ -43,15 +46,13 @@ def test_request_vm_existing_running_reassigns_same_host(
     )
 
     assert resp.status_code == 200
-    fake_db.reassign_crd.assert_called_once()
-    # Args may be positional or keyword — accept either
-    call_args = fake_db.reassign_crd.call_args
-    hostname_arg = (
-        call_args.kwargs.get("hostname")
-        if "hostname" in call_args.kwargs
-        else call_args.args[0]
+    # Conditional UPDATE carries expected_email for optimistic concurrency
+    fake_db.reassign_crd.assert_called_once_with(
+        hostname="vm-7",
+        crd_command=VALID_CRD_COMMAND,
+        pin=main.PIN,
+        expected_email="student@test.edu",
     )
-    assert hostname_arg == "vm-7"
     # Fresh assignment path is NOT taken
     fake_db.assign_vm.assert_not_called()
     fake_db.get_unassigned_vms.assert_not_called()
@@ -71,6 +72,7 @@ def test_request_vm_existing_rebooting_renders_recovery_page(
         "status": "rebooting",
         "reboot_count": 1,
     }
+    fake_db.reassign_crd.return_value = True
     monkeypatch.setattr(main, "database", fake_db, raising=False)
 
     resp = client.post(
@@ -87,6 +89,46 @@ def test_request_vm_existing_rebooting_renders_recovery_page(
     # Recovery page mentions the hostname
     assert b"vm-3" in resp.data
     assert b"Recovering" in resp.data
+
+
+def test_request_vm_reassign_race_renders_retry_message(
+    client, monkeypatch
+):
+    """reassign_crd returning False (race) renders a retry-page.
+
+    Simulates the race where auto-reboot's release_assignment fires
+    between get_assigned_vm_for_email and reassign_crd. The UPDATE's
+    useremail guard fails, reassign_crd returns False, the handler
+    asks the student to retry instead of rendering a misleading
+    success page.
+    """
+    from lablink_allocator_service import main
+
+    fake_db = MagicMock()
+    fake_db.get_assigned_vm_for_email.return_value = {
+        "hostname": "vm-7",
+        "status": "running",
+        "reboot_count": 0,
+    }
+    fake_db.reassign_crd.return_value = False  # race loss
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    resp = client.post(
+        REQUEST_VM_ENDPOINT,
+        data={
+            "email": "student@test.edu",
+            "crd_command": VALID_CRD_COMMAND,
+        },
+    )
+
+    assert resp.status_code == 200
+    fake_db.reassign_crd.assert_called_once()
+    # Not falsely presented as success
+    assert b"VM Assigned Successfully" not in resp.data
+    # Retry guidance surfaced to the student
+    assert b"try again" in resp.data.lower()
+    # Fresh assignment NOT auto-triggered (student must retry explicitly)
+    fake_db.assign_vm.assert_not_called()
 
 
 def test_request_vm_existing_error_renders_retry_message(

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -160,14 +160,17 @@ def test_release_assignment(db_instance):
     assert "crdcommand = NULL" in query
     assert "pin = NULL" in query
     assert "status = 'error'" in query
+    # reboot_count is intentionally preserved for diagnostics
+    assert "reboot_count" not in query
 
 
-def test_release_assignment_error(db_instance):
+def test_release_assignment_error(db_instance, caplog):
     """Test error handling in release_assignment."""
     db_instance.cursor.execute.side_effect = Exception("DB error")
     with pytest.raises(Exception, match="DB error"):
         db_instance.release_assignment("vm-1")
     db_instance.conn.rollback.assert_called_once()
+    assert "Failed to release assignment for" in caplog.text
 
 
 def test_get_reboot_info(db_instance):

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -131,6 +131,12 @@ def test_record_reboot(db_instance):
     db_instance.cursor.execute.assert_called_with(ANY, ("vm-1",))
     db_instance.conn.commit.assert_called_once()
 
+    # Verify assignment fields are cleared in the query
+    query = db_instance.cursor.execute.call_args[0][0]
+    assert "useremail = NULL" in query
+    assert "crdcommand = NULL" in query
+    assert "pin = NULL" in query
+
 
 def test_record_reboot_error(db_instance, caplog):
     """Test error handling in record_reboot."""

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -149,6 +149,27 @@ def test_record_reboot_error(db_instance, caplog):
     db_instance.conn.rollback.assert_called_once()
 
 
+def test_release_assignment(db_instance):
+    """Test releasing a VM's assignment when reboot attempts are exhausted."""
+    db_instance.release_assignment("vm-1")
+    db_instance.cursor.execute.assert_called_with(ANY, ("vm-1",))
+    db_instance.conn.commit.assert_called_once()
+
+    query = db_instance.cursor.execute.call_args[0][0]
+    assert "useremail = NULL" in query
+    assert "crdcommand = NULL" in query
+    assert "pin = NULL" in query
+    assert "status = 'error'" in query
+
+
+def test_release_assignment_error(db_instance):
+    """Test error handling in release_assignment."""
+    db_instance.cursor.execute.side_effect = Exception("DB error")
+    with pytest.raises(Exception, match="DB error"):
+        db_instance.release_assignment("vm-1")
+    db_instance.conn.rollback.assert_called_once()
+
+
 def test_get_reboot_info(db_instance):
     """Test getting reboot info for a VM."""
     last_reboot = datetime(2025, 1, 1, 12, 0, 0)

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -131,11 +131,14 @@ def test_record_reboot(db_instance):
     db_instance.cursor.execute.assert_called_with(ANY, ("vm-1",))
     db_instance.conn.commit.assert_called_once()
 
-    # Verify assignment fields are cleared in the query
+    # Verify CRD-session fields are cleared but the student's assignment
+    # is preserved (so the student keeps their VM slot across reboots).
     query = db_instance.cursor.execute.call_args[0][0]
-    assert "useremail = NULL" in query
     assert "crdcommand = NULL" in query
     assert "pin = NULL" in query
+    assert "useremail = NULL" not in query
+    assert "status = 'rebooting'" in query
+    assert "reboot_count" in query
 
 
 def test_record_reboot_error(db_instance, caplog):

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -396,8 +396,8 @@ def test_reboot_vm_instance_not_found(monkeypatch):
 
 
 @patch.object(AutoRebootService, "_reboot_vm")
-def test_check_and_reboot_respects_max_attempts(mock_reboot):
-    """Test that VMs exceeding max attempts are skipped."""
+def test_check_and_reboot_releases_on_max_attempts(mock_reboot):
+    """Test that VMs exceeding max attempts have their assignment released."""
     mock_db = MagicMock()
     mock_db.get_failed_vms.return_value = [
         {
@@ -418,6 +418,33 @@ def test_check_and_reboot_respects_max_attempts(mock_reboot):
     service._check_and_reboot()
 
     mock_reboot.assert_not_called()
+    mock_db.release_assignment.assert_called_once_with("vm-1")
+
+
+@patch.object(AutoRebootService, "_reboot_vm")
+def test_check_and_reboot_below_max_does_not_release(mock_reboot):
+    """Test that VMs below max_attempts are not released."""
+    mock_db = MagicMock()
+    mock_db.get_failed_vms.return_value = [
+        {
+            "hostname": "vm-1",
+            "status": "error",
+            "healthy": None,
+            "reboot_count": 1,
+            "last_reboot_time": None,
+        }
+    ]
+
+    service = AutoRebootService(
+        database=mock_db,
+        max_attempts=3,
+        cooldown_seconds=300,
+        terraform_dir="/tmp/terraform",
+    )
+    service._check_and_reboot()
+
+    mock_reboot.assert_called_once_with("vm-1")
+    mock_db.release_assignment.assert_not_called()
 
 
 @patch.object(AutoRebootService, "_reboot_vm")


### PR DESCRIPTION
## Summary

When an assigned VM fails and is auto-rebooted, this PR preserves the student's `useremail` so they keep their VM slot across the reboot. The student reconnects by re-submitting a new Chrome Remote Desktop enrollment code — the allocator detects the existing assignment and routes the fresh CRD to their existing VM instead of picking a new one. Only when reboot attempts are exhausted does the assignment get explicitly released (so the student can be re-routed to a fresh VM).

This is PR 1 of a larger failed-VM recovery roadmap (work-preservation, heartbeat detection, and instance-recycling are separate future PRs).

## What the student experiences

**Before this PR:** assigned VM fails → auto-reboot wipes `useremail`/`crdcommand`/`pin` → student re-submits → gets routed to a different VM, loses their slot.

**After this PR:** assigned VM fails → auto-reboot preserves `useremail`, wipes only the one-shot CRD fields → student generates a new CRD code in Chrome, re-submits with the same email → reassigned to the **same VM** via an in-place UPDATE of `crdcommand`/`pin` that fires the existing `pg_notify` trigger, waking the client's `LISTEN` loop.

Work inside the container is still lost on the destructive reboot path — container preservation is PR 2's job. PR 1's goal is slot preservation.

## Changes

### Database layer (`packages/allocator/src/lablink_allocator_service/database.py`)
- **`record_reboot()`**: no longer clears `useremail`. Still clears `crdcommand`/`pin` (CRD enrollment tokens are one-shot and invalidated by reboot) and updates status/counter/timestamp.
- **`release_assignment(hostname)`** *(new)*: clears `useremail`/`crdcommand`/`pin` and sets `status='error'`. Called when reboot attempts are exhausted. Preserves `reboot_count` for diagnostics.
- **`get_assigned_vm_for_email(email)`** *(new)*: returns `{hostname, status, reboot_count}` if the email owns a VM, else `None`. Used by the request-flow handler.
- **`reassign_crd(hostname, crd_command, pin)`** *(new)*: UPDATE-only write of `crdcommand`/`pin` on an existing row. The existing Postgres trigger (`trigger_crd_command_insert_or_update`) fires `pg_notify` automatically, waking the client's `LISTEN` loop — no new transport needed.

### Auto-reboot service (`packages/allocator/src/lablink_allocator_service/reboot.py`)
- When `reboot_count >= max_attempts`, the loop now calls `release_assignment(hostname)` (wrapped in try/except for defensive logging) instead of silently skipping. Students stuck on unrecoverable VMs are freed to request a fresh one.

### Request flow (`packages/allocator/src/lablink_allocator_service/main.py`)
- `/api/request_vm` (`submit_vm_details`) refactored to branch on existing assignment:
  - No existing assignment → original fresh-assignment path (unchanged).
  - `status='running'` → `reassign_crd` + render `success.html` with same hostname.
  - `status in ('rebooting','initializing')` → `reassign_crd` (queues CRD on the row; race-condition path at `main.py:526` picks it up when the client eventually calls `/vm_startup` after recovery) + render new `recovery.html`.
  - `status='error'` → render retry message (explicitly does NOT call `reassign_crd` — writing a CRD onto a row that `release_assignment` is about to null out creates a race).
  - Unexpected status → log warning, fall through to fresh-assignment path.

## Design decisions

- **Why invert the previous approach (clear all three fields) rather than add a flag:** preserving `useremail` by default gives the right UX for the common case (reboot succeeds, student reconnects to same VM). An opt-in flag would require every caller to remember to set it. The escape hatch for the uncommon case (unrecoverable VM) is explicit and narrow (`release_assignment` from the reboot service).
- **Why `reassign_crd` is UPDATE-only and not merged with `assign_vm`:** `assign_vm` must pick a hostname, enforce the unassigned-pool invariant, and start from a clean row. `reassign_crd` must target a specific hostname and leave every other field alone. Merging them would create awkward conditionals and violate single responsibility.
- **Why queue the CRD during `rebooting`/`initializing` instead of blocking:** the existing race-condition path at `main.py:526` already handles "VM came up after the CRD was set"; reusing it is simpler than introducing a separate handshake.
- **Why the `error` branch does NOT call `reassign_crd`:** calling it would write a CRD onto a row that `release_assignment` is about to null out within one reboot-service tick. Skipping the write and rendering a retry message produces the correct end state (student's next submission lands on a freshly-assigned VM).

## Known issues tracked for follow-ups

- **Premature `status='running'` signal:** `user_data.sh:153` sends `status='running'` the instant `docker run` returns, before the container's own startup (custom-startup script, background services) completes. PR 1's reassignment flow lands in the \`running\` branch during this window and the client's `subscribe` hasn't started yet. The race-condition path at `main.py:526` eventually rescues this (client reads the queued CRD from the row on its `/vm_startup` call), but it observably delays Chrome connection. Fix planned as a small follow-up PR: move the `status='running'` signal into `start.sh` after background services launch.
- **NOTIFY-on-NULL from `record_reboot`/`release_assignment`:** setting `crdcommand = NULL` fires the CRD trigger with a NULL payload; the LISTEN loop discards it but emits a spurious \"Invalid notification payload\" warning per listening client per reboot. Not a correctness bug; `WHEN (NEW.CrdCommand IS NOT NULL)` guard on the trigger fixes it. Tracked for PR 4 in the recovery roadmap.

## Related PRs

- PR 2 (future) — keep the container alive across reboots for assigned VMs (`--restart unless-stopped` + plain `sudo reboot` path for assigned VMs).
- PR 3 (future) — persistent workspace EBS volume so work survives container recreation.
- PR 4 (future) — heartbeat / `last_seen_at` to detect silent failures the allocator currently can't see.
- PR 5 (future) — targeted instance termination and pool replenishment when a VM is truly unrecoverable.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)