### PR TITLE
chore: prepare lablink-cli for PyPI release

### DIFF
--- a/.github/workflows/publish-pip.yml
+++ b/.github/workflows/publish-pip.yml
@@ -7,11 +7,12 @@ on:
     tags:
       - lablink-allocator-service_v*
       - lablink-client-service_v*
+      - lablink-cli_v*
   workflow_dispatch:
     inputs:
       package:
         type: choice
-        options: [lablink-allocator-service, lablink-client-service]
+        options: [lablink-allocator-service, lablink-client-service, lablink-cli]
         required: true
         description: Which package to publish
       dry_run:
@@ -35,13 +36,20 @@ jobs:
       matrix:
         include:
           - package: lablink-allocator-service
+            module: lablink_allocator_service
             dir: packages/allocator
             tag_prefix: lablink-allocator-service_v
             path_filter: packages/allocator
           - package: lablink-client-service
+            module: lablink_client_service
             dir: packages/client
             tag_prefix: lablink-client-service_v
             path_filter: packages/client
+          - package: lablink-cli
+            module: lablink_cli
+            dir: packages/cli
+            tag_prefix: lablink-cli_v
+            path_filter: packages/cli
 
     steps:
       # Check if this matrix job should run
@@ -166,7 +174,7 @@ jobs:
           echo "Running test suite..."
           uv run pytest tests \
             --ignore=tests/terraform \
-            --cov=src/${{ matrix.package }} \
+            --cov=src/${{ matrix.module }} \
             --cov-report=term-missing \
             --cov-fail-under=0
           echo "✅ Tests passed"

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This repository contains the **core LabLink packages, Docker images, and documen
 
 - **[lablink-cli](packages/cli/)** - Command-line tool to deploy and manage LabLink infrastructure
   ```bash
-  pip install lablink-cli
+  uv tool install lablink-cli
   ```
 
 ### Docker Images (Published to GHCR)

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![PyPI - lablink-allocator-service](https://img.shields.io/pypi/v/lablink-allocator-service?label=allocator)](https://pypi.org/project/lablink-allocator-service/)
 [![PyPI - lablink-client-service](https://img.shields.io/pypi/v/lablink-client-service?label=client)](https://pypi.org/project/lablink-client-service/)
+[![PyPI - lablink-cli](https://img.shields.io/pypi/v/lablink-cli?label=cli)](https://pypi.org/project/lablink-cli/)
 [![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://talmolab.github.io/lablink/)
 [![License](https://img.shields.io/github/license/talmolab/lablink)](LICENSE)
 
@@ -23,6 +24,11 @@ This repository contains the **core LabLink packages, Docker images, and documen
 - **[lablink-client](packages/client/)** - Client Service
   ```bash
   pip install lablink-client
+  ```
+
+- **[lablink-cli](packages/cli/)** - Command-line tool to deploy and manage LabLink infrastructure
+  ```bash
+  pip install lablink-cli
   ```
 
 ### Docker Images (Published to GHCR)
@@ -114,11 +120,14 @@ lablink/
 │   │   ├── tests/                   # Unit tests including Terraform tests
 │   │   ├── Dockerfile               # Production image (from PyPI)
 │   │   └── Dockerfile.dev           # Development image (local code)
-│   └── client/                      # Client Python package
-│       ├── src/lablink_client/      # Source code
-│       ├── tests/                   # Unit tests
-│       ├── Dockerfile               # Production image (from PyPI)
-│       └── Dockerfile.dev           # Development image (local code)
+│   ├── client/                      # Client Python package
+│   │   ├── src/lablink_client/      # Source code
+│   │   ├── tests/                   # Unit tests
+│   │   ├── Dockerfile               # Production image (from PyPI)
+│   │   └── Dockerfile.dev           # Development image (local code)
+│   └── cli/                         # CLI Python package (Typer + Textual)
+│       ├── src/lablink_cli/         # Source code (commands, TUI, config)
+│       └── tests/                   # Unit tests
 ├── docs/                            # MkDocs documentation
 └── .github/workflows/               # CI/CD workflows
     ├── ci.yml                       # Tests, linting, Docker builds
@@ -137,6 +146,7 @@ LabLink uses **independent versioning** for its packages:
 
 - **lablink-allocator-service**: [![PyPI](https://img.shields.io/pypi/v/lablink-allocator-service)](https://pypi.org/project/lablink-allocator-service/)
 - **lablink-client-service**: [![PyPI](https://img.shields.io/pypi/v/lablink-client-service)](https://pypi.org/project/lablink-client-service/)
+- **lablink-cli**: [![PyPI](https://img.shields.io/pypi/v/lablink-cli)](https://pypi.org/project/lablink-cli/)
 
 See the [Release Process](https://talmolab.github.io/lablink/contributing/#release-process) for how releases are managed.
 

--- a/packages/cli/README.md
+++ b/packages/cli/README.md
@@ -1,0 +1,41 @@
+# LabLink CLI
+
+Command-line tool for deploying and managing LabLink teaching lab infrastructure on AWS.
+
+## Installation
+
+```bash
+uv tool install lablink-cli
+```
+
+This installs `lablink` as a global command in an isolated environment. See the [uv docs](https://docs.astral.sh/uv/guides/tools/) for more on `uv tool`.
+
+## Usage
+
+```bash
+lablink --help
+lablink --version   # or -v
+```
+
+### Commands
+
+| Command | Description |
+|---------|-------------|
+| `configure` | Create or edit LabLink configuration (interactive TUI) |
+| `setup` | Create S3 + DynamoDB resources for remote Terraform state |
+| `deploy` | Deploy LabLink infrastructure with Terraform |
+| `destroy` | Tear down LabLink infrastructure |
+| `launch-client` | Launch client VMs via the allocator service |
+| `status` | Health checks, Terraform state, and cost estimate |
+| `logs` | View VM logs in an interactive TUI |
+| `cleanup` | Clean up orphaned AWS resources and local state |
+| `doctor` | Check prerequisites and configuration |
+| `show-config` | View the current LabLink configuration |
+| `cache-clear` | Clear LabLink caches (Terraform templates, deployment metrics) |
+| `export-metrics` | Export deployment metrics to CSV or JSON |
+
+Run `lablink <command> --help` for details on any command.
+
+## Documentation
+
+Full CLI documentation: https://talmolab.github.io/lablink/cli/

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -1,5 +1,10 @@
 [project]
 name = "lablink-cli"
+authors = [
+  {name = "Elizabeth Berrigan", email = "eberrigan@salk.edu"},
+  {name = "Talmo Pereira", email = "talmo@salk.edu"},
+  {name = "Andrew Park", email = "hep003@ucsd.edu"},
+]
 version = "0.1.0"
 description = "CLI tool for deploying and managing LabLink infrastructure"
 readme = "README.md"
@@ -41,3 +46,7 @@ exclude_lines = [
     "pragma: no cover",
     "if __name__",
 ]
+
+[project.urls]
+Homepage = "https://github.com/talmolab/lablink"
+Issues = "https://github.com/talmolab/lablink/issues"

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -13,6 +13,28 @@ app = typer.Typer(
 DEFAULT_CONFIG = Path.home() / ".lablink" / "config.yaml"
 
 
+def _version_callback(value: bool) -> None:
+    if value:
+        from importlib.metadata import version
+
+        typer.echo(f"lablink-cli {version('lablink-cli')}")
+        raise typer.Exit()
+
+
+@app.callback()
+def _root(
+    _version: bool = typer.Option(
+        False,
+        "--version",
+        "-v",
+        callback=_version_callback,
+        is_eager=True,
+        help="Show the CLI version and exit.",
+    ),
+) -> None:
+    """Deploy and manage LabLink teaching lab infrastructure."""
+
+
 def _load_cfg(config: str | None):
     """Load config from path, exit with message if not found."""
     from lablink_cli.config.schema import load_config

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -6,7 +6,6 @@ import typer
 
 app = typer.Typer(
     name="lablink",
-    help="Deploy and manage LabLink teaching lab infrastructure.",
     no_args_is_help=True,
 )
 

--- a/packages/cli/tests/test_app.py
+++ b/packages/cli/tests/test_app.py
@@ -56,6 +56,18 @@ class TestCLICommands:
         out = _plain(result.output).lower()
         assert "lablink" in out or "deploy" in out
 
+    def test_version_long_flag(self):
+        from importlib.metadata import version
+
+        result = runner.invoke(app, ["--version"])
+        assert result.exit_code == 0
+        assert f"lablink-cli {version('lablink-cli')}" in _plain(result.output)
+
+    def test_version_short_flag(self):
+        result = runner.invoke(app, ["-v"])
+        assert result.exit_code == 0
+        assert "lablink-cli" in _plain(result.output)
+
     def test_doctor_command_exists(self):
         result = runner.invoke(app, ["doctor", "--help"])
         assert result.exit_code == 0


### PR DESCRIPTION
## Summary
- Wires `lablink-cli` into the existing `publish-pip.yml` release workflow so the package can be cut with a `lablink-cli_v*` tag
- Adds a `--version` / `-v` flag to the CLI, backed by `importlib.metadata`
- Fills in package metadata (`authors`, `project.urls`) so PyPI's metadata guardrails pass
- Writes the CLI README (was empty — would have published blank to PyPI) and updates the root README to reference the new package

## Changes Made

### CI (`e65cd6c`)
- Add `lablink-cli_v*` tag trigger and `lablink-cli` workflow_dispatch option in `publish-pip.yml`
- Add matrix entry for `lablink-cli` (`dir: packages/cli`, `tag_prefix: lablink-cli_v`, `path_filter: packages/cli`)
- Introduce a `module:` matrix field (e.g. `lablink_cli`, `lablink_allocator_service`) and switch the test step's `--cov=src/${{ matrix.package }}` → `--cov=src/${{ matrix.module }}`. Fixes a latent bug where coverage silently reported nothing for existing packages because `matrix.package` uses dashes (`lablink-allocator-service`) but source dirs use underscores (`lablink_allocator_service`)

### Feature (`4318a49`)
- Add `--version` / `-v` global flag via a Typer root callback
- Version string is read at runtime from `importlib.metadata.version("lablink-cli")`, so it stays in sync with `pyproject.toml` automatically
- Output format: `lablink-cli 0.1.0`

### Metadata (`100bd44`)
- Add `authors` (required by the publish workflow's metadata guardrail at `publish-pip.yml:128`)
- Add `project.urls` (Homepage, Issues)

### Docs (`3b41489`)
- Write `packages/cli/README.md` (previously empty): install via `uv tool install`, top-level command table, link to https://talmolab.github.io/lablink/cli/
- Update root `README.md`: add PyPI badge for `lablink-cli`, add CLI to Python Packages section, add `packages/cli/` to the repo-structure tree, add CLI to the Package Versioning list

## Testing
- `ruff check packages/cli` — clean
- `uv run pytest tests/test_app.py` in `packages/cli` — 33 passed, including two new tests (`test_version_long_flag`, `test_version_short_flag`)
- Manual smoke: `uv run lablink --version` and `uv run lablink -v` both print `lablink-cli 0.1.0`

## Design Decisions
- **`importlib.metadata.version` vs hardcoded `__version__`** — reads installed package metadata directly, avoiding drift between `pyproject.toml` and a constant
- **`module:` matrix field in `publish-pip.yml`** — chose explicit parameterization over a string transform (`${{ matrix.package }} | replace('-', '_')`) for readability and because it also documents the expected source-dir name alongside the package name
- **`uv tool install` in CLI README** — idiomatic for CLI packages (equivalent of `pipx install`); installs `lablink` globally in an isolated env

## Release Checklist (follow-up, not part of this PR)
- [ ] Configure a **pending trusted publisher** on PyPI for `lablink-cli` (Owner: `talmolab`, Repo: `lablink`, Workflow: `publish-pip.yml`, Environment: blank)
- [ ] Optional: dry-run the workflow via `workflow_dispatch` with `package: lablink-cli`, `dry_run: true`
- [ ] Tag `lablink-cli_v0.1.0` from `main` to publish

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)