### PR TITLE
refactor(cli): simplify resolve_admin_credentials and _run_ssh_command

### DIFF
--- a/packages/cli/src/lablink_cli/commands/logs.py
+++ b/packages/cli/src/lablink_cli/commands/logs.py
@@ -101,19 +101,12 @@ def fetch_client_logs(
 # ------------------------------------------------------------------
 # Log fetching — allocator VM (via SSH)
 # ------------------------------------------------------------------
-def _run_ssh_command(
+def _ssh_via_instance_connect(
     instance_id: str,
-    public_ip: str,
     region: str,
     command: str,
-    deploy_dir: Path,
 ) -> str | None:
-    """Run a command on the allocator via SSH.
-
-    Tries ec2-instance-connect first, then falls back to direct SSH
-    using the terraform private key.
-    """
-    # Attempt 1: ec2-instance-connect ssh
+    """Try SSH via ec2-instance-connect. Returns stdout or None."""
     try:
         result = subprocess.run(
             [
@@ -139,15 +132,22 @@ def _run_ssh_command(
             return result.stdout
     except (subprocess.TimeoutExpired, FileNotFoundError):
         pass
+    return None
 
-    # Attempt 2: direct SSH with terraform private key
+
+def _ssh_via_private_key(
+    public_ip: str,
+    command: str,
+    deploy_dir: Path,
+) -> str | None:
+    """Try SSH with terraform private key. Returns stdout/stderr or None."""
+    ip = public_ip if public_ip != "—" else None
+    if not ip:
+        return None
+
     outputs = get_terraform_outputs(deploy_dir)
     private_key_pem = outputs.get("private_key_pem", "")
     if not private_key_pem:
-        return None
-
-    ip = public_ip if public_ip != "—" else None
-    if not ip:
         return None
 
     key_file = None
@@ -179,12 +179,32 @@ def _run_ssh_command(
         )
         if result.returncode == 0:
             return result.stdout
-        return result.stderr or f"SSH exited with code {result.returncode}"
+        return (
+            result.stderr
+            or f"SSH exited with code {result.returncode}"
+        )
     except (subprocess.TimeoutExpired, FileNotFoundError):
         return None
     finally:
         if key_file and os.path.exists(key_file.name):
             os.unlink(key_file.name)
+
+
+def _run_ssh_command(
+    instance_id: str,
+    public_ip: str,
+    region: str,
+    command: str,
+    deploy_dir: Path,
+) -> str | None:
+    """Run a command on the allocator via SSH.
+
+    Tries ec2-instance-connect first, then falls back to direct SSH
+    using the terraform private key.
+    """
+    return _ssh_via_instance_connect(
+        instance_id, region, command
+    ) or _ssh_via_private_key(public_ip, command, deploy_dir)
 
 
 _LOG_DELIMITER = "===LABLINK_LOG_SEPARATOR==="

--- a/packages/cli/src/lablink_cli/commands/utils.py
+++ b/packages/cli/src/lablink_cli/commands/utils.py
@@ -164,6 +164,62 @@ def get_allocator_url(cfg: Config) -> str:
     return ""
 
 
+_MISSING = ("MISSING", "")
+
+
+def _resolve_from_config(
+    cfg: Config,
+) -> tuple[str, str] | None:
+    """Try to get credentials from the main config."""
+    user = cfg.app.admin_user
+    pw = cfg.app.admin_password
+    if user not in _MISSING and pw not in _MISSING:
+        return user, pw
+    return None
+
+
+def _resolve_from_deploy_dir(
+    cfg: Config,
+) -> tuple[str, str] | None:
+    """Try to get credentials from the deployment config."""
+    import yaml
+
+    deploy_config_path = (
+        get_deploy_dir(cfg) / "config" / "config.yaml"
+    )
+    if not deploy_config_path.exists():
+        return None
+
+    with open(deploy_config_path) as f:
+        deploy_cfg = yaml.safe_load(f) or {}
+
+    app_cfg = deploy_cfg.get("app", {})
+    user = app_cfg.get("admin_user", "")
+    pw = app_cfg.get("admin_password", "")
+
+    if user and user not in _MISSING and pw and pw not in _MISSING:
+        return user, pw
+    return None
+
+
+def _resolve_from_prompt() -> tuple[str, str]:
+    """Prompt the user for admin credentials."""
+    import getpass
+
+    admin_user = (
+        input("  Admin username [admin]: ").strip()
+        or "admin"
+    )
+    admin_pw = getpass.getpass("  Admin password: ")
+    if not admin_pw:
+        console.print(
+            "  [red]Admin password is required[/red]"
+        )
+        raise SystemExit(1)
+    console.print()
+    return admin_user, admin_pw
+
+
 def resolve_admin_credentials(
     cfg: Config,
 ) -> tuple[str, str]:
@@ -176,40 +232,8 @@ def resolve_admin_credentials(
 
     Returns ``(admin_user, admin_password)``.
     """
-    import getpass
-
-    import yaml
-
-    admin_user = cfg.app.admin_user
-    admin_pw = cfg.app.admin_password
-
-    deploy_config_path = (
-        get_deploy_dir(cfg) / "config" / "config.yaml"
+    return (
+        _resolve_from_config(cfg)
+        or _resolve_from_deploy_dir(cfg)
+        or _resolve_from_prompt()
     )
-    if (
-        admin_user in ("MISSING", "")
-        or admin_pw in ("MISSING", "")
-    ) and deploy_config_path.exists():
-        with open(deploy_config_path) as f:
-            deploy_cfg = yaml.safe_load(f) or {}
-        app_cfg = deploy_cfg.get("app", {})
-        if admin_user in ("MISSING", ""):
-            admin_user = app_cfg.get("admin_user", "")
-        if admin_pw in ("MISSING", ""):
-            admin_pw = app_cfg.get("admin_password", "")
-
-    if admin_user in ("MISSING", ""):
-        admin_user = (
-            input("  Admin username [admin]: ").strip()
-            or "admin"
-        )
-    if admin_pw in ("MISSING", ""):
-        admin_pw = getpass.getpass("  Admin password: ")
-        if not admin_pw:
-            console.print(
-                "  [red]Admin password is required[/red]"
-            )
-            raise SystemExit(1)
-        console.print()
-
-    return admin_user, admin_pw

--- a/packages/cli/tests/test_logs.py
+++ b/packages/cli/tests/test_logs.py
@@ -1,0 +1,116 @@
+"""Tests for lablink_cli.commands.logs SSH helpers."""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from lablink_cli.commands.logs import (
+    _ssh_via_instance_connect,
+    _ssh_via_private_key,
+)
+
+
+class TestSshViaInstanceConnect:
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    def test_success(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="log output"
+        )
+        result = _ssh_via_instance_connect(
+            "i-123", "us-east-1", "echo hello"
+        )
+        assert result == "log output"
+        mock_run.assert_called_once()
+
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    def test_nonzero_exit_returns_none(self, mock_run):
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="error"
+        )
+        result = _ssh_via_instance_connect(
+            "i-123", "us-east-1", "echo hello"
+        )
+        assert result is None
+
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    def test_timeout_returns_none(self, mock_run):
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd="ssh", timeout=30
+        )
+        result = _ssh_via_instance_connect(
+            "i-123", "us-east-1", "echo hello"
+        )
+        assert result is None
+
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    def test_file_not_found_returns_none(self, mock_run):
+        mock_run.side_effect = FileNotFoundError("aws not found")
+        result = _ssh_via_instance_connect(
+            "i-123", "us-east-1", "echo hello"
+        )
+        assert result is None
+
+
+class TestSshViaPrivateKey:
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    @patch("lablink_cli.commands.logs.get_terraform_outputs")
+    def test_success(self, mock_outputs, mock_run, tmp_path):
+        mock_outputs.return_value = {
+            "private_key_pem": "-----BEGIN RSA PRIVATE KEY-----\n"
+            "fake\n"
+            "-----END RSA PRIVATE KEY-----"
+        }
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="log output"
+        )
+        result = _ssh_via_private_key(
+            "1.2.3.4", "echo hello", tmp_path
+        )
+        assert result == "log output"
+
+    @patch("lablink_cli.commands.logs.get_terraform_outputs")
+    def test_no_private_key_returns_none(self, mock_outputs, tmp_path):
+        mock_outputs.return_value = {}
+        result = _ssh_via_private_key(
+            "1.2.3.4", "echo hello", tmp_path
+        )
+        assert result is None
+
+    def test_no_ip_returns_none(self, tmp_path):
+        result = _ssh_via_private_key(
+            "\u2014", "echo hello", tmp_path
+        )
+        assert result is None
+
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    @patch("lablink_cli.commands.logs.get_terraform_outputs")
+    def test_nonzero_exit_returns_stderr(self, mock_outputs, mock_run, tmp_path):
+        mock_outputs.return_value = {
+            "private_key_pem": "-----BEGIN RSA PRIVATE KEY-----\n"
+            "fake\n"
+            "-----END RSA PRIVATE KEY-----"
+        }
+        mock_run.return_value = MagicMock(
+            returncode=1, stdout="", stderr="connection refused"
+        )
+        result = _ssh_via_private_key(
+            "1.2.3.4", "echo hello", tmp_path
+        )
+        assert "connection refused" in result
+
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    @patch("lablink_cli.commands.logs.get_terraform_outputs")
+    def test_timeout_returns_none(self, mock_outputs, mock_run, tmp_path):
+        mock_outputs.return_value = {
+            "private_key_pem": "-----BEGIN RSA PRIVATE KEY-----\n"
+            "fake\n"
+            "-----END RSA PRIVATE KEY-----"
+        }
+        mock_run.side_effect = subprocess.TimeoutExpired(
+            cmd="ssh", timeout=30
+        )
+        result = _ssh_via_private_key(
+            "1.2.3.4", "echo hello", tmp_path
+        )
+        assert result is None

--- a/packages/cli/tests/test_utils_full.py
+++ b/packages/cli/tests/test_utils_full.py
@@ -8,6 +8,8 @@ import pytest
 import yaml
 
 from lablink_cli.commands.utils import (
+    _resolve_from_config,
+    _resolve_from_deploy_dir,
     get_allocator_url,
     get_deploy_dir,
     resolve_admin_credentials,
@@ -157,3 +159,59 @@ class TestResolveAdminCredentials:
             mock_dir.return_value = tmp_path / "nonexistent"
             with pytest.raises(SystemExit):
                 resolve_admin_credentials(mock_cfg)
+
+
+# ------------------------------------------------------------------
+# _resolve_from_config
+# ------------------------------------------------------------------
+class TestResolveFromConfig:
+    def test_returns_credentials(self, mock_cfg):
+        mock_cfg.app.admin_user = "myuser"
+        mock_cfg.app.admin_password = "mypass"
+        result = _resolve_from_config(mock_cfg)
+        assert result == ("myuser", "mypass")
+
+    def test_returns_none_when_missing(self, mock_cfg):
+        mock_cfg.app.admin_user = "MISSING"
+        mock_cfg.app.admin_password = "MISSING"
+        result = _resolve_from_config(mock_cfg)
+        assert result is None
+
+    def test_returns_none_when_empty(self, mock_cfg):
+        mock_cfg.app.admin_user = ""
+        mock_cfg.app.admin_password = ""
+        result = _resolve_from_config(mock_cfg)
+        assert result is None
+
+    def test_returns_none_when_partial(self, mock_cfg):
+        mock_cfg.app.admin_user = "myuser"
+        mock_cfg.app.admin_password = "MISSING"
+        result = _resolve_from_config(mock_cfg)
+        assert result is None
+
+
+class TestResolveFromDeployDir:
+    def test_returns_credentials(self, mock_cfg, tmp_path):
+        deploy_config = tmp_path / "config" / "config.yaml"
+        deploy_config.parent.mkdir(parents=True)
+        data = {"app": {"admin_user": "deploy-user", "admin_password": "deploy-pw"}}
+        deploy_config.write_text(yaml.dump(data))
+        with patch("lablink_cli.commands.utils.get_deploy_dir") as mock_dir:
+            mock_dir.return_value = tmp_path
+            result = _resolve_from_deploy_dir(mock_cfg)
+        assert result == ("deploy-user", "deploy-pw")
+
+    def test_returns_none_when_no_deploy_dir(self, mock_cfg, tmp_path):
+        with patch("lablink_cli.commands.utils.get_deploy_dir") as mock_dir:
+            mock_dir.return_value = tmp_path / "nonexistent"
+            result = _resolve_from_deploy_dir(mock_cfg)
+        assert result is None
+
+    def test_returns_none_when_missing_keys(self, mock_cfg, tmp_path):
+        deploy_config = tmp_path / "config" / "config.yaml"
+        deploy_config.parent.mkdir(parents=True)
+        deploy_config.write_text(yaml.dump({"app": {}}))
+        with patch("lablink_cli.commands.utils.get_deploy_dir") as mock_dir:
+            mock_dir.return_value = tmp_path
+            result = _resolve_from_deploy_dir(mock_cfg)
+        assert result is None


### PR DESCRIPTION
## Summary

- Refactor `resolve_admin_credentials` (CC=11→2) with chain-of-resolvers pattern
- Refactor `_run_ssh_command` (CC=11→1) by extracting per-method SSH helpers
- Reduces C-grade functions in CLI from 3 to 1

## Changes Made

### `commands/utils.py`
- Extracted `_resolve_from_config(cfg)` — returns credentials from main config or `None`
- Extracted `_resolve_from_deploy_dir(cfg)` — returns credentials from deploy config YAML or `None`
- Extracted `_resolve_from_prompt()` — interactive prompt fallback
- `resolve_admin_credentials` is now a one-liner: `_resolve_from_config(cfg) or _resolve_from_deploy_dir(cfg) or _resolve_from_prompt()`

### `commands/logs.py`
- Extracted `_ssh_via_instance_connect(instance_id, region, command)` — tries ec2-instance-connect SSH
- Extracted `_ssh_via_private_key(public_ip, command, deploy_dir)` — tries direct SSH with terraform key
- `_run_ssh_command` is now a one-liner chaining both helpers

### New tests
- `test_utils_full.py` — 7 new tests for `_resolve_from_config` and `_resolve_from_deploy_dir`
- `test_logs.py` — 9 new tests for `_ssh_via_instance_connect` and `_ssh_via_private_key`

## Testing

- 237 tests pass, 1 deselected (integration test)
- All existing tests continue to pass unchanged
- Ruff linting clean

## Metrics

| Function | CC Before | CC After |
|----------|-----------|----------|
| `resolve_admin_credentials` | 11 (C) | 2 (A) |
| `_run_ssh_command` | 11 (C) | 1 (A) |
| **C-grade functions remaining** | **3** | **1** (`_prepare_working_dir`) |

## Related

- Follows PR #315 which addressed the two worst offenders (`run_status` CC=27, `run_destroy` CC=17)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)