### PR TITLE
refactor(allocator): replace shared DB conn + RLock with ThreadedConnectionPool

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,20 @@ jobs:
   test:
     name: Test - ${{ matrix.package }}
     runs-on: ubuntu-latest
+    services:
+      postgres:
+        image: postgres:17
+        env:
+          POSTGRES_USER: lablink
+          POSTGRES_PASSWORD: lablink
+          POSTGRES_DB: lablink_db
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd pg_isready
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
     strategy:
       matrix:
         include:

--- a/packages/allocator/pyproject.toml
+++ b/packages/allocator/pyproject.toml
@@ -11,7 +11,7 @@ authors = [
 dependencies = [
   "flask~=3.1.2",
   "werkzeug~=3.1.3",
-  "flask_sqlalchemy~=3.1.1",
+
   "sqlalchemy>=2.0,<3.0",
   "psycopg2-binary~=2.9.10",
   "hydra-core>=1.3,<2.0",

--- a/packages/allocator/pyproject.toml
+++ b/packages/allocator/pyproject.toml
@@ -11,7 +11,6 @@ authors = [
 dependencies = [
   "flask~=3.1.2",
   "werkzeug~=3.1.3",
-
   "sqlalchemy>=2.0,<3.0",
   "psycopg2-binary~=2.9.10",
   "hydra-core>=1.3,<2.0",

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -40,13 +40,14 @@ class _PooledCursor:
 
     def __enter__(self):
         self._conn = self._pool.getconn()
-        # Mirror pre-refactor behavior: every connection runs in autocommit.
-        # Applied per checkout — cheap, and defensive against anything that
-        # ever flips isolation levels on a pooled conn.
-        self._conn.set_isolation_level(
-            psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
-        )
         try:
+            # Mirror pre-refactor behavior: every connection runs in
+            # autocommit. Applied per checkout — cheap, and defensive
+            # against anything that ever flips isolation levels on a
+            # pooled conn.
+            self._conn.set_isolation_level(
+                psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
+            )
             self._cur = self._conn.cursor()
             return self._cur
         except Exception:

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -2,16 +2,16 @@ from datetime import datetime, timezone
 import select
 import json
 import logging
-import threading
 from typing import List, Optional
 
 import psycopg2
+import psycopg2.pool
 
 # Set up logging
 logger = logging.getLogger(__name__)
 
 try:
-    import psycopg2
+    import psycopg2  # noqa: F811 (re-imported for the ImportError guard)
 except ImportError as e:
     logger.error(
         "psycopg2 is not installed in the development environment. "
@@ -20,41 +20,52 @@ except ImportError as e:
     raise e
 
 
-class _LockedCursor:
-    """Context manager that acquires a lock before opening a cursor.
+# Pool sizing. Internal: end users deploying the allocator don't need to
+# reason about this. Raise these in-code if production metrics show
+# getconn blocking during traffic bursts.
+POOL_MIN_SIZE = 2
+POOL_MAX_SIZE = 20
 
-    Delegates to conn.cursor() as a context manager so it works with
-    both real psycopg2 connections and mock objects that return a
-    context-manager from cursor().
+
+class _PooledCursor:
+    """Checks out an autocommit connection from the pool, opens a cursor,
+    and returns both to the pool/closes on exit. Preserves the per-call
+    context-manager API previously provided by _LockedCursor.
     """
 
-    def __init__(self, conn, lock):
-        self._conn = conn
-        self._lock = lock
-        self._cm = None
+    def __init__(self, pool):
+        self._pool = pool
+        self._conn = None
+        self._cur = None
 
     def __enter__(self):
-        self._lock.acquire()
+        self._conn = self._pool.getconn()
+        # Mirror pre-refactor behavior: every connection runs in autocommit.
+        # Applied per checkout — cheap, and defensive against anything that
+        # ever flips isolation levels on a pooled conn.
+        self._conn.set_isolation_level(
+            psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
+        )
         try:
-            self._cm = self._conn.cursor()
-            # Support both context-manager cursors and plain cursors
-            if hasattr(self._cm, '__enter__'):
-                return self._cm.__enter__()
-            return self._cm
+            self._cur = self._conn.cursor()
+            return self._cur
         except Exception:
-            self._lock.release()
+            self._pool.putconn(self._conn)
+            self._conn = None
             raise
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         try:
-            if self._cm is not None:
-                if hasattr(self._cm, '__exit__'):
-                    self._cm.__exit__(exc_type, exc_val, exc_tb)
-                else:
-                    self._cm.close()
+            if self._cur is not None:
+                self._cur.close()
         finally:
-            self._lock.release()
-        return False
+            if self._conn is not None:
+                # On exception, discard the conn so a bad connection doesn't
+                # re-enter the pool. Happy path: return it for reuse.
+                self._pool.putconn(
+                    self._conn, close=(exc_type is not None)
+                )
+        return False  # don't swallow exceptions
 
 
 class PostgresqlDatabase:
@@ -72,8 +83,11 @@ class PostgresqlDatabase:
         port: int,
         table_name: str,
         message_channel: str,
+        pool_min_size: int = POOL_MIN_SIZE,
+        pool_max_size: int = POOL_MAX_SIZE,
     ):
-        """Initialize the database connection.
+        """Initialize the database connection pool.
+
         Args:
             dbname (str): The name of the database.
             user (str): The username to connect to the database.
@@ -82,7 +96,19 @@ class PostgresqlDatabase:
             port (int): The port number for the database connection.
             table_name (str): The name of the table to interact with.
             message_channel (str): The name of the message channel to listen to.
+            pool_min_size (int): Minimum pooled connections. Defaults to
+                POOL_MIN_SIZE. Override in tests only.
+            pool_max_size (int): Maximum pooled connections. Defaults to
+                POOL_MAX_SIZE. Override in tests only.
+
+        Raises:
+            ValueError: If pool sizing is invalid.
         """
+        if pool_min_size < 1 or pool_max_size < pool_min_size:
+            raise ValueError(
+                f"Invalid pool sizes: min={pool_min_size}, max={pool_max_size}"
+            )
+
         self.dbname = dbname
         self.user = user
         self.password = password
@@ -91,8 +117,9 @@ class PostgresqlDatabase:
         self.table_name = table_name
         self.message_channel = message_channel
 
-        # Connect to the PostgreSQL database
-        self.conn = psycopg2.connect(
+        self._pool = psycopg2.pool.ThreadedConnectionPool(
+            minconn=pool_min_size,
+            maxconn=pool_max_size,
             dbname=dbname,
             user=user,
             password=password,
@@ -100,21 +127,16 @@ class PostgresqlDatabase:
             port=port,
         )
 
-        # Set the isolation level to autocommit
-        self.conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
-
-        # Reentrant lock for thread-safe access to the shared connection
-        self._lock = threading.RLock()
-
     @property
     def _cursor(self):
-        """Return a context manager that acquires the lock and yields a cursor.
+        """Return a context manager that checks out a pooled connection
+        and yields a cursor.
 
         Usage:
             with self._cursor as cursor:
                 cursor.execute(...)
         """
-        return _LockedCursor(self.conn, self._lock)
+        return _PooledCursor(self._pool)
 
     def get_all_vms(self) -> list:
         """Get all VMs from the table, excluding logs.
@@ -219,10 +241,8 @@ class PostgresqlDatabase:
                     f"({columns}) VALUES ({placeholders});"
                 )
                 cursor.execute(sql, values)
-                self.conn.commit()
             except Exception as e:
                 logger.error(f"Failed to insert VM '{hostname}': {e}")
-                self.conn.rollback()
                 raise
 
     def get_vm_by_hostname(self, hostname: str) -> dict:
@@ -512,7 +532,6 @@ class PostgresqlDatabase:
                 cursor.execute(
                     query, (email, crd_command, pin, hostname)
                 )
-                self.conn.commit()
                 logger.info(
                     f"Assigned VM '{hostname}' to user '{email}'"
                 )
@@ -520,7 +539,6 @@ class PostgresqlDatabase:
                 logger.error(
                     f"Failed to assign VM '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def reassign_crd(
@@ -570,7 +588,6 @@ class PostgresqlDatabase:
                     query, (crd_command, pin, hostname, expected_email)
                 )
                 updated = cursor.rowcount > 0
-                self.conn.commit()
                 if updated:
                     logger.info(
                         f"Reassigned CRD for VM '{hostname}'"
@@ -586,7 +603,6 @@ class PostgresqlDatabase:
                 logger.error(
                     f"Failed to reassign CRD for '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def get_first_available_vm(self) -> str:
@@ -619,27 +635,19 @@ class PostgresqlDatabase:
         with self._cursor as cursor:
             try:
                 cursor.execute(query, (in_use, hostname))
-                self.conn.commit()
             except Exception as e:
                 logger.error(
                     f"Failed to update in-use status "
                     f"for VM '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def clear_database(self) -> None:
         """Delete all VMs from the table."""
         query = f"DELETE FROM {self.table_name};"
         with self._cursor as cursor:
-            try:
-                cursor.execute(query)
-                self.conn.commit()
-                logger.info("Cleared all VMs from database")
-            except Exception as e:
-                logger.error(f"Failed to clear database: {e}")
-                self.conn.rollback()
-                raise
+            cursor.execute(query)
+            logger.info("Cleared all VMs from database")
 
     def update_health(self, hostname: str, healthy: str) -> None:
         """Modify the health status of a VM.
@@ -655,13 +663,11 @@ class PostgresqlDatabase:
         with self._cursor as cursor:
             try:
                 cursor.execute(query, (healthy, hostname))
-                self.conn.commit()
             except Exception as e:
                 logger.error(
                     f"Failed to update health status "
                     f"for VM '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def get_gpu_health(self, hostname: str) -> str:
@@ -783,13 +789,11 @@ class PostgresqlDatabase:
         with self._cursor as cursor:
             try:
                 cursor.execute(query, (logs, hostname))
-                self.conn.commit()
             except Exception as e:
                 logger.error(
                     f"Failed to save {log_type} logs "
                     f"for VM '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def append_logs_by_hostname(
@@ -839,13 +843,11 @@ class PostgresqlDatabase:
                 cursor.execute(
                     query, (max_size, max_size, new_logs, hostname)
                 )
-                self.conn.commit()
             except Exception as e:
                 logger.error(
                     f"Failed to append {log_type} logs "
                     f"for VM '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def get_all_vm_status(self) -> dict:
@@ -895,7 +897,6 @@ class PostgresqlDatabase:
         with self._cursor as cursor:
             try:
                 cursor.execute(query, (hostname, status))
-                self.conn.commit()
                 logger.debug(
                     f"VM '{hostname}' status: {status}"
                 )
@@ -904,27 +905,36 @@ class PostgresqlDatabase:
                     f"Failed to update status "
                     f"for VM '{hostname}': {e}"
                 )
-                self.conn.rollback()
 
     @classmethod
     def load_database(
-        cls, dbname, user, password, host, port, table_name, message_channel
+        cls,
+        dbname,
+        user,
+        password,
+        host,
+        port,
+        table_name,
+        message_channel,
+        pool_min_size: int = POOL_MIN_SIZE,
+        pool_max_size: int = POOL_MAX_SIZE,
     ) -> "PostgresqlDatabase":
         """Loads an existing database from PostgreSQL.
 
-        Args:
-            dbname (str): The name of the database.
-            user (str): The username to connect to the database.
-            password (str): The password for the user.
-            host (str): The host where the database is located.
-            port (int): The port number for the database connection.
-            table_name (str): The name of the table to interact with.
-            message_channel (str): The name of the message channel to listen to.
-
-        Returns:
-            PostgresqlDatabase: An instance of the PostgresqlDatabase class.
+        Args match __init__. Provided for callers that prefer the
+        classmethod style.
         """
-        return cls(dbname, user, password, host, port, table_name, message_channel)
+        return cls(
+            dbname,
+            user,
+            password,
+            host,
+            port,
+            table_name,
+            message_channel,
+            pool_min_size=pool_min_size,
+            pool_max_size=pool_max_size,
+        )
 
     @staticmethod
     def _naive_utc(dt: datetime) -> datetime:
@@ -972,12 +982,10 @@ class PostgresqlDatabase:
                         self._naive_utc(per_instance_end_time),
                     ),
                 )
-                self.conn.commit()
             except Exception as e:
                 logger.error(
                     f"Failed to update Terraform timing for VM '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def update_vm_metrics_atomic(self, hostname: str, metrics: dict) -> None:
@@ -1057,7 +1065,6 @@ class PostgresqlDatabase:
             try:
                 cursor.execute(query, tuple(values))
                 result = cursor.fetchone()
-                self.conn.commit()
 
                 # Log total startup time when available
                 if result and result[0] is not None and result[0] > 0:
@@ -1068,7 +1075,6 @@ class PostgresqlDatabase:
                 logger.error(
                     f"Failed to update metrics for VM '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def create_scheduled_destruction(
@@ -1107,7 +1113,6 @@ class PostgresqlDatabase:
                     ),
                 )
                 destruction_id = cursor.fetchone()[0]
-                self.conn.commit()
                 logger.info(
                     f"Created scheduled destruction "
                     f"'{schedule_name}' "
@@ -1116,7 +1121,6 @@ class PostgresqlDatabase:
                 return destruction_id
 
             except psycopg2.IntegrityError as e:
-                self.conn.rollback()
                 if (
                     'schedule_name' in str(e)
                     or 'unique constraint' in str(e).lower()
@@ -1136,7 +1140,6 @@ class PostgresqlDatabase:
                     ) from e
 
             except Exception as e:
-                self.conn.rollback()
                 logger.error(
                     f"Failed to create scheduled destruction "
                     f"'{schedule_name}': {e}"
@@ -1229,7 +1232,6 @@ class PostgresqlDatabase:
             cursor.execute(
                 query, (status, execution_result, schedule_id)
             )
-            self.conn.commit()
 
     def cancel_scheduled_destruction(self, schedule_id: int) -> None:
         """Cancel a scheduled destruction."""
@@ -1239,7 +1241,6 @@ class PostgresqlDatabase:
         )
         with self._cursor as cursor:
             cursor.execute(query, (schedule_id,))
-            self.conn.commit()
 
     def ensure_reboot_columns(self) -> None:
         """Add reboot tracking columns to vm_table if they don't exist."""
@@ -1255,12 +1256,10 @@ class PostgresqlDatabase:
                         f"ADD COLUMN IF NOT EXISTS "
                         f"{col_name} {col_type};"
                     )
-                    self.conn.commit()
                 except Exception as e:
                     logger.error(
                         f"Failed to add column {col_name}: {e}"
                     )
-                    self.conn.rollback()
 
     def record_heartbeat(
         self,
@@ -1332,11 +1331,9 @@ class PostgresqlDatabase:
                         hostname,
                     ),
                 )
-                self.conn.commit()
                 return True
         except Exception as e:
             logger.error(f"Failed to record heartbeat for {hostname}: {e}")
-            self.conn.rollback()
             return False
 
     def touch_last_seen(self, hostname: str) -> None:
@@ -1354,10 +1351,8 @@ class PostgresqlDatabase:
         try:
             with self._cursor as cursor:
                 cursor.execute(query, (hostname,))
-                self.conn.commit()
         except Exception as e:
             logger.error(f"Failed to touch last_seen for {hostname}: {e}")
-            self.conn.rollback()
 
     def get_failed_vms(
         self,
@@ -1474,7 +1469,6 @@ class PostgresqlDatabase:
         with self._cursor as cursor:
             try:
                 cursor.execute(query, (hostname,))
-                self.conn.commit()
                 logger.info(
                     f"Recorded reboot for VM '{hostname}'"
                 )
@@ -1483,7 +1477,6 @@ class PostgresqlDatabase:
                     f"Failed to record reboot "
                     f"for VM '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def release_assignment(self, hostname: str) -> None:
@@ -1515,7 +1508,6 @@ class PostgresqlDatabase:
         with self._cursor as cursor:
             try:
                 cursor.execute(query, (hostname,))
-                self.conn.commit()
                 logger.info(
                     f"Released assignment for unrecoverable VM '{hostname}'"
                 )
@@ -1523,7 +1515,6 @@ class PostgresqlDatabase:
                 logger.error(
                     f"Failed to release assignment for '{hostname}': {e}"
                 )
-                self.conn.rollback()
                 raise
 
     def get_reboot_info(self, hostname: str) -> Optional[dict]:
@@ -1559,6 +1550,10 @@ class PostgresqlDatabase:
             return None
 
     def __del__(self):
-        """Close the database connection when the object is deleted."""
-        if hasattr(self, "conn") and self.conn:
-            self.conn.close()
+        """Close all pooled connections when the object is deleted."""
+        if hasattr(self, "_pool") and self._pool is not None:
+            try:
+                self._pool.closeall()
+            except Exception:
+                # Pool may already be closed; nothing to do.
+                pass

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -10,15 +10,6 @@ import psycopg2.pool
 # Set up logging
 logger = logging.getLogger(__name__)
 
-try:
-    import psycopg2  # noqa: F811 (re-imported for the ImportError guard)
-except ImportError as e:
-    logger.error(
-        "psycopg2 is not installed in the development environment. "
-        "Please install it using `pip install psycopg2`"
-    )
-    raise e
-
 
 # Pool sizing. Internal: end users deploying the allocator don't need to
 # reason about this. Raise these in-code if production metrics show

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -22,7 +22,7 @@ from flask import (
 )
 from flask_httpauth import HTTPBasicAuth
 from werkzeug.security import generate_password_hash, check_password_hash
-from flask_sqlalchemy import SQLAlchemy
+
 import psycopg2
 
 from lablink_allocator_service.get_config import get_config
@@ -56,11 +56,9 @@ TERRAFORM_DIR = (Path(__file__).parent / "terraform").resolve()
 # Load the configuration
 cfg = get_config()
 
-db_uri = f"postgresql://{cfg.db.user}:{cfg.db.password}@{cfg.db.host}:{cfg.db.port}/{cfg.db.dbname}"
-os.environ["DATABASE_URL"] = db_uri
-app.config["SQLALCHEMY_DATABASE_URI"] = os.getenv("DATABASE_URL", db_uri)
-app.config["SQLALCHEMY_TRACK_MODIFICATIONS"] = False
-db = SQLAlchemy(app)
+os.environ["DATABASE_URL"] = (
+    f"postgresql://{cfg.db.user}:{cfg.db.password}@{cfg.db.host}:{cfg.db.port}/{cfg.db.dbname}"
+)
 
 # Validate that required secrets are configured
 _missing = []
@@ -1202,7 +1200,6 @@ def main():
     try:
         _startup_time = time.monotonic()
         with app.app_context():
-            db.create_all()
             init_database()
 
         # Initialize scheduler service

--- a/packages/allocator/tests/conftest.py
+++ b/packages/allocator/tests/conftest.py
@@ -1,3 +1,5 @@
+import os
+
 import pytest
 from unittest.mock import MagicMock
 from omegaconf import OmegaConf
@@ -331,3 +333,71 @@ def write_config_file(tmp_path):
         return str(config_file)
 
     return _write
+
+
+@pytest.fixture
+def real_db():
+    """Yield a PostgresqlDatabase connected to a real Postgres.
+
+    Used by the concurrency test that asserts pool checkouts actually
+    overlap in wall-clock time. If Postgres is unreachable (typical for
+    local dev without a running instance), the fixture calls pytest.skip
+    so the rest of the suite is unaffected.
+
+    Connection details come from env vars with defaults matching the CI
+    service container.
+    """
+    # Import here so the fixture doesn't force real-psycopg2 import at
+    # module load time (tests/test_database.py patches psycopg2 at import).
+    try:
+        import psycopg2
+    except ImportError:
+        pytest.skip("psycopg2 not installed")
+
+    from lablink_allocator_service.database import PostgresqlDatabase
+
+    host = os.getenv("POSTGRES_HOST", "localhost")
+    port = int(os.getenv("POSTGRES_PORT", "5432"))
+    user = os.getenv("POSTGRES_USER", "lablink")
+    password = os.getenv("POSTGRES_PASSWORD", "lablink")
+    dbname = os.getenv("POSTGRES_DB", "lablink_db")
+
+    # Probe connectivity before building the pool; the pool eagerly opens
+    # min_conn connections and will raise on unreachable hosts.
+    try:
+        probe = psycopg2.connect(
+            dbname=dbname, user=user, password=password,
+            host=host, port=port,
+        )
+        probe.close()
+    except psycopg2.Error as e:
+        pytest.skip(f"Postgres not reachable at {host}:{port}: {e}")
+
+    # Ensure a minimal vms table exists for the test queries.
+    setup = psycopg2.connect(
+        dbname=dbname, user=user, password=password, host=host, port=port,
+    )
+    setup.autocommit = True
+    with setup.cursor() as cur:
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS vms ("
+            "hostname text PRIMARY KEY"
+            ");"
+        )
+    setup.close()
+
+    db = PostgresqlDatabase(
+        dbname=dbname,
+        user=user,
+        password=password,
+        host=host,
+        port=port,
+        table_name="vms",
+        message_channel="test_channel",
+        pool_min_size=2,
+        pool_max_size=8,
+    )
+    try:
+        yield db
+    finally:
+        db._pool.closeall()

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -16,33 +16,51 @@ mock_psycopg2.IntegrityError = MockIntegrityError
 
 with patch.dict(
     "sys.modules",
-    {"psycopg2": mock_psycopg2, "psycopg2.extensions": MagicMock()},
+    {
+        "psycopg2": mock_psycopg2,
+        "psycopg2.extensions": MagicMock(),
+        "psycopg2.pool": mock_psycopg2.pool,
+    },
 ):
     from lablink_allocator_service.database import PostgresqlDatabase
 
 
 @pytest.fixture
 def mock_db_connection():
-    """Fixture to create a mock database connection and cursor."""
+    """Fixture returning (mock_conn, mock_cursor, mock_pool).
+
+    The connection-pool mock is wired so that:
+      - PostgresqlDatabase.__init__ receives a mock pool (via the patched
+        psycopg2.pool.ThreadedConnectionPool factory) instead of opening
+        a real pool.
+      - mock_pool.getconn() returns mock_conn.
+      - mock_conn.cursor() returns mock_cursor directly.
+
+    Tests that previously reassigned db.conn and db.cursor after
+    instantiation continue to work via the convenience aliases set in
+    db_instance below.
+    """
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
 
-    # Make cursor() return a context manager that returns the mock cursor
-    mock_cursor_context = MagicMock()
-    mock_cursor_context.__enter__ = MagicMock(return_value=mock_cursor)
-    mock_cursor_context.__exit__ = MagicMock(return_value=False)
-    mock_conn.cursor.return_value = mock_cursor_context
+    # conn.cursor() returns the cursor directly (real psycopg2 behavior).
+    # _PooledCursor calls conn.cursor() and uses the result as the cursor.
+    mock_conn.cursor.return_value = mock_cursor
 
-    # When PostgresqlDatabase is initialized, it calls psycopg2.connect()
-    mock_psycopg2.connect.return_value = mock_conn
-    return mock_conn, mock_cursor
+    mock_pool = MagicMock()
+    mock_pool.getconn.return_value = mock_conn
+
+    # PostgresqlDatabase.__init__ calls psycopg2.pool.ThreadedConnectionPool(...).
+    # Route that through the mock so no real connection is attempted.
+    mock_psycopg2.pool.ThreadedConnectionPool.return_value = mock_pool
+
+    return mock_conn, mock_cursor, mock_pool
 
 
 @pytest.fixture
 def db_instance(mock_db_connection):
-    """Fixture to create an instance of the PostgresqlDatabase class."""
-    # The mock_db_connection fixture ensures that the call to psycopg2.connect()
-    # in the __init__ method returns our mock connection.
+    """Fixture returning a PostgresqlDatabase wired to a mocked pool."""
+    mock_conn, mock_cursor, mock_pool = mock_db_connection
     db = PostgresqlDatabase(
         dbname="testdb",
         user="testuser",
@@ -52,8 +70,11 @@ def db_instance(mock_db_connection):
         table_name="vms",
         message_channel="test_channel",
     )
-    # We can also directly access the mocked connection and cursor for manipulation
-    db.conn, db.cursor = mock_db_connection
+    # Convenience aliases so test bodies can keep using db_instance.cursor
+    # and db_instance.conn without knowing about pool internals.
+    db.conn = mock_conn
+    db.cursor = mock_cursor
+    db._pool = mock_pool
     return db
 
 
@@ -110,7 +131,6 @@ def test_insert_vm(db_instance):
     # The values should correspond to the mocked column names
     expected_values = [hostname, False, None, None, None, None, None, None, None]
     db_instance.cursor.execute.assert_called_with(expected_sql, expected_values)
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_get_vm_by_hostname_found(db_instance):
@@ -305,7 +325,6 @@ def test_assign_vm(db_instance):
     db_instance.cursor.execute.assert_called_with(
         ANY, (email, crd_command, pin, hostname)
     )
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_assign_vm_no_available(db_instance):
@@ -335,14 +354,12 @@ def test_update_vm_in_use(db_instance):
     db_instance.cursor.execute.assert_called_with(
         "UPDATE vms SET inuse = %s WHERE hostname = %s", (in_use, hostname)
     )
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_clear_database(db_instance):
     """Test clearing all VMs from the database."""
     db_instance.clear_database()
     db_instance.cursor.execute.assert_called_with("DELETE FROM vms;")
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_update_health(db_instance):
@@ -353,7 +370,6 @@ def test_update_health(db_instance):
     db_instance.cursor.execute.assert_called_with(
         "UPDATE vms SET healthy = %s WHERE hostname = %s;", (healthy, hostname)
     )
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_get_gpu_health(db_instance):
@@ -430,7 +446,6 @@ def test_save_logs_by_hostname(db_instance):
     db_instance.cursor.execute.assert_called_with(
         "UPDATE vms SET cloudinitlogs = %s WHERE hostname = %s;", (logs, hostname)
     )
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_save_docker_logs_by_hostname(db_instance):
@@ -441,7 +456,6 @@ def test_save_docker_logs_by_hostname(db_instance):
     db_instance.cursor.execute.assert_called_with(
         "UPDATE vms SET dockerlogs = %s WHERE hostname = %s;", (logs, hostname)
     )
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_append_logs_by_hostname(db_instance):
@@ -460,7 +474,6 @@ def test_append_logs_by_hostname(db_instance):
     assert "cloudinitlogs" in query
     # Params: (max_size, max_size, new_logs, hostname)
     assert params == (1 * 1024 * 1024, 1 * 1024 * 1024, new_logs, hostname)
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_append_docker_logs_by_hostname(db_instance):
@@ -473,7 +486,6 @@ def test_append_docker_logs_by_hostname(db_instance):
     call_args = db_instance.cursor.execute.call_args
     query = call_args[0][0]
     assert "dockerlogs" in query
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_append_logs_custom_max_size(db_instance):
@@ -495,7 +507,6 @@ def test_append_logs_rollback_on_error(db_instance):
     db_instance.cursor.execute.side_effect = Exception("DB error")
     with pytest.raises(Exception, match="DB error"):
         db_instance.append_logs_by_hostname(hostname, "logs")
-    db_instance.conn.rollback.assert_called_once()
 
 
 def test_old_read_modify_write_race_condition():
@@ -708,7 +719,6 @@ def test_update_vm_status(db_instance):
 
     # Using ANY to avoid matching the exact whitespace in the multi-line query string
     db_instance.cursor.execute.assert_called_with(ANY, (hostname, status))
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_update_vm_status_invalid(db_instance, caplog):
@@ -730,20 +740,21 @@ def test_load_database():
         )
 
     mock_init.assert_called_once_with(
-        "db", "user", "pass", "host", 5432, "table", "channel"
+        "db", "user", "pass", "host", 5432, "table", "channel",
+        pool_min_size=2, pool_max_size=20,
     )
 
     assert isinstance(inst, PostgresqlDatabase)
 
 
 def test_del(db_instance):
-    """Test that the destructor closes the database connection."""
-    conn = db_instance.conn
+    """Test that the destructor closes all pooled connections."""
+    pool = db_instance._pool
 
     # Call __del__ directly for predictable testing, as garbage collection is not guaranteed
     db_instance.__del__()
 
-    conn.close.assert_called_once()
+    pool.closeall.assert_called_once()
 
 
 def test_get_crd_command_no_vm(db_instance):
@@ -778,7 +789,6 @@ def test_assign_vm_db_error(db_instance, caplog):
     with pytest.raises(Exception, match="DB error"):
         db_instance.assign_vm("user@example.com", "cmd", "123")
     assert "Failed to assign VM" in caplog.text
-    db_instance.conn.rollback.assert_called_once()
 
 
 def test_get_gpu_health_not_found(db_instance):
@@ -824,7 +834,6 @@ def test_update_vm_status_db_error(db_instance, caplog):
     db_instance.cursor.execute.side_effect = Exception("DB error")
     db_instance.update_vm_status(hostname, status)
     assert "Failed to update status for VM" in caplog.text
-    db_instance.conn.rollback.assert_called_once()
 
 
 def test_get_all_vms(db_instance):
@@ -1038,7 +1047,6 @@ def test_update_vm_metrics_atomic_cloud_init_only(db_instance):
 
     # Check values passed (timestamps, duration, inlined duration for total, hostname)
     assert values == (1609459200, 1609459260, 60.0, 60.0, hostname)
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_update_vm_metrics_atomic_container_only(db_instance):
@@ -1065,7 +1073,6 @@ def test_update_vm_metrics_atomic_container_only(db_instance):
 
     # Extra value for inlined container duration in total formula
     assert values == (1609459300, 1609459360, 60.0, 60.0, hostname)
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_create_scheduled_destruction(db_instance):
@@ -1110,7 +1117,6 @@ def test_create_scheduled_destruction(db_instance):
         True,
         1,
     )
-    db_instance.conn.commit.assert_called_once()
     assert schedule_id == 1
 
 
@@ -1162,7 +1168,6 @@ def test_create_scheduled_destruction_error(db_instance, caplog):
         )
 
     assert "Failed to create scheduled destruction" in caplog.text
-    db_instance.conn.rollback.assert_called_once()
 
 
 def test_get_scheduled_destruction(db_instance):
@@ -1295,7 +1300,6 @@ def test_update_scheduled_destruction_status(db_instance):
     args = db_instance.cursor.execute.call_args[0]
     assert "".join(args[0].split()) == "".join(expected_query.split())
     assert args[1] == (status, execution_result, schedule_id)
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_update_scheduled_destruction_status_failed(db_instance):
@@ -1312,7 +1316,6 @@ def test_update_scheduled_destruction_status_failed(db_instance):
 
     args = db_instance.cursor.execute.call_args[0]
     assert args[1] == (status, execution_result, schedule_id)
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_cancel_scheduled_destruction(db_instance):
@@ -1325,7 +1328,6 @@ def test_cancel_scheduled_destruction(db_instance):
         "UPDATE scheduled_destructions SET status = 'cancelled' WHERE id = %s;",
         (schedule_id,),
     )
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_get_assigned_vm_for_email_found(db_instance):
@@ -1398,7 +1400,6 @@ def test_reassign_crd_succeeds_when_row_still_owned(db_instance):
     assert args[2] == "vm-7"
     assert args[3] == "student@test.edu"
 
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_reassign_crd_returns_false_when_row_released(db_instance, caplog):
@@ -1417,7 +1418,6 @@ def test_reassign_crd_returns_false_when_row_released(db_instance, caplog):
     )
 
     assert result is False
-    db_instance.conn.commit.assert_called_once()
     assert "row no longer owned by 'student@test.edu'" in caplog.text
 
 
@@ -1428,5 +1428,92 @@ def test_reassign_crd_error(db_instance, caplog):
         db_instance.reassign_crd(
             "vm-7", "cmd", "000000", "student@test.edu"
         )
-    db_instance.conn.rollback.assert_called_once()
     assert "Failed to reassign CRD" in caplog.text
+
+
+# ---------------------------------------------------------------------------
+# Pool-behavior tests (PR 1: connection pool refactor)
+# ---------------------------------------------------------------------------
+
+
+def test_pool_size_validation_rejects_min_zero():
+    """pool_min_size must be >= 1."""
+    with pytest.raises(ValueError, match="Invalid pool sizes"):
+        PostgresqlDatabase(
+            dbname="testdb",
+            user="testuser",
+            password="testpassword",
+            host="localhost",
+            port=5432,
+            table_name="vms",
+            message_channel="test_channel",
+            pool_min_size=0,
+            pool_max_size=5,
+        )
+
+
+def test_pool_size_validation_rejects_max_below_min():
+    """pool_max_size must be >= pool_min_size."""
+    with pytest.raises(ValueError, match="Invalid pool sizes"):
+        PostgresqlDatabase(
+            dbname="testdb",
+            user="testuser",
+            password="testpassword",
+            host="localhost",
+            port=5432,
+            table_name="vms",
+            message_channel="test_channel",
+            pool_min_size=5,
+            pool_max_size=2,
+        )
+
+
+def test_cursor_returns_connection_on_success(db_instance):
+    """After a successful `with self._cursor` block, the pool's
+    putconn is called once with close=False."""
+    mock_pool = db_instance._pool
+    with db_instance._cursor as cur:
+        cur.execute("SELECT 1;")
+    mock_pool.putconn.assert_called_once()
+    # close defaults to False on success; verify via kwargs or positional
+    _, kwargs = mock_pool.putconn.call_args
+    assert kwargs.get("close", False) is False
+
+
+def test_cursor_discards_connection_on_exception(db_instance):
+    """If a query raises, putconn is called with close=True so the bad
+    connection is evicted from the pool."""
+    mock_pool = db_instance._pool
+    db_instance.cursor.execute.side_effect = RuntimeError("boom")
+    with pytest.raises(RuntimeError):
+        with db_instance._cursor as cur:
+            cur.execute("SELECT 1;")
+    mock_pool.putconn.assert_called_once()
+    _, kwargs = mock_pool.putconn.call_args
+    assert kwargs.get("close") is True
+
+
+def test_cursor_sets_autocommit_per_checkout(db_instance):
+    """Every checkout applies ISOLATION_LEVEL_AUTOCOMMIT, preserving
+    the pre-refactor per-statement-transaction behavior."""
+    mock_conn = db_instance.conn
+    mock_conn.set_isolation_level.reset_mock()
+    with db_instance._cursor:
+        pass
+    mock_conn.set_isolation_level.assert_called_once()
+
+
+def test_del_closes_pool(mock_db_connection):
+    """__del__ closes the pool (releases all connections)."""
+    mock_conn, mock_cursor, mock_pool = mock_db_connection
+    db = PostgresqlDatabase(
+        dbname="testdb",
+        user="testuser",
+        password="testpassword",
+        host="localhost",
+        port=5432,
+        table_name="vms",
+        message_channel="test_channel",
+    )
+    db.__del__()
+    mock_pool.closeall.assert_called_once()

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -1517,3 +1517,44 @@ def test_del_closes_pool(mock_db_connection):
     )
     db.__del__()
     mock_pool.closeall.assert_called_once()
+
+
+def test_concurrent_queries_do_not_serialize(real_db):
+    """4 threads each running SELECT pg_sleep(0.2) should complete in
+    well under the serial time (~800ms). Under the old single-lock
+    design they would serialize. With the pool they overlap."""
+    import threading
+    import time
+
+    barrier = threading.Barrier(4)
+    start_times: list[float] = []
+    end_times: list[float] = []
+    errors: list[BaseException] = []
+
+    def slow_query():
+        try:
+            barrier.wait(timeout=5)
+            t0 = time.monotonic()
+            with real_db._cursor as cur:
+                cur.execute("SELECT pg_sleep(0.2);")
+            end_times.append(time.monotonic())
+            start_times.append(t0)
+        except BaseException as e:  # noqa: BLE001
+            errors.append(e)
+
+    threads = [threading.Thread(target=slow_query) for _ in range(4)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert len(start_times) == 4 and len(end_times) == 4
+
+    total = max(end_times) - min(start_times)
+    # Serial time would be ~4 × 0.2 = 0.8s. Parallel should finish in
+    # well under 0.5s. Give generous slack for CI jitter.
+    assert total < 0.5, (
+        f"Queries appear serialized: wall-clock total {total:.2f}s "
+        f"(serial would be ~0.8s)"
+    )

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -678,11 +678,11 @@ def test_threading_lock_prevents_interleaved_reads_and_writes(
     assert db_instance.cursor.execute.call_count == 10
 
 
-def test_lock_released_when_cursor_creation_fails(db_instance):
-    """Verify the lock is released if conn.cursor() raises.
+def test_cursor_creation_failure_does_not_poison_pool(db_instance):
+    """Verify the connection is returned to the pool if conn.cursor() raises.
 
-    Without the fix, a failed cursor() call would leave the RLock
-    permanently acquired, deadlocking all subsequent database operations.
+    Without the fix, a failed cursor() call would leave the connection
+    leaked from the pool, preventing subsequent database operations.
     """
     # Make cursor() raise on first call, then succeed on second
     db_instance.conn.cursor.side_effect = [
@@ -1496,11 +1496,16 @@ def test_cursor_discards_connection_on_exception(db_instance):
 def test_cursor_sets_autocommit_per_checkout(db_instance):
     """Every checkout applies ISOLATION_LEVEL_AUTOCOMMIT, preserving
     the pre-refactor per-statement-transaction behavior."""
+    # mock_psycopg2 is the module-level mock installed in sys.modules before
+    # database.py was imported; the production code's psycopg2.extensions
+    # resolves to mock_psycopg2.extensions, so reference the same sentinel here.
     mock_conn = db_instance.conn
     mock_conn.set_isolation_level.reset_mock()
     with db_instance._cursor:
         pass
-    mock_conn.set_isolation_level.assert_called_once()
+    mock_conn.set_isolation_level.assert_called_once_with(
+        mock_psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
+    )
 
 
 def test_del_closes_pool(mock_db_connection):

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -10,7 +10,11 @@ mock_psycopg2.IntegrityError = type("IntegrityError", (Exception,), {})
 
 with patch.dict(
     "sys.modules",
-    {"psycopg2": mock_psycopg2, "psycopg2.extensions": MagicMock()},
+    {
+        "psycopg2": mock_psycopg2,
+        "psycopg2.extensions": MagicMock(),
+        "psycopg2.pool": mock_psycopg2.pool,
+    },
 ):
     from lablink_allocator_service.database import PostgresqlDatabase
     import lablink_allocator_service.reboot as reboot_mod
@@ -19,18 +23,23 @@ with patch.dict(
 
 @pytest.fixture
 def mock_db_connection():
+    """Fixture returning (mock_conn, mock_cursor, mock_pool)."""
     mock_conn = MagicMock()
     mock_cursor = MagicMock()
-    mock_cursor_context = MagicMock()
-    mock_cursor_context.__enter__ = MagicMock(return_value=mock_cursor)
-    mock_cursor_context.__exit__ = MagicMock(return_value=False)
-    mock_conn.cursor.return_value = mock_cursor_context
-    mock_psycopg2.connect.return_value = mock_conn
-    return mock_conn, mock_cursor
+    # conn.cursor() returns the cursor directly (real psycopg2 behavior).
+    mock_conn.cursor.return_value = mock_cursor
+
+    mock_pool = MagicMock()
+    mock_pool.getconn.return_value = mock_conn
+    mock_psycopg2.pool.ThreadedConnectionPool.return_value = mock_pool
+
+    return mock_conn, mock_cursor, mock_pool
 
 
 @pytest.fixture
 def db_instance(mock_db_connection):
+    """Fixture returning a PostgresqlDatabase wired to a mocked pool."""
+    mock_conn, mock_cursor, mock_pool = mock_db_connection
     db = PostgresqlDatabase(
         dbname="testdb",
         user="testuser",
@@ -40,7 +49,9 @@ def db_instance(mock_db_connection):
         table_name="vms",
         message_channel="test_channel",
     )
-    db.conn, db.cursor = mock_db_connection
+    db.conn = mock_conn
+    db.cursor = mock_cursor
+    db._pool = mock_pool
     return db
 
 
@@ -51,7 +62,6 @@ def test_update_vm_status_rebooting(db_instance):
     """Test that 'rebooting' is a valid VM status."""
     db_instance.update_vm_status("vm-1", "rebooting")
     db_instance.cursor.execute.assert_called_with(ANY, ("vm-1", "rebooting"))
-    db_instance.conn.commit.assert_called_once()
 
 
 def test_get_failed_vms(db_instance):
@@ -338,7 +348,6 @@ def test_record_reboot(db_instance):
     """Test recording a reboot attempt."""
     db_instance.record_reboot("vm-1")
     db_instance.cursor.execute.assert_called_with(ANY, ("vm-1",))
-    db_instance.conn.commit.assert_called_once()
 
     # Verify CRD-session fields are cleared but the student's assignment
     # is preserved (so the student keeps their VM slot across reboots).
@@ -355,14 +364,12 @@ def test_record_reboot_error(db_instance, caplog):
     db_instance.cursor.execute.side_effect = Exception("DB error")
     with pytest.raises(Exception, match="DB error"):
         db_instance.record_reboot("vm-1")
-    db_instance.conn.rollback.assert_called_once()
 
 
 def test_release_assignment(db_instance):
     """Test releasing a VM's assignment when reboot attempts are exhausted."""
     db_instance.release_assignment("vm-1")
     db_instance.cursor.execute.assert_called_with(ANY, ("vm-1",))
-    db_instance.conn.commit.assert_called_once()
 
     query = db_instance.cursor.execute.call_args[0][0]
     assert "useremail = NULL" in query
@@ -378,7 +385,6 @@ def test_release_assignment_error(db_instance, caplog):
     db_instance.cursor.execute.side_effect = Exception("DB error")
     with pytest.raises(Exception, match="DB error"):
         db_instance.release_assignment("vm-1")
-    db_instance.conn.rollback.assert_called_once()
     assert "Failed to release assignment for" in caplog.text
 
 


### PR DESCRIPTION
## Summary

- Swap the allocator's single shared `psycopg2.connection` + process-wide `threading.RLock` for a `psycopg2.pool.ThreadedConnectionPool`. Every DB call previously serialized through one lock, capping throughput at `1 / avg_query_latency` regardless of concurrency.
- Preserve the `with self._cursor as cursor:` call-site API and autocommit-per-statement semantics so no callers change.
- Delete dead Flask-SQLAlchemy wiring (imported and instantiated, but never used — no `db.Model`, no `db.session`).
- Add mock-based pool unit tests + one real-Postgres concurrency test proving queries actually overlap in wall-clock time.
- Add a Postgres service container to CI so the concurrency test runs for real.

## Problem

`PostgresqlDatabase` held one connection and one `threading.RLock`. Every DB call acquired the lock, executed on the shared connection, and released — service-wide serialization of everything that touches the DB. Hot paths that suffered: heartbeats (every 30s × N VMs), log shippers (multi-MB UPDATE under lock), admin bulk reads (`get_all_vms_for_export`), scheduler and auto-reboot background threads, and every Flask request thread.

## Changes

| Commit | What it does |
|---|---|
| `dd8537a` | Remove dead `flask_sqlalchemy` import/config/`create_all`. Keep `sqlalchemy` dep (APScheduler's `SQLAlchemyJobStore` needs it). |
| `d27dcf6` | Core refactor: `_PooledCursor` replaces `_LockedCursor`; pool replaces shared conn + RLock; strip ~30 now-redundant `self.conn.commit()`/`rollback()` calls. Fixtures in `test_database.py` + `test_reboot.py` updated in lockstep. |
| `7470571` | Add `real_db` pytest fixture (skip-on-no-conn) and `test_concurrent_queries_do_not_serialize` proving 4 parallel queries complete in < 0.5s vs ~0.8s serial. |
| `d05af2b` | Add Postgres service container to the `test` job in CI so the concurrency test runs against a live DB. |
| `62ca274` | Code-review cleanup: guard `set_isolation_level` inside the try/except (prevents conn leak on rare failures); strengthen autocommit-arg assertion in test; rename `test_lock_released_*` → `test_cursor_creation_failure_does_not_poison_pool` (no more lock). |

## Testing

- **Mock-based unit tests (new):** 6 pool-behavior tests covering pool-size validation (min/max), putconn on success (`close=False`), putconn on exception (`close=True`, evicts bad conn), per-checkout autocommit isolation, `__del__` closing the pool.
- **Real-Postgres concurrency test (new):** `test_concurrent_queries_do_not_serialize` — 4 threads run `SELECT pg_sleep(0.2)`; assertion `total < 0.5s` proves overlap (serial time would be ~0.8s).
- **Existing coverage preserved:** 395 tests total pass, 1 skipped locally (the concurrency test — runs in CI via the new service container).
- **Ruff clean** across `src tests`.

## Design decisions

- **Autocommit preserved per-checkout** (not per-context-manager transactions). Keeps behavior identical to pre-refactor; drops ~30 now-redundant `commit()`/`rollback()` calls.
- **Pool sizing as internal constants**, not user-facing config. `POOL_MIN_SIZE=2`, `POOL_MAX_SIZE=20` in `database.py`. End users deploying the allocator don't need to reason about pool tuning; raise the constants in-code if metrics ever show saturation.
- **`listen_for_notifications` unchanged** — it opens its own dedicated connection because LISTEN needs a long-lived socket.
- **Rejected alternative: SQLAlchemy Core migration.** Larger diff (~500 lines across every query call site), different LISTEN/NOTIFY handling, complete test-mock rewrite. Coupling an ORM migration to a contention fix makes both harder to review and revert. `ThreadedConnectionPool` is sufficient and battle-tested.
- **Accepted trade-off on `record_heartbeat`:** SELECT + UPDATE now run on one pooled connection but are no longer serialized against other hostnames' heartbeats. The warning-log races (boot_id changed, crd_active flipped) are advisory — the UPDATE itself is atomic and idempotent.

## Manual verification (before merging)

- [ ] Spin up allocator against a real Postgres. Hammer `/api/health` with `ab -n 100 -c 10`; confirm latency does not scale linearly with concurrency.
- [ ] Trigger `get_all_vms_for_export` while heartbeats flow; confirm heartbeats don't queue.
- [ ] Kill and restart Postgres mid-request; confirm the pool evicts the bad connection and the next call succeeds on a fresh one.
---
🤖 Generated with [Claude Code](https://claude.com/claude-code)