### PR TITLE
feat(cli): first-run welcome panel + health-poll spinner + 300s timeout

### DIFF
--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -43,6 +43,30 @@ You should see the grouped command list (Setup, Deployment, Operations, Maintena
 !!! tip "Running from outside the repo"
     If you want `lablink` available from any directory, activate `.venv` in your shell profile, or install via `uv tool install --from ./packages/cli lablink-cli` (note: this will fail today because the CLI's workspace dep on `lablink-allocator-service` isn't yet resolvable outside the workspace — revisit after PyPI publish).
 
+## Verify the installation
+
+Once installed, run `lablink` with no arguments to confirm everything is wired up:
+
+```bash
+uv run lablink
+```
+
+On a fresh install (no config yet), you'll see a **Getting started** panel pointing at the next three commands:
+
+```text
+╭─ Getting started ──────────────────────────────────────╮
+│ Welcome to LabLink. First-time setup:                  │
+│                                                        │
+│   1. lablink configure   create config + AWS state…    │
+│   2. lablink doctor      verify prerequisites          │
+│   3. lablink deploy      deploy the allocator          │
+│                                                        │
+│ For the full command list, run 'lablink --help'.       │
+╰────────────────────────────────────────────────────────╯
+```
+
+If you instead see the full command list (Setup / Deployment / Operations / Maintenance panels), it means `~/.lablink/config.yaml` already exists from a previous run — that's fine, skip ahead to [Step 1: Configure](first-deployment.md#step-1-configure).
+
 ## Check your environment
 
 Run `lablink doctor` to validate prerequisites end-to-end:

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -6,7 +6,6 @@ import typer
 
 app = typer.Typer(
     name="lablink",
-    no_args_is_help=True,
 )
 
 DEFAULT_CONFIG = Path.home() / ".lablink" / "config.yaml"
@@ -23,8 +22,9 @@ def _version_callback(value: bool) -> None:
         raise typer.Exit()
 
 
-@app.callback()
+@app.callback(invoke_without_command=True)
 def _root(
+    ctx: typer.Context,
     _version: bool = typer.Option(
         False,
         "--version",
@@ -35,6 +35,31 @@ def _root(
     ),
 ) -> None:
     """Deploy and manage LabLink teaching lab infrastructure."""
+    if ctx.invoked_subcommand is not None:
+        return
+
+    if not DEFAULT_CONFIG.exists():
+        from rich.console import Console
+        from rich.panel import Panel
+
+        Console().print(
+            Panel(
+                "Welcome to LabLink. First-time setup:\n\n"
+                "  1. [bold]lablink configure[/bold]   "
+                "create config + AWS state resources\n"
+                "  2. [bold]lablink doctor[/bold]      "
+                "verify prerequisites\n"
+                "  3. [bold]lablink deploy[/bold]      "
+                "deploy the allocator\n\n"
+                "For the full command list, run 'lablink --help'.",
+                border_style="cyan",
+                title="Getting started",
+                title_align="left",
+            )
+        )
+        raise typer.Exit()
+
+    typer.echo(ctx.get_help())
 
 
 def _load_cfg(config: str | None):

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -248,31 +248,34 @@ def _poll_allocator_health(
     start = time.monotonic()
     elapsed = 0.0
 
-    while elapsed < max_wait:
-        result = check_health_endpoint(poll_url)
-        elapsed = time.monotonic() - start
+    with console.status(
+        f"connecting... (0s / {max_wait}s)", spinner="dots"
+    ) as status:
+        while elapsed < max_wait:
+            result = check_health_endpoint(poll_url)
+            elapsed = time.monotonic() - start
 
-        if result["healthy"]:
-            return {
-                "healthy": True,
-                "elapsed": elapsed,
-                "timed_out": False,
-                "uptime_seconds": result.get("uptime_seconds"),
-            }
+            if result["healthy"]:
+                return {
+                    "healthy": True,
+                    "elapsed": elapsed,
+                    "timed_out": False,
+                    "uptime_seconds": result.get("uptime_seconds"),
+                }
 
-        # Adaptive interval based on elapsed time
-        if elapsed < 30:
-            interval = 3
-        elif elapsed < 90:
-            interval = 5
-        else:
-            interval = 10
+            # Adaptive interval based on elapsed time
+            if elapsed < 30:
+                interval = 3
+            elif elapsed < 90:
+                interval = 5
+            else:
+                interval = 10
 
-        console.print(
-            f"[dim]  {result['status']}... ({elapsed:.0f}s / {max_wait}s)[/dim]"
-        )
-        time.sleep(interval)
-        elapsed = time.monotonic() - start
+            status.update(
+                f"{result['status']}... ({elapsed:.0f}s / {max_wait}s)"
+            )
+            time.sleep(interval)
+            elapsed = time.monotonic() - start
 
     return {
         "healthy": False,
@@ -417,7 +420,7 @@ def run_deploy(
         outputs = get_terraform_outputs(deploy_dir)
         ec2_ip = outputs.get("ec2_public_ip", "")
 
-        max_wait = 300 if has_ssl else 120
+        max_wait = 300
 
         # Phase 1: Poll EC2 IP directly for allocator readiness.
         # Uses port 80 (nginx) — the EC2 security group does not expose

--- a/packages/cli/tests/test_app.py
+++ b/packages/cli/tests/test_app.py
@@ -120,11 +120,31 @@ class TestCLICommands:
         result = runner.invoke(app, ["logs", "--help"])
         assert result.exit_code == 0
 
-    def test_no_args_shows_help(self):
-        result = runner.invoke(app, [])
-        assert result.exit_code in (0, 2)
-        out = _plain(result.output).lower()
-        assert "deploy" in out or "usage" in out
+    def test_no_args_no_config_shows_welcome(self, tmp_path):
+        """With no config, bare `lablink` prints the first-run welcome panel."""
+        missing = tmp_path / "no-such-config.yaml"
+        with patch("lablink_cli.app.DEFAULT_CONFIG", missing):
+            result = runner.invoke(app, [])
+        assert result.exit_code == 0
+        out = _plain(result.output)
+        assert "Welcome to LabLink" in out
+        assert "lablink configure" in out
+        assert "lablink doctor" in out
+        assert "lablink deploy" in out
+
+    def test_no_args_with_config_shows_help(self, tmp_path):
+        """With a config present, bare `lablink` falls through to --help output."""
+        cfg = tmp_path / "config.yaml"
+        cfg.write_text("deployment_name: test\n")
+        with patch("lablink_cli.app.DEFAULT_CONFIG", cfg):
+            result = runner.invoke(app, [])
+        assert result.exit_code == 0
+        out = _plain(result.output)
+        assert "Welcome to LabLink" not in out
+        for panel in ("Setup", "Deployment", "Operations", "Maintenance"):
+            assert panel in out, (
+                f"expected panel heading {panel!r} in no-args help fallthrough"
+            )
 
     def test_help_groups_commands_into_panels(self):
         """Top-level --help groups commands under the four Option-A panels."""


### PR DESCRIPTION
## Summary

Three small UX wins for the `lablink` CLI bundled together since they all touch first-impression / deploy-time feedback:

- **First-run welcome panel** when `lablink` is invoked with no args and no config exists yet — points the user at `configure → doctor → deploy` instead of dumping the full command tree at a stranger.
- **Spinner during the post-`apply` health-poll** — replaces the flat dim-text status lines that made the 2–5 minute wait feel like the CLI had hung.
- **Bump health-poll ceiling from 120s to 300s** for non-SSL deploys — cold AMIs / first-boot Docker pulls regularly exceed two minutes, and the existing SSL branch already used 300s.

## Changes

### `packages/cli/src/lablink_cli/app.py`

- Removed `no_args_is_help=True` from the Typer instance and added `invoke_without_command=True` to `_root` so the no-args path is now under our control.
- When no subcommand was given:
  - If `~/.lablink/config.yaml` doesn't exist → print a "Getting started" panel pointing at `configure → doctor → deploy`.
  - If the config exists → fall through to `ctx.get_help()` (returning users see the full command list as before, no regression).
- `--help` and `--version` paths are unchanged.

**Before** (no args, fresh install): full 4-panel command tree dumped at the user.

**After** (no args, no config):
```
╭─ Getting started ──────────────────────────────────────╮
│ Welcome to LabLink. First-time setup:                  │
│                                                        │
│   1. lablink configure   create config + AWS state…    │
│   2. lablink doctor      verify prerequisites          │
│   3. lablink deploy      deploy the allocator          │
│                                                        │
│ For the full command list, run 'lablink --help'.       │
╰────────────────────────────────────────────────────────╯
```

### `packages/cli/src/lablink_cli/commands/deploy.py`

- Wrapped the polling loop in `_poll_allocator_health` (around line 248) in `console.status(...)` with a `dots` spinner. Per-poll updates now call `status.update(...)` instead of printing a new dim line each time, so the message updates **in place** and the user can see the CLI is alive. Rich's `Status` auto-degrades on non-TTY (CI logs), so this doesn't spam carriage-return frames in CI.
- Bumped the non-SSL `max_wait` from 120s → 300s at the call site (`run_deploy`, around line 423). The conditional `300 if has_ssl else 120` collapses to a single 300s ceiling — one number to think about, matches the docs prediction of "1–3 minutes for the allocator to finish its first-boot container start" with margin.

## Testing

- All 293 existing CLI tests pass: `cd packages/cli && PYTHONPATH=src pytest`
- Lint clean: `ruff check packages/cli`
- Manually verified the no-args panel via `CliRunner` with both `DEFAULT_CONFIG` present and absent.
- `--help` and `--version` still produce identical output to pre-change.

## Design Decisions

- **Why state-aware no-args output (not always-on welcome panel):** returning users (those who have already run `configure`) keep seeing the full help table, so this isn't a regression for anyone past the first 5 minutes. The signal `~/.lablink/config.yaml` exists is reliable: it's only created by `configure`.
- **Why a spinner only on the health-poll, not on terraform phases:** Rich's `Status` and Terraform's streamed stdout don't compose well — wrapping `_run_terraform` in a spinner would clobber Terraform's own output. Terraform already provides plenty of motion via its streamed lines; the health-poll was the only "flat pause" phase.
- **Why bump non-SSL to 300s (not add a `--health-timeout` flag):** keeps the surface tight ahead of the first PyPI release. A flag can be added later if 300s turns out to be too short or too long for someone, without re-thinking this default.

## Related Issues

None directly. Follow-up to #335 (the `--version` template-version surface) as part of pre-PyPI CLI polish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
