### PR TITLE
feat: warm reboot for assigned VMs to preserve container state

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -1285,7 +1285,7 @@ class PostgresqlDatabase:
 
         Returns:
             list: VMs eligible for reboot with hostname, status, healthy,
-                  reboot_count, and last_reboot_time.
+                  reboot_count, last_reboot_time, and useremail.
         """
         init_minutes = int(stale_initializing_minutes)
         reboot_minutes = int(stale_rebooting_minutes)

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -1292,7 +1292,7 @@ class PostgresqlDatabase:
         query = f"""
             SELECT hostname, status, healthy,
                    COALESCE(reboot_count, 0) as reboot_count,
-                   last_reboot_time
+                   last_reboot_time, useremail
             FROM {self.table_name}
             WHERE status = 'error'
                OR (healthy = 'Unhealthy'
@@ -1317,6 +1317,7 @@ class PostgresqlDatabase:
                     "healthy": row[2],
                     "reboot_count": row[3],
                     "last_reboot_time": row[4],
+                    "useremail": row[5],
                 }
                 for row in rows
             ]

--- a/packages/allocator/src/lablink_allocator_service/reboot.py
+++ b/packages/allocator/src/lablink_allocator_service/reboot.py
@@ -1,7 +1,13 @@
 """Automated VM reboot service.
 
-Periodically checks for failed VMs and reboots them via SSH hard reboot
-(cloud-init clean + reboot) with stop/start fallback.
+Periodically checks for failed VMs and reboots them.
+
+Assigned VMs get a warm reboot (plain ``sudo reboot``) so the container
+survives via its ``--restart unless-stopped`` policy. Unassigned VMs get
+a cold reboot (``cloud-init clean && sudo reboot``) that recreates the
+container from scratch. Both paths fall back to EC2 stop/start (always
+cold) when SSH is unavailable.
+
 Respects cooldown periods and maximum reboot attempt limits.
 """
 
@@ -119,17 +125,19 @@ class AutoRebootService:
                     )
                     continue
 
-            self._reboot_vm(hostname)
+            assigned = vm.get("useremail") is not None
+            self._reboot_vm(hostname, assigned=assigned)
 
-    def _ssh_hard_reboot(self, ip: str, key_path: str) -> bool:
-        """Perform a hard reboot via SSH (cloud-init clean + reboot).
+    def _ssh_reboot(self, ip: str, key_path: str, command: str) -> bool:
+        """Send a reboot command to a VM via SSH.
 
         Args:
             ip: The public IP address of the instance.
             key_path: Path to the SSH private key file.
+            command: The shell command to execute (e.g. "sudo reboot").
 
         Returns:
-            True if the SSH reboot command was sent successfully, False otherwise.
+            True if the SSH command was sent successfully, False otherwise.
         """
         cmd = [
             "ssh",
@@ -137,7 +145,7 @@ class AutoRebootService:
             "-o", "ConnectTimeout=10",
             "-i", key_path,
             f"ubuntu@{ip}",
-            "sudo cloud-init clean && sudo reboot",
+            command,
         ]
         try:
             result = subprocess.run(
@@ -145,35 +153,61 @@ class AutoRebootService:
             )
             # Exit code 0 = success, 255 = connection reset by reboot (expected)
             if result.returncode in (0, 255):
-                logger.info(f"SSH hard reboot sent to {ip}")
+                logger.info(f"SSH reboot sent to {ip}: {command}")
                 return True
             logger.warning(
-                f"SSH hard reboot to {ip} returned exit code {result.returncode}: "
+                f"SSH reboot to {ip} returned exit code {result.returncode}: "
                 f"{result.stderr.strip()}"
             )
             return False
         except subprocess.TimeoutExpired:
-            logger.warning(f"SSH hard reboot to {ip} timed out")
+            logger.warning(f"SSH reboot to {ip} timed out")
             return False
         except Exception as e:
-            logger.error(f"SSH hard reboot to {ip} failed: {e}")
+            logger.error(f"SSH reboot to {ip} failed: {e}")
             return False
 
-    def _reboot_vm(self, hostname: str) -> bool:
+    def _ssh_cold_reboot(self, ip: str, key_path: str) -> bool:
+        """Cold reboot: wipe cloud-init state so user_data re-runs.
+
+        Used for unassigned VMs where we want a fresh container.
+        """
+        return self._ssh_reboot(
+            ip, key_path, "sudo cloud-init clean && sudo reboot"
+        )
+
+    def _ssh_warm_reboot(self, ip: str, key_path: str) -> bool:
+        """Warm reboot: plain OS reboot, container survives via restart policy.
+
+        Used for assigned VMs to preserve the student's container state.
+        cloud-init is NOT cleaned, so user_data does not re-run and the
+        existing container (with --restart unless-stopped) auto-starts
+        when the Docker daemon comes back.
+        """
+        return self._ssh_reboot(ip, key_path, "sudo reboot")
+
+    def _reboot_vm(self, hostname: str, assigned: bool = False) -> bool:
         """Reboot a single VM by hostname.
 
         Tries two methods in order:
-        1. SSH hard reboot (cloud-init clean + reboot)
-        2. Stop/start — last resort, relies on per-boot cloud-init
-           config to re-run user_data
+        1. SSH reboot — warm (plain reboot) for assigned VMs to preserve
+           the container, cold (cloud-init clean + reboot) for unassigned.
+        2. Stop/start — last resort. Always a cold reboot because
+           cloud-init re-runs user_data on the next boot.
 
         Args:
             hostname: The VM hostname (matches EC2 Name tag).
+            assigned: True if the VM has a student assigned (useremail set).
+                Assigned VMs get a warm reboot to preserve the container.
 
         Returns:
             True if reboot was initiated, False otherwise.
         """
-        logger.info(f"Attempting to reboot VM '{hostname}'")
+        reboot_type = "warm" if assigned else "cold"
+        logger.info(
+            f"Attempting {reboot_type} reboot for VM '{hostname}' "
+            f"(assigned={assigned})"
+        )
 
         # Look up EC2 instance ID by hostname (Name tag)
         instance_id = get_instance_id_by_name(
@@ -186,29 +220,33 @@ class AutoRebootService:
             )
             return False
 
-        # 1) Try SSH hard reboot
+        # 1) Try SSH reboot (warm or cold depending on assignment)
         ip = get_instance_public_ip(
             instance_id, region=self.region
         )
         if ip and self.terraform_dir:
             try:
                 key_path = get_ssh_private_key(self.terraform_dir)
-                if self._ssh_hard_reboot(ip, key_path):
+                ssh_reboot = (
+                    self._ssh_warm_reboot if assigned
+                    else self._ssh_cold_reboot
+                )
+                if ssh_reboot(ip, key_path):
                     self.database.record_reboot(hostname)
                     logger.info(
-                        f"SSH hard reboot initiated for VM "
+                        f"SSH {reboot_type} reboot initiated for VM "
                         f"'{hostname}' ({instance_id})"
                     )
                     return True
             except Exception as e:
                 logger.warning(
-                    f"Could not get SSH key for hard reboot: {e}"
+                    f"Could not get SSH key for reboot: {e}"
                 )
 
-        # 2) Last resort: stop/start
+        # 2) Last resort: stop/start (always cold — cloud-init re-runs)
         logger.info(
             f"SSH unavailable for VM '{hostname}', falling back "
-            f"to stop/start"
+            f"to stop/start (cold reboot)"
         )
         success = stop_start_ec2_instance(
             instance_id, region=self.region

--- a/packages/allocator/src/lablink_allocator_service/reboot.py
+++ b/packages/allocator/src/lablink_allocator_service/reboot.py
@@ -168,12 +168,21 @@ class AutoRebootService:
             return False
 
     def _ssh_cold_reboot(self, ip: str, key_path: str) -> bool:
-        """Cold reboot: wipe cloud-init state so user_data re-runs.
+        """Cold reboot: destroy container, wipe cloud-init state, reboot.
 
-        Used for unassigned VMs where we want a fresh container.
+        Used for unassigned VMs where we want a fresh container. The
+        explicit ``docker rm -f`` ensures the container is gone before
+        reboot, so the warm-reboot idempotence guard in ``user_data.sh``
+        falls through to full provisioning on the next boot rather than
+        no-op'ing. ``xargs -r`` skips the rm entirely when no containers
+        exist, and ``;`` (not ``&&``) lets cloud-init clean + reboot
+        proceed even if rm fails.
         """
         return self._ssh_reboot(
-            ip, key_path, "sudo cloud-init clean && sudo reboot"
+            ip,
+            key_path,
+            "sudo docker ps -aq | sudo xargs -r docker rm -f; "
+            "sudo cloud-init clean && sudo reboot",
         )
 
     def _ssh_warm_reboot(self, ip: str, key_path: str) -> bool:

--- a/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
+++ b/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
@@ -139,7 +139,7 @@ if [ -n "$EXISTING" ]; then
 fi
 
 echo ">> Starting container..."
-if docker run -dit $DOCKER_GPU_ARGS \
+if docker run -dit --restart unless-stopped $DOCKER_GPU_ARGS \
     --mount type=bind,src=/etc/config,dst=/docker_scripts/,ro \
     -e ALLOCATOR_HOST="${allocator_ip}" \
     -e ALLOCATOR_URL="${allocator_url}" \

--- a/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
+++ b/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
@@ -1,22 +1,6 @@
 #!/bin/bash
 set -Eeuo pipefail
 
-# --- Warm-reboot idempotence guard ---
-# If a container for our image already exists on this host, provisioning
-# already completed on a prior boot. Docker's --restart unless-stopped
-# policy will resume the container automatically — running user_data.sh
-# again would destroy the student's writable layer (including the CRD
-# host registration in /home/client/.config/chrome-remote-desktop/).
-#
-# The cold-reboot path in the allocator's reboot service explicitly runs
-# `docker rm -f` before `cloud-init clean && reboot`, so reaching this
-# point with an existing container unambiguously means a warm re-run.
-if docker ps -a --filter "ancestor=${image_name}" -q 2>/dev/null | grep -q .; then
-    echo ">> Existing container for image ${image_name} detected."
-    echo ">> Warm reboot — skipping provisioning; restart policy handles the container."
-    exit 0
-fi
-
 # Start time
 CLOUD_INIT_START_TIME=$(date +%s)
 
@@ -64,6 +48,26 @@ nohup /usr/local/bin/log_shipper.sh "$CLOUD_INIT_LOG" "$ALLOCATOR_URL" "$VM_NAME
     >> /var/log/log_shipper.log 2>&1 &
 LOG_SHIPPER_CLOUD_INIT_PID=$!
 echo ">> Log shipper started (PID: $LOG_SHIPPER_CLOUD_INIT_PID)"
+
+# --- Warm-reboot idempotence guard ---
+# If a container for our image already exists, provisioning already
+# completed on a prior boot. Restart the docker log shipper (killed by
+# the OS reboot, like the cloud-init shipper started above) and skip
+# the rest — Docker's --restart unless-stopped resumes the container
+# with its writable layer intact (student work, CRD host registration).
+#
+# The cold-reboot path in the allocator's reboot service explicitly runs
+# `docker rm -f` before `cloud-init clean && reboot`, so reaching this
+# point with an existing container unambiguously means a warm re-run.
+EXISTING_CONTAINER=$(docker ps -a --filter "ancestor=${image_name}" -q 2>/dev/null | head -n 1 || true)
+if [ -n "$EXISTING_CONTAINER" ]; then
+    echo ">> Existing container detected: $EXISTING_CONTAINER"
+    echo ">> Warm reboot — restarting docker log shipper and skipping provisioning."
+    nohup /usr/local/bin/log_shipper.sh "docker:$EXISTING_CONTAINER" "$ALLOCATOR_URL" "$VM_NAME" "$LOG_GROUP-docker" "$API_TOKEN" \
+        >> /var/log/log_shipper.log 2>&1 &
+    echo ">> Docker log shipper started (PID: $!)"
+    exit 0
+fi
 
 echo ">> Checking GPU Support…"
 

--- a/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
+++ b/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
@@ -1,6 +1,22 @@
 #!/bin/bash
 set -Eeuo pipefail
 
+# --- Warm-reboot idempotence guard ---
+# If a container for our image already exists on this host, provisioning
+# already completed on a prior boot. Docker's --restart unless-stopped
+# policy will resume the container automatically — running user_data.sh
+# again would destroy the student's writable layer (including the CRD
+# host registration in /home/client/.config/chrome-remote-desktop/).
+#
+# The cold-reboot path in the allocator's reboot service explicitly runs
+# `docker rm -f` before `cloud-init clean && reboot`, so reaching this
+# point with an existing container unambiguously means a warm re-run.
+if docker ps -a --filter "ancestor=${image_name}" -q 2>/dev/null | grep -q .; then
+    echo ">> Existing container for image ${image_name} detected."
+    echo ">> Warm reboot — skipping provisioning; restart policy handles the container."
+    exit 0
+fi
+
 # Start time
 CLOUD_INIT_START_TIME=$(date +%s)
 

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -764,3 +764,109 @@ def test_check_and_reboot_passes_assigned_false_for_unassigned_vm(mock_reboot):
     service._check_and_reboot()
 
     mock_reboot.assert_called_once_with("vm-1", assigned=False)
+
+
+def test_reboot_vm_ssh_fails_stop_start_assigned_falls_back(monkeypatch):
+    """Assigned VM: SSH warm reboot fails, stop/start fallback still fires.
+
+    Documents that stop/start is invoked regardless of assignment state.
+    The "stop/start is always cold" semantic refers to post-boot behavior
+    (cloud-init re-runs user_data), not to whether fallback triggers.
+    """
+    monkeypatch.setattr(
+        reboot_mod, "get_instance_id_by_name", lambda *a, **kw: "i-12345"
+    )
+    monkeypatch.setattr(
+        reboot_mod, "get_instance_public_ip", lambda *a, **kw: "1.2.3.4"
+    )
+    monkeypatch.setattr(
+        reboot_mod, "get_ssh_private_key", lambda *a, **kw: "/tmp/key.pem"
+    )
+    mock_stop_start = MagicMock(return_value=True)
+    monkeypatch.setattr(reboot_mod, "stop_start_ec2_instance", mock_stop_start)
+
+    mock_db = MagicMock()
+    service = AutoRebootService(
+        database=mock_db,
+        region="us-west-2",
+        terraform_dir="/tmp/terraform",
+    )
+
+    # SSH fails with a non-zero, non-255 exit code
+    mock_run = MagicMock()
+    mock_run.return_value.returncode = 1
+    mock_run.return_value.stderr = "Connection refused"
+    monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
+
+    result = service._reboot_vm("vm-1", assigned=True)
+
+    assert result is True
+    # SSH attempt was the warm path (sudo reboot, no cloud-init clean)
+    cmd = mock_run.call_args[0][0]
+    assert cmd[-1] == "sudo reboot"
+    # Stop/start was invoked as fallback
+    mock_stop_start.assert_called_once_with("i-12345", region="us-west-2")
+    mock_db.record_reboot.assert_called_once_with("vm-1")
+
+
+def test_reboot_vm_no_ip_assigned_falls_back_to_stop_start(monkeypatch):
+    """Assigned VM with no public IP skips SSH and goes straight to stop/start."""
+    monkeypatch.setattr(
+        reboot_mod, "get_instance_id_by_name", lambda *a, **kw: "i-12345"
+    )
+    monkeypatch.setattr(
+        reboot_mod, "get_instance_public_ip", lambda *a, **kw: None
+    )
+    mock_stop_start = MagicMock(return_value=True)
+    monkeypatch.setattr(reboot_mod, "stop_start_ec2_instance", mock_stop_start)
+
+    # Guard: subprocess.run must NOT be called (no SSH attempt without IP)
+    mock_run = MagicMock()
+    monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
+
+    mock_db = MagicMock()
+    service = AutoRebootService(
+        database=mock_db,
+        region="us-west-2",
+        terraform_dir="/tmp/terraform",
+    )
+
+    result = service._reboot_vm("vm-1", assigned=True)
+
+    assert result is True
+    mock_run.assert_not_called()
+    mock_stop_start.assert_called_once_with("i-12345", region="us-west-2")
+    mock_db.record_reboot.assert_called_once_with("vm-1")
+
+
+def test_reboot_vm_all_methods_fail_assigned(monkeypatch):
+    """Assigned VM: when SSH and stop/start both fail, no reboot recorded."""
+    monkeypatch.setattr(
+        reboot_mod, "get_instance_id_by_name", lambda *a, **kw: "i-12345"
+    )
+    monkeypatch.setattr(
+        reboot_mod, "get_instance_public_ip", lambda *a, **kw: "1.2.3.4"
+    )
+    monkeypatch.setattr(
+        reboot_mod, "get_ssh_private_key", lambda *a, **kw: "/tmp/key.pem"
+    )
+    mock_stop_start = MagicMock(return_value=False)
+    monkeypatch.setattr(reboot_mod, "stop_start_ec2_instance", mock_stop_start)
+
+    mock_db = MagicMock()
+    service = AutoRebootService(
+        database=mock_db,
+        region="us-west-2",
+        terraform_dir="/tmp/terraform",
+    )
+
+    mock_run = MagicMock()
+    mock_run.return_value.returncode = 1
+    mock_run.return_value.stderr = "Connection refused"
+    monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
+
+    result = service._reboot_vm("vm-1", assigned=True)
+
+    assert result is False
+    mock_stop_start.assert_called_once_with("i-12345", region="us-west-2")
+    mock_db.record_reboot.assert_not_called()

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -57,8 +57,8 @@ def test_update_vm_status_rebooting(db_instance):
 def test_get_failed_vms(db_instance):
     """Test retrieving failed VMs."""
     db_instance.cursor.fetchall.return_value = [
-        ("vm-1", "error", None, 0, None),
-        ("vm-2", "running", "Unhealthy", 1, datetime(2025, 1, 1)),
+        ("vm-1", "error", None, 0, None, None),
+        ("vm-2", "running", "Unhealthy", 1, datetime(2025, 1, 1), "user@test.com"),
     ]
 
     result = db_instance.get_failed_vms()
@@ -70,6 +70,19 @@ def test_get_failed_vms(db_instance):
     assert result[1]["hostname"] == "vm-2"
     assert result[1]["healthy"] == "Unhealthy"
     assert result[1]["reboot_count"] == 1
+
+
+def test_get_failed_vms_includes_useremail(db_instance):
+    """Test that get_failed_vms returns useremail for assignment-aware reboot."""
+    db_instance.cursor.fetchall.return_value = [
+        ("vm-assigned", "error", None, 1, None, "student@example.com"),
+        ("vm-unassigned", "error", None, 0, None, None),
+    ]
+
+    result = db_instance.get_failed_vms()
+
+    assert result[0]["useremail"] == "student@example.com"
+    assert result[1]["useremail"] is None
 
 
 def test_get_failed_vms_empty(db_instance):
@@ -90,7 +103,7 @@ def test_get_failed_vms_error(db_instance, caplog):
 def test_get_failed_vms_includes_stale_initializing(db_instance):
     """Test that stale initializing VMs are included in failed VMs query."""
     db_instance.cursor.fetchall.return_value = [
-        ("vm-stale", "initializing", None, 0, None),
+        ("vm-stale", "initializing", None, 0, None, None),
     ]
 
     result = db_instance.get_failed_vms(stale_initializing_minutes=15)
@@ -125,7 +138,7 @@ def test_get_failed_vms_default_stale_initializing_is_25_minutes(db_instance):
 def test_get_failed_vms_includes_stuck_rebooting(db_instance):
     """Test that VMs stuck in rebooting state are re-eligible."""
     db_instance.cursor.fetchall.return_value = [
-        ("vm-stuck", "rebooting", None, 1, datetime(2025, 1, 1)),
+        ("vm-stuck", "rebooting", None, 1, datetime(2025, 1, 1), None),
     ]
 
     result = db_instance.get_failed_vms(stale_rebooting_minutes=10)
@@ -227,8 +240,8 @@ def test_ensure_reboot_columns(db_instance):
 # --- AutoRebootService tests ---
 
 
-def test_ssh_hard_reboot_success(monkeypatch):
-    """Test successful SSH hard reboot."""
+def test_ssh_cold_reboot_success(monkeypatch):
+    """Test successful SSH cold reboot."""
     mock_db = MagicMock()
     service = AutoRebootService(
         database=mock_db,
@@ -240,7 +253,7 @@ def test_ssh_hard_reboot_success(monkeypatch):
     mock_run.return_value.returncode = 0
     monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
 
-    result = service._ssh_hard_reboot("1.2.3.4", "/tmp/key.pem")
+    result = service._ssh_cold_reboot("1.2.3.4", "/tmp/key.pem")
 
     assert result is True
     mock_run.assert_called_once()
@@ -250,8 +263,8 @@ def test_ssh_hard_reboot_success(monkeypatch):
     assert "sudo cloud-init clean && sudo reboot" in cmd
 
 
-def test_ssh_hard_reboot_exit_255(monkeypatch):
-    """Test SSH hard reboot with exit code 255 (connection reset by reboot)."""
+def test_ssh_cold_reboot_exit_255(monkeypatch):
+    """Test SSH cold reboot with exit code 255 (connection reset by reboot)."""
     mock_db = MagicMock()
     service = AutoRebootService(
         database=mock_db,
@@ -262,12 +275,12 @@ def test_ssh_hard_reboot_exit_255(monkeypatch):
     mock_run.return_value.returncode = 255
     monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
 
-    result = service._ssh_hard_reboot("1.2.3.4", "/tmp/key.pem")
+    result = service._ssh_cold_reboot("1.2.3.4", "/tmp/key.pem")
     assert result is True
 
 
-def test_ssh_hard_reboot_timeout(monkeypatch):
-    """Test SSH hard reboot timeout."""
+def test_ssh_cold_reboot_timeout(monkeypatch):
+    """Test SSH cold reboot timeout."""
     import subprocess
 
     mock_db = MagicMock()
@@ -279,12 +292,12 @@ def test_ssh_hard_reboot_timeout(monkeypatch):
     mock_run = MagicMock(side_effect=subprocess.TimeoutExpired("ssh", 30))
     monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
 
-    result = service._ssh_hard_reboot("1.2.3.4", "/tmp/key.pem")
+    result = service._ssh_cold_reboot("1.2.3.4", "/tmp/key.pem")
     assert result is False
 
 
-def test_ssh_hard_reboot_failure(monkeypatch):
-    """Test SSH hard reboot with non-zero exit code."""
+def test_ssh_cold_reboot_failure(monkeypatch):
+    """Test SSH cold reboot with non-zero exit code."""
     mock_db = MagicMock()
     service = AutoRebootService(
         database=mock_db,
@@ -296,8 +309,48 @@ def test_ssh_hard_reboot_failure(monkeypatch):
     mock_run.return_value.stderr = "Connection refused"
     monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
 
-    result = service._ssh_hard_reboot("1.2.3.4", "/tmp/key.pem")
+    result = service._ssh_cold_reboot("1.2.3.4", "/tmp/key.pem")
     assert result is False
+
+
+def test_ssh_warm_reboot_success(monkeypatch):
+    """Test warm reboot sends 'sudo reboot' without cloud-init clean."""
+    mock_db = MagicMock()
+    service = AutoRebootService(
+        database=mock_db,
+        region="us-west-2",
+        terraform_dir="/tmp/terraform",
+    )
+
+    mock_run = MagicMock()
+    mock_run.return_value.returncode = 0
+    monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
+
+    result = service._ssh_warm_reboot("1.2.3.4", "/tmp/key.pem")
+
+    assert result is True
+    cmd = mock_run.call_args[0][0]
+    assert "ubuntu@1.2.3.4" in cmd
+    assert cmd[-1] == "sudo reboot"
+
+
+def test_ssh_warm_reboot_does_not_clean_cloud_init(monkeypatch):
+    """Warm reboot must NOT run cloud-init clean (container would be destroyed)."""
+    mock_db = MagicMock()
+    service = AutoRebootService(
+        database=mock_db,
+        terraform_dir="/tmp/terraform",
+    )
+
+    mock_run = MagicMock()
+    mock_run.return_value.returncode = 0
+    monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
+
+    service._ssh_warm_reboot("1.2.3.4", "/tmp/key.pem")
+
+    cmd = mock_run.call_args[0][0]
+    full_cmd = " ".join(cmd)
+    assert "cloud-init clean" not in full_cmd
 
 
 def test_reboot_vm_ssh_success(monkeypatch):
@@ -317,7 +370,7 @@ def test_reboot_vm_ssh_success(monkeypatch):
     mock_run.return_value.returncode = 0
     monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
 
-    result = service._reboot_vm("vm-1")
+    result = service._reboot_vm("vm-1", assigned=False)
 
     assert result is True
     mock_db.record_reboot.assert_called_once_with("vm-1")
@@ -343,7 +396,7 @@ def test_reboot_vm_ssh_fails_stop_start_succeeds(monkeypatch):
     mock_run.return_value.stderr = "Connection refused"
     monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
 
-    result = service._reboot_vm("vm-1")
+    result = service._reboot_vm("vm-1", assigned=False)
 
     assert result is True
     mock_db.record_reboot.assert_called_once_with("vm-1")
@@ -362,7 +415,7 @@ def test_reboot_vm_no_ip_stop_start_succeeds(monkeypatch):
         terraform_dir="/tmp/terraform",
     )
 
-    result = service._reboot_vm("vm-1")
+    result = service._reboot_vm("vm-1", assigned=False)
 
     assert result is True
     mock_db.record_reboot.assert_called_once_with("vm-1")
@@ -388,7 +441,7 @@ def test_reboot_vm_all_methods_fail(monkeypatch):
     mock_run.return_value.stderr = "Connection refused"
     monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
 
-    result = service._reboot_vm("vm-1")
+    result = service._reboot_vm("vm-1", assigned=False)
 
     assert result is False
     mock_db.record_reboot.assert_not_called()
@@ -405,10 +458,61 @@ def test_reboot_vm_instance_not_found(monkeypatch):
         terraform_dir="/tmp/terraform",
     )
 
-    result = service._reboot_vm("vm-nonexistent")
+    result = service._reboot_vm("vm-nonexistent", assigned=False)
 
     assert result is False
     mock_db.record_reboot.assert_not_called()
+
+
+def test_reboot_vm_uses_warm_reboot_for_assigned_vm(monkeypatch):
+    """Assigned VMs (useremail set) get warm reboot to preserve container."""
+    monkeypatch.setattr(reboot_mod, "get_instance_id_by_name", lambda *a, **kw: "i-12345")
+    monkeypatch.setattr(reboot_mod, "get_instance_public_ip", lambda *a, **kw: "1.2.3.4")
+    monkeypatch.setattr(reboot_mod, "get_ssh_private_key", lambda *a, **kw: "/tmp/key.pem")
+
+    mock_db = MagicMock()
+    service = AutoRebootService(
+        database=mock_db,
+        region="us-west-2",
+        terraform_dir="/tmp/terraform",
+    )
+
+    mock_run = MagicMock()
+    mock_run.return_value.returncode = 0
+    monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
+
+    result = service._reboot_vm("vm-1", assigned=True)
+
+    assert result is True
+    cmd = mock_run.call_args[0][0]
+    assert cmd[-1] == "sudo reboot"
+    assert "cloud-init clean" not in " ".join(cmd)
+    mock_db.record_reboot.assert_called_once_with("vm-1")
+
+
+def test_reboot_vm_uses_cold_reboot_for_unassigned_vm(monkeypatch):
+    """Unassigned VMs (no useremail) get cold reboot with cloud-init clean."""
+    monkeypatch.setattr(reboot_mod, "get_instance_id_by_name", lambda *a, **kw: "i-12345")
+    monkeypatch.setattr(reboot_mod, "get_instance_public_ip", lambda *a, **kw: "1.2.3.4")
+    monkeypatch.setattr(reboot_mod, "get_ssh_private_key", lambda *a, **kw: "/tmp/key.pem")
+
+    mock_db = MagicMock()
+    service = AutoRebootService(
+        database=mock_db,
+        region="us-west-2",
+        terraform_dir="/tmp/terraform",
+    )
+
+    mock_run = MagicMock()
+    mock_run.return_value.returncode = 0
+    monkeypatch.setattr(reboot_mod.subprocess, "run", mock_run)
+
+    result = service._reboot_vm("vm-1", assigned=False)
+
+    assert result is True
+    cmd = mock_run.call_args[0][0]
+    assert "sudo cloud-init clean && sudo reboot" in cmd
+    mock_db.record_reboot.assert_called_once_with("vm-1")
 
 
 @patch.object(AutoRebootService, "_reboot_vm")
@@ -422,6 +526,7 @@ def test_check_and_reboot_releases_on_max_attempts(mock_reboot):
             "healthy": None,
             "reboot_count": 3,
             "last_reboot_time": None,
+            "useremail": None,
         }
     ]
 
@@ -448,6 +553,7 @@ def test_check_and_reboot_below_max_does_not_release(mock_reboot):
             "healthy": None,
             "reboot_count": 1,
             "last_reboot_time": None,
+            "useremail": None,
         }
     ]
 
@@ -459,7 +565,7 @@ def test_check_and_reboot_below_max_does_not_release(mock_reboot):
     )
     service._check_and_reboot()
 
-    mock_reboot.assert_called_once_with("vm-1")
+    mock_reboot.assert_called_once_with("vm-1", assigned=False)
     mock_db.release_assignment.assert_not_called()
 
 
@@ -475,6 +581,7 @@ def test_check_and_reboot_respects_cooldown(mock_reboot):
             "healthy": None,
             "reboot_count": 1,
             "last_reboot_time": recent_reboot,
+            "useremail": None,
         }
     ]
 
@@ -500,6 +607,7 @@ def test_check_and_reboot_triggers_reboot(mock_reboot):
             "healthy": None,
             "reboot_count": 0,
             "last_reboot_time": None,
+            "useremail": None,
         }
     ]
 
@@ -511,7 +619,7 @@ def test_check_and_reboot_triggers_reboot(mock_reboot):
     )
     service._check_and_reboot()
 
-    mock_reboot.assert_called_once_with("vm-1")
+    mock_reboot.assert_called_once_with("vm-1", assigned=False)
 
 
 @patch.object(AutoRebootService, "_reboot_vm")
@@ -526,6 +634,7 @@ def test_check_and_reboot_after_cooldown_expired(mock_reboot):
             "healthy": None,
             "reboot_count": 1,
             "last_reboot_time": old_reboot,
+            "useremail": None,
         }
     ]
 
@@ -537,7 +646,7 @@ def test_check_and_reboot_after_cooldown_expired(mock_reboot):
     )
     service._check_and_reboot()
 
-    mock_reboot.assert_called_once_with("vm-1")
+    mock_reboot.assert_called_once_with("vm-1", assigned=False)
 
 
 @patch.object(AutoRebootService, "_reboot_vm")
@@ -553,6 +662,7 @@ def test_check_and_reboot_naive_timestamp(mock_reboot):
             "healthy": None,
             "reboot_count": 1,
             "last_reboot_time": naive_old_reboot,
+            "useremail": None,
         }
     ]
 
@@ -564,7 +674,7 @@ def test_check_and_reboot_naive_timestamp(mock_reboot):
     )
     service._check_and_reboot()
 
-    mock_reboot.assert_called_once_with("vm-1")
+    mock_reboot.assert_called_once_with("vm-1", assigned=False)
 
 
 @patch.object(AutoRebootService, "_reboot_vm")
@@ -596,3 +706,55 @@ def test_start_and_stop():
 
     service.stop()
     assert not service._thread.is_alive()
+
+
+@patch.object(AutoRebootService, "_reboot_vm")
+def test_check_and_reboot_passes_assigned_true_for_assigned_vm(mock_reboot):
+    """Test that assigned VMs get assigned=True passed to _reboot_vm."""
+    mock_db = MagicMock()
+    mock_db.get_failed_vms.return_value = [
+        {
+            "hostname": "vm-1",
+            "status": "error",
+            "healthy": None,
+            "reboot_count": 0,
+            "last_reboot_time": None,
+            "useremail": "student@example.com",
+        }
+    ]
+
+    service = AutoRebootService(
+        database=mock_db,
+        max_attempts=3,
+        cooldown_seconds=300,
+        terraform_dir="/tmp/terraform",
+    )
+    service._check_and_reboot()
+
+    mock_reboot.assert_called_once_with("vm-1", assigned=True)
+
+
+@patch.object(AutoRebootService, "_reboot_vm")
+def test_check_and_reboot_passes_assigned_false_for_unassigned_vm(mock_reboot):
+    """Test that unassigned VMs get assigned=False passed to _reboot_vm."""
+    mock_db = MagicMock()
+    mock_db.get_failed_vms.return_value = [
+        {
+            "hostname": "vm-1",
+            "status": "error",
+            "healthy": None,
+            "reboot_count": 0,
+            "last_reboot_time": None,
+            "useremail": None,
+        }
+    ]
+
+    service = AutoRebootService(
+        database=mock_db,
+        max_attempts=3,
+        cooldown_seconds=300,
+        terraform_dir="/tmp/terraform",
+    )
+    service._check_and_reboot()
+
+    mock_reboot.assert_called_once_with("vm-1", assigned=False)

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -260,7 +260,10 @@ def test_ssh_cold_reboot_success(monkeypatch):
     cmd = mock_run.call_args[0][0]
     assert "ssh" in cmd
     assert "ubuntu@1.2.3.4" in cmd
-    assert "sudo cloud-init clean && sudo reboot" in cmd
+    remote_cmd = cmd[-1]
+    assert "docker ps -aq" in remote_cmd
+    assert "xargs -r docker rm -f" in remote_cmd
+    assert "sudo cloud-init clean && sudo reboot" in remote_cmd
 
 
 def test_ssh_cold_reboot_exit_255(monkeypatch):
@@ -511,7 +514,10 @@ def test_reboot_vm_uses_cold_reboot_for_unassigned_vm(monkeypatch):
 
     assert result is True
     cmd = mock_run.call_args[0][0]
-    assert "sudo cloud-init clean && sudo reboot" in cmd
+    remote_cmd = cmd[-1]
+    assert "docker ps -aq" in remote_cmd
+    assert "xargs -r docker rm -f" in remote_cmd
+    assert "sudo cloud-init clean && sudo reboot" in remote_cmd
     mock_db.record_reboot.assert_called_once_with("vm-1")
 
 

--- a/packages/client/src/lablink_client_service/connect_crd.py
+++ b/packages/client/src/lablink_client_service/connect_crd.py
@@ -143,9 +143,20 @@ def start_crd_daemon() -> None:
         f"/opt/google/chrome-remote-desktop/user-session start -- "
         f"--config={config_path} --start"
     )
-    result = subprocess.run(
-        command, shell=True, capture_output=True, text=True
-    )
+    try:
+        result = subprocess.run(
+            command,
+            shell=True,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except subprocess.TimeoutExpired:
+        logger.error(
+            "Timed out waiting for CRD daemon to start; subscribe "
+            "will retry on the next NOTIFY"
+        )
+        return
     if result.returncode == 0:
         logger.info(f"CRD daemon restarted using {config_path}")
     else:

--- a/packages/client/src/lablink_client_service/connect_crd.py
+++ b/packages/client/src/lablink_client_service/connect_crd.py
@@ -1,4 +1,5 @@
 import argparse
+import glob
 import subprocess
 import logging
 import time
@@ -7,6 +8,12 @@ import os
 
 # Set up logging
 logger = logging.getLogger(__name__)
+
+# CRD writes a host#<hash>.json here after a successful auth-code exchange.
+# Its presence on container restart means the host is already registered —
+# re-running start-host would fail (code consumed / host already registered),
+# so we restart the daemon instead. Destroyed on cold reboot (fresh container).
+CRD_HOST_CONFIG_GLOB = "/home/client/.config/chrome-remote-desktop/host#*.json"
 
 
 def set_logger(external_logger):
@@ -111,3 +118,37 @@ def connect_to_crd(command, pin):
         logger.info("CRD connection established successfully")
     elif result.stderr:
         logger.error(f"CRD connection failed: {result.stderr}")
+
+
+def is_crd_registered() -> bool:
+    """Return True if CRD has already been registered on this container."""
+    return bool(glob.glob(CRD_HOST_CONFIG_GLOB))
+
+
+def start_crd_daemon() -> None:
+    """Start the CRD daemon from an existing host registration.
+
+    Used on warm container restarts where start-host would fail because
+    the auth code is already consumed or the host is already registered.
+    Mirrors the invocation that start-host uses on first boot (observed
+    via ps -ef): user-session runs as root and drops privileges to the
+    client user internally, then daemonizes.
+    """
+    config_paths = glob.glob(CRD_HOST_CONFIG_GLOB)
+    if not config_paths:
+        logger.error("No CRD host config found; cannot restart daemon")
+        return
+    config_path = config_paths[0]
+    command = (
+        f"/opt/google/chrome-remote-desktop/user-session start -- "
+        f"--config={config_path} --start"
+    )
+    result = subprocess.run(
+        command, shell=True, capture_output=True, text=True
+    )
+    if result.returncode == 0:
+        logger.info(f"CRD daemon restarted using {config_path}")
+    else:
+        logger.error(
+            f"Failed to restart CRD daemon: {result.stderr.strip()}"
+        )

--- a/packages/client/src/lablink_client_service/subscribe.py
+++ b/packages/client/src/lablink_client_service/subscribe.py
@@ -6,7 +6,12 @@ import hydra
 import logging
 
 from lablink_client_service.conf.structured_config import Config
-from lablink_client_service.connect_crd import connect_to_crd, set_logger
+from lablink_client_service.connect_crd import (
+    connect_to_crd,
+    is_crd_registered,
+    set_logger,
+    start_crd_daemon,
+)
 from lablink_client_service.http_utils import (
     get_auth_headers,
     get_client_env,
@@ -66,8 +71,16 @@ def subscribe(cfg: Config) -> None:
                     command = data["command"]
                     pin = data["pin"]
 
-                    # Execute the command
-                    connect_to_crd(pin=pin, command=command)
+                    # On warm container restart, the previous host registration
+                    # survives in the writable layer. Re-exchanging the auth
+                    # code would fail, so just restart the daemon instead.
+                    if is_crd_registered():
+                        logger.info(
+                            "Existing CRD registration found; restarting daemon"
+                        )
+                        start_crd_daemon()
+                    else:
+                        connect_to_crd(pin=pin, command=command)
                     logger.info("CRD setup complete")
                     break  # Success - exit retry loop
                 else:

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -29,6 +29,13 @@ send_status() {
     || echo ">> WARNING: failed to report status=$status (continuing)"
 }
 
+# Report 'initializing' as soon as the container's start.sh begins. On cold
+# reboot this is redundant with user_data.sh's earlier post, but on warm
+# reboot user_data.sh's guard may exit before reaching its send_status —
+# this call guarantees the transition rebooting → initializing → running
+# regardless of which path brought the container up.
+send_status "initializing"
+
 # Clone the tutorial repository if specified
 if [ -n "$TUTORIAL_REPO_TO_CLONE" ]; then
   mkdir -p /home/client/Desktop

--- a/packages/client/tests/test_connect_crd.py
+++ b/packages/client/tests/test_connect_crd.py
@@ -9,6 +9,8 @@ from lablink_client_service.connect_crd import (
     construct_command,
     reconstruct_command,
     connect_to_crd,
+    is_crd_registered,
+    start_crd_daemon,
 )
 
 
@@ -167,3 +169,66 @@ def test_cleanup_logs_exception(mock_sleep, mock_shutdown):
         connect_crd.cleanup_logs()
         mock_logger.error.assert_called_once()
         mock_sleep.assert_not_called()
+
+
+@patch("lablink_client_service.connect_crd.glob.glob")
+def test_is_crd_registered_true(mock_glob):
+    """Registered when a host#<hash>.json exists."""
+    mock_glob.return_value = [
+        "/home/client/.config/chrome-remote-desktop/host#abc.json"
+    ]
+    assert is_crd_registered() is True
+    mock_glob.assert_called_once_with(
+        "/home/client/.config/chrome-remote-desktop/host#*.json"
+    )
+
+
+@patch("lablink_client_service.connect_crd.glob.glob")
+def test_is_crd_registered_false(mock_glob):
+    """Not registered when no host config files are present."""
+    mock_glob.return_value = []
+    assert is_crd_registered() is False
+
+
+@patch("lablink_client_service.connect_crd.subprocess.run")
+@patch("lablink_client_service.connect_crd.glob.glob")
+def test_start_crd_daemon_success(mock_glob, mock_run):
+    """Daemon start invokes user-session with the discovered config path."""
+    config_path = "/home/client/.config/chrome-remote-desktop/host#abc.json"
+    mock_glob.return_value = [config_path]
+    mock_run.return_value = MagicMock(returncode=0, stderr="")
+
+    start_crd_daemon()
+
+    mock_run.assert_called_once_with(
+        f"/opt/google/chrome-remote-desktop/user-session start -- "
+        f"--config={config_path} --start",
+        shell=True,
+        capture_output=True,
+        text=True,
+    )
+
+
+@patch("lablink_client_service.connect_crd.subprocess.run")
+@patch("lablink_client_service.connect_crd.glob.glob")
+def test_start_crd_daemon_no_config(mock_glob, mock_run):
+    """Logs an error and skips subprocess when no host config is found."""
+    mock_glob.return_value = []
+
+    start_crd_daemon()
+
+    mock_run.assert_not_called()
+
+
+@patch("lablink_client_service.connect_crd.subprocess.run")
+@patch("lablink_client_service.connect_crd.glob.glob")
+def test_start_crd_daemon_failure(mock_glob, mock_run):
+    """Non-zero exit from user-session is logged but does not raise."""
+    mock_glob.return_value = [
+        "/home/client/.config/chrome-remote-desktop/host#abc.json"
+    ]
+    mock_run.return_value = MagicMock(returncode=1, stderr="oops")
+
+    # Should not raise
+    start_crd_daemon()
+    mock_run.assert_called_once()

--- a/packages/client/tests/test_connect_crd.py
+++ b/packages/client/tests/test_connect_crd.py
@@ -206,6 +206,7 @@ def test_start_crd_daemon_success(mock_glob, mock_run):
         shell=True,
         capture_output=True,
         text=True,
+        timeout=30,
     )
 
 
@@ -228,6 +229,28 @@ def test_start_crd_daemon_failure(mock_glob, mock_run):
         "/home/client/.config/chrome-remote-desktop/host#abc.json"
     ]
     mock_run.return_value = MagicMock(returncode=1, stderr="oops")
+
+    # Should not raise
+    start_crd_daemon()
+    mock_run.assert_called_once()
+
+
+@patch("lablink_client_service.connect_crd.subprocess.run")
+@patch("lablink_client_service.connect_crd.glob.glob")
+def test_start_crd_daemon_timeout(mock_glob, mock_run):
+    """TimeoutExpired from user-session is caught, logged, and swallowed.
+
+    Without this, a hanging `user-session start` would block the subscribe
+    loop forever and prevent any subsequent CRD reassignment.
+    """
+    import subprocess
+
+    mock_glob.return_value = [
+        "/home/client/.config/chrome-remote-desktop/host#abc.json"
+    ]
+    mock_run.side_effect = subprocess.TimeoutExpired(
+        cmd="user-session start", timeout=30
+    )
 
     # Should not raise
     start_crd_daemon()


### PR DESCRIPTION
## Summary
- Split the reboot path by VM assignment state: **assigned VMs** get a warm reboot (`sudo reboot`) that preserves the running container and the student's work, while **unassigned VMs** get a cold reboot that recreates everything from a clean slate.
- Add `--restart unless-stopped` so Docker auto-resumes the container after an OS reboot.
- Make the client's CRD subscribe flow idempotent across warm reboots by reusing the surviving `host#<hash>.json` registration instead of re-exchanging the (already-consumed) OAuth code — this fixes the "two hosts show up in Chrome Remote Desktop" regression caught during live testing.

## Changes Made

### Allocator
- **`reboot.py`** — warm/cold split:
  - Shared `_ssh_reboot(ip, key, command)` base. `_ssh_warm_reboot` sends `sudo reboot`; `_ssh_cold_reboot` sends `sudo docker ps -aq | sudo xargs -r docker rm -f; sudo cloud-init clean && sudo reboot`.
  - `_reboot_vm(hostname, assigned=bool)` picks the path; `_check_and_reboot` derives `assigned` from `useremail IS NOT NULL`.
  - Stop/start EC2 fallback is always semantically cold (cloud-init re-runs user_data on next boot).
- **`database.py`** — `get_failed_vms` now returns `useremail` so the reboot service can distinguish assigned from unassigned VMs.
- **`terraform/user_data.sh`**:
  - Added `--restart unless-stopped` to `docker run` so the container auto-resumes after an OS reboot.
  - Added a warm-reboot idempotence guard that exits early when a container for our image already exists, instead of destroying and re-creating it. Needed because the client AMI's cloud-init runs `scripts-user` on every boot (not once-per-instance), so `user_data.sh` re-executes even without `cloud-init clean`.
  - The guard also restarts the docker log shipper (killed by the OS reboot) so logs keep flowing to the allocator; the cloud-init log shipper is started before the guard for the same reason.

### Client
- **`connect_crd.py`** — new `is_crd_registered()` (glob check for `host#*.json`) and `start_crd_daemon()` that restarts the CRD daemon from the surviving registration via `user-session start -- --config=... --start`. Includes a 30s subprocess timeout so a hanging daemon start can't block `subscribe` indefinitely.
- **`subscribe.py`** — on receiving a CRD command after a warm reboot, check `is_crd_registered()`; if true, call `start_crd_daemon()` instead of `connect_to_crd()` (which would fail — the auth code is already consumed and the host is already registered).
- **`start.sh`** — send `status="initializing"` at the top of the script so the transition `rebooting → initializing → running` is guaranteed regardless of which path brought the container up (previously the transition relied on `user_data.sh` ordering).

## Testing

- **End-to-end live test** on a deployed allocator + assigned client VM:
  - Flipped VM to `Unhealthy` via `/api/gpu_health`.
  - Auto-reboot service correctly selected the warm path (`assigned=True`) and sent `sudo reboot`.
  - Container ID preserved across reboot; `host#<hash>.json` survived in the writable layer.
  - Student reconnected with the same CRD host identity — **one** entry in the Chrome Remote Desktop UI (no duplicate).

## Design Decisions
- **Reboot service is the sole authority on destroy-vs-preserve.** `user_data.sh` just reacts to what it finds. Warm path sends plain `sudo reboot` (container survives via restart policy); cold path explicitly `docker rm -f`s before `cloud-init clean && reboot` so the idempotence guard in `user_data.sh` falls through to full provisioning on cold reboots.
- **`assigned` derived from `useremail`.** If `useremail IS NOT NULL`, the VM has a student. No new DB columns or schema changes required.
- **CRD reuse over re-registration.** The OAuth code from `start-host` is one-shot; the allocator generates a fresh one on every CRD reassignment, but on warm reboot the client throws it away and reuses the persisted host config. Prevents the Google CRD account from accumulating stale duplicate host entries every time a VM reboots.
- **`start.sh` owns the `initializing → running` transition.** Previously only `user_data.sh` reported `initializing`. If `user_data.sh` short-circuits (as the warm-reboot guard does), the transition could skip. Tying the send to the container's own startup makes the invariant explicit.
- **30-second timeout on `start_crd_daemon`.** A hanging `user-session start` would otherwise block the subscribe loop and prevent any subsequent CRD reassignment.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)