### PR TITLE
ci: add three-layer CRD smoke test to verify-client job

### DIFF
--- a/.github/workflows/lablink-images.yml
+++ b/.github/workflows/lablink-images.yml
@@ -502,9 +502,12 @@ jobs:
           docker run --rm ${{ steps.get_tag.outputs.image }} bash -c '
             set +e
             runtime_dir="/run/user/$(id -u)"
-            sudo mkdir -p "$runtime_dir"
-            sudo chown "$(id -u):$(id -g)" "$runtime_dir"
-            sudo chmod 0700 "$runtime_dir"
+            sudo mkdir -p "$runtime_dir" \
+              || { echo "FAIL: mkdir $runtime_dir"; exit 1; }
+            sudo chown "$(id -u):$(id -g)" "$runtime_dir" \
+              || { echo "FAIL: chown $runtime_dir"; exit 1; }
+            sudo chmod 0700 "$runtime_dir" \
+              || { echo "FAIL: chmod $runtime_dir"; exit 1; }
             export XDG_RUNTIME_DIR="$runtime_dir"
 
             timeout 30 bash -c "{ echo 123456; echo 123456; } | DISPLAY= /opt/google/chrome-remote-desktop/start-host --code=4/FAKE --redirect-url=https://remotedesktop.google.com/_/oauthredirect --name=ci-smoke" >/tmp/out 2>&1

--- a/.github/workflows/lablink-images.yml
+++ b/.github/workflows/lablink-images.yml
@@ -443,7 +443,7 @@ jobs:
           echo "Docker container output:"
           echo "$OUTPUT"
 
-          if echo "$OUTPUT" | grep -q "CUSTOM_STARTUP_SCRIPT_EXECUTED_SUCCESSFULLY" && 
+          if echo "$OUTPUT" | grep -q "CUSTOM_STARTUP_SCRIPT_EXECUTED_SUCCESSFULLY" &&
              echo "$OUTPUT" | grep -q "JQ_VERSION: jq-"; then
             echo "✓ custom-startup.sh executed successfully and jq installed!"
           else
@@ -451,3 +451,70 @@ jobs:
             exit 1
           fi
           rm "$TEMP_SCRIPT_FILE"
+
+      # CRD smoke tests (issue #332). Three cumulative layers — each catches a
+      # distinct failure mode. Do not collapse into a single step; see issue
+      # for rationale.
+      - name: Verify runtime env matches runtime uid (CRD layer 1)
+        run: |
+          docker run --rm ${{ steps.get_tag.outputs.image }} bash -c '
+            set -eu
+            running_user=$(id -un)
+            if [ "${USER:-}" != "$running_user" ]; then
+              echo "FAIL: USER=${USER:-} != id -un=$running_user"
+              exit 1
+            fi
+            if [ "${LOGNAME:-}" != "$running_user" ]; then
+              echo "FAIL: LOGNAME=${LOGNAME:-} != id -un=$running_user"
+              exit 1
+            fi
+            if [ "${HOME:-}" != "/home/$running_user" ]; then
+              echo "FAIL: HOME=${HOME:-} (expected /home/$running_user)"
+              exit 1
+            fi
+            echo "✓ USER=$USER  LOGNAME=$LOGNAME  HOME=$HOME  uid=$(id -u)($running_user)"
+          '
+
+      - name: Verify CRD install integrity (CRD layer 2)
+        run: |
+          docker run --rm ${{ steps.get_tag.outputs.image }} bash -c '
+            set -eu
+            test -x /opt/google/chrome-remote-desktop/start-host \
+              || { echo "FAIL: start-host missing"; exit 1; }
+            test -x /opt/google/chrome-remote-desktop/chrome-remote-desktop \
+              || { echo "FAIL: chrome-remote-desktop wrapper missing"; exit 1; }
+            getent group chrome-remote-desktop >/dev/null \
+              || { echo "FAIL: chrome-remote-desktop group missing"; exit 1; }
+            groups client | grep -qw chrome-remote-desktop \
+              || { echo "FAIL: client not in chrome-remote-desktop group"; exit 1; }
+            echo "✓ CRD install integrity OK. Installed version:"
+            dpkg -l chrome-remote-desktop | tail -1
+          '
+
+      # Layer 3 runs actual CRD code — the only layer that catches an
+      # upstream regression (e.g. CRD v148 SIGTRAP in PR #330) rather than
+      # a known-shape defect. Demoted to continue-on-error until the flake
+      # rate of reaching Google's OAuth endpoint is understood; promote
+      # to required once stable.
+      - name: Smoke test start-host does not SIGTRAP (CRD layer 3)
+        continue-on-error: true
+        run: |
+          docker run --rm ${{ steps.get_tag.outputs.image }} bash -c '
+            set +e
+            runtime_dir="/run/user/$(id -u)"
+            sudo mkdir -p "$runtime_dir"
+            sudo chown "$(id -u):$(id -g)" "$runtime_dir"
+            sudo chmod 0700 "$runtime_dir"
+            export XDG_RUNTIME_DIR="$runtime_dir"
+
+            timeout 30 bash -c "{ echo 123456; echo 123456; } | DISPLAY= /opt/google/chrome-remote-desktop/start-host --code=4/FAKE --redirect-url=https://remotedesktop.google.com/_/oauthredirect --name=ci-smoke" >/tmp/out 2>&1
+            rc=$?
+            if [ "$rc" = "133" ]; then
+              echo "FAIL: start-host SIGTRAPed (exit 133 = 128 + SIGTRAP)."
+              echo "--- captured output ---"
+              cat /tmp/out
+              exit 1
+            fi
+            echo "✓ start-host exited with rc=$rc (not SIGTRAP)."
+            head -20 /tmp/out
+          '


### PR DESCRIPTION
## Summary

- Adds three cumulative CRD smoke-test layers to the `verify-client` job in `.github/workflows/lablink-images.yml`.
- Catches the class of regression that produced #330 (CRD v148 SIGTRAP) at PR time instead of in production.
- Each layer catches a distinct failure mode — they are cumulative, not redundant.

Closes #332.

## Motivation

PR #330 fixed a regression that would have been caught immediately by a trivial CI check: Google published `chrome-remote-desktop 148.0.7778.21` with stricter runtime requirements, our unpinned Dockerfile picked it up on the next rebuild, and `start-host` began SIGTRAPping on every production VM. CI had no CRD-specific checks, so the breakage was only caught by live-testing. This PR closes that gap.

## Changes Made

Three new steps added at the end of the `verify-client` job (deliberately ordered cheapest-to-costliest):

**Layer 1 — container env invariants (`~2s`, deterministic)**
Asserts that `USER`, `LOGNAME`, and `HOME` match the runtime uid returned by `id -un`. Catches the exact failure mode PR #330 found: Docker's `USER ${USERNAME}` directive only changes the effective uid, not env vars. If anything sets `ENV USER=root` earlier — or inherits one from a base-image bump — every process sees a `$USER` that disagrees with `getpwuid(getuid())`.

**Layer 2 — CRD install integrity (`~1s`, deterministic)**
Verifies the four things that must exist after `apt install chrome-remote-desktop` succeeds: the `start-host` binary, the `chrome-remote-desktop` wrapper binary, the `chrome-remote-desktop` group, and `client`'s membership in that group. Catches silent postinst failures (cf. PR #283 where the `_crd_network` user silently failed to create). Also logs `dpkg -l chrome-remote-desktop` output so every build records the installed CRD version in CI for future diffing.

**Layer 3 — `start-host` smoke test (`~10–30s`, `continue-on-error: true` initially)**
Runs `start-host` with a deliberately-fake `--code=4/FAKE` and asserts the exit code is not 133 (`128 + SIGTRAP`). This is the only layer that catches upstream runtime-requirement additions regardless of their shape — layers 1 and 2 can only check for known-shape defects, but whatever Google decides to require next month (a new AF_UNIX socket, a kernel capability, whatever) is invisible to static checks. The fake code fails fast at the OAuth exchange, but only after CRD's init checks have run — so if PR #330 were reverted on this branch, exit=133 would reappear immediately and this test would fail.

## Rollout Plan

Per the issue, layers 1 and 2 are required from day one. Layer 3 starts as `continue-on-error: true` to absorb any flakes from reaching Google's OAuth endpoint — the plan is to track flake rate for a week or two, then promote to required. If flake rate is non-trivial, an alternative is to short-circuit the OAuth call with a loopback/invalid `--redirect-url` to decouple the smoke test from external network dependencies.

## Testing

- YAML validated with `python3 -c "import yaml; yaml.safe_load(...)"` locally.
- Each layer's bash script syntax-checked with `bash -n`.
- Layers 1 and 2 assertions hand-verified against the current `packages/client/Dockerfile`:
  - `USER=client`, `LOGNAME=client`, `HOME=/home/client` set on lines 137-139.
  - `start-host` / wrapper at `/opt/google/chrome-remote-desktop/`.
  - `chrome-remote-desktop` group created by the CRD postinst, `client` added via `usermod -aG`.
- Layer 3 `sudo`-requiring setup works because the Dockerfile grants `NOPASSWD:ALL` sudo to `client`.
- Full end-to-end validation requires running the workflow against a built image, which happens automatically on this PR.

## Design Decisions

- **Three separate steps, not one combined script.** Each layer attributes failures to a specific cause in the CI log: "env drift" vs "install missing a piece" vs "upstream changed something". A single merged script would obscure that signal.
- **Ordering from cheap → costly.** Layer 1 (~2s) runs first so env regressions fail fast; layer 3 (~30s with network) runs last.
- **`{ echo 123456; echo 123456; } | ...` for PIN input** (instead of `echo -e "123456\n123456"` from the issue's draft). Avoids the 4-backslash-deep escape chain that arises when a `printf`/`echo -e` with `\n` is nested inside two layers of `bash -c` quoting. Functionally identical, much harder to break on future edits.
- **`continue-on-error` for layer 3 only.** Layers 1 and 2 are deterministic and have no network dependency, so they block merge. Layer 3 has a small network-flake surface and is demoted until that risk is quantified.
- **Placed at end of `verify-client`.** Keeps existing step ordering stable; CRD checks are logically a distinct concern from package imports / console scripts / startup hooks.

## Related Issues

- Closes #332
- Motivated by #330 (the incident)
- Companion: #331 (pin CRD version in Dockerfile) — defense-in-depth, not a substitute for this

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)