### PR TITLE
feat: heartbeat liveness signal for silent-failure detection

### DIFF
--- a/openspec/specs/api/spec.md
+++ b/openspec/specs/api/spec.md
@@ -117,12 +117,11 @@ expired CRD token, out-of-band EC2 termination) can be detected.
   - `boot_id`: Kernel per-boot UUID from `/proc/sys/kernel/random/boot_id`
   - `timestamp`: ISO 8601 client-clock timestamp
   - `crd_active`: Boolean — is chrome-remote-desktop running
-  - `docker_healthy`: Boolean — does `docker info` succeed
   - `disk_free_pct`: Integer — percent free on the container filesystem
 - **THEN** the allocator updates `last_seen_at = NOW()` on the VM row
 - **AND** persists the reported fields
-- **AND** logs warnings on unexpected `boot_id` change, `crd_active` or
-  `docker_healthy` transitioning to `false`, or `disk_free_pct` below 10 %
+- **AND** logs warnings on unexpected `boot_id` change,
+  `crd_active` transitioning to `false`, or `disk_free_pct` below 10 %
 - **AND** returns 200 `{"ok": true}`
 
 #### Scenario: Heartbeat for unknown hostname

--- a/openspec/specs/api/spec.md
+++ b/openspec/specs/api/spec.md
@@ -105,6 +105,39 @@ The allocator SHALL provide endpoints for client VMs to report health status.
 - **WHEN** the client submits health check data
 - **THEN** the VM's health status is updated in the database
 
+### Requirement: Heartbeat Endpoint
+The allocator SHALL provide an endpoint for client VMs to report active
+liveness so silent failures (dead container, broken network, hung host,
+expired CRD token, out-of-band EC2 termination) can be detected.
+
+#### Scenario: Client reports liveness
+- **GIVEN** a registered client VM
+- **WHEN** the client submits `POST /api/heartbeat` with JSON body:
+  - `vm_id`: The VM's hostname (required)
+  - `boot_id`: Kernel per-boot UUID from `/proc/sys/kernel/random/boot_id`
+  - `timestamp`: ISO 8601 client-clock timestamp
+  - `crd_active`: Boolean — is chrome-remote-desktop running
+  - `docker_healthy`: Boolean — does `docker info` succeed
+  - `disk_free_pct`: Integer — percent free on the container filesystem
+- **THEN** the allocator updates `last_seen_at = NOW()` on the VM row
+- **AND** persists the reported fields
+- **AND** logs warnings on unexpected `boot_id` change, `crd_active` or
+  `docker_healthy` transitioning to `false`, or `disk_free_pct` below 10 %
+- **AND** returns 200 `{"ok": true}`
+
+#### Scenario: Heartbeat for unknown hostname
+- **GIVEN** a hostname not present in the VM table
+- **WHEN** the client submits `POST /api/heartbeat`
+- **THEN** the allocator returns 404
+
+#### Scenario: Passive liveness refresh
+- **GIVEN** an authenticated client-to-allocator endpoint other than
+  `/api/heartbeat` (e.g. `/api/gpu_health`, `/api/vm-status`,
+  `/api/vm-metrics/<hostname>`, `/vm_startup`)
+- **WHEN** the client submits a valid request
+- **THEN** the allocator refreshes `last_seen_at` for the VM as a
+  side-effect, so ongoing traffic prevents false-positive staleness
+
 ### Requirement: Status Update Endpoint
 The allocator SHALL provide an endpoint for client VMs to update their in-use status.
 

--- a/openspec/specs/database/spec.md
+++ b/openspec/specs/database/spec.md
@@ -20,6 +20,15 @@ The database SHALL store VM information in a `vms` table with the following sche
   - `crd_command`: TEXT (nullable, command to run)
   - `created_at`: TIMESTAMP DEFAULT NOW()
   - `updated_at`: TIMESTAMP DEFAULT NOW()
+  - `last_seen_at`: TIMESTAMP (nullable, updated on heartbeat or any
+    authenticated client-to-allocator request)
+  - `boot_id`: VARCHAR(64) (nullable, kernel per-boot UUID reported by
+    the client; used to detect unexpected host reboots)
+  - `crd_active`: BOOLEAN (nullable, last heartbeat's CRD-daemon status)
+  - `docker_healthy`: BOOLEAN (nullable, last heartbeat's Docker daemon
+    probe result)
+  - `disk_free_pct`: SMALLINT (nullable, percent free on the container
+    filesystem at the last heartbeat)
 
 ### Requirement: VM State Machine
 VMs SHALL transition through defined states based on their lifecycle.
@@ -52,6 +61,35 @@ The database SHALL notify the allocator of VM state changes for real-time update
 - **WHEN** any row in the `vms` table is updated
 - **THEN** a PostgreSQL NOTIFY is sent on the `vm_updates` channel
 - **AND** the payload contains the updated VM information
+
+#### Scenario: CRD-command trigger guard
+- **GIVEN** the `trigger_crd_command_insert_or_update` trigger is
+  configured on the VM table
+- **WHEN** a VM row is updated with `CrdCommand = NULL` (e.g. during
+  `record_reboot` or `release_assignment`)
+- **THEN** the trigger's `WHEN (NEW.CrdCommand IS NOT NULL)` guard
+  suppresses the NOTIFY
+- **AND** legitimate non-null `CrdCommand` updates still fire a NOTIFY
+
+### Requirement: Heartbeat Liveness
+The allocator SHALL detect silent client-VM failures by tracking a
+`last_seen_at` timestamp refreshed on every authenticated
+client-to-allocator interaction.
+
+#### Scenario: Heartbeat staleness
+- **GIVEN** a VM row with `status = 'running'` and
+  `last_seen_at IS NOT NULL`
+- **WHEN** `last_seen_at` is older than the configured staleness
+  threshold (default 3 minutes)
+- **THEN** the VM is returned by `get_failed_vms()` and feeds into the
+  reboot pipeline
+
+#### Scenario: Brand-new VM guard
+- **GIVEN** a VM row with `last_seen_at IS NULL` (no heartbeat received
+  yet)
+- **WHEN** `get_failed_vms()` runs
+- **THEN** the VM is NOT flagged as silent, regardless of `status` or
+  `created_at`
 
 ### Requirement: Hostname Uniqueness
 Each VM hostname SHALL be unique in the database.

--- a/openspec/specs/database/spec.md
+++ b/openspec/specs/database/spec.md
@@ -25,8 +25,6 @@ The database SHALL store VM information in a `vms` table with the following sche
   - `boot_id`: VARCHAR(64) (nullable, kernel per-boot UUID reported by
     the client; used to detect unexpected host reboots)
   - `crd_active`: BOOLEAN (nullable, last heartbeat's CRD-daemon status)
-  - `docker_healthy`: BOOLEAN (nullable, last heartbeat's Docker daemon
-    probe result)
   - `disk_free_pct`: SMALLINT (nullable, percent free on the container
     filesystem at the last heartbeat)
 

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -1262,15 +1262,122 @@ class PostgresqlDatabase:
                     )
                     self.conn.rollback()
 
+    def record_heartbeat(
+        self,
+        hostname: str,
+        boot_id: Optional[str],
+        crd_active: Optional[bool],
+        docker_healthy: Optional[bool],
+        disk_free_pct: Optional[int],
+    ) -> bool:
+        """Record a client-VM heartbeat and emit warnings on anomalies.
+
+        Updates last_seen_at and the four reported health fields. Logs a
+        warning (not an error) when:
+
+        - boot_id changed vs the previous value (unexpected host reboot),
+        - crd_active transitioned from True to False,
+        - docker_healthy transitioned from True to False,
+        - disk_free_pct dropped below 10.
+
+        Returns True if the row was updated, False if the hostname is
+        unknown.
+        """
+        select_query = (
+            f"SELECT boot_id, crd_active, docker_healthy "
+            f"FROM {self.table_name} WHERE hostname = %s;"
+        )
+        update_query = f"""
+            UPDATE {self.table_name}
+            SET last_seen_at = NOW(),
+                boot_id = %s,
+                crd_active = %s,
+                docker_healthy = %s,
+                disk_free_pct = %s
+            WHERE hostname = %s;
+        """
+        try:
+            with self._cursor as cursor:
+                cursor.execute(select_query, (hostname,))
+                row = cursor.fetchone()
+                if row is None:
+                    logger.warning(
+                        f"Heartbeat for unknown hostname {hostname}"
+                    )
+                    return False
+                prev_boot_id, prev_crd, prev_docker = row
+
+                if (
+                    boot_id is not None
+                    and prev_boot_id is not None
+                    and prev_boot_id != boot_id
+                ):
+                    logger.warning(
+                        f"boot_id changed for {hostname}: "
+                        f"{prev_boot_id} -> {boot_id}"
+                    )
+                if prev_crd is True and crd_active is False:
+                    logger.warning(
+                        f"crd_active flipped False for {hostname}"
+                    )
+                if prev_docker is True and docker_healthy is False:
+                    logger.warning(
+                        f"docker_healthy flipped False for {hostname}"
+                    )
+                if disk_free_pct is not None and disk_free_pct < 10:
+                    logger.warning(
+                        f"disk_free_pct low for {hostname}: "
+                        f"{disk_free_pct}%"
+                    )
+
+                cursor.execute(
+                    update_query,
+                    (
+                        boot_id,
+                        crd_active,
+                        docker_healthy,
+                        disk_free_pct,
+                        hostname,
+                    ),
+                )
+                self.conn.commit()
+                return True
+        except Exception as e:
+            logger.error(f"Failed to record heartbeat for {hostname}: {e}")
+            self.conn.rollback()
+            return False
+
+    def touch_last_seen(self, hostname: str) -> None:
+        """Bump last_seen_at for a VM without touching other columns.
+
+        Called at the top of every authenticated client->allocator
+        endpoint so that any client traffic refreshes the liveness
+        timer. Heartbeat remains the primary signal; this is cheap
+        insurance against false-positive staleness.
+        """
+        query = (
+            f"UPDATE {self.table_name} "
+            f"SET last_seen_at = NOW() WHERE hostname = %s;"
+        )
+        try:
+            with self._cursor as cursor:
+                cursor.execute(query, (hostname,))
+                self.conn.commit()
+        except Exception as e:
+            logger.error(f"Failed to touch last_seen for {hostname}: {e}")
+            self.conn.rollback()
+
     def get_failed_vms(
         self,
         stale_initializing_minutes: int = 25,
         stale_rebooting_minutes: int = 10,
+        stale_heartbeat_minutes: int = 3,
     ) -> List[dict]:
         """Get VMs that need a reboot attempt.
 
         Detects VMs in error state, with unhealthy GPUs, stuck initializing,
-        or stuck in rebooting state (failed to come back after a reboot).
+        stuck in rebooting state (failed to come back after a reboot), or
+        running but silent (no heartbeat within the staleness window).
 
         Args:
             stale_initializing_minutes: Minutes after which an initializing VM
@@ -1282,17 +1389,23 @@ class PostgresqlDatabase:
                 once client services are about to launch.
             stale_rebooting_minutes: Minutes after which a rebooting VM is
                 considered stuck and eligible for another reboot attempt.
+            stale_heartbeat_minutes: Minutes after which a running VM is
+                considered silent and eligible for reboot. Default 3 min
+                (6x the 30s heartbeat cadence). Brand-new VMs with
+                last_seen_at IS NULL are not flagged — they must heartbeat
+                at least once to be eligible for staleness detection.
 
         Returns:
             list: VMs eligible for reboot with hostname, status, healthy,
-                  reboot_count, last_reboot_time, and useremail.
+                  reboot_count, last_reboot_time, useremail, and last_seen_at.
         """
         init_minutes = int(stale_initializing_minutes)
         reboot_minutes = int(stale_rebooting_minutes)
+        heartbeat_minutes = int(stale_heartbeat_minutes)
         query = f"""
             SELECT hostname, status, healthy,
                    COALESCE(reboot_count, 0) as reboot_count,
-                   last_reboot_time, useremail
+                   last_reboot_time, useremail, last_seen_at
             FROM {self.table_name}
             WHERE status = 'error'
                OR (healthy = 'Unhealthy'
@@ -1304,7 +1417,11 @@ class PostgresqlDatabase:
                OR (status = 'rebooting'
                    AND last_reboot_time IS NOT NULL
                    AND last_reboot_time < NOW()
-                   - INTERVAL '{reboot_minutes} minutes');
+                   - INTERVAL '{reboot_minutes} minutes')
+               OR (status = 'running'
+                   AND last_seen_at IS NOT NULL
+                   AND last_seen_at < NOW()
+                   - INTERVAL '{heartbeat_minutes} minutes');
         """
         try:
             with self._cursor as cursor:
@@ -1318,6 +1435,7 @@ class PostgresqlDatabase:
                     "reboot_count": row[3],
                     "last_reboot_time": row[4],
                     "useremail": row[5],
+                    "last_seen_at": row[6],
                 }
                 for row in rows
             ]

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -1267,24 +1267,22 @@ class PostgresqlDatabase:
         hostname: str,
         boot_id: Optional[str],
         crd_active: Optional[bool],
-        docker_healthy: Optional[bool],
         disk_free_pct: Optional[int],
     ) -> bool:
         """Record a client-VM heartbeat and emit warnings on anomalies.
 
-        Updates last_seen_at and the four reported health fields. Logs a
+        Updates last_seen_at and the three reported health fields. Logs a
         warning (not an error) when:
 
         - boot_id changed vs the previous value (unexpected host reboot),
         - crd_active transitioned from True to False,
-        - docker_healthy transitioned from True to False,
         - disk_free_pct dropped below 10.
 
         Returns True if the row was updated, False if the hostname is
         unknown.
         """
         select_query = (
-            f"SELECT boot_id, crd_active, docker_healthy "
+            f"SELECT boot_id, crd_active "
             f"FROM {self.table_name} WHERE hostname = %s;"
         )
         update_query = f"""
@@ -1292,7 +1290,6 @@ class PostgresqlDatabase:
             SET last_seen_at = NOW(),
                 boot_id = %s,
                 crd_active = %s,
-                docker_healthy = %s,
                 disk_free_pct = %s
             WHERE hostname = %s;
         """
@@ -1305,7 +1302,7 @@ class PostgresqlDatabase:
                         f"Heartbeat for unknown hostname {hostname}"
                     )
                     return False
-                prev_boot_id, prev_crd, prev_docker = row
+                prev_boot_id, prev_crd = row
 
                 if (
                     boot_id is not None
@@ -1320,10 +1317,6 @@ class PostgresqlDatabase:
                     logger.warning(
                         f"crd_active flipped False for {hostname}"
                     )
-                if prev_docker is True and docker_healthy is False:
-                    logger.warning(
-                        f"docker_healthy flipped False for {hostname}"
-                    )
                 if disk_free_pct is not None and disk_free_pct < 10:
                     logger.warning(
                         f"disk_free_pct low for {hostname}: "
@@ -1335,7 +1328,6 @@ class PostgresqlDatabase:
                     (
                         boot_id,
                         crd_active,
-                        docker_healthy,
                         disk_free_pct,
                         hostname,
                     ),

--- a/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
+++ b/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
@@ -82,7 +82,6 @@ CREATE TABLE IF NOT EXISTS {VM_TABLE} (
     last_seen_at TIMESTAMP,
     boot_id VARCHAR(64),
     crd_active BOOLEAN,
-    docker_healthy BOOLEAN,
     disk_free_pct SMALLINT
 );
 

--- a/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
+++ b/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
@@ -79,11 +79,11 @@ CREATE TABLE IF NOT EXISTS {VM_TABLE} (
     ContainerStartupDurationSeconds FLOAT,
     TotalStartupDurationSeconds FLOAT,
     CreatedAt TIMESTAMP DEFAULT NOW(),
-    LastSeenAt TIMESTAMP,
-    BootId VARCHAR(64),
-    CrdActive BOOLEAN,
-    DockerHealthy BOOLEAN,
-    DiskFreePct SMALLINT
+    last_seen_at TIMESTAMP,
+    boot_id VARCHAR(64),
+    crd_active BOOLEAN,
+    docker_healthy BOOLEAN,
+    disk_free_pct SMALLINT
 );
 
 CREATE OR REPLACE FUNCTION notify_crd_command_update()

--- a/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
+++ b/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
@@ -78,7 +78,12 @@ CREATE TABLE IF NOT EXISTS {VM_TABLE} (
     ContainerEndTime TIMESTAMP,
     ContainerStartupDurationSeconds FLOAT,
     TotalStartupDurationSeconds FLOAT,
-    CreatedAt TIMESTAMP DEFAULT NOW()
+    CreatedAt TIMESTAMP DEFAULT NOW(),
+    LastSeenAt TIMESTAMP,
+    BootId VARCHAR(64),
+    CrdActive BOOLEAN,
+    DockerHealthy BOOLEAN,
+    DiskFreePct SMALLINT
 );
 
 CREATE OR REPLACE FUNCTION notify_crd_command_update()
@@ -99,6 +104,7 @@ $$ LANGUAGE plpgsql;
 CREATE TRIGGER trigger_crd_command_insert_or_update
 AFTER INSERT OR UPDATE OF CrdCommand ON {VM_TABLE}
 FOR EACH ROW
+WHEN (NEW.CrdCommand IS NOT NULL)
 EXECUTE FUNCTION notify_crd_command_update();
 
 """

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -596,6 +596,8 @@ def vm_startup():
     if not vm:
         return jsonify({"error": "VM not found."}), 404
 
+    database.touch_last_seen(hostname=hostname)
+
     # Check if the VM already has a CRD command assigned (handles race condition
     # where user submitted CRD before client called /vm_startup)
     if vm.get("crdcommand") and vm.get("pin"):
@@ -758,12 +760,43 @@ def update_gpu_health():
         return jsonify({"error": "GPU status and hostname are required."}), 400
 
     try:
+        database.touch_last_seen(hostname=hostname)
         database.update_health(hostname=hostname, healthy=gpu_status)
         logger.debug(f"Updated GPU health status for {hostname} to {gpu_status}")
         return jsonify({"message": "GPU health status updated successfully."}), 200
     except Exception as e:
         logger.error(f"Error updating GPU health status: {e}")
         return jsonify({"error": "Failed to update GPU health status."}), 500
+
+
+@app.route("/api/heartbeat", methods=["POST"])
+@require_api_token
+def heartbeat():
+    """Record a client-VM liveness heartbeat."""
+    data = request.get_json() or {}
+    hostname = data.get("vm_id")
+    if not hostname:
+        return jsonify({"error": "vm_id is required."}), 400
+
+    boot_id = data.get("boot_id")
+    crd_active = data.get("crd_active")
+    docker_healthy = data.get("docker_healthy")
+    disk_free_pct = data.get("disk_free_pct")
+
+    try:
+        ok = database.record_heartbeat(
+            hostname=hostname,
+            boot_id=boot_id,
+            crd_active=crd_active,
+            docker_healthy=docker_healthy,
+            disk_free_pct=disk_free_pct,
+        )
+        if not ok:
+            return jsonify({"error": "Unknown hostname."}), 404
+        return jsonify({"ok": True}), 200
+    except Exception as e:
+        logger.error(f"Error recording heartbeat for {hostname}: {e}")
+        return jsonify({"error": "Failed to record heartbeat."}), 500
 
 
 @app.route("/api/vm-status", methods=["POST"])
@@ -777,6 +810,7 @@ def update_vm_status():
         if not hostname or status is None:
             return jsonify({"error": "Hostname and status are required."}), 400
 
+        database.touch_last_seen(hostname=hostname)
         database.update_vm_status(hostname=hostname, status=status)
 
         return jsonify({"message": "VM status updated successfully."}), 200
@@ -958,6 +992,7 @@ def receive_vm_metrics(hostname):
             logger.error(f"VM with hostname {hostname} does not exist.")
             return jsonify({"error": "VM not found."}), 404
 
+        database.touch_last_seen(hostname=hostname)
         # Update VM metrics and calculate total startup time atomically
         # This combines two database operations into one for better performance
         database.update_vm_metrics_atomic(hostname=hostname, metrics=data)

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -780,7 +780,6 @@ def heartbeat():
 
     boot_id = data.get("boot_id")
     crd_active = data.get("crd_active")
-    docker_healthy = data.get("docker_healthy")
     disk_free_pct = data.get("disk_free_pct")
 
     try:
@@ -788,7 +787,6 @@ def heartbeat():
             hostname=hostname,
             boot_id=boot_id,
             crd_active=crd_active,
-            docker_healthy=docker_healthy,
             disk_free_pct=disk_free_pct,
         )
         if not ok:

--- a/packages/allocator/tests/test_api_calls.py
+++ b/packages/allocator/tests/test_api_calls.py
@@ -2140,7 +2140,6 @@ def _heartbeat_payload(**overrides):
         "boot_id": "bid-abc",
         "timestamp": "2026-04-20T12:00:00+00:00",
         "crd_active": True,
-        "docker_healthy": True,
         "disk_free_pct": 80,
     }
     base.update(overrides)
@@ -2167,7 +2166,6 @@ def test_heartbeat_success(client, api_token_headers, monkeypatch):
         hostname="test-vm-dev-1",
         boot_id="bid-abc",
         crd_active=True,
-        docker_healthy=True,
         disk_free_pct=80,
     )
 
@@ -2251,13 +2249,13 @@ def test_heartbeat_accepts_null_health_fields(
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
 
-    payload = _heartbeat_payload(crd_active=None, docker_healthy=None)
+    payload = _heartbeat_payload(crd_active=None, disk_free_pct=None)
     resp = client.post(HEARTBEAT_ENDPOINT, json=payload, headers=api_token_headers)
 
     assert resp.status_code == 200
     call = fake_db.record_heartbeat.call_args
     assert call.kwargs["crd_active"] is None
-    assert call.kwargs["docker_healthy"] is None
+    assert call.kwargs["disk_free_pct"] is None
 
 
 # -- Cross-endpoint last_seen_at refresh --------------------------------

--- a/packages/allocator/tests/test_api_calls.py
+++ b/packages/allocator/tests/test_api_calls.py
@@ -17,6 +17,7 @@ VM_STATUS_UPDATE_ENDPOINT = "/api/vm-status"
 VM_LOGS_ENDPOINT = "/api/vm-logs"
 METRICS_ENDPOINT = "/api/vm-metrics"
 SCHEDULE_DESTRUCTION_ENDPOINT = "/api/schedule-destruction"
+HEARTBEAT_ENDPOINT = "/api/heartbeat"
 
 
 def test_vm_startup_success(client, api_token_headers, monkeypatch):
@@ -2129,3 +2130,207 @@ def test_request_vm_does_not_require_token(client, monkeypatch):
 
     # Should NOT return 401 - returns 200 with "no available VMs" message
     assert resp.status_code != 401
+
+
+# -- Heartbeat endpoint --------------------------------------------------
+
+def _heartbeat_payload(**overrides):
+    base = {
+        "vm_id": "test-vm-dev-1",
+        "boot_id": "bid-abc",
+        "timestamp": "2026-04-20T12:00:00+00:00",
+        "crd_active": True,
+        "docker_healthy": True,
+        "disk_free_pct": 80,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_heartbeat_success(client, api_token_headers, monkeypatch):
+    """Valid heartbeat payload returns 200 and calls record_heartbeat."""
+    fake_db = MagicMock()
+    fake_db.record_heartbeat.return_value = True
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.post(
+        HEARTBEAT_ENDPOINT,
+        json=_heartbeat_payload(),
+        headers=api_token_headers,
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}
+    fake_db.record_heartbeat.assert_called_once_with(
+        hostname="test-vm-dev-1",
+        boot_id="bid-abc",
+        crd_active=True,
+        docker_healthy=True,
+        disk_free_pct=80,
+    )
+
+
+def test_heartbeat_rejects_missing_token(client, monkeypatch):
+    """Heartbeat endpoint requires API token."""
+    fake_db = MagicMock()
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.post(HEARTBEAT_ENDPOINT, json=_heartbeat_payload())
+
+    assert resp.status_code == 401
+    fake_db.record_heartbeat.assert_not_called()
+
+
+def test_heartbeat_rejects_missing_vm_id(client, api_token_headers, monkeypatch):
+    """Missing vm_id returns 400."""
+    fake_db = MagicMock()
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    payload = _heartbeat_payload()
+    payload.pop("vm_id")
+    resp = client.post(HEARTBEAT_ENDPOINT, json=payload, headers=api_token_headers)
+
+    assert resp.status_code == 400
+    fake_db.record_heartbeat.assert_not_called()
+
+
+def test_heartbeat_unknown_hostname_returns_404(
+    client, api_token_headers, monkeypatch
+):
+    """record_heartbeat returning False surfaces as 404."""
+    fake_db = MagicMock()
+    fake_db.record_heartbeat.return_value = False
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.post(
+        HEARTBEAT_ENDPOINT,
+        json=_heartbeat_payload(vm_id="ghost"),
+        headers=api_token_headers,
+    )
+
+    assert resp.status_code == 404
+
+
+def test_heartbeat_db_error_returns_500(client, api_token_headers, monkeypatch):
+    """Unexpected exceptions surface as 500."""
+    fake_db = MagicMock()
+    fake_db.record_heartbeat.side_effect = Exception("boom")
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.post(
+        HEARTBEAT_ENDPOINT,
+        json=_heartbeat_payload(),
+        headers=api_token_headers,
+    )
+
+    assert resp.status_code == 500
+
+
+def test_heartbeat_accepts_null_health_fields(
+    client, api_token_headers, monkeypatch
+):
+    """Partial sampler failure (null booleans) must still be accepted.
+
+    The client sets a field to None when its probe fails; we want the
+    row updated with whatever was reported rather than rejecting the
+    whole heartbeat.
+    """
+    fake_db = MagicMock()
+    fake_db.record_heartbeat.return_value = True
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    payload = _heartbeat_payload(crd_active=None, docker_healthy=None)
+    resp = client.post(HEARTBEAT_ENDPOINT, json=payload, headers=api_token_headers)
+
+    assert resp.status_code == 200
+    call = fake_db.record_heartbeat.call_args
+    assert call.kwargs["crd_active"] is None
+    assert call.kwargs["docker_healthy"] is None
+
+
+# -- Cross-endpoint last_seen_at refresh --------------------------------
+
+def test_gpu_health_bumps_last_seen(client, api_token_headers, monkeypatch):
+    """POST /api/gpu_health refreshes last_seen_at for the VM."""
+    fake_db = MagicMock()
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.post(
+        UPDATE_GPU_HEALTH_ENDPOINT,
+        json={"hostname": "vm-1", "gpu_status": "Healthy"},
+        headers=api_token_headers,
+    )
+
+    assert resp.status_code == 200
+    fake_db.touch_last_seen.assert_called_once_with(hostname="vm-1")
+
+
+def test_vm_status_bumps_last_seen(client, api_token_headers, monkeypatch):
+    """POST /api/vm-status refreshes last_seen_at for the VM."""
+    fake_db = MagicMock()
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.post(
+        VM_STATUS_UPDATE_ENDPOINT,
+        json={"hostname": "vm-1", "status": "running"},
+        headers=api_token_headers,
+    )
+
+    assert resp.status_code == 200
+    fake_db.touch_last_seen.assert_called_once_with(hostname="vm-1")
+
+
+def test_vm_metrics_bumps_last_seen(client, api_token_headers, monkeypatch):
+    """POST /api/vm-metrics/<hostname> refreshes last_seen_at."""
+    fake_db = MagicMock()
+    fake_db.vm_exists.return_value = True
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.post(
+        f"{METRICS_ENDPOINT}/vm-1",
+        json={"container_start": 0, "container_end": 1},
+        headers=api_token_headers,
+    )
+
+    assert resp.status_code == 200
+    fake_db.touch_last_seen.assert_called_once_with(hostname="vm-1")
+
+
+def test_vm_startup_bumps_last_seen(client, api_token_headers, monkeypatch):
+    """POST /vm_startup refreshes last_seen_at once the VM is found."""
+    fake_db = MagicMock()
+    fake_db.get_vm_by_hostname.return_value = {
+        "hostname": "vm-1",
+        "crdcommand": "cmd",
+        "pin": "123456",
+    }
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.post(
+        VM_STARTUP_ENDPOINT,
+        json={"hostname": "vm-1"},
+        headers=api_token_headers,
+    )
+
+    assert resp.status_code == 200
+    fake_db.touch_last_seen.assert_called_once_with(hostname="vm-1")

--- a/packages/allocator/tests/test_generate_init_sql.py
+++ b/packages/allocator/tests/test_generate_init_sql.py
@@ -1,0 +1,71 @@
+"""Tests for generate_init_sql — in particular the trigger WHEN guard."""
+
+from unittest.mock import patch, mock_open, MagicMock
+
+
+def test_crd_command_trigger_has_when_guard(monkeypatch):
+    """The notify trigger must only fire when CrdCommand is non-null.
+
+    Without the WHEN guard, record_reboot and release_assignment (which
+    set CrdCommand = NULL) produce NOTIFY payloads the LISTEN loop
+    already discards, spamming "Invalid notification payload" warnings
+    in every listening client.
+    """
+    mock_config = MagicMock()
+    mock_config.db.dbname = "d"
+    mock_config.db.user = "u"
+    mock_config.db.password = "p"
+    mock_config.db.table_name = "vms"
+    mock_config.db.message_channel = "ch"
+
+    monkeypatch.setattr(
+        "lablink_allocator_service.generate_init_sql.get_config",
+        lambda: mock_config,
+    )
+
+    from lablink_allocator_service.generate_init_sql import main
+
+    m = mock_open()
+    with patch("builtins.open", m):
+        main()
+
+    handle = m()
+    written = "".join(
+        call.args[0] for call in handle.write.call_args_list
+    )
+    assert "CREATE TRIGGER trigger_crd_command_insert_or_update" in written
+    assert "WHEN (NEW.CrdCommand IS NOT NULL)" in written
+
+
+def test_vm_table_includes_heartbeat_columns(monkeypatch):
+    """The VM table schema must declare the five heartbeat columns."""
+    mock_config = MagicMock()
+    mock_config.db.dbname = "d"
+    mock_config.db.user = "u"
+    mock_config.db.password = "p"
+    mock_config.db.table_name = "vms"
+    mock_config.db.message_channel = "ch"
+
+    monkeypatch.setattr(
+        "lablink_allocator_service.generate_init_sql.get_config",
+        lambda: mock_config,
+    )
+
+    from lablink_allocator_service.generate_init_sql import main
+
+    m = mock_open()
+    with patch("builtins.open", m):
+        main()
+
+    handle = m()
+    written = "".join(
+        call.args[0] for call in handle.write.call_args_list
+    )
+    for col in [
+        "LastSeenAt",
+        "BootId",
+        "CrdActive",
+        "DockerHealthy",
+        "DiskFreePct",
+    ]:
+        assert col in written

--- a/packages/allocator/tests/test_generate_init_sql.py
+++ b/packages/allocator/tests/test_generate_init_sql.py
@@ -69,7 +69,6 @@ def test_vm_table_includes_heartbeat_columns(monkeypatch):
         "last_seen_at",
         "boot_id",
         "crd_active",
-        "docker_healthy",
         "disk_free_pct",
     ]:
         assert col in written

--- a/packages/allocator/tests/test_generate_init_sql.py
+++ b/packages/allocator/tests/test_generate_init_sql.py
@@ -61,11 +61,15 @@ def test_vm_table_includes_heartbeat_columns(monkeypatch):
     written = "".join(
         call.args[0] for call in handle.write.call_args_list
     )
+    # Columns must be declared in lowercase-with-underscores so Postgres
+    # stores them as `last_seen_at` etc. — queries throughout database.py
+    # reference them that way. CamelCase names (e.g. `LastSeenAt`) would
+    # be folded to `lastseenat`, breaking every query.
     for col in [
-        "LastSeenAt",
-        "BootId",
-        "CrdActive",
-        "DockerHealthy",
-        "DiskFreePct",
+        "last_seen_at",
+        "boot_id",
+        "crd_active",
+        "docker_healthy",
+        "disk_free_pct",
     ]:
         assert col in written

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -216,13 +216,12 @@ def test_get_failed_vms_heartbeat_only_matches_running(db_instance):
 
 
 def test_record_heartbeat_updates_columns(db_instance):
-    """record_heartbeat persists all five columns and bumps last_seen_at."""
-    db_instance.cursor.fetchone.return_value = (None, None, None)
+    """record_heartbeat persists all four columns and bumps last_seen_at."""
+    db_instance.cursor.fetchone.return_value = (None, None)
     ok = db_instance.record_heartbeat(
         hostname="vm-1",
         boot_id="abc-123",
         crd_active=True,
-        docker_healthy=True,
         disk_free_pct=87,
     )
     assert ok is True
@@ -234,9 +233,8 @@ def test_record_heartbeat_updates_columns(db_instance):
     assert "last_seen_at = NOW()" in query
     assert "boot_id = %s" in query
     assert "crd_active = %s" in query
-    assert "docker_healthy = %s" in query
     assert "disk_free_pct = %s" in query
-    assert params == ("abc-123", True, True, 87, "vm-1")
+    assert params == ("abc-123", True, 87, "vm-1")
 
 
 def test_record_heartbeat_unknown_hostname_returns_false(db_instance, caplog):
@@ -247,7 +245,6 @@ def test_record_heartbeat_unknown_hostname_returns_false(db_instance, caplog):
         hostname="vm-missing",
         boot_id="bid",
         crd_active=True,
-        docker_healthy=True,
         disk_free_pct=50,
     )
 
@@ -257,13 +254,12 @@ def test_record_heartbeat_unknown_hostname_returns_false(db_instance, caplog):
 
 def test_record_heartbeat_warns_on_boot_id_change(db_instance, caplog):
     """Heartbeat with a different boot_id than stored emits a warning."""
-    db_instance.cursor.fetchone.return_value = ("prev-bid", True, True)
+    db_instance.cursor.fetchone.return_value = ("prev-bid", True)
 
     db_instance.record_heartbeat(
         hostname="vm-1",
         boot_id="new-bid",
         crd_active=True,
-        docker_healthy=True,
         disk_free_pct=50,
     )
 
@@ -272,43 +268,26 @@ def test_record_heartbeat_warns_on_boot_id_change(db_instance, caplog):
 
 def test_record_heartbeat_warns_on_crd_flip(db_instance, caplog):
     """Heartbeat where crd_active transitions True -> False warns."""
-    db_instance.cursor.fetchone.return_value = ("bid", True, True)
+    db_instance.cursor.fetchone.return_value = ("bid", True)
 
     db_instance.record_heartbeat(
         hostname="vm-1",
         boot_id="bid",
         crd_active=False,
-        docker_healthy=True,
         disk_free_pct=50,
     )
 
     assert "crd_active flipped False" in caplog.text
 
 
-def test_record_heartbeat_warns_on_docker_flip(db_instance, caplog):
-    """Heartbeat where docker_healthy transitions True -> False warns."""
-    db_instance.cursor.fetchone.return_value = ("bid", True, True)
-
-    db_instance.record_heartbeat(
-        hostname="vm-1",
-        boot_id="bid",
-        crd_active=True,
-        docker_healthy=False,
-        disk_free_pct=50,
-    )
-
-    assert "docker_healthy flipped False" in caplog.text
-
-
 def test_record_heartbeat_warns_on_low_disk(db_instance, caplog):
     """disk_free_pct under 10 % emits a warning."""
-    db_instance.cursor.fetchone.return_value = ("bid", True, True)
+    db_instance.cursor.fetchone.return_value = ("bid", True)
 
     db_instance.record_heartbeat(
         hostname="vm-1",
         boot_id="bid",
         crd_active=True,
-        docker_healthy=True,
         disk_free_pct=5,
     )
 
@@ -317,13 +296,12 @@ def test_record_heartbeat_warns_on_low_disk(db_instance, caplog):
 
 def test_record_heartbeat_no_warn_on_first_boot_id(db_instance, caplog):
     """First heartbeat (previous boot_id is NULL) must not warn."""
-    db_instance.cursor.fetchone.return_value = (None, None, None)
+    db_instance.cursor.fetchone.return_value = (None, None)
 
     db_instance.record_heartbeat(
         hostname="vm-1",
         boot_id="new-bid",
         crd_active=True,
-        docker_healthy=True,
         disk_free_pct=50,
     )
 
@@ -339,7 +317,6 @@ def test_touch_last_seen_only_updates_timestamp(db_instance):
     # No other mutable columns touched.
     assert "boot_id" not in query
     assert "crd_active" not in query
-    assert "docker_healthy" not in query
     assert "status" not in query
 
 

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -57,8 +57,16 @@ def test_update_vm_status_rebooting(db_instance):
 def test_get_failed_vms(db_instance):
     """Test retrieving failed VMs."""
     db_instance.cursor.fetchall.return_value = [
-        ("vm-1", "error", None, 0, None, None),
-        ("vm-2", "running", "Unhealthy", 1, datetime(2025, 1, 1), "user@test.com"),
+        ("vm-1", "error", None, 0, None, None, None),
+        (
+            "vm-2",
+            "running",
+            "Unhealthy",
+            1,
+            datetime(2025, 1, 1),
+            "user@test.com",
+            None,
+        ),
     ]
 
     result = db_instance.get_failed_vms()
@@ -75,8 +83,8 @@ def test_get_failed_vms(db_instance):
 def test_get_failed_vms_includes_useremail(db_instance):
     """Test that get_failed_vms returns useremail for assignment-aware reboot."""
     db_instance.cursor.fetchall.return_value = [
-        ("vm-assigned", "error", None, 1, None, "student@example.com"),
-        ("vm-unassigned", "error", None, 0, None, None),
+        ("vm-assigned", "error", None, 1, None, "student@example.com", None),
+        ("vm-unassigned", "error", None, 0, None, None, None),
     ]
 
     result = db_instance.get_failed_vms()
@@ -103,7 +111,7 @@ def test_get_failed_vms_error(db_instance, caplog):
 def test_get_failed_vms_includes_stale_initializing(db_instance):
     """Test that stale initializing VMs are included in failed VMs query."""
     db_instance.cursor.fetchall.return_value = [
-        ("vm-stale", "initializing", None, 0, None, None),
+        ("vm-stale", "initializing", None, 0, None, None, None),
     ]
 
     result = db_instance.get_failed_vms(stale_initializing_minutes=15)
@@ -138,7 +146,7 @@ def test_get_failed_vms_default_stale_initializing_is_25_minutes(db_instance):
 def test_get_failed_vms_includes_stuck_rebooting(db_instance):
     """Test that VMs stuck in rebooting state are re-eligible."""
     db_instance.cursor.fetchall.return_value = [
-        ("vm-stuck", "rebooting", None, 1, datetime(2025, 1, 1), None),
+        ("vm-stuck", "rebooting", None, 1, datetime(2025, 1, 1), None, None),
     ]
 
     result = db_instance.get_failed_vms(stale_rebooting_minutes=10)
@@ -152,6 +160,201 @@ def test_get_failed_vms_includes_stuck_rebooting(db_instance):
     assert "rebooting" in query
     assert "last_reboot_time" in query
     assert "10 minutes" in query
+
+
+def test_get_failed_vms_includes_silent_running_vm(db_instance):
+    """Running VM with stale last_seen_at is flagged for reboot."""
+    stale = datetime(2025, 1, 1, tzinfo=timezone.utc)
+    db_instance.cursor.fetchall.return_value = [
+        ("vm-silent", "running", "Healthy", 0, None, "s@test", stale),
+    ]
+
+    result = db_instance.get_failed_vms(stale_heartbeat_minutes=3)
+
+    assert len(result) == 1
+    assert result[0]["hostname"] == "vm-silent"
+    assert result[0]["last_seen_at"] == stale
+
+    query = db_instance.cursor.execute.call_args[0][0]
+    assert "last_seen_at" in query
+    assert "3 minutes" in query
+
+
+def test_get_failed_vms_default_stale_heartbeat_is_3_minutes(db_instance):
+    """Default stale_heartbeat_minutes is 3 (6x the 30s heartbeat cadence)."""
+    db_instance.cursor.fetchall.return_value = []
+    db_instance.get_failed_vms()  # no explicit arguments
+
+    query = db_instance.cursor.execute.call_args[0][0]
+    assert "3 minutes" in query
+
+
+def test_get_failed_vms_null_last_seen_not_flagged(db_instance):
+    """Brand-new VMs with last_seen_at IS NULL must not be flagged.
+
+    Otherwise every VM would be marked silent immediately on creation,
+    before the heartbeat thread has had a chance to post.
+    """
+    db_instance.cursor.fetchall.return_value = []
+    db_instance.get_failed_vms(stale_heartbeat_minutes=3)
+
+    query = db_instance.cursor.execute.call_args[0][0]
+    assert "last_seen_at IS NOT NULL" in query
+
+
+def test_get_failed_vms_heartbeat_only_matches_running(db_instance):
+    """The heartbeat staleness branch guards on status='running' so we
+    don't double-count VMs already caught by the rebooting/initializing
+    stale predicates."""
+    db_instance.cursor.fetchall.return_value = []
+    db_instance.get_failed_vms()
+
+    query = db_instance.cursor.execute.call_args[0][0]
+    # The heartbeat branch appears alongside status = 'running'
+    assert "status = 'running'" in query
+    assert "last_seen_at IS NOT NULL" in query
+
+
+def test_record_heartbeat_updates_columns(db_instance):
+    """record_heartbeat persists all five columns and bumps last_seen_at."""
+    db_instance.cursor.fetchone.return_value = (None, None, None)
+    ok = db_instance.record_heartbeat(
+        hostname="vm-1",
+        boot_id="abc-123",
+        crd_active=True,
+        docker_healthy=True,
+        disk_free_pct=87,
+    )
+    assert ok is True
+
+    # The UPDATE call is the second execute (first was the SELECT).
+    update_call = db_instance.cursor.execute.call_args_list[-1]
+    query = update_call[0][0]
+    params = update_call[0][1]
+    assert "last_seen_at = NOW()" in query
+    assert "boot_id = %s" in query
+    assert "crd_active = %s" in query
+    assert "docker_healthy = %s" in query
+    assert "disk_free_pct = %s" in query
+    assert params == ("abc-123", True, True, 87, "vm-1")
+
+
+def test_record_heartbeat_unknown_hostname_returns_false(db_instance, caplog):
+    """Heartbeat for an unknown hostname returns False and logs warning."""
+    db_instance.cursor.fetchone.return_value = None
+
+    ok = db_instance.record_heartbeat(
+        hostname="vm-missing",
+        boot_id="bid",
+        crd_active=True,
+        docker_healthy=True,
+        disk_free_pct=50,
+    )
+
+    assert ok is False
+    assert "unknown hostname" in caplog.text.lower()
+
+
+def test_record_heartbeat_warns_on_boot_id_change(db_instance, caplog):
+    """Heartbeat with a different boot_id than stored emits a warning."""
+    db_instance.cursor.fetchone.return_value = ("prev-bid", True, True)
+
+    db_instance.record_heartbeat(
+        hostname="vm-1",
+        boot_id="new-bid",
+        crd_active=True,
+        docker_healthy=True,
+        disk_free_pct=50,
+    )
+
+    assert "boot_id changed" in caplog.text
+
+
+def test_record_heartbeat_warns_on_crd_flip(db_instance, caplog):
+    """Heartbeat where crd_active transitions True -> False warns."""
+    db_instance.cursor.fetchone.return_value = ("bid", True, True)
+
+    db_instance.record_heartbeat(
+        hostname="vm-1",
+        boot_id="bid",
+        crd_active=False,
+        docker_healthy=True,
+        disk_free_pct=50,
+    )
+
+    assert "crd_active flipped False" in caplog.text
+
+
+def test_record_heartbeat_warns_on_docker_flip(db_instance, caplog):
+    """Heartbeat where docker_healthy transitions True -> False warns."""
+    db_instance.cursor.fetchone.return_value = ("bid", True, True)
+
+    db_instance.record_heartbeat(
+        hostname="vm-1",
+        boot_id="bid",
+        crd_active=True,
+        docker_healthy=False,
+        disk_free_pct=50,
+    )
+
+    assert "docker_healthy flipped False" in caplog.text
+
+
+def test_record_heartbeat_warns_on_low_disk(db_instance, caplog):
+    """disk_free_pct under 10 % emits a warning."""
+    db_instance.cursor.fetchone.return_value = ("bid", True, True)
+
+    db_instance.record_heartbeat(
+        hostname="vm-1",
+        boot_id="bid",
+        crd_active=True,
+        docker_healthy=True,
+        disk_free_pct=5,
+    )
+
+    assert "disk_free_pct low" in caplog.text
+
+
+def test_record_heartbeat_no_warn_on_first_boot_id(db_instance, caplog):
+    """First heartbeat (previous boot_id is NULL) must not warn."""
+    db_instance.cursor.fetchone.return_value = (None, None, None)
+
+    db_instance.record_heartbeat(
+        hostname="vm-1",
+        boot_id="new-bid",
+        crd_active=True,
+        docker_healthy=True,
+        disk_free_pct=50,
+    )
+
+    assert "boot_id changed" not in caplog.text
+
+
+def test_touch_last_seen_only_updates_timestamp(db_instance):
+    """touch_last_seen updates last_seen_at without touching other columns."""
+    db_instance.touch_last_seen("vm-1")
+
+    query = db_instance.cursor.execute.call_args[0][0]
+    assert "last_seen_at = NOW()" in query
+    # No other mutable columns touched.
+    assert "boot_id" not in query
+    assert "crd_active" not in query
+    assert "docker_healthy" not in query
+    assert "status" not in query
+
+
+def test_touch_last_seen_swallows_errors(db_instance, caplog):
+    """touch_last_seen logs and continues on DB error; never raises.
+
+    It is called on the hot path of every client->allocator endpoint,
+    so a failure here must not take the endpoint down.
+    """
+    db_instance.cursor.execute.side_effect = Exception("DB down")
+
+    # No exception should propagate.
+    db_instance.touch_last_seen("vm-1")
+
+    assert "touch last_seen" in caplog.text.lower()
 
 
 def test_record_reboot(db_instance):

--- a/packages/client/pyproject.toml
+++ b/packages/client/pyproject.toml
@@ -32,6 +32,7 @@ Issues = "https://github.com/talmolab/lablink/issues"
 
 [project.scripts]
 check_gpu = "lablink_client_service.check_gpu:main"
+heartbeat = "lablink_client_service.heartbeat:main"
 subscribe = "lablink_client_service.subscribe:main"
 update_inuse_status = "lablink_client_service.update_inuse_status:main"
 

--- a/packages/client/src/lablink_client_service/heartbeat.py
+++ b/packages/client/src/lablink_client_service/heartbeat.py
@@ -10,7 +10,7 @@ import logging
 import os
 import shutil
 import subprocess
-import time
+import threading
 from datetime import datetime, timezone
 
 import hydra
@@ -125,8 +125,15 @@ def run_heartbeat_loop(
     allocator_url: str,
     api_token: str = "",
     interval: int = HEARTBEAT_INTERVAL_SECONDS,
+    stop_event: threading.Event | None = None,
 ) -> None:
-    """Long-running loop that sends a heartbeat every `interval` seconds."""
+    """Long-running loop that sends a heartbeat every `interval` seconds.
+
+    Mirrors the AutoRebootService loop shape in reboot.py: an Event-driven
+    sleep so callers can stop the loop, and an outer exception guard so a
+    rogue exception in a sampler does not silently kill the thread and
+    leave the container running with no liveness signal.
+    """
     logger.info("Starting heartbeat loop")
     base_url = sanitize_url(allocator_url)
     headers = {"Content-Type": "application/json"}
@@ -135,10 +142,16 @@ def run_heartbeat_loop(
     vm_id = os.getenv("VM_NAME")
     boot_id = read_boot_id()
 
-    while True:
-        payload = build_payload(vm_id=vm_id, boot_id=boot_id)
-        send_heartbeat(base_url=base_url, headers=headers, payload=payload)
-        time.sleep(interval)
+    if stop_event is None:
+        stop_event = threading.Event()
+
+    while not stop_event.is_set():
+        try:
+            payload = build_payload(vm_id=vm_id, boot_id=boot_id)
+            send_heartbeat(base_url=base_url, headers=headers, payload=payload)
+        except Exception:
+            logger.exception("Heartbeat iteration failed; continuing")
+        stop_event.wait(interval)
 
 
 @hydra.main(version_base=None, config_name="config")

--- a/packages/client/src/lablink_client_service/heartbeat.py
+++ b/packages/client/src/lablink_client_service/heartbeat.py
@@ -1,0 +1,153 @@
+"""Liveness heartbeat for the LabLink client VM.
+
+Sends a small POST to the allocator every HEARTBEAT_INTERVAL_SECONDS so
+the allocator can detect silent failures (dead container, broken network,
+hung host, expired CRD token, out-of-band EC2 termination). The body
+also carries a handful of cheap health signals for early warning.
+"""
+
+import logging
+import os
+import shutil
+import subprocess
+import time
+from datetime import datetime, timezone
+
+import hydra
+import requests
+
+from lablink_client_service.conf.structured_config import Config
+from lablink_client_service.http_utils import (
+    get_auth_headers,
+    get_client_env,
+    sanitize_url,
+)
+from lablink_client_service.logger_utils import CloudAndConsoleLogger
+
+
+logger = logging.getLogger(__name__)
+
+HEARTBEAT_INTERVAL_SECONDS = 30
+HEARTBEAT_POST_TIMEOUT_SECONDS = 5
+DOCKER_PROBE_TIMEOUT_SECONDS = 3
+BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id"
+
+
+def read_boot_id() -> str | None:
+    """Read the kernel-assigned per-boot UUID. Cached by the caller."""
+    try:
+        with open(BOOT_ID_PATH, "r") as f:
+            return f.read().strip()
+    except OSError as e:
+        logger.warning(f"Could not read boot_id: {e}")
+        return None
+
+
+def sample_crd_active() -> bool:
+    """Return True if the chrome-remote-desktop session is active."""
+    try:
+        result = subprocess.run(
+            ["pgrep", "-f", "chrome-remote-desktop"],
+            capture_output=True,
+            timeout=2,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.debug(f"crd_active probe failed: {e}")
+        return False
+
+
+def sample_docker_healthy() -> bool:
+    """Return True if `docker info` returns within the probe timeout."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=DOCKER_PROBE_TIMEOUT_SECONDS,
+        )
+        return result.returncode == 0
+    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
+        logger.debug(f"docker_healthy probe failed: {e}")
+        return False
+
+
+def sample_disk_free_pct(path: str = "/") -> int:
+    """Return integer percent of free space on the filesystem at `path`."""
+    try:
+        usage = shutil.disk_usage(path)
+        if usage.total == 0:
+            return 0
+        return int((usage.free / usage.total) * 100)
+    except OSError as e:
+        logger.debug(f"disk_free_pct probe failed: {e}")
+        return 0
+
+
+def build_payload(vm_id: str | None, boot_id: str | None) -> dict:
+    """Build the heartbeat JSON payload."""
+    return {
+        "vm_id": vm_id,
+        "boot_id": boot_id,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+        "crd_active": sample_crd_active(),
+        "docker_healthy": sample_docker_healthy(),
+        "disk_free_pct": sample_disk_free_pct(),
+    }
+
+
+def send_heartbeat(
+    base_url: str,
+    headers: dict,
+    payload: dict,
+) -> None:
+    """POST one heartbeat. Swallows network errors — never raises.
+
+    Heartbeat integrity is in the allocator noticing when we *stop*
+    sending. A failed individual POST is not worth crashing the client.
+    """
+    try:
+        response = requests.post(
+            f"{base_url}/api/heartbeat",
+            json=payload,
+            headers=headers,
+            timeout=HEARTBEAT_POST_TIMEOUT_SECONDS,
+        )
+        if response.status_code >= 400:
+            logger.debug(
+                f"Heartbeat POST returned {response.status_code}: "
+                f"{response.text[:200]}"
+            )
+    except requests.exceptions.RequestException as e:
+        logger.debug(f"Heartbeat POST failed: {e}")
+
+
+def run_heartbeat_loop(
+    allocator_url: str,
+    api_token: str = "",
+    interval: int = HEARTBEAT_INTERVAL_SECONDS,
+) -> None:
+    """Long-running loop that sends a heartbeat every `interval` seconds."""
+    logger.info("Starting heartbeat loop")
+    base_url = sanitize_url(allocator_url)
+    headers = {"Content-Type": "application/json"}
+    headers.update(get_auth_headers(api_token))
+
+    vm_id = os.getenv("VM_NAME")
+    boot_id = read_boot_id()
+
+    while True:
+        payload = build_payload(vm_id=vm_id, boot_id=boot_id)
+        send_heartbeat(base_url=base_url, headers=headers, payload=payload)
+        time.sleep(interval)
+
+
+@hydra.main(version_base=None, config_name="config")
+def main(cfg: Config) -> None:
+    global logger
+    logger = CloudAndConsoleLogger(module_name="heartbeat")
+    base_url, api_token, _ = get_client_env(cfg)
+    run_heartbeat_loop(allocator_url=base_url, api_token=api_token)
+
+
+if __name__ == "__main__":
+    main()

--- a/packages/client/src/lablink_client_service/heartbeat.py
+++ b/packages/client/src/lablink_client_service/heartbeat.py
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 
 HEARTBEAT_INTERVAL_SECONDS = 30
 HEARTBEAT_POST_TIMEOUT_SECONDS = 5
-DOCKER_PROBE_TIMEOUT_SECONDS = 3
 BOOT_ID_PATH = "/proc/sys/kernel/random/boot_id"
 
 
@@ -57,20 +56,6 @@ def sample_crd_active() -> bool:
         return False
 
 
-def sample_docker_healthy() -> bool:
-    """Return True if `docker info` returns within the probe timeout."""
-    try:
-        result = subprocess.run(
-            ["docker", "info"],
-            capture_output=True,
-            timeout=DOCKER_PROBE_TIMEOUT_SECONDS,
-        )
-        return result.returncode == 0
-    except (subprocess.TimeoutExpired, FileNotFoundError, OSError) as e:
-        logger.debug(f"docker_healthy probe failed: {e}")
-        return False
-
-
 def sample_disk_free_pct(path: str = "/") -> int:
     """Return integer percent of free space on the filesystem at `path`."""
     try:
@@ -90,7 +75,6 @@ def build_payload(vm_id: str | None, boot_id: str | None) -> dict:
         "boot_id": boot_id,
         "timestamp": datetime.now(timezone.utc).isoformat(),
         "crd_active": sample_crd_active(),
-        "docker_healthy": sample_docker_healthy(),
         "disk_free_pct": sample_disk_free_pct(),
     }
 

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -101,6 +101,11 @@ check_gpu \
   allocator.host=$ALLOCATOR_HOST allocator.port=80 \
   2>&1 | tee "$LOG_DIR/check_gpu.log" &
 
+# Run heartbeat loop (silent-failure detection)
+heartbeat \
+  allocator.host=$ALLOCATOR_HOST allocator.port=80 \
+  2>&1 | tee "$LOG_DIR/heartbeat.log" &
+
 touch "$LOG_DIR/placeholder.log"
 
 # End time
@@ -119,4 +124,4 @@ curl -X POST "$ALLOCATOR_URL/api/vm-metrics/$VM_NAME" \
   }" --max-time 5 || true
 
 # Keep container alive
-tail -F "$LOG_DIR/subscribe.log" "$LOG_DIR/update_inuse_status.log" "$LOG_DIR/check_gpu.log" "$LOG_DIR/placeholder.log"
+tail -F "$LOG_DIR/subscribe.log" "$LOG_DIR/update_inuse_status.log" "$LOG_DIR/check_gpu.log" "$LOG_DIR/heartbeat.log" "$LOG_DIR/placeholder.log"

--- a/packages/client/tests/test_heartbeat.py
+++ b/packages/client/tests/test_heartbeat.py
@@ -1,6 +1,7 @@
 """Tests for the client-side heartbeat module."""
 
 import subprocess
+import threading
 from unittest.mock import patch, MagicMock, mock_open
 
 import pytest
@@ -142,30 +143,72 @@ def test_send_heartbeat_does_not_raise_on_4xx(mock_post):
     )
 
 
-@patch("lablink_client_service.heartbeat.time.sleep")
 @patch(
     "lablink_client_service.heartbeat.build_payload",
     return_value={"vm_id": "vm-1"},
 )
-@patch("lablink_client_service.heartbeat.send_heartbeat")
 @patch("lablink_client_service.heartbeat.read_boot_id", return_value="bid-1")
-def test_run_heartbeat_loop_reads_boot_id_once(
-    mock_boot, mock_send, mock_build, mock_sleep, vm_env
+def test_run_heartbeat_loop_reads_boot_id_once_and_respects_stop_event(
+    mock_boot, mock_build, vm_env
 ):
-    # Break out of the infinite loop after the second tick.
-    # build_payload is patched so the real samplers (which shell out to
-    # pgrep/docker via subprocess.run) never run — subprocess uses
-    # time.sleep internally on Linux, which would consume the mock's
-    # side_effect list prematurely.
-    mock_sleep.side_effect = [None, KeyboardInterrupt]
+    """The loop caches boot_id across ticks and exits cleanly when
+    stop_event is set. Uses a captured send_heartbeat that flips the
+    event on its second call, so the loop runs exactly twice and then
+    returns — no time.sleep patching, no KeyboardInterrupt gymnastics.
+    """
+    stop = threading.Event()
+    calls = []
 
-    with pytest.raises(KeyboardInterrupt):
+    def capture(base_url, headers, payload):
+        calls.append(payload)
+        if len(calls) >= 2:
+            stop.set()
+
+    with patch(
+        "lablink_client_service.heartbeat.send_heartbeat", side_effect=capture
+    ):
         heartbeat.run_heartbeat_loop(
             allocator_url="http://alloc",
             api_token="tok",
             interval=0,
+            stop_event=stop,
         )
 
     assert mock_boot.call_count == 1
-    assert mock_send.call_count == 2
     assert mock_build.call_count == 2
+    assert len(calls) == 2
+
+
+@patch("lablink_client_service.heartbeat.read_boot_id", return_value="bid-1")
+def test_run_heartbeat_loop_logs_and_continues_on_unexpected_exception(
+    mock_boot, vm_env, caplog
+):
+    """An exception outside the samplers' caught tuples must not kill the
+    loop: log the traceback and proceed to the next tick. Without the
+    outer guard, the thread would die silently and the container would
+    remain alive but go silent — triggering an unnecessary reboot cycle
+    instead of letting the process self-heal on the next iteration.
+    """
+    stop = threading.Event()
+    call_count = {"n": 0}
+
+    def raise_then_stop(vm_id, boot_id):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            raise RuntimeError("simulated sampler failure")
+        stop.set()
+        return {"vm_id": vm_id}
+
+    with patch(
+        "lablink_client_service.heartbeat.build_payload",
+        side_effect=raise_then_stop,
+    ):
+        with patch("lablink_client_service.heartbeat.send_heartbeat"):
+            heartbeat.run_heartbeat_loop(
+                allocator_url="http://alloc",
+                interval=0,
+                stop_event=stop,
+            )
+
+    assert call_count["n"] == 2  # continued past the raising iteration
+    assert "simulated sampler failure" in caplog.text

--- a/packages/client/tests/test_heartbeat.py
+++ b/packages/client/tests/test_heartbeat.py
@@ -52,18 +52,6 @@ def test_sample_crd_active_false_on_missing_binary(mock_run):
     assert heartbeat.sample_crd_active() is False
 
 
-@patch("lablink_client_service.heartbeat.subprocess.run")
-def test_sample_docker_healthy_true(mock_run):
-    mock_run.return_value = MagicMock(returncode=0)
-    assert heartbeat.sample_docker_healthy() is True
-
-
-@patch("lablink_client_service.heartbeat.subprocess.run")
-def test_sample_docker_healthy_false_on_timeout(mock_run):
-    mock_run.side_effect = subprocess.TimeoutExpired("docker", 3)
-    assert heartbeat.sample_docker_healthy() is False
-
-
 @patch("lablink_client_service.heartbeat.shutil.disk_usage")
 def test_sample_disk_free_pct(mock_usage):
     mock_usage.return_value = MagicMock(total=100, free=47, used=53)
@@ -83,16 +71,15 @@ def test_sample_disk_free_pct_handles_oserror(mock_usage):
 
 
 @patch("lablink_client_service.heartbeat.sample_disk_free_pct", return_value=80)
-@patch("lablink_client_service.heartbeat.sample_docker_healthy", return_value=True)
 @patch("lablink_client_service.heartbeat.sample_crd_active", return_value=True)
-def test_build_payload_well_formed(mock_crd, mock_docker, mock_disk):
+def test_build_payload_well_formed(mock_crd, mock_disk):
     payload = heartbeat.build_payload(vm_id="vm-1", boot_id="bid")
     assert payload["vm_id"] == "vm-1"
     assert payload["boot_id"] == "bid"
     assert payload["crd_active"] is True
-    assert payload["docker_healthy"] is True
     assert payload["disk_free_pct"] == 80
     assert isinstance(payload["timestamp"], str)
+    assert "docker_healthy" not in payload
 
 
 @patch("lablink_client_service.heartbeat.requests.post")

--- a/packages/client/tests/test_heartbeat.py
+++ b/packages/client/tests/test_heartbeat.py
@@ -143,12 +143,20 @@ def test_send_heartbeat_does_not_raise_on_4xx(mock_post):
 
 
 @patch("lablink_client_service.heartbeat.time.sleep")
+@patch(
+    "lablink_client_service.heartbeat.build_payload",
+    return_value={"vm_id": "vm-1"},
+)
 @patch("lablink_client_service.heartbeat.send_heartbeat")
 @patch("lablink_client_service.heartbeat.read_boot_id", return_value="bid-1")
 def test_run_heartbeat_loop_reads_boot_id_once(
-    mock_boot, mock_send, mock_sleep, vm_env
+    mock_boot, mock_send, mock_build, mock_sleep, vm_env
 ):
     # Break out of the infinite loop after the second tick.
+    # build_payload is patched so the real samplers (which shell out to
+    # pgrep/docker via subprocess.run) never run — subprocess uses
+    # time.sleep internally on Linux, which would consume the mock's
+    # side_effect list prematurely.
     mock_sleep.side_effect = [None, KeyboardInterrupt]
 
     with pytest.raises(KeyboardInterrupt):
@@ -160,3 +168,4 @@ def test_run_heartbeat_loop_reads_boot_id_once(
 
     assert mock_boot.call_count == 1
     assert mock_send.call_count == 2
+    assert mock_build.call_count == 2

--- a/packages/client/tests/test_heartbeat.py
+++ b/packages/client/tests/test_heartbeat.py
@@ -1,0 +1,162 @@
+"""Tests for the client-side heartbeat module."""
+
+import subprocess
+from unittest.mock import patch, MagicMock, mock_open
+
+import pytest
+import requests
+
+from lablink_client_service import heartbeat
+
+
+@pytest.fixture
+def vm_env(monkeypatch):
+    monkeypatch.setenv("VM_NAME", "vm-1")
+
+
+def test_read_boot_id_returns_trimmed_contents():
+    fake = mock_open(read_data="abc-123\n")
+    with patch("builtins.open", fake):
+        assert heartbeat.read_boot_id() == "abc-123"
+
+
+def test_read_boot_id_returns_none_on_oserror(caplog):
+    with patch("builtins.open", side_effect=OSError("permission denied")):
+        result = heartbeat.read_boot_id()
+    assert result is None
+    assert "boot_id" in caplog.text
+
+
+@patch("lablink_client_service.heartbeat.subprocess.run")
+def test_sample_crd_active_true_when_pgrep_succeeds(mock_run):
+    mock_run.return_value = MagicMock(returncode=0)
+    assert heartbeat.sample_crd_active() is True
+
+
+@patch("lablink_client_service.heartbeat.subprocess.run")
+def test_sample_crd_active_false_when_pgrep_fails(mock_run):
+    mock_run.return_value = MagicMock(returncode=1)
+    assert heartbeat.sample_crd_active() is False
+
+
+@patch("lablink_client_service.heartbeat.subprocess.run")
+def test_sample_crd_active_false_on_timeout(mock_run):
+    mock_run.side_effect = subprocess.TimeoutExpired("pgrep", 2)
+    assert heartbeat.sample_crd_active() is False
+
+
+@patch("lablink_client_service.heartbeat.subprocess.run")
+def test_sample_crd_active_false_on_missing_binary(mock_run):
+    mock_run.side_effect = FileNotFoundError
+    assert heartbeat.sample_crd_active() is False
+
+
+@patch("lablink_client_service.heartbeat.subprocess.run")
+def test_sample_docker_healthy_true(mock_run):
+    mock_run.return_value = MagicMock(returncode=0)
+    assert heartbeat.sample_docker_healthy() is True
+
+
+@patch("lablink_client_service.heartbeat.subprocess.run")
+def test_sample_docker_healthy_false_on_timeout(mock_run):
+    mock_run.side_effect = subprocess.TimeoutExpired("docker", 3)
+    assert heartbeat.sample_docker_healthy() is False
+
+
+@patch("lablink_client_service.heartbeat.shutil.disk_usage")
+def test_sample_disk_free_pct(mock_usage):
+    mock_usage.return_value = MagicMock(total=100, free=47, used=53)
+    assert heartbeat.sample_disk_free_pct() == 47
+
+
+@patch("lablink_client_service.heartbeat.shutil.disk_usage")
+def test_sample_disk_free_pct_handles_zero_total(mock_usage):
+    mock_usage.return_value = MagicMock(total=0, free=0, used=0)
+    assert heartbeat.sample_disk_free_pct() == 0
+
+
+@patch("lablink_client_service.heartbeat.shutil.disk_usage")
+def test_sample_disk_free_pct_handles_oserror(mock_usage):
+    mock_usage.side_effect = OSError("boom")
+    assert heartbeat.sample_disk_free_pct() == 0
+
+
+@patch("lablink_client_service.heartbeat.sample_disk_free_pct", return_value=80)
+@patch("lablink_client_service.heartbeat.sample_docker_healthy", return_value=True)
+@patch("lablink_client_service.heartbeat.sample_crd_active", return_value=True)
+def test_build_payload_well_formed(mock_crd, mock_docker, mock_disk):
+    payload = heartbeat.build_payload(vm_id="vm-1", boot_id="bid")
+    assert payload["vm_id"] == "vm-1"
+    assert payload["boot_id"] == "bid"
+    assert payload["crd_active"] is True
+    assert payload["docker_healthy"] is True
+    assert payload["disk_free_pct"] == 80
+    assert isinstance(payload["timestamp"], str)
+
+
+@patch("lablink_client_service.heartbeat.requests.post")
+def test_send_heartbeat_posts_to_correct_url(mock_post):
+    mock_post.return_value = MagicMock(status_code=200, text="")
+    heartbeat.send_heartbeat(
+        base_url="http://alloc:5000",
+        headers={"Authorization": "Bearer tok"},
+        payload={"vm_id": "vm-1"},
+    )
+    mock_post.assert_called_once()
+    args, kwargs = mock_post.call_args
+    assert args[0] == "http://alloc:5000/api/heartbeat"
+    assert kwargs["json"] == {"vm_id": "vm-1"}
+    assert kwargs["headers"] == {"Authorization": "Bearer tok"}
+    assert kwargs["timeout"] == heartbeat.HEARTBEAT_POST_TIMEOUT_SECONDS
+
+
+@patch("lablink_client_service.heartbeat.requests.post")
+def test_send_heartbeat_swallows_connection_error(mock_post, caplog):
+    mock_post.side_effect = requests.exceptions.ConnectionError("unreachable")
+    heartbeat.send_heartbeat(
+        base_url="http://alloc",
+        headers={},
+        payload={"vm_id": "vm-1"},
+    )
+
+
+@patch("lablink_client_service.heartbeat.requests.post")
+def test_send_heartbeat_swallows_timeout(mock_post):
+    mock_post.side_effect = requests.exceptions.Timeout
+    # Must not raise.
+    heartbeat.send_heartbeat(
+        base_url="http://alloc",
+        headers={},
+        payload={"vm_id": "vm-1"},
+    )
+
+
+@patch("lablink_client_service.heartbeat.requests.post")
+def test_send_heartbeat_does_not_raise_on_4xx(mock_post):
+    mock_post.return_value = MagicMock(status_code=404, text="not found")
+    # Must not raise.
+    heartbeat.send_heartbeat(
+        base_url="http://alloc",
+        headers={},
+        payload={"vm_id": "vm-1"},
+    )
+
+
+@patch("lablink_client_service.heartbeat.time.sleep")
+@patch("lablink_client_service.heartbeat.send_heartbeat")
+@patch("lablink_client_service.heartbeat.read_boot_id", return_value="bid-1")
+def test_run_heartbeat_loop_reads_boot_id_once(
+    mock_boot, mock_send, mock_sleep, vm_env
+):
+    # Break out of the infinite loop after the second tick.
+    mock_sleep.side_effect = [None, KeyboardInterrupt]
+
+    with pytest.raises(KeyboardInterrupt):
+        heartbeat.run_heartbeat_loop(
+            allocator_url="http://alloc",
+            api_token="tok",
+            interval=0,
+        )
+
+    assert mock_boot.call_count == 1
+    assert mock_send.call_count == 2


### PR DESCRIPTION
## Summary
- Adds an active liveness contract between client VMs and the allocator so silent post-assignment failures (dead container, broken network, hung host, expired CRD token, out-of-band EC2 termination) feed into the existing reboot pipeline.
- Clients POST `/api/heartbeat` every 30 s with a small health payload; the allocator tracks `last_seen_at` plus four reported fields and flags any running VM silent for more than 3 min as failed.

## Changes Made

**Allocator**
- `generate_init_sql.py`: new columns `LastSeenAt`, `BootId`, `CrdActive`, `DockerHealthy`, `DiskFreePct` on the VM table; `WHEN (NEW.CrdCommand IS NOT NULL)` guard on `trigger_crd_command_insert_or_update` to suppress spurious NOTIFYs on reboot.
- `database.py`: new `record_heartbeat()` (updates the five columns + warns on boot_id change / crd flip / docker flip / disk_free_pct < 10 %), `touch_last_seen()` (cheap timestamp bump), and a new `stale_heartbeat_minutes: int = 3` parameter on `get_failed_vms()` adding the `status='running' AND last_seen_at IS NOT NULL AND last_seen_at < NOW() - INTERVAL ...` branch. `last_seen_at` is now in the returned dict.
- `main.py`: new `POST /api/heartbeat` endpoint (API-token protected). `touch_last_seen()` wired into `/api/gpu_health`, `/api/vm-status`, `/api/vm-metrics/<hostname>`, and `/vm_startup` so any client traffic refreshes the liveness timer.

**Client**
- New `lablink_client_service/heartbeat.py` module: cached `boot_id` from `/proc/sys/kernel/random/boot_id`, samplers for `crd_active` (pgrep), `docker_healthy` (`docker info` with timeout), `disk_free_pct` (`shutil.disk_usage('/')`). Long-running loop posts every 30 s with a 5 s timeout and swallows network errors.
- New `heartbeat` entry point in `pyproject.toml`; `start.sh` launches it alongside `check_gpu` / `subscribe` / `update_inuse_status` and tails its log.

## Testing

- New: `test_heartbeat.py` in both packages (17 client-side tests for samplers, payload shape, network-error handling, boot_id caching; DB-side coverage for all four warning paths, unknown-hostname, and the staleness predicate including the `IS NOT NULL` brand-new-VM guard).
- Extended `test_api_calls.py`: heartbeat endpoint auth/validation/success/404/500 and cross-endpoint `touch_last_seen` bump assertions for all four wired endpoints.
- New `test_generate_init_sql.py`: asserts the trigger `WHEN` guard and the five column declarations land in the generated SQL.
- Existing `get_failed_vms` tests updated to handle the new 7-column row shape.
- **164 allocator PR-4 tests passing, 82 client tests passing (17 new), ruff clean**. Terraform plan tests in the allocator suite fail with backend-init errors — unrelated and pre-existing.

## Design Decisions

- **Dedicated endpoint + passive refresh on existing traffic.** Heartbeat is the contract, but any authenticated client→allocator call (gpu_health, vm-status, vm-metrics, vm_startup) also bumps `last_seen_at`. Prevents false-positive staleness when other signals are flowing, without making GPU reports load-bearing for liveness semantics.
- **`IS NOT NULL` guard in the staleness branch.** Brand-new VMs have `last_seen_at IS NULL` until their first heartbeat. Without the guard, every VM would be flagged silent at creation time, well before the first 30 s tick and host startup could complete.
- **`status = 'running'` guard.** The heartbeat branch only matches running VMs so rebooting/initializing VMs aren't double-counted with the existing stale-rebooting and stale-initializing predicates.
- **Trigger `WHEN` guard.** `record_reboot` and `release_assignment` set `CrdCommand = NULL`; the old trigger fired anyway and the LISTEN loop discarded the payload with an "Invalid notification payload" warning. The `WHEN (NEW.CrdCommand IS NOT NULL)` clause suppresses the NOTIFY at source.
- **Thresholds hard-coded.** 30 s heartbeat cadence, 3 min staleness, 10 % disk-free warning. Promoted to config only if production feedback demands it — keeps the PR's config surface zero.
- **No automatic remediation on flipped flags.** `crd_active = false`, `docker_healthy = false`, `boot_id` change, and low `disk_free_pct` log warnings but do not themselves trigger a reboot. Staleness is the only trigger; policy for acting on the flags belongs to a later PR.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)