### PR TITLE
feat: -y/--yes auto-accept flag + grouped CLI help

### DIFF
--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -27,7 +27,7 @@ def _load_cfg(config: str | None):
     return load_config(config_path)
 
 
-@app.command()
+@app.command(rich_help_panel="Setup")
 def configure(
     config: str = typer.Option(
         None,
@@ -66,7 +66,7 @@ def configure(
     run_setup(load_config(config_path), config_path=config_path)
 
 
-@app.command()
+@app.command(rich_help_panel="Setup")
 def setup(
     config: str = typer.Option(
         None,
@@ -86,7 +86,7 @@ def setup(
     run_setup(_load_cfg(config), config_path=config_path)
 
 
-@app.command()
+@app.command(rich_help_panel="Deployment")
 def deploy(
     config: str = typer.Option(
         None,
@@ -124,7 +124,7 @@ def deploy(
     )
 
 
-@app.command()
+@app.command(rich_help_panel="Deployment")
 def destroy(
     config: str = typer.Option(
         None,
@@ -146,7 +146,7 @@ def destroy(
     run_destroy(_load_cfg(config), yes=yes)
 
 
-@app.command("launch-client")
+@app.command("launch-client", rich_help_panel="Deployment")
 def launch_client(
     num_vms: int = typer.Option(
         ...,
@@ -167,7 +167,7 @@ def launch_client(
     run_launch(_load_cfg(config), num_vms=num_vms)
 
 
-@app.command()
+@app.command(rich_help_panel="Operations")
 def status(
     config: str = typer.Option(
         None,
@@ -182,7 +182,7 @@ def status(
     run_status(_load_cfg(config))
 
 
-@app.command()
+@app.command(rich_help_panel="Operations")
 def logs(
     config: str = typer.Option(
         None,
@@ -197,7 +197,7 @@ def logs(
     run_logs(_load_cfg(config))
 
 
-@app.command()
+@app.command(rich_help_panel="Maintenance")
 def cleanup(
     config: str = typer.Option(
         None,
@@ -220,7 +220,7 @@ def cleanup(
     )
 
 
-@app.command()
+@app.command(rich_help_panel="Setup")
 def doctor() -> None:
     """Check prerequisites and configuration."""
     from lablink_cli.commands.doctor import run_doctor
@@ -228,7 +228,7 @@ def doctor() -> None:
     run_doctor()
 
 
-@app.command("show-config")
+@app.command("show-config", rich_help_panel="Maintenance")
 def show_config(
     config: str = typer.Option(
         None,
@@ -345,7 +345,7 @@ def _clear_deployments_cache(console, stale_only: bool = False) -> None:
     )
 
 
-@app.command("cache-clear")
+@app.command("cache-clear", rich_help_panel="Maintenance")
 def cache_clear(
     deployments: bool = typer.Option(
         False,
@@ -399,7 +399,7 @@ def cache_clear(
         _clear_terraform_cache(console)
 
 
-@app.command("export-metrics")
+@app.command("export-metrics", rich_help_panel="Operations")
 def export_metrics(
     output: str = typer.Option(
         None,

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -105,6 +105,13 @@ def deploy(
         "--terraform-bundle",
         help="Path to a local template tarball for offline deploys.",
     ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompts. Does not bypass credential prompts "
+        "(admin/db passwords still required interactively).",
+    ),
 ) -> None:
     """Deploy LabLink infrastructure with Terraform."""
     from lablink_cli.commands.deploy import run_deploy
@@ -113,6 +120,7 @@ def deploy(
         _load_cfg(config),
         template_version=template_version,
         terraform_bundle=terraform_bundle,
+        yes=yes,
     )
 
 
@@ -124,11 +132,18 @@ def destroy(
         "-c",
         help="Path to config.yaml (default: ~/.lablink/config.yaml)",
     ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompts. Does not bypass credential prompts "
+        "(admin/db passwords still required interactively).",
+    ),
 ) -> None:
     """Tear down LabLink infrastructure."""
     from lablink_cli.commands.deploy import run_destroy
 
-    run_destroy(_load_cfg(config))
+    run_destroy(_load_cfg(config), yes=yes)
 
 
 @app.command("launch-client")

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -289,12 +289,7 @@ def run_deploy(
     terraform_bundle: str | None = None,
     yes: bool = False,
 ) -> None:
-    """Deploy LabLink infrastructure.
-
-    ``yes=True`` skips the interactive "Type 'yes' to apply" confirmation
-    after ``terraform plan``. Credential prompts in ``_prompt_passwords``
-    are not affected and still require interactive input.
-    """
+    """Deploy LabLink infrastructure. ``yes=True`` skips confirmation prompts."""
     from lablink_cli import TEMPLATE_VERSION
 
     console.print()
@@ -655,12 +650,7 @@ def _terraform_destroy(
 
 
 def run_destroy(cfg: Config, *, yes: bool = False) -> None:
-    """Destroy LabLink infrastructure.
-
-    ``yes=True`` skips the "Are you sure?" confirmation and auto-accepts
-    the metrics-export prompt's existing default (= export). Credential
-    lookup via ``resolve_admin_credentials`` is unaffected.
-    """
+    """Destroy LabLink infrastructure. ``yes=True`` skips confirmation prompts."""
     check_credentials(_get_session(cfg.app.region))
 
     deploy_dir = get_deploy_dir(cfg)

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -287,8 +287,14 @@ def run_deploy(
     *,
     template_version: str | None = None,
     terraform_bundle: str | None = None,
+    yes: bool = False,
 ) -> None:
-    """Deploy LabLink infrastructure."""
+    """Deploy LabLink infrastructure.
+
+    ``yes=True`` skips the interactive "Type 'yes' to apply" confirmation
+    after ``terraform plan``. Credential prompts in ``_prompt_passwords``
+    are not affected and still require interactive input.
+    """
     from lablink_cli import TEMPLATE_VERSION
 
     console.print()
@@ -376,19 +382,21 @@ def run_deploy(
             )
         console.print()
 
-        # Confirm before apply (user think-time intentionally excluded from phases)
-        console.print(
-            "[bold yellow]Review the plan above.[/bold yellow] "
-            "Type 'yes' to apply: ",
-            end="",
-        )
-        answer = input()
-        if answer.strip().lower() != "yes":
+        # Confirm before apply (user think-time intentionally excluded from phases).
+        # ``yes=True`` skips this gate for scripted invocations.
+        if not yes:
             console.print(
-                "[dim]Cancelled. No resources were created.[/dim]"
+                "[bold yellow]Review the plan above.[/bold yellow] "
+                "Type 'yes' to apply: ",
+                end="",
             )
-            raise SystemExit(0)
-        console.print()
+            answer = input()
+            if answer.strip().lower() != "yes":
+                console.print(
+                    "[dim]Cancelled. No resources were created.[/dim]"
+                )
+                raise SystemExit(0)
+            console.print()
 
         # Terraform apply
         console.print("[bold]Step 3/3:[/bold] Terraform apply")
@@ -646,8 +654,13 @@ def _terraform_destroy(
     console.print("[bold]Infrastructure destroyed.[/bold]")
 
 
-def run_destroy(cfg: Config) -> None:
-    """Destroy LabLink infrastructure."""
+def run_destroy(cfg: Config, *, yes: bool = False) -> None:
+    """Destroy LabLink infrastructure.
+
+    ``yes=True`` skips the "Are you sure?" confirmation and auto-accepts
+    the metrics-export prompt's existing default (= export). Credential
+    lookup via ``resolve_admin_credentials`` is unaffected.
+    """
     check_credentials(_get_session(cfg.app.region))
 
     deploy_dir = get_deploy_dir(cfg)
@@ -687,24 +700,29 @@ def run_destroy(cfg: Config) -> None:
 
     admin_user, admin_pw = resolve_admin_credentials(cfg)
 
-    console.print(
-        "[bold yellow]Are you sure?[/bold yellow] "
-        "Type 'yes' to confirm: ",
-        end="",
-    )
-    answer = input()
-    if answer.strip().lower() != "yes":
-        console.print("[dim]Cancelled.[/dim]")
-        raise SystemExit(0)
-    console.print()
+    if not yes:
+        console.print(
+            "[bold yellow]Are you sure?[/bold yellow] "
+            "Type 'yes' to confirm: ",
+            end="",
+        )
+        answer = input()
+        if answer.strip().lower() != "yes":
+            console.print("[dim]Cancelled.[/dim]")
+            raise SystemExit(0)
+        console.print()
 
     # Offer one last chance to export metrics — once destroy runs, the
     # allocator's per-VM metrics are gone forever. Default = yes.
-    console.print(
-        "[bold]Export metrics before destroying?[/bold] [Y/n]: ",
-        end="",
-    )
-    export_answer = input().strip().lower()
+    # Under ``yes=True`` we take that default without prompting.
+    if yes:
+        export_answer = ""
+    else:
+        console.print(
+            "[bold]Export metrics before destroying?[/bold] [Y/n]: ",
+            end="",
+        )
+        export_answer = input().strip().lower()
     if export_answer in ("", "y", "yes"):
         # Timestamped filename prevents overwriting prior exports when the
         # same cwd is reused for multiple deployments. The absolute cwd is

--- a/packages/cli/tests/test_app.py
+++ b/packages/cli/tests/test_app.py
@@ -106,6 +106,16 @@ class TestCLICommands:
         out = _plain(result.output).lower()
         assert "deploy" in out or "usage" in out
 
+    def test_help_groups_commands_into_panels(self):
+        """Top-level --help groups commands under the four Option-A panels."""
+        result = runner.invoke(app, ["--help"])
+        assert result.exit_code == 0
+        out = _plain(result.output)
+        for panel in ("Setup", "Deployment", "Operations", "Maintenance"):
+            assert panel in out, (
+                f"expected panel heading {panel!r} in --help output"
+            )
+
 
 class TestCacheClear:
     def test_cache_clear_command_exists(self):

--- a/packages/cli/tests/test_deploy.py
+++ b/packages/cli/tests/test_deploy.py
@@ -605,3 +605,77 @@ class TestRunDestroyExportPrompt:
                 run_destroy(mock_cfg)
 
             mock_export.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# run_deploy / run_destroy — -y / --yes auto-accept flag
+# ------------------------------------------------------------------
+class TestRunDeployYesFlag:
+    def test_yes_skips_apply_confirm(self, mock_cfg, tmp_path, monkeypatch):
+        """yes=True → no input() for apply-confirm; terraform apply still runs."""
+        cache_dir = tmp_path / "cache"
+        monkeypatch.setattr(
+            deployment_metrics, "DEPLOYMENTS_DIR", cache_dir
+        )
+
+        deploy_dir = tmp_path / "deploy"
+        (deploy_dir / "config").mkdir(parents=True)
+        (deploy_dir / "config" / "config.yaml").write_text(
+            "app: {}\ndb: {}\n"
+        )
+
+        with ExitStack() as stack:
+            # Enter helper mocks; then override builtins.input with a strict
+            # mock that fails the test if input() is called at all.
+            for cm in _patch_deploy_deps(deploy_dir):
+                stack.enter_context(cm)
+            stack.enter_context(
+                patch(
+                    "builtins.input",
+                    side_effect=AssertionError(
+                        "input() must not be called when yes=True"
+                    ),
+                )
+            )
+            mock_tf = stack.enter_context(
+                patch("lablink_cli.commands.deploy._run_terraform")
+            )
+
+            run_deploy(mock_cfg, yes=True)
+
+        apply_calls = [
+            c
+            for c in mock_tf.call_args_list
+            if c.args and c.args[0] == ["apply", "-auto-approve", "tfplan"]
+        ]
+        assert len(apply_calls) == 1, (
+            f"expected one `terraform apply` call, got {mock_tf.call_args_list}"
+        )
+
+
+class TestRunDestroyYesFlag:
+    def test_yes_skips_all_prompts_and_exports_by_default(
+        self, mock_cfg, tmp_path
+    ):
+        """yes=True → no input() for destroy-confirm or export prompt; export runs."""
+        deploy_dir = tmp_path / "deploy"
+        _setup_destroy_dir(deploy_dir)
+
+        with ExitStack() as stack:
+            mocks = _patch_destroy_deps(deploy_dir, stack)
+            mock_export = stack.enter_context(
+                patch("lablink_cli.commands.deploy.run_export_metrics")
+            )
+            stack.enter_context(
+                patch(
+                    "builtins.input",
+                    side_effect=AssertionError(
+                        "input() must not be called when yes=True"
+                    ),
+                )
+            )
+
+            run_destroy(mock_cfg, yes=True)
+
+            mock_export.assert_called_once()
+            mocks["terraform_destroy"].assert_called_once()


### PR DESCRIPTION
## Summary
- Add `-y` / `--yes` flag to `lablink deploy` and `lablink destroy` to skip the "type 'yes'" confirmation prompts. Credential prompts (admin / db password) are intentionally untouched — unattended CI deploys are a follow-up that needs env-var support for those.
- Group the 12 top-level CLI commands under four `rich_help_panel`s in `lablink --help` output: **Setup**, **Deployment**, **Operations**, **Maintenance**.

## Changes

### `-y` / `--yes` flag
- `packages/cli/src/lablink_cli/app.py` — add `yes: bool = typer.Option(False, "--yes", "-y", ...)` to both `deploy` and `destroy`, forwarded to `run_deploy(..., yes=yes)` / `run_destroy(..., yes=yes)`.
- `packages/cli/src/lablink_cli/commands/deploy.py` — `run_deploy` and `run_destroy` accept `yes: bool = False`. Three `input()` sites guarded:
  - Deploy's apply-confirm (`Type 'yes' to apply`).
  - Destroy's confirm (`Are you sure?`).
  - Destroy's metrics-export prompt — under `-y`, takes its existing default (= export).
- Help text on the flag: *"Skip confirmation prompts. Does not bypass credential prompts (admin/db passwords still required interactively)."*

### CLI command grouping
- Added `rich_help_panel=...` to each command decorator. Mapping:
  - **Setup** — `configure`, `setup`, `doctor`
  - **Deployment** — `deploy`, `destroy`, `launch-client`
  - **Operations** — `status`, `logs`, `export-metrics`
  - **Maintenance** — `cleanup`, `show-config`, `cache-clear`
- Pure cosmetic — no new commands, no renames, no flag changes.

## Testing
- `packages/cli/tests/test_deploy.py` — two new tests:
  - `TestRunDeployYesFlag::test_yes_skips_apply_confirm` — patches `builtins.input` with `side_effect=AssertionError(...)` so any prompt fails the test; verifies `terraform apply` still runs.
  - `TestRunDestroyYesFlag::test_yes_skips_all_prompts_and_exports_by_default` — same input-forbidden pattern; verifies `run_export_metrics` and `_terraform_destroy` still run.
- `packages/cli/tests/test_app.py` — one new test: `test_help_groups_commands_into_panels` asserts the four panel headings appear in top-level `--help` output.
- Full suite: **291 passed, 1 deselected** (integration marker); `ruff check packages/cli` clean.
- Smoke-checked `lablink deploy --help`, `lablink destroy --help`, and `lablink --help` — panels + flag render correctly.

## Design Decisions
- `-y` does **not** bypass `_prompt_passwords()`. Those take real input, not yes/no, and adding env-var / flag support for them is a separate concern tracked as a follow-up. `-y` alone is still useful — it removes the think-time gate for operators who've already reviewed the plan.
- The metrics-export prompt on `destroy` has an existing default-yes behavior; `-y` preserves that default (exports before destroying). Keeping destruction-is-irreversible safety intact.
- Panel grouping uses Typer's built-in `rich_help_panel` — no custom help renderer, no dependency bumps.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)