### PR TITLE
fix(docker): ensure chrome-remote-desktop group exists before usermod

### DIFF
--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -117,8 +117,13 @@ RUN useradd -m -s /bin/bash ${USERNAME} && echo "${USERNAME}:password" | chpassw
     chmod 0440 /etc/sudoers.d/${USERNAME} && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
-# Add USERNAME to the chrome-remote-desktop group
-RUN usermod -aG chrome-remote-desktop ${USERNAME}
+# Add USERNAME to the chrome-remote-desktop group.
+# `groupadd -f` guarantees the group exists even when the CRD package
+# postinst skips creating it (observed with Google's current
+# chrome-remote-desktop deb), making the build robust to upstream
+# packaging changes.
+RUN groupadd -f chrome-remote-desktop && \
+    usermod -aG chrome-remote-desktop ${USERNAME}
 
 # Ensure Chrome directories are accessible to the client user
 RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -117,8 +117,13 @@ RUN useradd -m -s /bin/bash ${USERNAME} && echo "${USERNAME}:password" | chpassw
     chmod 0440 /etc/sudoers.d/${USERNAME} && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
-# Add USERNAME to the chrome-remote-desktop group
-RUN usermod -aG chrome-remote-desktop ${USERNAME}
+# Add USERNAME to the chrome-remote-desktop group.
+# `groupadd -f` guarantees the group exists even when the CRD package
+# postinst skips creating it (observed with Google's current
+# chrome-remote-desktop deb), making the build robust to upstream
+# packaging changes.
+RUN groupadd -f chrome-remote-desktop && \
+    usermod -aG chrome-remote-desktop ${USERNAME}
 
 # Ensure Chrome directories are accessible to the client user
 RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \


### PR DESCRIPTION
## Summary
- Client base image build is failing at `usermod -aG chrome-remote-desktop ${USERNAME}` with `group 'chrome-remote-desktop' does not exist`, even though the preceding `apt install chrome-remote-desktop` returns 0.
- Fix: add `groupadd -f chrome-remote-desktop` immediately before the `usermod`, in both `Dockerfile` and `Dockerfile.dev`. `groupadd -f` is a no-op if the group already exists, so we no longer rely on the CRD package's postinst to create it.

## Changes Made
- `packages/client/Dockerfile`: prepend `groupadd -f chrome-remote-desktop && \\` to the `usermod` line.
- `packages/client/Dockerfile.dev`: same change.
- Short comment explaining why the explicit `groupadd` is there, so a future reader doesn't take it as redundant.

## Design Decisions
- **Why defensive rather than diagnostic.** The root cause is external (CRD is closed-source; `apt install` returns 0 even when its postinst partially fails, and the exact version causing the break isn't pinned). Rather than pin a CRD version or debug Google's postinst, this fix removes the repo's dependence on an external postinst side-effect. The build stops caring whether the group was created by the package or by us.
- **Both Dockerfiles patched, not just the one in the failing job.** The failing job is the `dev` base image, but the production `Dockerfile` has the identical line and would break the same way on its next rebuild from scratch. Fixing only one would leave a latent ticking bomb.
- **No version pinning of `chrome-remote-desktop`.** Pinning solves today's symptom but creates a maintenance burden (security patches, future CRD upgrades all need a manual bump). Defensive `groupadd` keeps the package floating without coupling our build to postinst behaviour.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)