### PR TITLE
fix(client): repair CRD host registration on client VMs (CRD v148 regression)

### DIFF
--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -127,9 +127,12 @@ RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.config
 
 # Switch to non-root user for Google Chrome Remote Desktop to work.
-# USER/LOGNAME/HOME must match the actual runtime uid — start-host uses
-# them to decide whether it is running as root (it refuses to) and to
-# resolve paths like ~/.config/chrome-remote-desktop.
+# Align USER/LOGNAME/HOME with the runtime uid. Docker's USER directive
+# only changes the effective uid; $USER / $LOGNAME / $HOME are left
+# untouched and would otherwise inherit stale values from the build
+# stage. Keeping them wrong pollutes every tool that reads them (CRD
+# logs visible username-mismatch warnings; anything else that looks at
+# $HOME or $USER sees the wrong value) and makes debugging harder.
 USER ${USERNAME}
 ENV USER=${USERNAME} \
     LOGNAME=${USERNAME} \

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -8,9 +8,6 @@ ARG USERNAME="client"
 # Set non-interactive mode
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Set user
-ENV USER=root
-
 # Set NVIDIA driver capabilities
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
@@ -130,7 +127,13 @@ RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.config
 
 # Switch to non-root user for Google Chrome Remote Desktop to work.
+# USER/LOGNAME/HOME must match the actual runtime uid — start-host uses
+# them to decide whether it is running as root (it refuses to) and to
+# resolve paths like ~/.config/chrome-remote-desktop.
 USER ${USERNAME}
+ENV USER=${USERNAME} \
+    LOGNAME=${USERNAME} \
+    HOME=/home/${USERNAME}
 WORKDIR /home/${USERNAME}
 
 # Create scripts directory with miniforge, uv, and nvm installation scripts

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -72,16 +72,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
-# Pre-create the chrome-remote-desktop system user and group before the
-# CRD install so the postinst sees them and does not skip user-ownership
-# setup. The CRD runtime opens /etc/passwd and aborts via
-# base::ImmediateCrash() (SIGTRAP, exit 133, no log line) if the
-# chrome-remote-desktop user is missing — even though the group alone
-# was enough pre-v148.
-RUN groupadd -r chrome-remote-desktop && \
-    useradd -r -g chrome-remote-desktop -M -s /usr/sbin/nologin \
-            -d /var/lib/chrome-remote-desktop chrome-remote-desktop
-
 # Install Chrome Remote Desktop
 # CRD v147+ creates _crd_network system user; Ubuntu 22.04 adduser rejects the
 # leading underscore. Relax NAME_REGEX_SYSTEM so the postinst script succeeds.
@@ -124,9 +114,13 @@ RUN useradd -m -s /bin/bash ${USERNAME} && echo "${USERNAME}:password" | chpassw
     chmod 0440 /etc/sudoers.d/${USERNAME} && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
-# Add USERNAME to the chrome-remote-desktop group (group is pre-created
-# above so the CRD install sees it).
-RUN usermod -aG chrome-remote-desktop ${USERNAME}
+# Add USERNAME to the chrome-remote-desktop group.
+# `groupadd -f` guarantees the group exists even when the CRD package
+# postinst skips creating it (observed with Google's current
+# chrome-remote-desktop deb), making the build robust to upstream
+# packaging changes.
+RUN groupadd -f chrome-remote-desktop && \
+    usermod -aG chrome-remote-desktop ${USERNAME}
 
 # Ensure Chrome directories are accessible to the client user
 RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -72,6 +72,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
+# Pre-create the chrome-remote-desktop system user and group before the
+# CRD install so the postinst sees them and does not skip user-ownership
+# setup. The CRD runtime opens /etc/passwd and aborts via
+# base::ImmediateCrash() (SIGTRAP, exit 133, no log line) if the
+# chrome-remote-desktop user is missing — even though the group alone
+# was enough pre-v148.
+RUN groupadd -r chrome-remote-desktop && \
+    useradd -r -g chrome-remote-desktop -M -s /usr/sbin/nologin \
+            -d /var/lib/chrome-remote-desktop chrome-remote-desktop
+
 # Install Chrome Remote Desktop
 # CRD v147+ creates _crd_network system user; Ubuntu 22.04 adduser rejects the
 # leading underscore. Relax NAME_REGEX_SYSTEM so the postinst script succeeds.
@@ -114,13 +124,9 @@ RUN useradd -m -s /bin/bash ${USERNAME} && echo "${USERNAME}:password" | chpassw
     chmod 0440 /etc/sudoers.d/${USERNAME} && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
-# Add USERNAME to the chrome-remote-desktop group.
-# `groupadd -f` guarantees the group exists even when the CRD package
-# postinst skips creating it (observed with Google's current
-# chrome-remote-desktop deb), making the build robust to upstream
-# packaging changes.
-RUN groupadd -f chrome-remote-desktop && \
-    usermod -aG chrome-remote-desktop ${USERNAME}
+# Add USERNAME to the chrome-remote-desktop group (group is pre-created
+# above so the CRD install sees it).
+RUN usermod -aG chrome-remote-desktop ${USERNAME}
 
 # Ensure Chrome directories are accessible to the client user
 RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -127,9 +127,12 @@ RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.config
 
 # Switch to non-root user for Google Chrome Remote Desktop to work.
-# USER/LOGNAME/HOME must match the actual runtime uid — start-host uses
-# them to decide whether it is running as root (it refuses to) and to
-# resolve paths like ~/.config/chrome-remote-desktop.
+# Align USER/LOGNAME/HOME with the runtime uid. Docker's USER directive
+# only changes the effective uid; $USER / $LOGNAME / $HOME are left
+# untouched and would otherwise inherit stale values from the build
+# stage. Keeping them wrong pollutes every tool that reads them (CRD
+# logs visible username-mismatch warnings; anything else that looks at
+# $HOME or $USER sees the wrong value) and makes debugging harder.
 USER ${USERNAME}
 ENV USER=${USERNAME} \
     LOGNAME=${USERNAME} \

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -8,9 +8,6 @@ ARG USERNAME="client"
 # Set non-interactive mode
 ENV DEBIAN_FRONTEND=noninteractive
 
-# Set user
-ENV USER=root
-
 # Set NVIDIA driver capabilities
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
@@ -130,7 +127,13 @@ RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}/.config
 
 # Switch to non-root user for Google Chrome Remote Desktop to work.
+# USER/LOGNAME/HOME must match the actual runtime uid — start-host uses
+# them to decide whether it is running as root (it refuses to) and to
+# resolve paths like ~/.config/chrome-remote-desktop.
 USER ${USERNAME}
+ENV USER=${USERNAME} \
+    LOGNAME=${USERNAME} \
+    HOME=/home/${USERNAME}
 WORKDIR /home/${USERNAME}
 
 # Ensure miniforge Python is in PATH for all subsequent commands

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -72,16 +72,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
-# Pre-create the chrome-remote-desktop system user and group before the
-# CRD install so the postinst sees them and does not skip user-ownership
-# setup. The CRD runtime opens /etc/passwd and aborts via
-# base::ImmediateCrash() (SIGTRAP, exit 133, no log line) if the
-# chrome-remote-desktop user is missing — even though the group alone
-# was enough pre-v148.
-RUN groupadd -r chrome-remote-desktop && \
-    useradd -r -g chrome-remote-desktop -M -s /usr/sbin/nologin \
-            -d /var/lib/chrome-remote-desktop chrome-remote-desktop
-
 # Install Chrome Remote Desktop
 # CRD v147+ creates _crd_network system user; Ubuntu 22.04 adduser rejects the
 # leading underscore. Relax NAME_REGEX_SYSTEM so the postinst script succeeds.
@@ -124,9 +114,13 @@ RUN useradd -m -s /bin/bash ${USERNAME} && echo "${USERNAME}:password" | chpassw
     chmod 0440 /etc/sudoers.d/${USERNAME} && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
-# Add USERNAME to the chrome-remote-desktop group (group is pre-created
-# above so the CRD install sees it).
-RUN usermod -aG chrome-remote-desktop ${USERNAME}
+# Add USERNAME to the chrome-remote-desktop group.
+# `groupadd -f` guarantees the group exists even when the CRD package
+# postinst skips creating it (observed with Google's current
+# chrome-remote-desktop deb), making the build robust to upstream
+# packaging changes.
+RUN groupadd -f chrome-remote-desktop && \
+    usermod -aG chrome-remote-desktop ${USERNAME}
 
 # Ensure Chrome directories are accessible to the client user
 RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -72,6 +72,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
 
+# Pre-create the chrome-remote-desktop system user and group before the
+# CRD install so the postinst sees them and does not skip user-ownership
+# setup. The CRD runtime opens /etc/passwd and aborts via
+# base::ImmediateCrash() (SIGTRAP, exit 133, no log line) if the
+# chrome-remote-desktop user is missing — even though the group alone
+# was enough pre-v148.
+RUN groupadd -r chrome-remote-desktop && \
+    useradd -r -g chrome-remote-desktop -M -s /usr/sbin/nologin \
+            -d /var/lib/chrome-remote-desktop chrome-remote-desktop
+
 # Install Chrome Remote Desktop
 # CRD v147+ creates _crd_network system user; Ubuntu 22.04 adduser rejects the
 # leading underscore. Relax NAME_REGEX_SYSTEM so the postinst script succeeds.
@@ -114,13 +124,9 @@ RUN useradd -m -s /bin/bash ${USERNAME} && echo "${USERNAME}:password" | chpassw
     chmod 0440 /etc/sudoers.d/${USERNAME} && \
     chown -R ${USERNAME}:${USERNAME} /home/${USERNAME}
 
-# Add USERNAME to the chrome-remote-desktop group.
-# `groupadd -f` guarantees the group exists even when the CRD package
-# postinst skips creating it (observed with Google's current
-# chrome-remote-desktop deb), making the build robust to upstream
-# packaging changes.
-RUN groupadd -f chrome-remote-desktop && \
-    usermod -aG chrome-remote-desktop ${USERNAME}
+# Add USERNAME to the chrome-remote-desktop group (group is pre-created
+# above so the CRD install sees it).
+RUN usermod -aG chrome-remote-desktop ${USERNAME}
 
 # Ensure Chrome directories are accessible to the client user
 RUN mkdir -p /home/${USERNAME}/.config/google-chrome && \

--- a/packages/client/src/lablink_client_service/connect_crd.py
+++ b/packages/client/src/lablink_client_service/connect_crd.py
@@ -119,11 +119,11 @@ def connect_to_crd(command, pin):
     # is no systemd running, so the systemctl call fails and start-host
     # reports a non-zero exit — but the registration itself succeeded.
     # If the host config is present, start the daemon directly via
-    # user-session, bypassing systemd entirely.
+    # chrome-remote-desktop --start, bypassing systemd entirely.
     if is_crd_registered():
         logger.info(
             "CRD host registered (start-host exit=%d); "
-            "starting daemon via user-session.",
+            "starting daemon via chrome-remote-desktop --start.",
             result.returncode,
         )
         start_crd_daemon()

--- a/packages/client/src/lablink_client_service/connect_crd.py
+++ b/packages/client/src/lablink_client_service/connect_crd.py
@@ -145,21 +145,26 @@ def is_crd_registered() -> bool:
 def start_crd_daemon() -> None:
     """Start the CRD daemon from an existing host registration.
 
-    Used on warm container restarts where start-host would fail because
-    the auth code is already consumed or the host is already registered.
-    Mirrors the invocation that start-host uses on first boot (observed
-    via ps -ef): user-session runs as root and drops privileges to the
-    client user internally, then daemonizes.
+    Runs the same command systemd's ``chrome-remote-desktop@<user>``
+    unit would invoke (``/opt/google/chrome-remote-desktop/chrome-remote-desktop
+    --start --new-session``), bypassing systemd entirely. Used both on
+    warm container restarts (where start-host would fail because the
+    auth code is already consumed) and on first boot after start-host
+    registers the host but cannot launch the daemon because systemctl
+    is not available in the container.
     """
-    config_paths = glob.glob(CRD_HOST_CONFIG_GLOB)
-    if not config_paths:
-        logger.error("No CRD host config found; cannot restart daemon")
+    if not is_crd_registered():
+        logger.error("No CRD host config found; cannot start daemon")
         return
-    config_path = config_paths[0]
     command = (
-        f"/opt/google/chrome-remote-desktop/user-session start -- "
-        f"--config={config_path} --start"
+        "/opt/google/chrome-remote-desktop/chrome-remote-desktop "
+        "--start --new-session"
     )
+    env = {
+        **os.environ,
+        "XDG_SESSION_CLASS": "user",
+        "XDG_SESSION_TYPE": "x11",
+    }
     try:
         result = subprocess.run(
             command,
@@ -167,6 +172,7 @@ def start_crd_daemon() -> None:
             capture_output=True,
             text=True,
             timeout=30,
+            env=env,
         )
     except subprocess.TimeoutExpired:
         logger.error(
@@ -175,8 +181,8 @@ def start_crd_daemon() -> None:
         )
         return
     if result.returncode == 0:
-        logger.info(f"CRD daemon restarted using {config_path}")
+        logger.info("CRD daemon started")
     else:
         logger.error(
-            f"Failed to restart CRD daemon: {result.stderr.strip()}"
+            f"Failed to start CRD daemon: {result.stderr.strip()}"
         )

--- a/packages/client/src/lablink_client_service/connect_crd.py
+++ b/packages/client/src/lablink_client_service/connect_crd.py
@@ -114,10 +114,27 @@ def connect_to_crd(command, pin):
         text=True,
     )
 
-    if result.returncode == 0:
+    # start-host writes the host config to ~/.config/chrome-remote-desktop/
+    # BEFORE it tries to launch the daemon via systemctl. In Docker there
+    # is no systemd running, so the systemctl call fails and start-host
+    # reports a non-zero exit — but the registration itself succeeded.
+    # If the host config is present, start the daemon directly via
+    # user-session, bypassing systemd entirely.
+    if is_crd_registered():
+        logger.info(
+            "CRD host registered (start-host exit=%d); "
+            "starting daemon via user-session.",
+            result.returncode,
+        )
+        start_crd_daemon()
+    elif result.returncode == 0:
         logger.info("CRD connection established successfully")
-    elif result.stderr:
-        logger.error(f"CRD connection failed: {result.stderr}")
+    else:
+        logger.error(
+            "CRD connection failed (exit %d): %s",
+            result.returncode,
+            result.stderr.strip(),
+        )
 
 
 def is_crd_registered() -> bool:

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -4,6 +4,16 @@ export PYTHONUNBUFFERED=1
 # Start
 CONTAINER_START_TIME=$(date +%s)
 
+# Ensure XDG_RUNTIME_DIR exists. Chrome Remote Desktop's start-host
+# stats this path early in init and aborts via base::ImmediateCrash()
+# (SIGTRAP, exit 133, no log line) when it is missing. Outside a
+# container, systemd-logind creates /run/user/$UID on login; Docker
+# does not run logind, so we create it ourselves before CRD runs.
+runtime_dir="/run/user/$(id -u)"
+mkdir -p "$runtime_dir"
+chmod 0700 "$runtime_dir"
+export XDG_RUNTIME_DIR="$runtime_dir"
+
 # Activate virtual environment
 source /home/client/.venv/bin/activate
 

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -9,9 +9,12 @@ CONTAINER_START_TIME=$(date +%s)
 # (SIGTRAP, exit 133, no log line) when it is missing. Outside a
 # container, systemd-logind creates /run/user/$UID on login; Docker
 # does not run logind, so we create it ourselves before CRD runs.
+# /run is a fresh tmpfs owned by root, so mkdir requires sudo here —
+# the client user has passwordless sudo via /etc/sudoers.d/client.
 runtime_dir="/run/user/$(id -u)"
-mkdir -p "$runtime_dir"
-chmod 0700 "$runtime_dir"
+sudo mkdir -p "$runtime_dir"
+sudo chown "$(id -u):$(id -g)" "$runtime_dir"
+sudo chmod 0700 "$runtime_dir"
 export XDG_RUNTIME_DIR="$runtime_dir"
 
 # Activate virtual environment

--- a/packages/client/tests/test_connect_crd.py
+++ b/packages/client/tests/test_connect_crd.py
@@ -88,15 +88,19 @@ def test_whole_reconstruction():
     assert command == crd_command
 
 
+@patch("lablink_client_service.connect_crd.is_crd_registered", return_value=False)
 @patch("lablink_client_service.connect_crd.subprocess.run")
 @patch("lablink_client_service.connect_crd.reconstruct_command")
-def test_connect_to_crd(mock_reconstruct_command, mock_subprocess_run):
+def test_connect_to_crd(
+    mock_reconstruct_command, mock_subprocess_run, mock_is_registered
+):
     input_command = CRD_COMMAND_WITH_CODE
     reconstructed_command = CRD_COMMAND_WITH_CODE
 
     mock_reconstruct_command.return_value = reconstructed_command
     pin = "123456"
     mock_result = MagicMock()
+    mock_result.returncode = 0
     mock_result.stdout = "Connection successful"
     mock_result.stderr = ""
     mock_subprocess_run.return_value = mock_result
@@ -113,10 +117,14 @@ def test_connect_to_crd(mock_reconstruct_command, mock_subprocess_run):
     )
 
 
+@patch("lablink_client_service.connect_crd.is_crd_registered", return_value=False)
 @patch("lablink_client_service.connect_crd.subprocess.run")
-def test_whole_connection_workflow(mock_subprocess_run):
+def test_whole_connection_workflow(mock_subprocess_run, mock_is_registered):
     input_command = CRD_COMMAND_WITH_CODE
     pin = "123456"
+    mock_subprocess_run.return_value = MagicMock(
+        returncode=0, stdout="", stderr=""
+    )
 
     with patch.dict(os.environ, {"VM_NAME": "test_vm"}):
         connect_to_crd(input_command, pin)
@@ -132,6 +140,25 @@ def test_whole_connection_workflow(mock_subprocess_run):
         capture_output=True,
         text=True,
     )
+
+
+@patch("lablink_client_service.connect_crd.start_crd_daemon")
+@patch("lablink_client_service.connect_crd.is_crd_registered", return_value=True)
+@patch("lablink_client_service.connect_crd.subprocess.run")
+def test_connect_to_crd_starts_daemon_when_host_registered_despite_nonzero_exit(
+    mock_subprocess_run, mock_is_registered, mock_start_daemon
+):
+    """start-host returns non-zero in Docker because systemctl can't
+    run, but host registration still succeeded (config file written).
+    In that case connect_to_crd should start the daemon itself via
+    user-session instead of surfacing an error."""
+    mock_subprocess_run.return_value = MagicMock(
+        returncode=1, stdout="", stderr="Failed to start host."
+    )
+    with patch.dict(os.environ, {"VM_NAME": "test_vm"}):
+        connect_to_crd(CRD_COMMAND_WITH_CODE, "123456")
+    mock_is_registered.assert_called_once()
+    mock_start_daemon.assert_called_once()
 
 
 def test_set_logger():

--- a/packages/client/tests/test_connect_crd.py
+++ b/packages/client/tests/test_connect_crd.py
@@ -220,21 +220,24 @@ def test_is_crd_registered_false(mock_glob):
 @patch("lablink_client_service.connect_crd.subprocess.run")
 @patch("lablink_client_service.connect_crd.glob.glob")
 def test_start_crd_daemon_success(mock_glob, mock_run):
-    """Daemon start invokes user-session with the discovered config path."""
+    """Daemon start invokes chrome-remote-desktop --start --new-session,
+    matching the ExecStart in /lib/systemd/system/chrome-remote-desktop@.service.
+    """
     config_path = "/home/client/.config/chrome-remote-desktop/host#abc.json"
     mock_glob.return_value = [config_path]
     mock_run.return_value = MagicMock(returncode=0, stderr="")
 
     start_crd_daemon()
 
-    mock_run.assert_called_once_with(
-        f"/opt/google/chrome-remote-desktop/user-session start -- "
-        f"--config={config_path} --start",
-        shell=True,
-        capture_output=True,
-        text=True,
-        timeout=30,
+    call = mock_run.call_args
+    assert call.args[0] == (
+        "/opt/google/chrome-remote-desktop/chrome-remote-desktop "
+        "--start --new-session"
     )
+    assert call.kwargs["shell"] is True
+    assert call.kwargs["timeout"] == 30
+    assert call.kwargs["env"]["XDG_SESSION_CLASS"] == "user"
+    assert call.kwargs["env"]["XDG_SESSION_TYPE"] == "x11"
 
 
 @patch("lablink_client_service.connect_crd.subprocess.run")
@@ -251,7 +254,7 @@ def test_start_crd_daemon_no_config(mock_glob, mock_run):
 @patch("lablink_client_service.connect_crd.subprocess.run")
 @patch("lablink_client_service.connect_crd.glob.glob")
 def test_start_crd_daemon_failure(mock_glob, mock_run):
-    """Non-zero exit from user-session is logged but does not raise."""
+    """Non-zero exit is logged but does not raise."""
     mock_glob.return_value = [
         "/home/client/.config/chrome-remote-desktop/host#abc.json"
     ]
@@ -265,9 +268,9 @@ def test_start_crd_daemon_failure(mock_glob, mock_run):
 @patch("lablink_client_service.connect_crd.subprocess.run")
 @patch("lablink_client_service.connect_crd.glob.glob")
 def test_start_crd_daemon_timeout(mock_glob, mock_run):
-    """TimeoutExpired from user-session is caught, logged, and swallowed.
+    """TimeoutExpired is caught, logged, and swallowed.
 
-    Without this, a hanging `user-session start` would block the subscribe
+    Without this, a hanging daemon start would block the subscribe
     loop forever and prevent any subsequent CRD reassignment.
     """
     import subprocess
@@ -276,7 +279,7 @@ def test_start_crd_daemon_timeout(mock_glob, mock_run):
         "/home/client/.config/chrome-remote-desktop/host#abc.json"
     ]
     mock_run.side_effect = subprocess.TimeoutExpired(
-        cmd="user-session start", timeout=30
+        cmd="chrome-remote-desktop --start", timeout=30
     )
 
     # Should not raise

--- a/packages/client/tests/test_connect_crd.py
+++ b/packages/client/tests/test_connect_crd.py
@@ -151,7 +151,7 @@ def test_connect_to_crd_starts_daemon_when_host_registered_despite_nonzero_exit(
     """start-host returns non-zero in Docker because systemctl can't
     run, but host registration still succeeded (config file written).
     In that case connect_to_crd should start the daemon itself via
-    user-session instead of surfacing an error."""
+    start_crd_daemon() instead of surfacing an error."""
     mock_subprocess_run.return_value = MagicMock(
         returncode=1, stdout="", stderr="Failed to start host."
     )


### PR DESCRIPTION
## Summary

- CRD `start-host` was failing on every fresh client VM, first silently via `SIGTRAP` (exit 133, no log line), then via "Failed to start host: System has not been booted with systemd as init system" once the trap was fixed. The end result: no student could connect to a VM via the CRD web UI.
- Root cause chain: Google published `chrome-remote-desktop 148.0.7778.21` on 2026-04-11 with stricter runtime checks. The Dockerfile installs CRD without a version pin, so the next image rebuild silently picked up the new package and every one of its new requirements — none of which our container satisfied.
- Three minimal, targeted client-side fixes get registration + daemon start working end-to-end. Verified on a live client VM: student can now connect via the CRD web UI.

## Root cause analysis

**Why it started failing:** `apt-get install --assume-yes chrome-remote-desktop` with no version pin means the image picks up whatever is current on Google's repo at build time. `file` output in the running container showed CRD binaries dated Apr 11 — matching the publication date of v148.0.7778.21. Before Apr 11, builds produced working images; after Apr 11, they did not, with no change in our code.

**Layer 1 — SIGTRAP on missing `XDG_RUNTIME_DIR`.** `strace` pinpointed the last three syscalls before the trap:

```
getuid()                    = 1000
stat("/run/user/1000", ...) = -1 ENOENT
--- SIGTRAP (si_code=SI_KERNEL) ---
```

`base::ImmediateCrash()` fires from Chromium's base library when `/run/user/$UID` is absent. Outside a container `systemd-logind` creates this path; Docker containers don't run `logind`. Confirmed causally by manually creating the directory and retesting — `start-host` then exited cleanly with a Google OAuth error (exit=1) instead of SIGTRAP.

**Layer 2 — `start-host` aborts when post-registration `systemctl start` fails.** After the XDG fix, `start-host` progressed to creating a systemd unit symlink and then calling `systemctl start chrome-remote-desktop@client`. In a container without systemd the call fails and `start-host` reports non-zero — but inspection showed `/home/client/.config/chrome-remote-desktop/host#<hash>.json` was written before the systemctl step, meaning registration succeeded. Only the "start the daemon now" step failed.

**Layer 3 — outdated helper path in the existing `start_crd_daemon()`.** The existing helper (originally for warm-restart paths) invoked `/opt/google/chrome-remote-desktop/user-session start -- --config=... --start`. That helper does not exist in CRD v148's layout (verified by `ls /opt/google/chrome-remote-desktop/`). The shipped systemd unit `/lib/systemd/system/chrome-remote-desktop@.service` shows the canonical command is `chrome-remote-desktop --start --new-session`, with env vars `XDG_SESSION_CLASS=user XDG_SESSION_TYPE=x11`.

## Changes Made

**`packages/client/start.sh`** (the SIGTRAP fix)
- Create `/run/user/$(id -u)` via `sudo`, set mode 0700, export `XDG_RUNTIME_DIR` before activating the venv. `/run` is a fresh tmpfs per container start so this must happen at runtime. `sudo` is required because `/run` is owned by `root:root 0755`; the Dockerfile grants `client` passwordless sudo.

**`packages/client/src/lablink_client_service/connect_crd.py`** (the two daemon fixes)
- After `start-host` returns, check `is_crd_registered()`. If the `host#<hash>.json` file is present, registration succeeded — call `start_crd_daemon()` to bring the daemon up ourselves, ignoring `start-host`'s non-zero exit caused by the systemctl failure.
- Change `start_crd_daemon()` to invoke `/opt/google/chrome-remote-desktop/chrome-remote-desktop --start --new-session` with `XDG_SESSION_CLASS=user XDG_SESSION_TYPE=x11`, matching the shipped systemd unit.

**`packages/client/Dockerfile` and `Dockerfile.dev`** (hygiene, not load-bearing)
- Remove stale `ENV USER=root` and set `USER`/`LOGNAME`/`HOME = ${USERNAME}/home/${USERNAME}` immediately after the `USER ${USERNAME}` directive. Does not affect CRD functionality but eliminates the misleading username-mismatch warnings that obscured the real root cause during debugging.

**Tests updated** in `packages/client/tests/test_connect_crd.py`:
- Existing `test_connect_to_crd` / `test_whole_connection_workflow` stub `is_crd_registered` and set explicit `returncode` to account for the new branch.
- New `test_connect_to_crd_starts_daemon_when_host_registered_despite_nonzero_exit` covers the first-boot-in-Docker path (start-host fails at systemctl, but daemon still gets started).
- `test_start_crd_daemon_*` updated to assert on the new canonical command + XDG env vars.

## Testing

- All 17 tests in `packages/client/tests/test_connect_crd.py` pass.
- `ruff check packages/client` clean.
- **End-to-end on a live client VM**: `subscribe.log` shows `CRD host registered (start-host exit=1); starting daemon via user-session.` followed by `CRD setup complete`, no error. Student successfully connects to the assigned VM via `remotedesktop.google.com`.

## Design Decisions

- **Fix at the layer matching the problem.** Runtime directory in `start.sh` (can't live in the image — `/run` is tmpfs). Daemon-launch logic in Python (per-request concern). Env hygiene in the Dockerfile (build-time).
- **Bypass systemd rather than shim it.** Considered installing a fake `/usr/local/bin/systemctl` so `start-host`'s final step appears to succeed, but that would lie to the binary and the daemon still wouldn't actually start. Calling the exact command systemd would run (`chrome-remote-desktop --start --new-session`) is honest and reuses the existing helper.
- **Reused `start_crd_daemon()` across two lifecycles.** Originally written for warm-restart paths; now also called from `connect_to_crd` on first-boot. The preconditions are identical in both cases (config file exists, daemon needs to start), so the reuse is semantically clean. Docstring updated to acknowledge both callers.
- **Dropped the speculative `chrome-remote-desktop` user creation.** Commit `292be1c` added it based on a wrong hypothesis (we thought a missing user caused the SIGTRAP). Reverted in `e4b5492` once `XDG_RUNTIME_DIR` proved to be the real cause.

## Deferred follow-ups (not in this PR)

- **Pin the CRD version** in the Dockerfile (`chrome-remote-desktop=148.0.7778.21-1`, or whatever is known-good) so future image rebuilds do not silently adopt unknown upstream changes. Would have prevented this incident entirely.
- **Add a CI smoke test** that runs `start-host --code=4/FAKE ...` against the freshly built client image and asserts the exit code is not 133 (SIGTRAP). Single check that catches this regression the moment Google publishes a CRD release with new requirements.

## Related

- Follow-up from CRD failure observed during verification of #329 (the command-injection fix, a separate PR).