### PR TITLE
docs: add CLI tutorials, CLI reference, and split quickstart

### DIFF
--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -1,9 +1,8 @@
 # AWS Setup from Scratch
 
 !!! tip "Automated Setup Recommended"
-    The [Quickstart](quickstart.md) guide uses `setup.sh` to automate all required AWS resource creation.
-    This manual guide is provided as a reference for advanced users who prefer to create
-    resources individually. See [Quickstart](quickstart.md) for the recommended approach.
+    The [Quickstart: Template repo](quickstart-template.md) guide uses `setup.sh` to automate all required AWS resource creation. The [Quickstart: CLI](cli/first-deployment.md) path automates the same work through `lablink configure`.
+    This manual guide is provided as a reference for advanced users who prefer to create resources individually.
 
 This comprehensive guide walks you through setting up all required AWS resources for LabLink deployment from scratch.
 
@@ -316,7 +315,7 @@ region = "us-west-2"
 ## Step 3: Elastic IP Allocation
 
 !!! tip "Automated Setup"
-    The `scripts/setup-aws-infrastructure.sh` script from the template repository also handles Elastic IP allocation. See the [Quickstart](quickstart.md) for the script-driven workflow.
+    The `scripts/setup-aws-infrastructure.sh` script from the template repository also handles Elastic IP allocation. See the [Quickstart: Template repo](quickstart-template.md) for the script-driven workflow.
 
 Allocate static IPs for test and production environments.
 
@@ -1563,7 +1562,7 @@ Running EC2 instances cost extra. See [Cost Estimation](cost-estimation.md) for 
 
 With AWS resources configured:
 
-1. **[Quickstart](quickstart.md)**: Deploy LabLink to AWS
+1. **[Quickstart](quickstart.md)**: Pick a deployment path — template repo or CLI
 2. **[Security](security.md)**: Review security best practices
 3. **[Workflows](workflows.md)**: Understand CI/CD pipelines
 

--- a/docs/cli/first-deployment.md
+++ b/docs/cli/first-deployment.md
@@ -1,0 +1,123 @@
+# First Deployment
+
+This walkthrough takes you from a clean install through a live allocator and back to an empty AWS account. Budget about 15 minutes end to end.
+
+## Before you start
+
+Make sure you've completed [Installation](installation.md) and that `lablink doctor` reports clean values for "Terraform installed" and "AWS credentials". The other checks will light up as you go.
+
+## Step 1: Configure
+
+```bash
+lablink configure
+```
+
+This launches an interactive TUI wizard that walks you through:
+
+- **Deployment name** — a short label (e.g. `sleap-workshop`, `dev`). Used to tag AWS resources and as the folder name under `~/.lablink/deploys/`.
+- **AWS region** — e.g. `us-west-2`. Must be a region the CLI has an AMI mapping for (run `lablink doctor` to see the list).
+- **Machine settings** — client VM instance type and AMI. Defaults come from the bundled `lablink-template` config.
+- **DNS / SSL** — optional Route 53 domain and ACM certificate configuration.
+- **Monitoring** — optional CloudWatch alarms and CloudTrail.
+
+The wizard writes `~/.lablink/config.yaml` and then **automatically runs `lablink setup`** to create the two AWS resources Terraform needs before it can run:
+
+1. An **S3 bucket** for Terraform state (versioned + encrypted).
+2. A **DynamoDB table** for state locking.
+
+!!! tip "Re-running the wizard"
+    `lablink configure` is idempotent. Run it again anytime to edit the config — it loads your existing values as defaults.
+
+You can inspect what was written with:
+
+```bash
+lablink show-config
+```
+
+## Step 2: Sanity check
+
+```bash
+lablink doctor
+```
+
+All six checks should now pass:
+
+```text
+┌─────────────────────────┬────────┬─────────────────────────────────────┐
+│ Check                   │ Status │ Detail                              │
+├─────────────────────────┼────────┼─────────────────────────────────────┤
+│ Terraform installed     │ PASS   │ v1.6.6 (/usr/local/bin/terraform)   │
+│ Config file             │ PASS   │ ~/.lablink/config.yaml              │
+│ Config validates        │ PASS   │ No errors                           │
+│ AWS credentials         │ PASS   │ Account: 123…, Identity: arn:…      │
+│ S3 state bucket         │ PASS   │ tf-state-lablink-…                  │
+│ AMI for region          │ PASS   │ us-west-2 → ami-0bd08c9d…           │
+└─────────────────────────┴────────┴─────────────────────────────────────┘
+```
+
+If any row is `FAIL`, the detail column tells you which command to run next (usually `lablink configure` or `aws configure`).
+
+## Step 3: Deploy
+
+```bash
+lablink deploy
+```
+
+This will:
+
+1. Download the pinned `lablink-template` Terraform files into `~/.lablink/cache/terraform/<version>/` (first run only).
+2. Copy them into a working directory at `~/.lablink/deploys/<deployment-name>/`.
+3. Prompt you once for an **admin password** and **database password**. These are injected into the Terraform variables — they are not stored in `config.yaml`.
+4. Run `terraform init` + `terraform apply`, showing the plan and asking for confirmation.
+5. Wait for the allocator EC2 instance to come up and its `/api/health` endpoint to report `healthy`.
+
+Expect 2–5 minutes for Terraform + another 1–3 minutes for the allocator to finish its first-boot container start.
+
+!!! tip "Skip interactive confirmations"
+    Pass `-y` / `--yes` to skip Terraform plan confirmation. Admin/DB passwords are still prompted for.
+
+When deploy completes, note the `ec2_public_ip` in the Terraform output — that's your allocator URL.
+
+## Step 4: Verify
+
+```bash
+lablink status
+```
+
+This shows four sections:
+
+- **Terraform State** — outputs like `ec2_public_ip`, `ec2_public_dns`, and any DNS/ALB records.
+- **Health Checks** — DNS resolution (if you configured a domain), `/api/health` response, and SSL certificate expiry (if HTTPS is enabled).
+- **Client VMs** — per-VM state reported by the allocator (empty until you run `lablink launch-client`).
+- **Cost Estimate** — daily and monthly dollar estimates for the allocator, EBS, optional ALB/Route 53, and running client VMs.
+
+Open the allocator in a browser using `http://<ec2_public_ip>` (or your configured domain) and log in with username `admin` and the admin password you entered during deploy.
+
+## Step 5: Launch a client VM
+
+```bash
+lablink launch-client --num-vms 1
+```
+
+The CLI calls the allocator's create-VM endpoint, which provisions the instance via the allocator's own Terraform workspace (not the CLI's). Run `lablink status` again to see the new VM appear.
+
+## Step 6: Tear down
+
+When you're done, destroy everything the CLI created:
+
+```bash
+lablink destroy
+```
+
+This runs `terraform destroy` on the deployment workspace and removes the EC2 instance, security groups, key pair, and any ALB/Route 53 records Terraform owns. Client VMs launched through the allocator are destroyed along with the allocator.
+
+!!! warning "Costs don't stop until destroy finishes"
+    The allocator EC2 instance, EBS volume, and (if configured) ALB accrue charges while running. See [Cost Estimation](../cost-estimation.md).
+
+After destroy, the S3 state bucket and DynamoDB lock table still exist — they're cheap (~$0.05/month) and reused on the next deploy. If you want to remove them too, see [cleanup](managing-deployments.md#cleanup-orphaned-resources).
+
+## Next steps
+
+- [Managing Deployments](managing-deployments.md) — day-to-day operations, logs, metrics export.
+- [CLI Reference](../reference/cli.md) — every command and flag.
+- [Configuration](../configuration.md) — full reference for the `config.yaml` schema the wizard writes.

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,0 +1,49 @@
+# LabLink CLI
+
+The `lablink` command is a local alternative to the [lablink-template](https://github.com/talmolab/lablink-template) repository. It deploys the same allocator infrastructure to AWS, but drives Terraform from your own machine instead of GitHub Actions.
+
+!!! note "Status: pre-PyPI"
+    The CLI is not yet published to PyPI. For now, install it from source — see [Installation](installation.md). `pip install lablink` will be the path once the package is released.
+
+## CLI vs. template repo
+
+Both paths deploy the same allocator service and manage the same set of AWS resources. They differ in **where Terraform runs** and **where state lives**.
+
+| | Template repo | CLI |
+|---|---|---|
+| Where Terraform runs | GitHub Actions | Your machine |
+| Where state lives | Shared S3 (per-repo) | Local S3 bucket you own |
+| How you trigger a deploy | Push to `main` / run workflow | `lablink deploy` |
+| Secrets management | GitHub repository secrets | AWS credentials on your machine, passwords prompted |
+| Who can deploy | Anyone with repo access | Whoever has the AWS creds locally |
+| Best for | Workshops, shared environments, production | Solo development, pre-workshop iteration, local debugging |
+
+## When to pick which
+
+Pick the **CLI** when you want to:
+
+- Stand a deployment up quickly from your laptop
+- Iterate on configuration or Terraform changes without pushing commits
+- Debug a failed deploy with direct access to Terraform output and logs
+- Export metrics from a deployment that's already been torn down
+
+Pick the **template repo** when you want to:
+
+- Hand the deployment off to a team via GitHub permissions
+- Run reproducible, audited deploys from CI
+- Run workshops where multiple people may trigger deploys
+
+You can also switch between them later — both read the same `config.yaml` schema.
+
+## Current limitations
+
+- **Local deployment only.** The CLI manages Terraform state in an S3 bucket you control from your own AWS credentials; it does not integrate with GitHub Actions or shared CI-managed state.
+- **Not on PyPI yet.** Install from source (see [Installation](installation.md)).
+- **No Windows support tested.** macOS and Linux only for now.
+
+## Next steps
+
+1. [Install the CLI](installation.md)
+2. [Run your first deployment](first-deployment.md)
+3. [Manage an existing deployment](managing-deployments.md)
+4. Full command reference: [CLI Reference](../reference/cli.md)

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -3,7 +3,7 @@
 The `lablink` command is a CLI-driven alternative to the [lablink-template](https://github.com/talmolab/lablink-template) repository. It deploys the same allocator infrastructure to AWS — cloud resources are identical either way — but drives Terraform from your own machine instead of GitHub Actions.
 
 !!! note "Status: pre-PyPI"
-    The CLI is not yet published to PyPI. For now, install it from source with `uv sync` — see [Installation](installation.md). `uv tool install lablink` will be the path once the package is released.
+    The CLI is not yet published to PyPI. For now, install it from source with `uv sync --all-packages` — see [Installation](installation.md). `uv tool install lablink` will be the path once the package is released.
 
 ## CLI vs. template repo
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -1,9 +1,9 @@
 # LabLink CLI
 
-The `lablink` command is a local alternative to the [lablink-template](https://github.com/talmolab/lablink-template) repository. It deploys the same allocator infrastructure to AWS, but drives Terraform from your own machine instead of GitHub Actions.
+The `lablink` command is a CLI-driven alternative to the [lablink-template](https://github.com/talmolab/lablink-template) repository. It deploys the same allocator infrastructure to AWS — cloud resources are identical either way — but drives Terraform from your own machine instead of GitHub Actions.
 
 !!! note "Status: pre-PyPI"
-    The CLI is not yet published to PyPI. For now, install it from source — see [Installation](installation.md). `pip install lablink` will be the path once the package is released.
+    The CLI is not yet published to PyPI. For now, install it from source with `uv sync` — see [Installation](installation.md). `uv tool install lablink` will be the path once the package is released.
 
 ## CLI vs. template repo
 
@@ -34,12 +34,6 @@ Pick the **template repo** when you want to:
 - Run workshops where multiple people may trigger deploys
 
 You can also switch between them later — both read the same `config.yaml` schema.
-
-## Current limitations
-
-- **Local deployment only.** The CLI manages Terraform state in an S3 bucket you control from your own AWS credentials; it does not integrate with GitHub Actions or shared CI-managed state.
-- **Not on PyPI yet.** Install from source (see [Installation](installation.md)).
-- **No Windows support tested.** macOS and Linux only for now.
 
 ## Next steps
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -7,33 +7,36 @@ The `lablink` command is a CLI-driven alternative to the [lablink-template](http
 
 ## CLI vs. template repo
 
-Both paths deploy the same allocator service and manage the same set of AWS resources. They differ in **where Terraform runs** and **where state lives**.
+Both paths deploy the same allocator service and manage the same set of AWS resources. The practical difference is **how much of the deployment you own and configure yourself**.
 
 | | Template repo | CLI |
 |---|---|---|
+| What you maintain | A full repo forked from `lablink-template` (Dockerfile, Terraform `.tf` files, GitHub Actions workflows, configs) | A single `config.yaml` |
+| Customization surface | Every file in the repo — tweak AMIs, Docker images, Terraform resources, CI workflow, secrets | Whatever the `config.yaml` schema exposes (instance type, region, DNS, SSL, monitoring) |
 | Where Terraform runs | GitHub Actions | Your machine |
 | Where state lives | Shared S3 (per-repo) | Local S3 bucket you own |
 | How you trigger a deploy | Push to `main` / run workflow | `lablink deploy` |
 | Secrets management | GitHub repository secrets | AWS credentials on your machine, passwords prompted |
 | Who can deploy | Anyone with repo access | Whoever has the AWS creds locally |
-| Best for | Workshops, shared environments, production | Solo development, pre-workshop iteration, local debugging |
+| Best for | Deployments you need to customize — bring-your-own Docker image, extra AWS resources, custom CI, bespoke workflow edits | Standard deployments where you just want it up — no repo to own, no workflow to maintain |
 
 ## When to pick which
 
 Pick the **CLI** when you want to:
 
-- Stand a deployment up quickly from your laptop
-- Iterate on configuration or Terraform changes without pushing commits
-- Debug a failed deploy with direct access to Terraform output and logs
-- Export metrics from a deployment that's already been torn down
+- Stand up a standard deployment without maintaining a fork of the template
+- Keep the surface small — one config file, no Dockerfile or `.tf` edits
+- Skip hopping between a GitHub repo, Actions logs, and local tooling
+- Drive Terraform directly from your laptop and see its output inline
 
 Pick the **template repo** when you want to:
 
-- Hand the deployment off to a team via GitHub permissions
-- Run reproducible, audited deploys from CI
-- Run workshops where multiple people may trigger deploys
+- Bring your own Docker image, custom AMI baking, or your own entrypoint
+- Add or modify AWS resources Terraform doesn't provision by default
+- Customize the GitHub Actions workflow (extra steps, different triggers, etc.)
+- Hand the deployment off to a team via GitHub permissions instead of sharing AWS credentials
 
-You can also switch between them later — both read the same `config.yaml` schema.
+You can switch between them later — both read the same `config.yaml` schema for the settings the CLI exposes.
 
 ## Next steps
 

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -1,0 +1,100 @@
+# Installing the CLI
+
+The `lablink` command is distributed with the [LabLink repository](https://github.com/talmolab/lablink) under `packages/cli/`. Until it's published to PyPI, install it from source.
+
+!!! note "PyPI coming soon"
+    Once published, `pip install lablink` will be the recommended install. For now, use one of the methods below.
+
+## Prerequisites
+
+Before installing, make sure you have:
+
+- **Python 3.10+** — check with `python --version`.
+- **Terraform 1.6+** — the CLI drives Terraform under the hood. Install from [developer.hashicorp.com/terraform/install](https://developer.hashicorp.com/terraform/install).
+- **AWS credentials** configured locally (either `aws configure` or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables). See [Prerequisites](../prerequisites.md#configure-aws-credentials).
+- **An AWS account** with permissions to create EC2, S3, DynamoDB, IAM, and (optionally) Route 53 resources. See [AWS Setup (Manual)](../aws-setup.md) for the full permission list.
+
+## Install from source
+
+Clone the repo and install the CLI package in editable mode:
+
+```bash
+git clone https://github.com/talmolab/lablink.git
+cd lablink
+pip install -e packages/cli
+```
+
+!!! tip "Use a virtual environment"
+    Install into a dedicated venv so the `lablink` command and its dependencies stay isolated:
+    ```bash
+    python -m venv .venv
+    source .venv/bin/activate
+    pip install -e packages/cli
+    ```
+    Or with `uv`:
+    ```bash
+    uv venv
+    source .venv/bin/activate
+    uv pip install -e packages/cli
+    ```
+
+Verify the install:
+
+```bash
+lablink --help
+```
+
+You should see the grouped command list (Setup, Deployment, Operations, Maintenance).
+
+## Check your environment
+
+Run `lablink doctor` to validate prerequisites end-to-end:
+
+```bash
+lablink doctor
+```
+
+It checks:
+
+| Check | What it verifies |
+|---|---|
+| Terraform installed | `terraform` is on PATH and reports a version |
+| Config file | `~/.lablink/config.yaml` exists |
+| Config validates | The config parses and passes schema validation |
+| AWS credentials | `sts:GetCallerIdentity` succeeds for the configured region |
+| S3 state bucket | The `bucket_name` in your config actually exists |
+| AMI for region | The CLI knows an AMI for `cfg.app.region` |
+
+A fresh install (before `lablink configure`) will fail on "Config file" and anything that depends on it. That's expected — move on to [First Deployment](first-deployment.md).
+
+## Where things live
+
+The CLI stores state under `~/.lablink/`:
+
+| Path | Purpose |
+|---|---|
+| `~/.lablink/config.yaml` | Default config file written by `lablink configure` |
+| `~/.lablink/cache/terraform/<version>/` | Cached Terraform templates downloaded from the `lablink-template` repo |
+| `~/.lablink/deployments/` | Per-deploy metrics records (readable by `lablink export-metrics --allocator`) |
+| `~/.lablink/deploys/<name>/` | Working directory Terraform runs in for each deployment |
+
+Pass `--config /path/to/config.yaml` to any command to use a different config file.
+
+## Upgrading
+
+Pull the latest source and reinstall:
+
+```bash
+cd lablink
+git pull
+pip install -e packages/cli --upgrade
+```
+
+!!! note "Template version"
+    The CLI pins a specific version of the `lablink-template` Terraform files. After upgrading the CLI, the first `lablink deploy` will download the new template version into `~/.lablink/cache/terraform/`.
+
+## Next steps
+
+- [Run your first deployment](first-deployment.md)
+- [Day-to-day operations](managing-deployments.md)
+- Full command reference: [CLI Reference](../reference/cli.md)

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -1,6 +1,6 @@
 # Installing the CLI
 
-The `lablink` command is distributed with the [LabLink repository](https://github.com/talmolab/lablink) as one of three packages in a `uv` workspace (`packages/allocator`, `packages/client`, `packages/cli`). Until the CLI is published to PyPI, install it from source with `uv sync`.
+The `lablink` command is distributed with the [LabLink repository](https://github.com/talmolab/lablink) as one of three packages in a `uv` workspace (`packages/allocator`, `packages/client`, `packages/cli`). Until the CLI is published to PyPI, install it from source with `uv sync --all-packages`.
 
 !!! note "PyPI coming soon"
     Once published, `uv tool install lablink` (or `pip install lablink`) will be the recommended install. For now, use the workspace install below.
@@ -17,12 +17,12 @@ Before installing, make sure you have:
 
 ## Install from source
 
-Clone the repo and run `uv sync` at the root. This installs all three workspace packages (allocator, client, CLI) as editable — the CLI depends on `lablink-allocator-service`, which uv resolves from the workspace automatically.
+Clone the repo and run `uv sync --all-packages` at the root. This installs all three workspace packages (allocator, client, CLI) as editable — the CLI depends on `lablink-allocator-service`, which uv resolves from the workspace automatically.
 
 ```bash
 git clone https://github.com/talmolab/lablink.git
 cd lablink
-uv sync
+uv sync --all-packages
 ```
 
 uv creates `.venv/` on first sync. Run the CLI either directly through uv:
@@ -84,7 +84,7 @@ Pull the latest source and re-sync:
 ```bash
 cd lablink
 git pull
-uv sync
+uv sync --all-packages
 ```
 
 !!! note "Template version"

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -1,57 +1,54 @@
 # Installing the CLI
 
-The `lablink` command is distributed with the [LabLink repository](https://github.com/talmolab/lablink) under `packages/cli/`. Until it's published to PyPI, install it from source.
+The `lablink` command is distributed with the [LabLink repository](https://github.com/talmolab/lablink) as one of three packages in a `uv` workspace (`packages/allocator`, `packages/client`, `packages/cli`). Until the CLI is published to PyPI, install it from source with `uv sync`.
 
 !!! note "PyPI coming soon"
-    Once published, `pip install lablink` will be the recommended install. For now, use one of the methods below.
+    Once published, `uv tool install lablink` (or `pip install lablink`) will be the recommended install. For now, use the workspace install below.
 
 ## Prerequisites
 
 Before installing, make sure you have:
 
-- **Python 3.10+** — check with `python --version`.
+- **[uv](https://docs.astral.sh/uv/)** — the Python project manager used by this repo. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh` or see the [official install guide](https://docs.astral.sh/uv/getting-started/installation/).
+- **Python 3.10+** — uv can manage this for you (`uv python install 3.11`). Check with `python --version`.
 - **Terraform 1.6+** — the CLI drives Terraform under the hood. Install from [developer.hashicorp.com/terraform/install](https://developer.hashicorp.com/terraform/install).
 - **AWS credentials** configured locally (either `aws configure` or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables). See [Prerequisites](../prerequisites.md#configure-aws-credentials).
 - **An AWS account** with permissions to create EC2, S3, DynamoDB, IAM, and (optionally) Route 53 resources. See [AWS Setup (Manual)](../aws-setup.md) for the full permission list.
 
 ## Install from source
 
-Clone the repo and install the CLI package in editable mode:
+Clone the repo and run `uv sync` at the root. This installs all three workspace packages (allocator, client, CLI) as editable — the CLI depends on `lablink-allocator-service`, which uv resolves from the workspace automatically.
 
 ```bash
 git clone https://github.com/talmolab/lablink.git
 cd lablink
-pip install -e packages/cli
+uv sync
 ```
 
-!!! tip "Use a virtual environment"
-    Install into a dedicated venv so the `lablink` command and its dependencies stay isolated:
-    ```bash
-    python -m venv .venv
-    source .venv/bin/activate
-    pip install -e packages/cli
-    ```
-    Or with `uv`:
-    ```bash
-    uv venv
-    source .venv/bin/activate
-    uv pip install -e packages/cli
-    ```
-
-Verify the install:
+uv creates `.venv/` on first sync. Run the CLI either directly through uv:
 
 ```bash
+uv run lablink --help
+```
+
+…or by activating the venv:
+
+```bash
+source .venv/bin/activate
 lablink --help
 ```
 
-You should see the grouped command list (Setup, Deployment, Operations, Maintenance).
+You should see the grouped command list (Setup, Deployment, Operations, Maintenance) — the same panels Typer prints for `--help`.
+
+!!! tip "Running from outside the repo"
+    If you want `lablink` available from any directory, activate `.venv` in your shell profile, or install via `uv tool install --from ./packages/cli lablink-cli` (note: this will fail today because the CLI's workspace dep on `lablink-allocator-service` isn't yet resolvable outside the workspace — revisit after PyPI publish).
 
 ## Check your environment
 
 Run `lablink doctor` to validate prerequisites end-to-end:
 
 ```bash
-lablink doctor
+uv run lablink doctor
 ```
 
 It checks:
@@ -82,12 +79,12 @@ Pass `--config /path/to/config.yaml` to any command to use a different config fi
 
 ## Upgrading
 
-Pull the latest source and reinstall:
+Pull the latest source and re-sync:
 
 ```bash
 cd lablink
 git pull
-pip install -e packages/cli --upgrade
+uv sync
 ```
 
 !!! note "Template version"

--- a/docs/cli/managing-deployments.md
+++ b/docs/cli/managing-deployments.md
@@ -1,0 +1,135 @@
+# Managing Deployments
+
+Day-to-day operations once an allocator is running: launch client VMs, follow logs, export metrics, and clean up.
+
+Every command on this page reads `~/.lablink/config.yaml` by default. Pass `--config /path/to/other.yaml` to target a different deployment.
+
+## Launch client VMs
+
+```bash
+lablink launch-client --num-vms 5
+```
+
+This asks the allocator to provision client VMs on your behalf. The allocator runs its own Terraform workspace inside the EC2 instance — the CLI only hits its HTTP API, so you don't need Terraform locally for this step.
+
+| Flag | Description |
+|---|---|
+| `-n`, `--num-vms` | Number of client VMs to launch. Required. |
+| `-c`, `--config` | Override the default config path. |
+
+Watch `lablink status` to see the VMs transition from pending → running.
+
+## Check status
+
+```bash
+lablink status
+```
+
+Shows Terraform outputs, health checks, per-VM state, and a cost estimate. This is the command to run when you want to know "is the allocator up and how much is this costing me?"
+
+See [First Deployment](first-deployment.md#step-4-verify) for what each section means.
+
+## Follow logs
+
+```bash
+lablink logs
+```
+
+Opens an interactive TUI that streams logs from the allocator and any running client VMs. Select a VM in the left pane to follow its `cloud-init` and container logs in the right pane.
+
+!!! tip "Quit and search"
+    Use `q` to exit. The viewer supports `/` to search, `n` / `N` for next/previous match, and arrow keys for navigation.
+
+## Export metrics
+
+```bash
+lablink export-metrics --format csv --output metrics.csv
+```
+
+Writes deployment metrics to disk for offline analysis. Two sources:
+
+| Flag | Data | Requires allocator running? |
+|---|---|---|
+| `--client` | Per-VM metrics pulled from the allocator's API (boot time, health status, logs) | Yes |
+| `--allocator` | Per-deploy metrics from the local cache at `~/.lablink/deployments/` (deploy duration, Terraform phase timings) | **No** — works after `lablink destroy` |
+| *(no flag)* | Both | Yes |
+
+Other flags:
+
+| Flag | Description |
+|---|---|
+| `-f`, `--format` | `csv` (default) or `json`. |
+| `-o`, `--output` | Output path. With both data sources selected, this is treated as a base name and `_client` / `_allocator` suffixes are added before the extension. |
+| `--include-logs` | Include `cloud_init_logs` and `docker_logs` columns. Large — opt-in only. |
+
+Example — only allocator metrics after tear-down:
+
+```bash
+lablink export-metrics --allocator --format json -o post-mortem.json
+```
+
+## Show the current config
+
+```bash
+lablink show-config
+```
+
+Pretty-prints `~/.lablink/config.yaml` with syntax highlighting and runs schema validation. Useful for spotting typos before a deploy.
+
+## Destroy the deployment
+
+```bash
+lablink destroy
+```
+
+Runs `terraform destroy` against the deployment's working directory (`~/.lablink/deploys/<name>/`). Tears down the allocator EC2 instance, security groups, key pair, and any ALB/Route 53 records. Client VMs owned by the allocator are destroyed along with it.
+
+Pass `-y` / `--yes` to skip the confirmation prompt. Password prompts still appear.
+
+## Cleanup orphaned resources
+
+If a destroy was interrupted — Ctrl-C, an AWS outage, a deleted workspace — leftover resources may stay behind. The cleanup command finds and removes them:
+
+```bash
+lablink cleanup --dry-run   # preview
+lablink cleanup             # actually delete
+```
+
+It targets resources tagged with your deployment name. `--dry-run` prints what would be deleted without touching AWS.
+
+## Clear local caches
+
+The CLI stores two caches you may want to clear occasionally:
+
+```bash
+# Clear the Terraform template cache (~/.lablink/cache/terraform/)
+lablink cache-clear
+
+# Clear the deployment metrics cache (~/.lablink/deployments/)
+lablink cache-clear --deployments
+
+# Clear both
+lablink cache-clear --all
+
+# Only prune in-progress records (leftovers from plan-cancel or Ctrl-C)
+lablink cache-clear --deployments --stale
+```
+
+Clearing the Terraform template cache forces the next deploy to re-download templates. Clearing the deployments cache removes the per-deploy records that back `lablink export-metrics --allocator`.
+
+## Switching between deployments
+
+Keep multiple config files if you manage more than one deployment:
+
+```bash
+lablink --config ~/configs/workshop.yaml deploy
+lablink --config ~/configs/dev.yaml status
+```
+
+Each deployment gets its own working directory under `~/.lablink/deploys/<name>/` keyed by the `deployment_name` field in its config.
+
+## Next steps
+
+- [CLI Reference](../reference/cli.md) — every command and flag in one page.
+- [Troubleshooting](../troubleshooting.md) — general LabLink issues (not CLI-specific).
+- [Configuration](../configuration.md) — full `config.yaml` schema reference.

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -859,7 +859,13 @@ mkdocs serve
 docs/
 ├── index.md           # Homepage
 ├── prerequisites.md   # Getting Started
-├── quickstart.md
+├── quickstart.md           # Landing (picks template vs CLI)
+├── quickstart-template.md  # Template-repo walkthrough
+├── cli/                    # CLI tutorials
+│   ├── index.md
+│   ├── installation.md
+│   ├── first-deployment.md
+│   └── managing-deployments.md
 ├── adapting.md        # Admin Guide
 ├── workshop-guide.md
 ├── configuration.md

--- a/docs/index.md
+++ b/docs/index.md
@@ -25,6 +25,8 @@ Students visit a link, enter their email, and get a full cloud desktop with your
 
 LabLink is **software-agnostic**. You can [adapt it for any software](adapting.md) that runs in Docker.
 
+Prefer a local workflow over the template repository? The [LabLink CLI](cli/index.md) deploys the same infrastructure from your own machine with `lablink configure && lablink deploy`.
+
 ---
 
 ## Getting Started
@@ -37,7 +39,7 @@ LabLink is **software-agnostic**. You can [adapt it for any software](adapting.m
 
 === "Quickstart"
 
-    :material-rocket-launch: Deploy LabLink to AWS using the template repository and automated setup scripts.
+    :material-rocket-launch: Deploy LabLink to AWS — pick the template repo path or the CLI path.
 
     [:octicons-arrow-right-24: Get started](quickstart.md)
 

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -177,5 +177,5 @@ uv python install 3.11
 
 Once you have the required tools installed:
 
-1. [**Quickstart**](quickstart.md): Deploy LabLink to AWS using the automated setup scripts
+1. [**Quickstart**](quickstart.md): Pick a deployment path (template repo or CLI)
 2. [**AWS Setup (Manual)**](aws-setup.md): Reference guide for creating AWS resources individually

--- a/docs/quickstart-template.md
+++ b/docs/quickstart-template.md
@@ -1,0 +1,205 @@
+# Quickstart: Template repo
+
+Deploy LabLink to AWS by creating a repository from [lablink-template](https://github.com/talmolab/lablink-template) and pushing commits to `main`. GitHub Actions runs Terraform against shared S3-backed state. Best for workshops, shared environments, and production.
+
+!!! tip "Prefer a local flow?"
+    The [CLI quickstart](cli/first-deployment.md) deploys the same infrastructure from your own machine with `lablink configure && lablink deploy`. Both paths are equivalent — pick whichever fits your setup.
+
+## Prerequisites
+
+Before starting, ensure you have completed:
+
+- [x] [Prerequisites](prerequisites.md): AWS Account, AWS CLI, GitHub CLI (`gh`), and Git installed
+
+## Step 1: Create Your Repository
+
+<div class="video-container">
+  <video controls width="100%">
+    <source src="../assets/videos/step1-create-repo.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+</div>
+
+Click the **"Use this template"** button on the [lablink-template repository](https://github.com/talmolab/lablink-template) to create your own deployment repository.
+
+Then clone your new repository:
+
+```bash
+git clone https://github.com/YOUR_ORG/YOUR_REPO.git
+cd YOUR_REPO
+```
+
+## Step 2: Run Setup
+
+<div class="video-container">
+  <video controls width="100%">
+    <source src="../assets/videos/step2-run-setup.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+</div>
+
+Run the setup script to create all required AWS resources and configure GitHub secrets:
+
+```bash
+./scripts/setup.sh
+```
+
+The script will prompt you for:
+
+- AWS region (e.g., `us-west-2`)
+- S3 bucket name for Terraform state
+- GitHub repository (e.g., `YOUR_ORG/YOUR_REPO`)
+- Optional DNS settings (Route 53)
+
+It automatically:
+
+- Creates an OIDC identity provider for GitHub Actions
+- Creates an IAM role with required permissions
+- Creates an S3 bucket for Terraform state (with versioning and encryption)
+- Creates a DynamoDB table for state locking
+- Optionally creates a Route 53 hosted zone
+- Sets four GitHub repository secrets: `AWS_ROLE_ARN`, `AWS_REGION`, `ADMIN_PASSWORD`, `DB_PASSWORD`
+- Generates secure passwords for admin and database access
+
+!!! tip "Manual Setup"
+    If you prefer to create AWS resources individually, see the [AWS Setup (Manual)](aws-setup.md) guide.
+
+## Step 3: Configure
+
+After setup completes, the script automatically runs `./scripts/configure.sh` to generate your deployment configuration.
+
+The configure script prompts for:
+
+- Instance type and AMI settings
+- DNS and SSL configuration
+- Monitoring options
+
+It generates `lablink-infrastructure/config/config.yaml` with your settings.
+
+!!! note "Re-running Configuration"
+    You can re-run the configuration script at any time to update settings:
+    ```bash
+    ./scripts/configure.sh
+    ```
+
+## Step 4: Commit and Deploy
+
+<div class="video-container">
+  <video controls width="100%">
+    <source src="../assets/videos/step4-commit-deploy.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+</div>
+
+Commit your configuration and push to the `main` branch:
+
+```bash
+git add lablink-infrastructure/config/config.yaml
+git commit -m "Add deployment configuration"
+git push
+```
+
+Monitor the deployment:
+
+1. Go to the **Actions** tab in your GitHub repository
+2. Run the **Terraform Deploy** workflow manually
+4. Wait for the workflow to complete (~2-5 minutes)
+
+<div class="video-container">
+  <video controls width="100%">
+    <source src="../assets/videos/step4-deploy.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+</div>
+
+The workflow will:
+
+- Authenticate to AWS via OIDC
+- Initialize Terraform with the S3 backend
+- Deploy the allocator EC2 instance, security groups, and SSH key pair
+
+## Step 5: Verify
+
+<div class="video-container">
+  <video controls width="100%">
+    <source src="../assets/videos/step5-verify.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+</div>
+
+Once the deployment completes:
+
+### Access the Web UI
+
+1. Find the allocator's public IP from the Terraform output in the GitHub Actions logs
+2. Navigate to `http://<ec2_public_ip>` in your browser
+3. Log in with username `admin` and the `ADMIN_PASSWORD` that was auto-generated during setup
+
+### Create Test VMs
+
+1. Go to `http://<ec2_public_ip>/admin`
+2. Click **"Create VMs"**
+3. Enter number of VMs (try 1-2 for testing)
+4. Click **"Launch VMs"** and wait ~5 minutes
+
+### Verify Deployment Script (Optional)
+
+The template includes a verification script:
+
+```bash
+./scripts/verify-deployment.sh
+```
+
+### SSH Check
+
+```bash
+# Download the SSH key from Terraform output (via GitHub Actions artifacts or manually)
+ssh -i ~/lablink-key.pem ubuntu@<ec2_public_ip>
+
+# Verify allocator is running
+sudo docker ps
+
+# Check VMs registered in database
+sudo docker exec $(sudo docker ps -q) psql -U lablink -d lablink_db -c "SELECT hostname FROM vms;"
+```
+
+## Step 6: Cleanup
+
+<div class="video-container">
+  <video controls width="100%">
+    <source src="../assets/videos/step6-cleanup.mp4" type="video/mp4">
+    Your browser does not support the video tag.
+  </video>
+</div>
+
+When you're done testing, destroy the infrastructure:
+
+=== "Via GitHub Actions"
+
+    Manually run the **Terraform Destroy** workflow from the Actions tab.
+
+=== "Via Terraform"
+
+    ```bash
+    cd lablink-infrastructure
+    scripts/init-terraform.sh test
+    terraform destroy -var="resource_suffix=test"
+    ```
+
+=== "Cleanup Orphaned Resources"
+
+    If resources were left behind (e.g., from a failed destroy), use the cleanup script:
+
+    ```bash
+    scripts/cleanup-orphaned-resources.sh test
+    ```
+
+!!! warning "AWS Costs"
+    EC2 instances incur charges while running. Always destroy test resources when not in use. See [Cost Estimation](cost-estimation.md) for details.
+
+## Next Steps
+
+- **[Configuration](configuration.md)**: Customize instance types, machine images, and deployment settings
+- **[Adapting for Your Software](adapting.md)**: Install your own tutorial software on client VMs
+- **[Deployment](deployment.md)**: Production deployment with CI/CD workflows
+- **[Security](security.md)**: Review security best practices before going to production

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -10,9 +10,9 @@ Pick whichever fits your setup. You can switch between them later; both read the
 
     ---
 
-    Create a repository from [lablink-template](https://github.com/talmolab/lablink-template). Push commits to `main` — GitHub Actions runs Terraform with shared S3-backed state.
+    Create a repository from [lablink-template](https://github.com/talmolab/lablink-template). You own the full repo — Dockerfile, Terraform `.tf` files, GitHub Actions workflows — and deploys run through CI.
 
-    Best for **workshops**, shared environments, and **production**: deploys are auditable, reproducible, and anyone with repo access can trigger one.
+    Best when you need to **customize** the deployment: bring-your-own Docker image, custom AMI, extra AWS resources, or bespoke workflow edits.
 
     [:octicons-arrow-right-24: Quickstart: Template repo](quickstart-template.md)
 
@@ -20,9 +20,9 @@ Pick whichever fits your setup. You can switch between them later; both read the
 
     ---
 
-    Install the `lablink` CLI and run `lablink configure && lablink deploy` from your own machine. Terraform state lives in an S3 bucket you own.
+    Install the `lablink` CLI and run `lablink configure && lablink deploy` from your own machine. A single `config.yaml` drives everything; Terraform templates are pulled from a pinned release under the hood.
 
-    Best for **solo iteration**, **local debugging**, and pre-workshop tinkering — no commits, no CI, direct access to Terraform output.
+    Best when you want a **standard deployment without maintaining a repo** — one config file, no Dockerfile or `.tf` to edit.
 
     [:octicons-arrow-right-24: Quickstart: CLI](cli/first-deployment.md)
 
@@ -32,12 +32,13 @@ Pick whichever fits your setup. You can switch between them later; both read the
 
 | If you want to… | Use |
 |---|---|
+| Use your own Docker image or custom AMI | Template repo |
+| Add or modify AWS resources Terraform doesn't provision by default | Template repo |
+| Customize the GitHub Actions workflow | Template repo |
 | Hand the deployment off to a team via GitHub permissions | Template repo |
-| Run reproducible, audited deploys from CI | Template repo |
-| Run a workshop where multiple people may trigger deploys | Template repo |
-| Stand a deployment up quickly from your laptop | CLI |
-| Iterate on config or Terraform changes without pushing commits | CLI |
-| Debug a failed deploy with direct Terraform access | CLI |
+| Stand up a standard deployment without forking the template | CLI |
+| Keep the configuration surface small — one `config.yaml`, no repo to own | CLI |
+| Drive Terraform directly from your laptop and see its output inline | CLI |
 | Export metrics from a deployment that's already been torn down | CLI |
 
 ## Prerequisites (both paths)

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -1,202 +1,56 @@
 # Quickstart
 
-Get LabLink deployed to AWS using the template repository and automated setup scripts.
+LabLink supports two equivalent deployment paths. Both produce the same allocator infrastructure on AWS — they differ in **where Terraform runs** and **where state lives**.
 
-## Prerequisites
+Pick whichever fits your setup. You can switch between them later; both read the same `config.yaml` schema.
 
-Before starting, ensure you have completed:
+<div class="grid cards" markdown>
 
-- [x] [Prerequisites](prerequisites.md): AWS Account, AWS CLI, GitHub CLI (`gh`), and Git installed
+- :material-source-branch: **Quickstart: Template repo**
 
-## Step 1: Create Your Repository
+    ---
 
-<div class="video-container">
-  <video controls width="100%">
-    <source src="../assets/videos/step1-create-repo.mp4" type="video/mp4">
-    Your browser does not support the video tag.
-  </video>
+    Create a repository from [lablink-template](https://github.com/talmolab/lablink-template). Push commits to `main` — GitHub Actions runs Terraform with shared S3-backed state.
+
+    Best for **workshops**, shared environments, and **production**: deploys are auditable, reproducible, and anyone with repo access can trigger one.
+
+    [:octicons-arrow-right-24: Quickstart: Template repo](quickstart-template.md)
+
+- :material-console: **Quickstart: CLI**
+
+    ---
+
+    Install the `lablink` CLI and run `lablink configure && lablink deploy` from your own machine. Terraform state lives in an S3 bucket you own.
+
+    Best for **solo iteration**, **local debugging**, and pre-workshop tinkering — no commits, no CI, direct access to Terraform output.
+
+    [:octicons-arrow-right-24: Quickstart: CLI](cli/first-deployment.md)
+
 </div>
 
-Click the **"Use this template"** button on the [lablink-template repository](https://github.com/talmolab/lablink-template) to create your own deployment repository.
+## Which path should I pick?
 
-Then clone your new repository:
+| If you want to… | Use |
+|---|---|
+| Hand the deployment off to a team via GitHub permissions | Template repo |
+| Run reproducible, audited deploys from CI | Template repo |
+| Run a workshop where multiple people may trigger deploys | Template repo |
+| Stand a deployment up quickly from your laptop | CLI |
+| Iterate on config or Terraform changes without pushing commits | CLI |
+| Debug a failed deploy with direct Terraform access | CLI |
+| Export metrics from a deployment that's already been torn down | CLI |
 
-```bash
-git clone https://github.com/YOUR_ORG/YOUR_REPO.git
-cd YOUR_REPO
-```
+## Prerequisites (both paths)
 
-## Step 2: Run Setup
+Both paths share the same base prerequisites:
 
-<div class="video-container">
-  <video controls width="100%">
-    <source src="../assets/videos/step2-run-setup.mp4" type="video/mp4">
-    Your browser does not support the video tag.
-  </video>
-</div>
+- [Prerequisites](prerequisites.md) — AWS account, AWS CLI, Git.
+- An AWS region with the permissions listed in [AWS Setup](aws-setup.md).
 
-Run the setup script to create all required AWS resources and configure GitHub secrets:
+The template path additionally needs the GitHub CLI (`gh`) for automated repo setup. The CLI path additionally needs Terraform installed locally — see [CLI: Installation](cli/installation.md).
 
-```bash
-./scripts/setup.sh
-```
+## Next steps
 
-The script will prompt you for:
-
-- AWS region (e.g., `us-west-2`)
-- S3 bucket name for Terraform state
-- GitHub repository (e.g., `YOUR_ORG/YOUR_REPO`)
-- Optional DNS settings (Route 53)
-
-It automatically:
-
-- Creates an OIDC identity provider for GitHub Actions
-- Creates an IAM role with required permissions
-- Creates an S3 bucket for Terraform state (with versioning and encryption)
-- Creates a DynamoDB table for state locking
-- Optionally creates a Route 53 hosted zone
-- Sets four GitHub repository secrets: `AWS_ROLE_ARN`, `AWS_REGION`, `ADMIN_PASSWORD`, `DB_PASSWORD`
-- Generates secure passwords for admin and database access
-
-!!! tip "Manual Setup"
-    If you prefer to create AWS resources individually, see the [AWS Setup (Manual)](aws-setup.md) guide.
-
-## Step 3: Configure
-
-After setup completes, the script automatically runs `./scripts/configure.sh` to generate your deployment configuration.
-
-The configure script prompts for:
-
-- Instance type and AMI settings
-- DNS and SSL configuration
-- Monitoring options
-
-It generates `lablink-infrastructure/config/config.yaml` with your settings.
-
-!!! note "Re-running Configuration"
-    You can re-run the configuration script at any time to update settings:
-    ```bash
-    ./scripts/configure.sh
-    ```
-
-## Step 4: Commit and Deploy
-
-<div class="video-container">
-  <video controls width="100%">
-    <source src="../assets/videos/step4-commit-deploy.mp4" type="video/mp4">
-    Your browser does not support the video tag.
-  </video>
-</div>
-
-Commit your configuration and push to the `main` branch:
-
-```bash
-git add lablink-infrastructure/config/config.yaml
-git commit -m "Add deployment configuration"
-git push
-```
-
-Monitor the deployment:
-
-1. Go to the **Actions** tab in your GitHub repository
-2. Run the **Terraform Deploy** workflow manually
-4. Wait for the workflow to complete (~2-5 minutes)
-
-<div class="video-container">
-  <video controls width="100%">
-    <source src="../assets/videos/step4-deploy.mp4" type="video/mp4">
-    Your browser does not support the video tag.
-  </video>
-</div>
-
-The workflow will:
-
-- Authenticate to AWS via OIDC
-- Initialize Terraform with the S3 backend
-- Deploy the allocator EC2 instance, security groups, and SSH key pair
-
-## Step 5: Verify
-
-<div class="video-container">
-  <video controls width="100%">
-    <source src="../assets/videos/step5-verify.mp4" type="video/mp4">
-    Your browser does not support the video tag.
-  </video>
-</div>
-
-Once the deployment completes:
-
-### Access the Web UI
-
-1. Find the allocator's public IP from the Terraform output in the GitHub Actions logs
-2. Navigate to `http://<ec2_public_ip>` in your browser
-3. Log in with username `admin` and the `ADMIN_PASSWORD` that was auto-generated during setup
-
-### Create Test VMs
-
-1. Go to `http://<ec2_public_ip>/admin`
-2. Click **"Create VMs"**
-3. Enter number of VMs (try 1-2 for testing)
-4. Click **"Launch VMs"** and wait ~5 minutes
-
-### Verify Deployment Script (Optional)
-
-The template includes a verification script:
-
-```bash
-./scripts/verify-deployment.sh
-```
-
-### SSH Check
-
-```bash
-# Download the SSH key from Terraform output (via GitHub Actions artifacts or manually)
-ssh -i ~/lablink-key.pem ubuntu@<ec2_public_ip>
-
-# Verify allocator is running
-sudo docker ps
-
-# Check VMs registered in database
-sudo docker exec $(sudo docker ps -q) psql -U lablink -d lablink_db -c "SELECT hostname FROM vms;"
-```
-
-## Step 6: Cleanup
-
-<div class="video-container">
-  <video controls width="100%">
-    <source src="../assets/videos/step6-cleanup.mp4" type="video/mp4">
-    Your browser does not support the video tag.
-  </video>
-</div>
-
-When you're done testing, destroy the infrastructure:
-
-=== "Via GitHub Actions"
-
-    Manually run the **Terraform Destroy** workflow from the Actions tab.
-
-=== "Via Terraform"
-
-    ```bash
-    cd lablink-infrastructure
-    scripts/init-terraform.sh test
-    terraform destroy -var="resource_suffix=test"
-    ```
-
-=== "Cleanup Orphaned Resources"
-
-    If resources were left behind (e.g., from a failed destroy), use the cleanup script:
-
-    ```bash
-    scripts/cleanup-orphaned-resources.sh test
-    ```
-
-!!! warning "AWS Costs"
-    EC2 instances incur charges while running. Always destroy test resources when not in use. See [Cost Estimation](cost-estimation.md) for details.
-
-## Next Steps
-
-- **[Configuration](configuration.md)**: Customize instance types, machine images, and deployment settings
-- **[Adapting for Your Software](adapting.md)**: Install your own tutorial software on client VMs
-- **[Deployment](deployment.md)**: Production deployment with CI/CD workflows
-- **[Security](security.md)**: Review security best practices before going to production
+- [:material-source-branch: Quickstart: Template repo](quickstart-template.md)
+- [:material-console: Quickstart: CLI](cli/first-deployment.md)
+- [CLI Overview](cli/index.md) — deeper comparison of the two paths.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,252 @@
+# CLI Reference
+
+Complete reference for every `lablink` command. Grouped to match the `lablink --help` output.
+
+!!! note "Manual reference"
+    This page is hand-written from `packages/cli/src/lablink_cli/app.py`. For the authoritative help text, run `lablink <command> --help`. Auto-generated reference is planned once the package is published to PyPI.
+
+## Global options
+
+Every subcommand accepts `--config` to override the default config path:
+
+```bash
+lablink <command> --config /path/to/config.yaml
+```
+
+Default: `~/.lablink/config.yaml`. If the file is missing, the command exits with a hint to run `lablink configure`.
+
+---
+
+## Setup commands
+
+### `configure`
+
+Create or edit the LabLink configuration.
+
+```bash
+lablink configure [--config PATH]
+```
+
+Launches a TUI wizard that generates or edits `config.yaml`, then automatically runs [`setup`](#setup) to create the AWS resources Terraform needs for remote state (S3 bucket + DynamoDB lock table).
+
+| Option | Description |
+|---|---|
+| `-c`, `--config PATH` | Path to `config.yaml`. Default: `~/.lablink/config.yaml`. |
+
+---
+
+### `setup`
+
+Create S3 + DynamoDB for remote Terraform state.
+
+```bash
+lablink setup [--config PATH]
+```
+
+Automatically run during [`configure`](#configure). Use this command on its own to recreate state resources if they were deleted out of band.
+
+| Option | Description |
+|---|---|
+| `-c`, `--config PATH` | Path to `config.yaml`. |
+
+---
+
+### `doctor`
+
+Check prerequisites and configuration.
+
+```bash
+lablink doctor
+```
+
+Runs six pre-flight checks: Terraform installed, config file exists, config validates, AWS credentials, S3 state bucket exists, AMI known for the configured region. Exit code is non-zero if any check fails.
+
+Takes no options.
+
+---
+
+## Deployment
+
+### `deploy`
+
+Deploy LabLink infrastructure with Terraform.
+
+```bash
+lablink deploy [--config PATH] [--template-version V] [--terraform-bundle PATH] [--yes]
+```
+
+Downloads the pinned `lablink-template` Terraform files (or uses a cached / bundled copy), renders your config into Terraform variables, and runs `terraform apply`. Prompts once for admin and database passwords — these are **not** stored in `config.yaml`.
+
+| Option | Description |
+|---|---|
+| `-c`, `--config PATH` | Path to `config.yaml`. |
+| `--template-version V` | Override the pinned template version (e.g. `v0.2.0`). Skips checksum verification. |
+| `--terraform-bundle PATH` | Path to a local template tarball for offline deploys. |
+| `-y`, `--yes` | Skip confirmation prompts. Does not bypass credential prompts (admin/db passwords are still required). |
+
+---
+
+### `destroy`
+
+Tear down LabLink infrastructure.
+
+```bash
+lablink destroy [--config PATH] [--yes]
+```
+
+Runs `terraform destroy` against the deployment's working directory. Removes the allocator EC2 instance, security groups, key pair, and any ALB/Route 53 records Terraform owns. Client VMs owned by the allocator are destroyed along with it.
+
+The S3 state bucket and DynamoDB lock table are **not** removed — reuse them on the next deploy, or tear them down with [`cleanup`](#cleanup).
+
+| Option | Description |
+|---|---|
+| `-c`, `--config PATH` | Path to `config.yaml`. |
+| `-y`, `--yes` | Skip confirmation prompts. Password prompts still appear. |
+
+---
+
+### `launch-client`
+
+Launch client VMs via the allocator service.
+
+```bash
+lablink launch-client --num-vms N [--config PATH]
+```
+
+Calls the allocator's create-VM endpoint. The allocator provisions the VMs in its own Terraform workspace — the CLI only speaks to its HTTP API here. Terraform is not required locally for this command.
+
+| Option | Description |
+|---|---|
+| `-n`, `--num-vms N` | Number of client VMs to launch. **Required.** |
+| `-c`, `--config PATH` | Path to `config.yaml`. |
+
+---
+
+## Operations
+
+### `status`
+
+Health checks, Terraform state, and cost estimate.
+
+```bash
+lablink status [--config PATH]
+```
+
+Shows four sections:
+
+1. **Terraform State** — outputs like `ec2_public_ip`, `ec2_public_dns`, DNS/ALB records.
+2. **Health Checks** — DNS resolution, allocator `/api/health`, SSL cert expiry (if HTTPS is enabled).
+3. **Client VMs** — per-VM state and current hourly burn rate.
+4. **Cost Estimate** — daily and monthly dollar estimates, pulled from the AWS Pricing API with a fallback table.
+
+| Option | Description |
+|---|---|
+| `-c`, `--config PATH` | Path to `config.yaml`. |
+
+---
+
+### `logs`
+
+View VM logs in an interactive TUI.
+
+```bash
+lablink logs [--config PATH]
+```
+
+Opens a Textual-based viewer that streams cloud-init and container logs from the allocator and any running client VMs.
+
+| Option | Description |
+|---|---|
+| `-c`, `--config PATH` | Path to `config.yaml`. |
+
+Use `q` to quit, `/` to search, `n`/`N` for next/previous match.
+
+---
+
+### `export-metrics`
+
+Export deployment metrics to CSV or JSON.
+
+```bash
+lablink export-metrics [--client] [--allocator] [--format FMT] [--output PATH] [--include-logs] [--config PATH]
+```
+
+Writes metrics to disk for offline analysis. Two data sources:
+
+- `--client` — per-VM metrics from the allocator's API (requires the allocator to be running).
+- `--allocator` — per-deploy metrics from the local cache at `~/.lablink/deployments/` (works after `lablink destroy`).
+
+With no source flag, both are exported and `_client` / `_allocator` suffixes are appended to the base output name.
+
+| Option | Description |
+|---|---|
+| `--client` | Export per-VM client metrics from the allocator. |
+| `--allocator` | Export per-deploy allocator metrics from the local cache. Skips the network. |
+| `-f`, `--format FMT` | `csv` (default) or `json`. |
+| `-o`, `--output PATH` | Output file path. With both sources, treated as a base name; `_client` / `_allocator` suffixes are added. Default: `metrics_client.<fmt>` and/or `metrics_allocator.<fmt>`. |
+| `--include-logs` | Include `cloud_init_logs` and `docker_logs` columns. |
+| `-c`, `--config PATH` | Path to `config.yaml`. Skipped when only `--allocator` is passed. |
+
+---
+
+## Maintenance
+
+### `show-config`
+
+View the current LabLink configuration.
+
+```bash
+lablink show-config [--config PATH]
+```
+
+Pretty-prints the YAML with syntax highlighting and runs schema validation. Reports validation errors inline.
+
+| Option | Description |
+|---|---|
+| `-c`, `--config PATH` | Path to `config.yaml`. |
+
+---
+
+### `cleanup`
+
+Clean up orphaned AWS resources and local state.
+
+```bash
+lablink cleanup [--dry-run] [--config PATH]
+```
+
+Finds resources tagged with your deployment name that were left behind by a failed or interrupted `destroy` and removes them.
+
+| Option | Description |
+|---|---|
+| `--dry-run` | Show what would be deleted without making changes. |
+| `-c`, `--config PATH` | Path to `config.yaml`. |
+
+---
+
+### `cache-clear`
+
+Clear LabLink caches.
+
+```bash
+lablink cache-clear [--deployments] [--all] [--stale]
+```
+
+By default clears the Terraform template cache at `~/.lablink/cache/terraform/`. With `--deployments`, clears the deployment metrics cache at `~/.lablink/deployments/` instead. With `--all`, clears both.
+
+| Option | Description |
+|---|---|
+| `--deployments` | Clear the deployment metrics cache instead of the Terraform template cache. |
+| `--all` | Clear all LabLink caches (Terraform templates and deployment metrics). |
+| `--stale` | With `--deployments`, delete only `in_progress` records (leftovers from plan-cancel or Ctrl-C). Ignored without `--deployments`. |
+
+---
+
+## Getting help at the command line
+
+For the authoritative, always-current help text, use:
+
+```bash
+lablink --help              # top-level: lists all commands
+lablink <command> --help    # per-command: lists all flags
+```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -65,7 +65,7 @@ Takes no options.
 
 ---
 
-## Deployment
+## Deployment commands
 
 ### `deploy`
 
@@ -122,7 +122,7 @@ Calls the allocator's create-VM endpoint. The allocator provisions the VMs in it
 
 ---
 
-## Operations
+## Operations commands
 
 ### `status`
 
@@ -189,7 +189,7 @@ With no source flag, both are exported and `_client` / `_allocator` suffixes are
 
 ---
 
-## Maintenance
+## Maintenance commands
 
 ### `show-config`
 

--- a/docs/scripts/gen_ref_pages.py
+++ b/docs/scripts/gen_ref_pages.py
@@ -1,99 +1,127 @@
 """Generate the code reference pages and navigation."""
 
-from pathlib import Path
-import mkdocs_gen_files
+import importlib.util
 import sys
+from dataclasses import dataclass
+from pathlib import Path
+
+import mkdocs_gen_files
+
+
+@dataclass
+class PackageInfo:
+    """One Python package to auto-document.
+
+    - ``path``: package source root to walk for .py files.
+    - ``import_name``: module used to check whether the package is installed.
+    """
+
+    path: Path
+    import_name: str
+
 
 root = Path(__file__).parent.parent.parent
 
-# Define the Python packages to document
-packages = {
-    "allocator": {
-        "path": root / "packages" / "allocator" / "src",
-        "module_name": "lablink_allocator",
-    },
-    "client": {
-        "path": root / "packages" / "client" / "src",
-        "module_name": "lablink_client",
-    },
+packages: dict[str, PackageInfo] = {
+    "allocator": PackageInfo(
+        path=root / "packages" / "allocator" / "src",
+        import_name="lablink_allocator_service",
+    ),
+    "client": PackageInfo(
+        path=root / "packages" / "client" / "src",
+        import_name="lablink_client_service",
+    ),
 }
 
-# Check if packages are installed (for full API generation)
-try:
-    import lablink_allocator_service  # noqa: F401
-    import lablink_client_service  # noqa: F401
-    packages_installed = True
-except ImportError:
-    packages_installed = False
-    print("⚠️  LabLink packages not installed - skipping API reference generation", file=sys.stderr)
+# Check installation per-package so a missing one doesn't block the others.
+installed = {
+    name: importlib.util.find_spec(info.import_name) is not None
+    for name, info in packages.items()
+}
+any_installed = any(installed.values())
+
+if not any_installed:
+    print(
+        "⚠️  LabLink packages not installed - skipping API reference generation",
+        file=sys.stderr,
+    )
     print("   For full docs with API reference, install packages:", file=sys.stderr)
     print("   uv pip install -e packages/allocator", file=sys.stderr)
     print("   uv pip install -e packages/client", file=sys.stderr)
 
-if packages_installed:
-    for pkg_name, pkg_info in packages.items():
-        package_root = pkg_info["path"]
+for pkg_name, pkg_info in packages.items():
+    if not installed[pkg_name]:
+        continue
 
-        if not package_root.exists():
+    package_root = pkg_info.path
+    if not package_root.exists():
+        continue
+
+    nav = mkdocs_gen_files.Nav()
+
+    for path in sorted(package_root.rglob("*.py")):
+        # Skip test files and generated files.
+        if "test" in path.parts or "conftest" in path.name:
             continue
 
-        # Create separate navigation for each package
-        nav = mkdocs_gen_files.Nav()
+        module_path = path.relative_to(package_root).with_suffix("")
+        doc_path = path.relative_to(package_root).with_suffix(".md")
+        full_doc_path = Path("reference", pkg_name, doc_path)
 
-        for path in sorted(package_root.rglob("*.py")):
-            # Skip test files and generated files
-            if "test" in path.parts or "conftest" in path.name:
+        parts = tuple(module_path.parts)
+
+        if parts[-1] == "__init__":
+            parts = parts[:-1]
+            if not parts:
                 continue
+            doc_path = doc_path.with_name("index.md")
+            full_doc_path = full_doc_path.with_name("index.md")
+        elif parts[-1] == "__main__":
+            continue
 
-            module_path = path.relative_to(package_root).with_suffix("")
-            doc_path = path.relative_to(package_root).with_suffix(".md")
-            # Organize under package-specific subdirectory
-            full_doc_path = Path("reference", pkg_name, doc_path)
+        nav[parts] = doc_path.as_posix()
 
-            parts = tuple(module_path.parts)
+        with mkdocs_gen_files.open(full_doc_path, "w") as fd:
+            ident = ".".join(parts)
+            fd.write(f"# {ident}\n\n")
+            fd.write(f"::: {ident}\n")
+            fd.write("    options:\n")
+            fd.write("      show_if_no_docstring: true\n")
 
-            if parts[-1] == "__init__":
-                parts = parts[:-1]
-                if not parts:
-                    continue
-                doc_path = doc_path.with_name("index.md")
-                full_doc_path = full_doc_path.with_name("index.md")
-            elif parts[-1] == "__main__":
-                continue
+        mkdocs_gen_files.set_edit_path(full_doc_path, path.relative_to(root))
 
-            nav[parts] = doc_path.as_posix()
+    with mkdocs_gen_files.open(f"reference/{pkg_name}/SUMMARY.md", "w") as nav_file:
+        nav_file.writelines(nav.build_literate_nav())
 
-            with mkdocs_gen_files.open(full_doc_path, "w") as fd:
-                ident = ".".join(parts)
-                fd.write(f"# {ident}\n\n")
-                fd.write(f"::: {ident}\n")
-                fd.write(f"    options:\n")
-                fd.write(f"      show_if_no_docstring: true\n")
 
-            mkdocs_gen_files.set_edit_path(full_doc_path, path.relative_to(root))
+# Build the main reference landing page.
+with mkdocs_gen_files.open("reference/index.md", "w") as index:
+    index.write("# Reference\n\n")
 
-        # Write navigation file for this package
-        with mkdocs_gen_files.open(f"reference/{pkg_name}/SUMMARY.md", "w") as nav_file:
-            nav_file.writelines(nav.build_literate_nav())
+    index.write("## API Reference\n\n")
+    index.write("Auto-generated API documentation from Python docstrings.\n\n")
 
-    # Create main reference index
-    with mkdocs_gen_files.open("reference/index.md", "w") as index:
-        index.write("# API Reference\n\n")
-        index.write("Auto-generated API documentation from Python docstrings.\n\n")
-        index.write("## Allocator Service\n\n")
+    if installed["allocator"]:
+        index.write("### Allocator Service\n\n")
         index.write("API documentation for the LabLink allocator service.\n\n")
         index.write("[Browse Allocator API →](allocator/SUMMARY.md)\n\n")
-        index.write("## Client Service\n\n")
+
+    if installed["client"]:
+        index.write("### Client Service\n\n")
         index.write("API documentation for the LabLink client service.\n\n")
         index.write("[Browse Client API →](client/SUMMARY.md)\n\n")
-else:
-    # Create placeholder when packages aren't installed
-    with mkdocs_gen_files.open("reference/index.md", "w") as index:
-        index.write("# API Reference\n\n")
-        index.write("API reference generation requires LabLink packages to be installed.\n\n")
+
+    if not any_installed:
+        index.write(
+            "API reference generation requires LabLink packages to be installed.\n\n"
+        )
         index.write("To generate full API documentation:\n\n")
         index.write("```bash\n")
         index.write("uv pip install -e packages/allocator\n")
         index.write("uv pip install -e packages/client\n")
         index.write("mkdocs build\n")
-        index.write("```\n")
+        index.write("```\n\n")
+
+    index.write("## CLI Reference\n\n")
+    index.write("Command-line reference for the `lablink` CLI.\n\n")
+    index.write("[Browse CLI Reference →](cli.md)\n\n")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -97,7 +97,6 @@ nav:
       - Prerequisites: prerequisites.md
       - Quickstart: quickstart.md
       - "Quickstart: Template repo": quickstart-template.md
-      - "Quickstart: CLI": cli/first-deployment.md
       - AWS Setup (Manual): aws-setup.md
   - CLI:
       - Overview: cli/index.md

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -96,7 +96,14 @@ nav:
   - Getting Started:
       - Prerequisites: prerequisites.md
       - Quickstart: quickstart.md
+      - "Quickstart: Template repo": quickstart-template.md
+      - "Quickstart: CLI": cli/first-deployment.md
       - AWS Setup (Manual): aws-setup.md
+  - CLI:
+      - Overview: cli/index.md
+      - Installation: cli/installation.md
+      - First Deployment: cli/first-deployment.md
+      - Managing Deployments: cli/managing-deployments.md
   - Admin Guide:
       - Adapting for Your Software: adapting.md
       - Workshop Guide: workshop-guide.md
@@ -118,8 +125,7 @@ nav:
       - Allocator Changelog: changelog-allocator.md
       - Client Changelog: changelog-client.md
       - Releases: https://github.com/talmolab/lablink/releases
-  - Reference:
-      - API Reference: reference/
+  - Reference: reference/
 
 extra:
   version:


### PR DESCRIPTION
## Summary

- Adds tutorials and a command reference for the \`lablink\` CLI, which previously had zero mention in the docs site.
- Frames the CLI and the \`lablink-template\` repo as equal alternatives by splitting Quickstart into a landing page plus two peer walkthroughs.
- Refactors the auto-generated reference landing page to surface the new CLI command reference alongside the existing allocator/client API reference.

## Changes Made

### New pages

- \`docs/cli/index.md\` — Overview: CLI vs. template repo, current limitations, status (pre-PyPI, local-state only).
- \`docs/cli/installation.md\` — Install-from-source instructions, \`lablink doctor\`, state layout under \`~/.lablink/\`, upgrade guidance.
- \`docs/cli/first-deployment.md\` — End-to-end walkthrough: \`configure\` → \`doctor\` → \`deploy\` → \`status\` → \`launch-client\` → \`destroy\`.
- \`docs/cli/managing-deployments.md\` — Day-to-day ops: \`launch-client\`, \`logs\` TUI, \`export-metrics\`, \`cleanup\`, \`cache-clear\`, multi-deployment switching.
- \`docs/reference/cli.md\` — Full command reference (Setup / Deployment / Operations / Maintenance panels), hand-written from \`app.py\` docstrings.

### Quickstart split

- \`docs/quickstart.md\` rewritten as a lightweight landing page with two equal-billing cards (template repo vs. CLI) and a \"which path should I pick?\" decision table.
- Previous quickstart content preserved verbatim (Steps 1–6 unchanged) at \`docs/quickstart-template.md\`, retitled \"Quickstart: Template repo\".

### Nav + cross-links

- \`mkdocs.yml\`: new top-level \"CLI\" section; Getting Started now exposes *Quickstart*, *Quickstart: Template repo*, and *Quickstart: CLI* as peers.
- \`docs/scripts/gen_ref_pages.py\`: refactored \`packages\` dict to a \`PackageInfo\` dataclass; per-package install detection so a missing package no longer blocks the others; generated landing page now includes a \"CLI Reference\" section linking to \`reference/cli.md\`.
- Template-specific callouts in \`aws-setup.md\` retargeted at \`quickstart-template.md\`; generic \"deploy\" links in \`prerequisites.md\` and \`index.md\` continue to point at the new landing.
- \`docs/contributing.md\` file-tree diagram updated to reflect the new structure.

## Testing

- \`uv run mkdocs build\` passes; no new warnings introduced beyond the pre-existing griffe warning on \`validate_config.py:57\`.
- Verified in \`site/\`: CLI tutorial pages render, command reference resolves at \`reference/cli/\`, quickstart landing surfaces both paths, cross-links from CLI tutorials to reference resolve (\`../reference/cli/\`), template-specific aws-setup callouts now point at \`quickstart-template/\`.
- Module-level Python docs for \`lablink_cli\` intentionally **not** generated — the CLI is a tool, not a library, and the command reference covers its public surface.

## Design Decisions

- **Manual command reference, not auto-generated.** Typer doesn't have Sphinx-grade autodoc. A hand-written page ships today; auto-generation can come after PyPI publish so versioned docs track shipped commands.
- **Quickstart split over tabs per step.** Inline tabs were a band-aid — the page title and intro still framed template as *the* quickstart. A landing page + two peer walkthroughs is the only structure that gives real parity.
- **\`docs/reference/cli.md\` lives alongside the auto-generated API tree.** Keeps \"all reference material in one place\" while not conflicting with the \`allocator/\` and \`client/\` auto-generated subdirs.

## Scope

Docs-only change. No Python source touched, no tests needed, no \`pyproject.toml\` or CI changes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)