### PR TITLE
feat(cli): add lablink login + AWS Identity Center bootstrap

### DIFF
--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -4,6 +4,9 @@
     The [Quickstart: Template repo](quickstart-template.md) guide uses `setup.sh` to automate all required AWS resource creation. The [Quickstart: CLI](cli/first-deployment.md) path automates the same work through `lablink configure`.
     This manual guide is provided as a reference for advanced users who prefer to create resources individually.
 
+!!! info "CLI users: a different path is available"
+    If you're using the [CLI](cli/index.md), you can authenticate without access keys via [`lablink login`](cli/login.md) (AWS Identity Center). This page is for users of the [template repo](quickstart-template.md) or anyone who prefers to set up access keys manually — both are fully supported.
+
 This comprehensive guide walks you through setting up all required AWS resources for LabLink deployment from scratch.
 
 ## Overview

--- a/docs/cli/first-deployment.md
+++ b/docs/cli/first-deployment.md
@@ -4,9 +4,20 @@ This walkthrough takes you from a clean install through a live allocator and bac
 
 ## Before you start
 
-Make sure you've completed [Installation](installation.md) and that `lablink doctor` reports clean values for "Terraform installed" and "AWS credentials". The other checks will light up as you go.
+Make sure you've completed [Installation](installation.md). The other prerequisite checks will light up as you complete each step below.
 
-## Step 1: Configure
+## Step 1: Sign in to AWS
+
+```bash
+lablink login
+```
+
+Authenticates your machine to AWS so the rest of the CLI can deploy. First run is a one-time guided Identity Center setup; after that, it's a quick browser sign-in. See [Sign in (lablink login)](login.md) for details and troubleshooting.
+
+!!! note "Already using `aws configure`?"
+    If you previously ran `aws configure` with access keys, those credentials still work — `lablink` falls back to env vars and `~/.aws/credentials` if no SSO profile exists. You can skip ahead to Step 2 and migrate to SSO later.
+
+## Step 2: Configure
 
 ```bash
 lablink configure
@@ -34,13 +45,13 @@ You can inspect what was written with:
 lablink show-config
 ```
 
-## Step 2: Sanity check
+## Step 3: Sanity check
 
 ```bash
 lablink doctor
 ```
 
-All six checks should now pass:
+All seven checks should now pass:
 
 ```text
 ┌─────────────────────────┬────────┬─────────────────────────────────────┐
@@ -50,14 +61,15 @@ All six checks should now pass:
 │ Config file             │ PASS   │ ~/.lablink/config.yaml              │
 │ Config validates        │ PASS   │ No errors                           │
 │ AWS credentials         │ PASS   │ Account: 123…, Identity: arn:…      │
+│ LabLink permissions     │ PASS   │ All required actions allowed        │
 │ S3 state bucket         │ PASS   │ tf-state-lablink-…                  │
 │ AMI for region          │ PASS   │ us-west-2 → ami-0bd08c9d…           │
 └─────────────────────────┴────────┴─────────────────────────────────────┘
 ```
 
-If any row is `FAIL`, the detail column tells you which command to run next (usually `lablink configure` or `aws configure`).
+If any row is `FAIL`, the detail column tells you which command to run next — usually `lablink login` (sign in / refresh token), `lablink login --update-policy` (permission set drift), or `lablink configure` (config issues).
 
-## Step 3: Deploy
+## Step 4: Deploy
 
 ```bash
 lablink deploy
@@ -78,7 +90,7 @@ Expect 2–5 minutes for Terraform + another 1–3 minutes for the allocator to 
 
 When deploy completes, note the `ec2_public_ip` in the Terraform output — that's your allocator URL.
 
-## Step 4: Verify
+## Step 5: Verify
 
 ```bash
 lablink status
@@ -93,7 +105,7 @@ This shows four sections:
 
 Open the allocator in a browser using `http://<ec2_public_ip>` (or your configured domain) and log in with username `admin` and the admin password you entered during deploy.
 
-## Step 5: Launch a client VM
+## Step 6: Launch a client VM
 
 ```bash
 lablink launch-client --num-vms 1
@@ -101,7 +113,7 @@ lablink launch-client --num-vms 1
 
 The CLI calls the allocator's create-VM endpoint, which provisions the instance via the allocator's own Terraform workspace (not the CLI's). Run `lablink status` again to see the new VM appear.
 
-## Step 6: Tear down
+## Step 7: Tear down
 
 When you're done, destroy everything the CLI created:
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -41,6 +41,7 @@ You can switch between them later — both read the same `config.yaml` schema fo
 ## Next steps
 
 1. [Install the CLI](installation.md)
-2. [Run your first deployment](first-deployment.md)
-3. [Manage an existing deployment](managing-deployments.md)
-4. Full command reference: [CLI Reference](../reference/cli.md)
+2. [Sign in to AWS via Identity Center](login.md) — `lablink login`
+3. [Run your first deployment](first-deployment.md)
+4. [Manage an existing deployment](managing-deployments.md)
+5. Full command reference: [CLI Reference](../reference/cli.md)

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -12,8 +12,9 @@ Before installing, make sure you have:
 - **[uv](https://docs.astral.sh/uv/)** — the Python project manager used by this repo. Install with `curl -LsSf https://astral.sh/uv/install.sh | sh` or see the [official install guide](https://docs.astral.sh/uv/getting-started/installation/).
 - **Python 3.10+** — uv can manage this for you (`uv python install 3.11`). Check with `python --version`.
 - **Terraform 1.6+** — the CLI drives Terraform under the hood. Install from [developer.hashicorp.com/terraform/install](https://developer.hashicorp.com/terraform/install).
-- **AWS credentials** configured locally (either `aws configure` or `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` environment variables). See [Prerequisites](../prerequisites.md#configure-aws-credentials).
-- **An AWS account** with permissions to create EC2, S3, DynamoDB, IAM, and (optionally) Route 53 resources. See [AWS Setup (Manual)](../aws-setup.md) for the full permission list.
+- **AWS CLI** — required by `lablink login` (which wraps `aws sso login` for the Identity Center flow) and used by `lablink logs` for one of two SSH paths. Install per the [AWS install guide](https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html). If you're skipping `lablink login` and using env-var access keys instead, AWS CLI is technically optional but still recommended.
+- **An AWS account** with the ability to enable AWS Identity Center (any standard account works). The CLI walks you through Identity Center setup the first time you run `lablink login` — see [Sign in](login.md).
+- **AWS credentials** are *not* configured up front anymore — `lablink login` handles that as the first step of [First Deployment](first-deployment.md). Existing access-key users keep working: env vars (`AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY`) and `~/.aws/credentials` profiles are honored as a fallback.
 
 ## Install from source
 
@@ -116,6 +117,7 @@ uv sync --all-packages
 
 ## Next steps
 
+- [Sign in to AWS via Identity Center](login.md) (run `lablink login` first)
 - [Run your first deployment](first-deployment.md)
 - [Day-to-day operations](managing-deployments.md)
 - Full command reference: [CLI Reference](../reference/cli.md)

--- a/docs/cli/login.md
+++ b/docs/cli/login.md
@@ -1,0 +1,212 @@
+# Sign in with `lablink login`
+
+`lablink login` authenticates you to AWS via **AWS Identity Center** (formerly AWS SSO). You sign in once with a username, password, and MFA code in your browser — no IAM access keys, no `aws configure` ever required.
+
+If you've been using LabLink with `aws configure` and access keys, that path still works as a fallback (env vars and `~/.aws/credentials` are honored). But Identity Center is the recommended setup for new users — it's safer (short-lived tokens, no long-lived secrets on disk) and easier (no need to find your access keys in the IAM console).
+
+## TL;DR
+
+```bash
+lablink login    # first-time: ~5 min guided bootstrap
+                 # subsequent: ~10 sec browser sign-in
+```
+
+After login, every other `lablink ...` command (`setup`, `deploy`, `doctor`, etc.) transparently uses the cached SSO credentials.
+
+## Before you start
+
+For your **first** `lablink login`, log into the AWS Console **as your root user** (or an admin IAM user) before running the command. The bootstrap flow opens browser tabs that take you to the AWS Console — if you're already logged in there, those tabs land you on the right page; otherwise they show the AWS sign-in screen mid-flow.
+
+```text
+1. Open https://console.aws.amazon.com in your browser.
+2. Sign in as the root user of the AWS account where you'll deploy LabLink.
+3. Then run `lablink login` in your terminal.
+```
+
+After bootstrap, you never need to log into the AWS Console again — all subsequent operations sign in via the Identity Center user, not the root user.
+
+## First-time bootstrap
+
+`lablink login` detects that no `[sso-session lablink]` block exists in `~/.aws/config` and walks you through enabling Identity Center. The flow is fully resumable — if you Ctrl-C between steps, re-running picks up where you left off.
+
+### Step 1 — Enable Identity Center
+
+The CLI opens the Identity Center landing page in your browser. There:
+
+1. Click **Enable**. If asked, choose **account instance** (recommended for personal accounts).
+2. Wait ~30 seconds for AWS to provision your Identity Center instance.
+3. In the left sidebar, click **Users → Add user**.
+4. Fill in your name and email, submit, and check your email for the **Accept invitation** link.
+5. Set your password and scan the MFA QR code with an authenticator app (Authy, Google Authenticator, 1Password, etc.).
+
+When you're done, return to the Identity Center dashboard and copy the **SSO Start URL** from the **AWS access portal URLs** section. It looks like `https://d-XXXXXXXXXX.awsapps.com/start`.
+
+Paste that URL back into the CLI when prompted, along with the AWS region your Identity Center is hosted in (visible in the Identity Center dashboard's URL bar — e.g., `us-east-1.console.aws.amazon.com/...`).
+
+!!! warning "Region matters"
+    The SSO region (where Identity Center lives) doesn't have to match your deployment region (where LabLink runs). But the CLI's `sso_region` config must match where Identity Center actually lives or `aws sso login` will fail with "InvalidRequestException: RegisterClient".
+
+### Step 2 — Create the LabLink permission set
+
+The CLI opens the Identity Center console again and copies the LabLink policy JSON to your clipboard. There:
+
+1. In the left sidebar, find **Permission sets**. (In newer consoles it's nested under **Multi-account permissions** — expand that first.)
+2. Click **Create permission set**.
+3. Choose **Custom permission set** and click **Next**.
+4. Under **AWS managed policies**, attach:
+    - `AmazonEC2FullAccess`
+    - `ElasticLoadBalancingFullAccess`
+    - `AmazonRoute53FullAccess`
+    - `IAMFullAccess`
+    - `CloudWatchFullAccess`
+    - `CloudWatchLogsFullAccess`
+    - `AWSCloudTrail_FullAccess`
+    - `AmazonSNSFullAccess`
+5. Expand **Custom inline policy**, paste from clipboard (`Cmd-V` / `Ctrl-V`), then click **Next**.
+6. Name it `lablink` and click **Next → Create**.
+
+The new permission set will show **Not provisioned** until you assign it in the next step. That's expected.
+
+### Step 3 — Assign your user
+
+Back in the Identity Center console:
+
+1. In the left sidebar, find **AWS accounts** (under **Multi-account permissions** if nested).
+2. Check the box next to your AWS account.
+3. Click **Assign users or groups**.
+4. On the **Users** tab, select your user and click **Next**.
+5. Select the `lablink` permission set and click **Next**.
+6. Click **Submit**.
+
+After this completes, Identity Center automatically creates the underlying IAM role (`AWSReservedSSO_lablink_<hash>`) in your AWS account. The permission set's status flips to **Provisioned**.
+
+### Step 4 — Sign in
+
+The CLI runs `aws sso login --sso-session lablink`, which opens your browser at the Identity Center sign-in page. Enter your username + password + MFA. AWS caches the access token at `~/.aws/sso/cache/<sha1>.json` and the CLI confirms:
+
+```text
+✓ Signed in via Identity Center
+✓ AWS Account: 123456789012
+✓ Permission set: lablink
+✓ Token valid for: 8h 0m
+```
+
+You're done — `lablink configure`, `lablink deploy`, etc. now use this session transparently.
+
+## Subsequent logins
+
+Once bootstrap is complete, `lablink login` skips straight to step 4. The browser opens for ~10 seconds while you confirm in the SSO sign-in page, and you're back. SSO access tokens live for 1–12 hours (8 hours by default in Identity Center).
+
+If you run `lablink login` while already signed in:
+
+```text
+Already signed in, valid for 4h 12m.
+Re-login? [y/N]:
+```
+
+Answer `n` if you didn't mean to re-authenticate. Answer `y` to refresh the token early.
+
+## Token expiration mid-command
+
+If your SSO token expires mid-deploy, `lablink ...` commands print:
+
+```text
+Your AWS session has expired. Run `lablink login` and try again.
+```
+
+Run `lablink login` and re-run the command. There's no silent auto-refresh — keeping the prompt explicit avoids unexpected browser pop-ups during long deploys.
+
+## Updating the policy
+
+When LabLink adds a feature that needs a new AWS service (rare), `lablink doctor` flags the gap:
+
+```text
+LabLink permissions   FAIL   Permission set is missing actions: budgets:DescribeBudgets.
+                              Run `lablink login --update-policy` to refresh.
+```
+
+Run:
+
+```bash
+lablink login --update-policy
+```
+
+The CLI re-copies the latest policy JSON to your clipboard and opens the AWS console at your `lablink` permission set. Replace the inline policy with the clipboard contents and click **Save**.
+
+## Common issues
+
+### "InvalidRequestException" / "RegisterClient" failure
+
+The `sso_region` in `~/.aws/config` doesn't match where Identity Center lives. Check the IdC dashboard URL (e.g., `https://us-west-2.console.aws.amazon.com/singlesignon/...`) and edit `~/.aws/config`:
+
+```ini
+[sso-session lablink]
+sso_start_url = https://d-XXXXXXXXXX.awsapps.com/start
+sso_region = us-west-2          # ← must match the URL above
+sso_registration_scopes = sso:account:access
+```
+
+Or wipe and re-bootstrap:
+
+```bash
+rm ~/.aws/config
+rm -rf ~/.aws/sso/cache
+rm -f ~/.lablink/bootstrap-state.json
+lablink login
+```
+
+### "No valid credential sources found" during `lablink deploy`
+
+Your SSO token has probably expired. Run `lablink login` and retry. If `aws sso login --sso-session lablink` succeeds but the deploy still fails, check that your Terraform version is **≥ 1.6** (older versions don't support SSO with the S3 backend).
+
+### "Permission set is missing actions" in `lablink doctor`
+
+Either the permission set hasn't been assigned to your AWS account yet (status shows "Not provisioned" in IdC), or the inline policy was modified manually. Re-run `lablink login --update-policy` to refresh.
+
+### Bootstrap was interrupted
+
+`lablink login` saves progress to `~/.lablink/bootstrap-state.json` after each step. Re-running picks up where you left off. To start over from scratch:
+
+```bash
+rm -f ~/.lablink/bootstrap-state.json
+```
+
+Then re-run `lablink login`.
+
+## Resetting login state
+
+To force a fresh first-time bootstrap (e.g., after manually deleting your IdC instance, or to test the flow):
+
+```bash
+rm ~/.aws/config                         # remove [sso-session lablink] + [profile lablink]
+rm -rf ~/.aws/sso/cache                  # clear cached tokens
+rm -f ~/.lablink/bootstrap-state.json    # clear partial bootstrap state
+lablink login
+```
+
+This **only** resets your local CLI state. Identity Center, your user, the permission set, and assignments persist in AWS — you can paste the same SSO Start URL when bootstrap re-prompts and reuse them.
+
+## Behind the scenes
+
+`lablink login` writes:
+
+| File | Purpose |
+|---|---|
+| `~/.aws/config` | Adds `[sso-session lablink]` + `[profile lablink]` blocks (preserves any other profiles) |
+| `~/.aws/sso/cache/<sha1(lablink)>.json` | The SSO access token — cached and refreshed by `aws sso login` |
+| `~/.lablink/bootstrap-state.json` | Bootstrap progress, removed once Step 4 completes |
+
+Subsequent `lablink ...` commands resolve credentials in this order:
+
+1. SSO profile `lablink` from `~/.aws/config` (preferred)
+2. `AWS_ACCESS_KEY_ID` + `AWS_SECRET_ACCESS_KEY` environment variables
+3. `~/.aws/credentials` default profile
+4. Fail with `Run lablink login`
+
+Terraform subprocesses inherit `AWS_PROFILE=lablink` automatically when (1) is in use, so the S3 backend can find your credentials.
+
+## See also
+
+- [First Deployment](first-deployment.md) — runs `lablink login` as Step 0
+- [Configuration](../configuration.md) — the `config.yaml` schema
+- [AWS Setup (Manual)](../aws-setup.md) — legacy access-key path for users who can't use Identity Center

--- a/docs/prerequisites.md
+++ b/docs/prerequisites.md
@@ -40,25 +40,11 @@ Verify installation:
 aws --version
 ```
 
-#### Configure AWS Credentials
+!!! note "AWS authentication is path-specific"
+    How you authenticate to AWS depends on which deployment path you choose. The relevant quickstart documents the auth step for that path:
 
-You have two options:
-
-**Option 1: AWS Access Keys (Local Development)**
-```bash
-aws configure
-```
-
-Enter your:
-
-- AWS Access Key ID
-- AWS Secret Access Key
-- Default region (e.g., `us-west-2`)
-- Default output format (`json`)
-
-**Option 2: OIDC (GitHub Actions)**
-
-For automated deployments, you'll configure OpenID Connect (OIDC) to allow GitHub Actions to assume an IAM role without storing credentials. See [AWS Setup from Scratch](aws-setup.md#step-4-github-actions-oidc-configuration) for details.
+    - **CLI:** [Sign in (lablink login)](cli/login.md) — Identity Center, no access keys
+    - **Template repo:** [Quickstart: Template repo](quickstart-template.md#step-1-authenticate-to-aws) — `aws configure` for the local `setup.sh` script, then OIDC takes over for GitHub Actions deployments
 
 ### 3. GitHub CLI (`gh`)
 

--- a/docs/quickstart-template.md
+++ b/docs/quickstart-template.md
@@ -11,7 +11,33 @@ Before starting, ensure you have completed:
 
 - [x] [Prerequisites](prerequisites.md): AWS Account, AWS CLI, GitHub CLI (`gh`), and Git installed
 
-## Step 1: Create Your Repository
+## Step 1: Authenticate to AWS
+
+The setup script you'll run in Step 3 needs AWS credentials with permission to create OIDC providers, IAM roles, S3 buckets, and DynamoDB tables. Configure them locally with:
+
+```bash
+aws configure
+```
+
+Enter your:
+
+- **AWS Access Key ID** (from IAM → Security credentials in the AWS Console)
+- **AWS Secret Access Key**
+- **Default region** (e.g., `us-west-2`)
+- **Default output format** (`json`)
+
+Verify you're authenticated:
+
+```bash
+aws sts get-caller-identity
+```
+
+You should see your account ID and IAM user ARN.
+
+!!! info "After setup completes, GitHub Actions takes over"
+    These local credentials are only used by `./scripts/setup.sh` to create the GitHub Actions OIDC role. Once setup finishes, all subsequent deployments run in GitHub Actions and use the OIDC role — no long-lived secrets in your repo.
+
+## Step 2: Create Your Repository
 
 <div class="video-container">
   <video controls width="100%">
@@ -29,7 +55,7 @@ git clone https://github.com/YOUR_ORG/YOUR_REPO.git
 cd YOUR_REPO
 ```
 
-## Step 2: Run Setup
+## Step 3: Run Setup
 
 <div class="video-container">
   <video controls width="100%">
@@ -64,7 +90,7 @@ It automatically:
 !!! tip "Manual Setup"
     If you prefer to create AWS resources individually, see the [AWS Setup (Manual)](aws-setup.md) guide.
 
-## Step 3: Configure
+## Step 4: Configure
 
 After setup completes, the script automatically runs `./scripts/configure.sh` to generate your deployment configuration.
 
@@ -82,7 +108,7 @@ It generates `lablink-infrastructure/config/config.yaml` with your settings.
     ./scripts/configure.sh
     ```
 
-## Step 4: Commit and Deploy
+## Step 5: Commit and Deploy
 
 <div class="video-container">
   <video controls width="100%">
@@ -118,7 +144,7 @@ The workflow will:
 - Initialize Terraform with the S3 backend
 - Deploy the allocator EC2 instance, security groups, and SSH key pair
 
-## Step 5: Verify
+## Step 6: Verify
 
 <div class="video-container">
   <video controls width="100%">
@@ -163,7 +189,7 @@ sudo docker ps
 sudo docker exec $(sudo docker ps -q) psql -U lablink -d lablink_db -c "SELECT hostname FROM vms;"
 ```
 
-## Step 6: Cleanup
+## Step 7: Cleanup
 
 <div class="video-container">
   <video controls width="100%">

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -101,6 +101,7 @@ nav:
   - CLI:
       - Overview: cli/index.md
       - Installation: cli/installation.md
+      - Sign in (lablink login): cli/login.md
       - First Deployment: cli/first-deployment.md
       - Managing Deployments: cli/managing-deployments.md
   - Admin Guide:

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "rich>=13.0",
     "pyyaml>=6.0",
     "boto3>=1.35",
+    "pyperclip>=1.8",
 ]
 
 [project.optional-dependencies]

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -83,6 +83,12 @@ def login(
         "--update-policy",
         help="Re-print the permission-set deep-link with current policy JSON.",
     ),
+    reset_bootstrap: bool = typer.Option(
+        False,
+        "--reset-bootstrap",
+        help="Discard any in-progress bootstrap state and start over. "
+        "Use this if you typo'd the SSO Start URL on a previous run.",
+    ),
     config: str = typer.Option(
         None,
         "--config",
@@ -103,7 +109,11 @@ def login(
         except typer.Exit:
             pass
 
-    run_login(deployment_region=deployment_region, update_policy=update_policy)
+    run_login(
+        deployment_region=deployment_region,
+        update_policy=update_policy,
+        reset_bootstrap=reset_bootstrap,
+    )
 
 
 @app.command(rich_help_panel="Setup")

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -77,6 +77,36 @@ def _load_cfg(config: str | None):
 
 
 @app.command(rich_help_panel="Setup")
+def login(
+    update_policy: bool = typer.Option(
+        False,
+        "--update-policy",
+        help="Re-print the permission-set deep-link with current policy JSON.",
+    ),
+    config: str = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to config.yaml (default: ~/.lablink/config.yaml). "
+        "Used only to determine deployment region for ~/.aws/config.",
+    ),
+) -> None:
+    """Sign in to AWS via Identity Center (no access keys required)."""
+    from lablink_cli.commands.login import run_login
+
+    deployment_region = None
+    config_path = Path(config) if config else DEFAULT_CONFIG
+    if config_path.exists():
+        try:
+            cfg = _load_cfg(str(config_path))
+            deployment_region = cfg.app.region
+        except typer.Exit:
+            pass
+
+    run_login(deployment_region=deployment_region, update_policy=update_policy)
+
+
+@app.command(rich_help_panel="Setup")
 def configure(
     config: str = typer.Option(
         None,

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -83,12 +83,6 @@ def login(
         "--update-policy",
         help="Re-print the permission-set deep-link with current policy JSON.",
     ),
-    reset_bootstrap: bool = typer.Option(
-        False,
-        "--reset-bootstrap",
-        help="Discard any in-progress bootstrap state and start over. "
-        "Use this if you typo'd the SSO Start URL on a previous run.",
-    ),
     config: str = typer.Option(
         None,
         "--config",
@@ -109,11 +103,7 @@ def login(
         except typer.Exit:
             pass
 
-    run_login(
-        deployment_region=deployment_region,
-        update_policy=update_policy,
-        reset_bootstrap=reset_bootstrap,
-    )
+    run_login(deployment_region=deployment_region, update_policy=update_policy)
 
 
 @app.command(rich_help_panel="Setup")

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -83,6 +83,13 @@ def login(
         "--update-policy",
         help="Re-print the permission-set deep-link with current policy JSON.",
     ),
+    manual: bool = typer.Option(
+        False,
+        "--manual",
+        help="Skip the CloudShell automation and walk through the AWS "
+        "Console manually (useful in CloudShell-unavailable regions or "
+        "for security auditors who prefer to do every step by hand).",
+    ),
     config: str = typer.Option(
         None,
         "--config",
@@ -103,7 +110,11 @@ def login(
         except typer.Exit:
             pass
 
-    run_login(deployment_region=deployment_region, update_policy=update_policy)
+    run_login(
+        deployment_region=deployment_region,
+        update_policy=update_policy,
+        manual=manual,
+    )
 
 
 @app.command(rich_help_panel="Setup")

--- a/packages/cli/src/lablink_cli/auth/__init__.py
+++ b/packages/cli/src/lablink_cli/auth/__init__.py
@@ -1,0 +1,1 @@
+"""LabLink AWS authentication: Identity Center login + credential resolution."""

--- a/packages/cli/src/lablink_cli/auth/bootstrap.py
+++ b/packages/cli/src/lablink_cli/auth/bootstrap.py
@@ -26,17 +26,14 @@ from lablink_cli.auth.utils import aws_config_path
 
 console = Console()
 
-IDENTITY_CENTER_CONSOLE_URL = (
-    "https://console.aws.amazon.com/singlesignon/home"
-)
-CREATE_PERMISSION_SET_URL = (
-    "https://console.aws.amazon.com/singlesignon/home"
-    "#/instances/permissionsets/create"
-)
-ASSIGN_USERS_URL = (
-    "https://console.aws.amazon.com/singlesignon/home"
-    "#/instances/aws-accounts"
-)
+# Identity Center console URL. We don't deep-link to /permissionsets/create
+# or /aws-accounts because those hash-routed URLs are unstable across AWS
+# console releases (they fail with "Cannot read properties of undefined
+# (reading 'noHash')" if the SPA isn't initialized yet). The textual copy
+# in each _step_ function below tells the user where to navigate from home.
+IDENTITY_CENTER_CONSOLE_URL = "https://console.aws.amazon.com/singlesignon/home"
+CREATE_PERMISSION_SET_URL = IDENTITY_CENTER_CONSOLE_URL
+ASSIGN_USERS_URL = IDENTITY_CENTER_CONSOLE_URL
 
 # Matches https://d-XXXXXXXXXX.awsapps.com/start or
 # https://<alias>.awsapps.com/start
@@ -182,10 +179,14 @@ def _step_enable_identity_center() -> tuple[str, str]:
         "  1. Click [bold]Enable[/bold]. (If asked, choose "
         "[bold]account instance[/bold] for personal accounts — either works.)\n"
         "  2. Wait ~30 seconds for it to provision.\n"
-        "  3. Click [bold]Add user[/bold] and enter your name + email.\n"
-        "  4. Check email for the password-set link; set a password and MFA.\n"
-        "  5. Once done, copy the [bold]SSO Start URL[/bold] from "
-        "Identity Center → Settings summary.\n"
+        "  3. In the left sidebar, click [bold]Users[/bold] → "
+        "[bold]Add user[/bold].\n"
+        "  4. Fill in your name + email and submit.\n"
+        "  5. Check your email for the [bold]Accept invitation[/bold] link; "
+        "set a password and MFA.\n"
+        "  6. Return to the Identity Center home (the page you opened in step 1).\n"
+        "  7. Copy the [bold]SSO Start URL[/bold] from the "
+        "[bold]AWS access portal URLs[/bold] section on the dashboard.\n"
     )
 
     while True:
@@ -224,22 +225,26 @@ def _step_create_permission_set() -> str:
         f"\nNow we need a Permission Set — this controls what LabLink can do.\n"
         f"{clipboard_msg}\n"
     )
-    input("Press Enter to open the AWS Console at the Create Permission Set page...")
+    input("Press Enter to open the Identity Center console...")
     webbrowser.open(CREATE_PERMISSION_SET_URL)
 
     console.print(
         "\nIn the AWS Console:\n"
-        "  1. Choose [bold]Custom permission set[/bold].\n"
-        "  2. Under [bold]AWS managed policies[/bold], attach all of:\n"
+        "  1. In the left sidebar, click [bold]Permission sets[/bold].\n"
+        "  2. Click [bold]Create permission set[/bold].\n"
+        "  3. Choose [bold]Custom permission set[/bold] and click "
+        "[bold]Next[/bold].\n"
+        "  4. Under [bold]AWS managed policies[/bold], search for and "
+        "attach each of:\n"
     )
     for arn in policy.MANAGED_POLICY_ARNS:
         name = arn.split("/")[-1]
         console.print(f"     • {name}")
     console.print(
-        "  3. Click [bold]Inline policy[/bold] and paste from clipboard "
-        "(Ctrl/Cmd-V).\n"
-        "  4. Name it [bold]lablink[/bold] (or your preference) and click "
-        "[bold]Create[/bold].\n"
+        "  5. Expand [bold]Custom inline policy[/bold], paste from "
+        "clipboard (Ctrl/Cmd-V), then click [bold]Next[/bold].\n"
+        "  6. Name it [bold]lablink[/bold] (or your preference) and click "
+        "[bold]Next[/bold] → [bold]Create[/bold].\n"
     )
 
     permission_set_name = typer.prompt(
@@ -255,16 +260,19 @@ def _step_assign_user(permission_set_name: str) -> None:
         f"\nLast step — assign your user to your AWS account with the "
         f"[bold]{permission_set_name}[/bold] permission set.\n"
     )
-    input("Press Enter to open the AWS Console at the Assign Users page...")
+    input("Press Enter to open the Identity Center console...")
     webbrowser.open(ASSIGN_USERS_URL)
 
     console.print(
         "\nIn the AWS Console:\n"
-        "  1. Select your AWS account.\n"
-        "  2. Click [bold]Assign users or groups[/bold].\n"
-        "  3. Select your user.\n"
-        f"  4. Select the [bold]{permission_set_name}[/bold] permission set.\n"
-        "  5. Click [bold]Submit[/bold].\n"
+        "  1. In the left sidebar, click [bold]AWS accounts[/bold].\n"
+        "  2. Check the box next to your AWS account.\n"
+        "  3. Click [bold]Assign users or groups[/bold].\n"
+        "  4. On the [bold]Users[/bold] tab, select your user, click "
+        "[bold]Next[/bold].\n"
+        f"  5. Select the [bold]{permission_set_name}[/bold] permission set, "
+        "click [bold]Next[/bold].\n"
+        "  6. Click [bold]Submit[/bold].\n"
     )
     input("Press Enter when done...")
 

--- a/packages/cli/src/lablink_cli/auth/bootstrap.py
+++ b/packages/cli/src/lablink_cli/auth/bootstrap.py
@@ -1,0 +1,309 @@
+"""First-time Identity Center setup — the console handoff flow.
+
+This drives the user through enabling Identity Center, creating
+themselves a user, creating the lablink permission set, and assigning
+the user to the AWS account. All steps happen in the AWS Console;
+this module just opens the right URLs, prompts for the SSO Start URL,
+and writes ~/.aws/config.
+"""
+
+from __future__ import annotations
+
+import configparser
+import json
+import os
+import re
+import webbrowser
+from dataclasses import dataclass, field, asdict
+from pathlib import Path
+
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+from lablink_cli.auth import policy
+from lablink_cli.auth.utils import aws_config_path
+
+console = Console()
+
+IDENTITY_CENTER_CONSOLE_URL = (
+    "https://console.aws.amazon.com/singlesignon/home"
+)
+CREATE_PERMISSION_SET_URL = (
+    "https://console.aws.amazon.com/singlesignon/home"
+    "#/instances/permissionsets/create"
+)
+ASSIGN_USERS_URL = (
+    "https://console.aws.amazon.com/singlesignon/home"
+    "#/instances/aws-accounts"
+)
+
+# Matches https://d-XXXXXXXXXX.awsapps.com/start or
+# https://<alias>.awsapps.com/start
+_SSO_URL_RE = re.compile(
+    r"^https://(?:d-[a-z0-9]{10}|[a-z0-9-]+)\.awsapps\.com/start/?$"
+)
+
+
+@dataclass
+class SSOBootstrapResult:
+    start_url: str
+    sso_region: str
+    permission_set_name: str
+    deployment_region: str
+
+
+@dataclass
+class BootstrapState:
+    """Bootstrap progress, persisted to ~/.lablink/bootstrap-state.json.
+
+    Resumability is purely file-based: instances do not hold a file
+    handle. `load` / `save` / `clear` operate on the well-known path
+    each time, so a Ctrl-C between steps simply leaves the file behind
+    for the next invocation to pick up.
+    """
+
+    sso_start_url: str
+    sso_region: str
+    permission_set_name: str
+    steps_complete: list[str] = field(default_factory=list)
+
+    @classmethod
+    def path(cls) -> Path:
+        """Return the on-disk location of the persisted state."""
+        home = Path(os.environ.get("HOME", str(Path.home())))
+        return home / ".lablink" / "bootstrap-state.json"
+
+    @classmethod
+    def load(cls) -> "BootstrapState | None":
+        """Read state from disk. Returns None if missing or corrupt."""
+        path = cls.path()
+        if not path.exists():
+            return None
+        try:
+            data = json.loads(path.read_text())
+            return cls(**data)
+        except (json.JSONDecodeError, TypeError, OSError):
+            return None
+
+    def save(self) -> None:
+        """Persist this state to disk, creating parent dirs as needed."""
+        path = self.path()
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text(json.dumps(asdict(self), indent=2))
+
+    @classmethod
+    def clear(cls) -> None:
+        """Remove the persisted state file if it exists."""
+        path = cls.path()
+        if path.exists():
+            path.unlink()
+
+
+def _is_valid_sso_start_url(url: str) -> bool:
+    return bool(_SSO_URL_RE.match(url.strip()))
+
+
+def _extract_region_from_url(url: str) -> str | None:
+    """Identity Center start URLs don't encode region; return None."""
+    return None
+
+
+def _write_aws_config(result: SSOBootstrapResult) -> None:
+    """Write [sso-session lablink] and [profile lablink] without clobbering others."""
+    config_path = aws_config_path()
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+
+    parser = configparser.ConfigParser()
+    if config_path.exists():
+        parser.read(config_path)
+
+    sso_session_section = "sso-session lablink"
+    profile_section = "profile lablink"
+
+    if sso_session_section not in parser.sections():
+        parser.add_section(sso_session_section)
+    parser.set(sso_session_section, "sso_start_url", result.start_url)
+    parser.set(sso_session_section, "sso_region", result.sso_region)
+    parser.set(sso_session_section, "sso_registration_scopes", "sso:account:access")
+
+    if profile_section not in parser.sections():
+        parser.add_section(profile_section)
+    parser.set(profile_section, "sso_session", "lablink")
+    parser.set(profile_section, "sso_role_name", result.permission_set_name)
+    parser.set(profile_section, "region", result.deployment_region)
+
+    with open(config_path, "w") as fp:
+        parser.write(fp)
+
+
+def _pyperclip_copy(text: str) -> None:
+    """Wrapped for testability — patch this to simulate pyperclip failures."""
+    import pyperclip
+
+    pyperclip.copy(text)
+
+
+def _copy_to_clipboard(payload: str) -> Path | None:
+    """Copy payload to clipboard. On failure, write to a file and return its path."""
+    try:
+        _pyperclip_copy(payload)
+        return None
+    except Exception:
+        home = Path(os.environ.get("HOME", str(Path.home())))
+        out = home / ".lablink" / "permission-set-policy.json"
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(payload)
+        return out
+
+
+def _step_enable_identity_center() -> tuple[str, str]:
+    """Walk the user through enabling Identity Center. Returns (start_url, region)."""
+    console.print(
+        Panel(
+            "Welcome to LabLink. It looks like this is your first login.\n"
+            "Setup takes about 5 minutes and only happens once.\n\n"
+            "You will:\n"
+            "  1. Enable AWS Identity Center in your AWS account\n"
+            "  2. Create yourself a user (your name, email, password)\n"
+            "  3. Attach the LabLink permission set to your user\n\n"
+            "You'll need an authenticator app on your phone (Authy, Google\n"
+            "Authenticator, 1Password) for the password setup step — Identity\n"
+            "Center enforces MFA.",
+            title="First-time setup",
+            border_style="cyan",
+        )
+    )
+    input("Press Enter to open the AWS Console in your browser...")
+    webbrowser.open(IDENTITY_CENTER_CONSOLE_URL)
+
+    console.print(
+        "\nIn the AWS Console:\n"
+        "  1. Click [bold]Enable[/bold]. (If asked, choose "
+        "[bold]account instance[/bold] for personal accounts — either works.)\n"
+        "  2. Wait ~30 seconds for it to provision.\n"
+        "  3. Click [bold]Add user[/bold] and enter your name + email.\n"
+        "  4. Check email for the password-set link; set a password and MFA.\n"
+        "  5. Once done, copy the [bold]SSO Start URL[/bold] from "
+        "Identity Center → Settings summary.\n"
+    )
+
+    while True:
+        start_url = typer.prompt("SSO Start URL")
+        if _is_valid_sso_start_url(start_url):
+            break
+        console.print(
+            "[red]That doesn't look like an SSO Start URL.[/red] "
+            "Expected something like https://d-9067abc123.awsapps.com/start"
+        )
+
+    sso_region = typer.prompt(
+        "AWS region where Identity Center is enabled",
+        default="us-east-1",
+    )
+    return start_url.strip(), sso_region.strip()
+
+
+def _step_create_permission_set() -> str:
+    """Walk the user through creating the lablink permission set."""
+    payload = policy.render_inline_policy_json()
+    fallback_path = _copy_to_clipboard(payload)
+
+    if fallback_path is None:
+        clipboard_msg = (
+            "The required policy JSON has been [bold]copied to your clipboard[/bold]."
+        )
+    else:
+        clipboard_msg = (
+            f"Your system doesn't have a clipboard, so the policy JSON was "
+            f"saved to:\n  [bold]{fallback_path}[/bold]\n"
+            "Open that file and copy its contents."
+        )
+
+    console.print(
+        f"\nNow we need a Permission Set — this controls what LabLink can do.\n"
+        f"{clipboard_msg}\n"
+    )
+    input("Press Enter to open the AWS Console at the Create Permission Set page...")
+    webbrowser.open(CREATE_PERMISSION_SET_URL)
+
+    console.print(
+        "\nIn the AWS Console:\n"
+        "  1. Choose [bold]Custom permission set[/bold].\n"
+        "  2. Under [bold]AWS managed policies[/bold], attach all of:\n"
+    )
+    for arn in policy.MANAGED_POLICY_ARNS:
+        name = arn.split("/")[-1]
+        console.print(f"     • {name}")
+    console.print(
+        "  3. Click [bold]Inline policy[/bold] and paste from clipboard "
+        "(Ctrl/Cmd-V).\n"
+        "  4. Name it [bold]lablink[/bold] (or your preference) and click "
+        "[bold]Create[/bold].\n"
+    )
+
+    permission_set_name = typer.prompt(
+        "What did you name the permission set?",
+        default=policy.PERMISSION_SET_NAME_DEFAULT,
+    )
+    input("Press Enter once the permission set is created...")
+    return permission_set_name.strip()
+
+
+def _step_assign_user(permission_set_name: str) -> None:
+    console.print(
+        f"\nLast step — assign your user to your AWS account with the "
+        f"[bold]{permission_set_name}[/bold] permission set.\n"
+    )
+    input("Press Enter to open the AWS Console at the Assign Users page...")
+    webbrowser.open(ASSIGN_USERS_URL)
+
+    console.print(
+        "\nIn the AWS Console:\n"
+        "  1. Select your AWS account.\n"
+        "  2. Click [bold]Assign users or groups[/bold].\n"
+        "  3. Select your user.\n"
+        f"  4. Select the [bold]{permission_set_name}[/bold] permission set.\n"
+        "  5. Click [bold]Submit[/bold].\n"
+    )
+    input("Press Enter when done...")
+
+
+def run_bootstrap(*, deployment_region: str) -> SSOBootstrapResult:
+    """Run the full first-time bootstrap flow with resumability."""
+    state = BootstrapState.load()
+
+    if state is None:
+        start_url, sso_region = _step_enable_identity_center()
+        state = BootstrapState(
+            sso_start_url=start_url,
+            sso_region=sso_region,
+            permission_set_name=policy.PERMISSION_SET_NAME_DEFAULT,
+            steps_complete=["enable"],
+        )
+        state.save()
+    else:
+        console.print(
+            "[dim]Resuming bootstrap from a previous run...[/dim]"
+        )
+
+    if "permission_set" not in state.steps_complete:
+        permission_set_name = _step_create_permission_set()
+        state.permission_set_name = permission_set_name
+        state.steps_complete.append("permission_set")
+        state.save()
+
+    if "assign" not in state.steps_complete:
+        _step_assign_user(state.permission_set_name)
+        state.steps_complete.append("assign")
+        state.save()
+
+    result = SSOBootstrapResult(
+        start_url=state.sso_start_url,
+        sso_region=state.sso_region,
+        permission_set_name=state.permission_set_name,
+        deployment_region=deployment_region,
+    )
+    _write_aws_config(result)
+    BootstrapState.clear()
+    return result

--- a/packages/cli/src/lablink_cli/auth/bootstrap.py
+++ b/packages/cli/src/lablink_cli/auth/bootstrap.py
@@ -101,11 +101,6 @@ def _is_valid_sso_start_url(url: str) -> bool:
     return bool(_SSO_URL_RE.match(url.strip()))
 
 
-def _extract_region_from_url(url: str) -> str | None:
-    """Identity Center start URLs don't encode region; return None."""
-    return None
-
-
 def _write_aws_config(result: SSOBootstrapResult) -> None:
     """Write [sso-session lablink] and [profile lablink] without clobbering others."""
     config_path = aws_config_path()

--- a/packages/cli/src/lablink_cli/auth/bootstrap.py
+++ b/packages/cli/src/lablink_cli/auth/bootstrap.py
@@ -230,8 +230,11 @@ def _step_create_permission_set() -> str:
 
     console.print(
         "\nIn the AWS Console:\n"
-        "  1. In the left sidebar, click [bold]Permission sets[/bold].\n"
-        "  2. Click [bold]Create permission set[/bold].\n"
+        "  1. In the left sidebar, find [bold]Permission sets[/bold]. "
+        "(In newer consoles it's nested under "
+        "[bold]Multi-account permissions[/bold] — expand that first.)\n"
+        "  2. Click the [bold]Create permission set[/bold] button on the "
+        "Permission sets page.\n"
         "  3. Choose [bold]Custom permission set[/bold] and click "
         "[bold]Next[/bold].\n"
         "  4. Under [bold]AWS managed policies[/bold], search for and "
@@ -265,7 +268,9 @@ def _step_assign_user(permission_set_name: str) -> None:
 
     console.print(
         "\nIn the AWS Console:\n"
-        "  1. In the left sidebar, click [bold]AWS accounts[/bold].\n"
+        "  1. In the left sidebar, find [bold]AWS accounts[/bold]. "
+        "(In newer consoles it's nested under "
+        "[bold]Multi-account permissions[/bold] — expand that first.)\n"
         "  2. Check the box next to your AWS account.\n"
         "  3. Click [bold]Assign users or groups[/bold].\n"
         "  4. On the [bold]Users[/bold] tab, select your user, click "

--- a/packages/cli/src/lablink_cli/auth/bootstrap.py
+++ b/packages/cli/src/lablink_cli/auth/bootstrap.py
@@ -141,7 +141,7 @@ def _pyperclip_copy(text: str) -> None:
     pyperclip.copy(text)
 
 
-def _copy_to_clipboard(payload: str) -> Path | None:
+def copy_to_clipboard(payload: str) -> Path | None:
     """Copy payload to clipboard. On failure, write to a file and return its path."""
     try:
         _pyperclip_copy(payload)
@@ -208,7 +208,7 @@ def _step_enable_identity_center() -> tuple[str, str]:
 def _step_create_permission_set() -> str:
     """Walk the user through creating the lablink permission set."""
     payload = policy.render_inline_policy_json()
-    fallback_path = _copy_to_clipboard(payload)
+    fallback_path = copy_to_clipboard(payload)
 
     if fallback_path is None:
         clipboard_msg = (

--- a/packages/cli/src/lablink_cli/auth/bootstrap.py
+++ b/packages/cli/src/lablink_cli/auth/bootstrap.py
@@ -1,15 +1,17 @@
 """First-time Identity Center setup — the console handoff flow.
 
-This drives the user through enabling Identity Center, creating
-themselves a user, creating the lablink permission set, and assigning
-the user to the AWS account. All steps happen in the AWS Console;
-this module just opens the right URLs, prompts for the SSO Start URL,
-and writes ~/.aws/config.
+This drives the user through enabling Identity Center, then automates
+the rest (permission set creation + user assignment) via a script the
+user pastes into AWS CloudShell. CloudShell inherits the user's
+console-session credentials, so no local AWS CLI auth is needed for
+the bootstrap. The CLI then writes ~/.aws/config and the user signs
+in via `aws sso login` for steady-state.
 """
 
 from __future__ import annotations
 
 import configparser
+import json
 import os
 import re
 import webbrowser
@@ -101,6 +103,140 @@ def copy_to_clipboard(payload: str) -> Path | None:
         return out
 
 
+# Matches a typical email address. Permissive — just enough to catch
+# obvious typos like missing "@". Identity Center accepts almost
+# anything as a username, so the script also tries UserName lookup as
+# a fallback when the email-by-attribute lookup fails.
+_EMAIL_RE = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+
+def _is_valid_email(email: str) -> bool:
+    return bool(_EMAIL_RE.match(email.strip()))
+
+
+# Tag used to delimit the bash heredoc the user pastes into CloudShell.
+# Picked to be unmistakable in the user's terminal; never appears
+# inside the script body.
+_HEREDOC_TAG = "LABLINK_SETUP"
+
+_BOOTSTRAP_SCRIPT_TEMPLATE = """\
+bash <<'__HEREDOC_TAG__'
+set -e
+
+EMAIL="__EMAIL__"
+PS_NAME="__PS_NAME__"
+
+# Inline policy as a multi-line single-quoted string. Keeping this as a
+# bash variable (rather than passing JSON inline on the aws CLI command)
+# avoids the long-line copy-paste issue where terminals soft-wrap and
+# insert spurious newlines mid-argument.
+INLINE_POLICY='__INLINE_POLICY_JSON__'
+
+INSTANCE_ARN=$(aws sso-admin list-instances \\
+  --query 'Instances[0].InstanceArn' --output text)
+ID_STORE_ID=$(aws sso-admin list-instances \\
+  --query 'Instances[0].IdentityStoreId' --output text)
+ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+
+echo "Setting up $PS_NAME permissions for $EMAIL on account $ACCOUNT_ID..."
+
+# Create or find the permission set (idempotent)
+PS_ARN=""
+for arn in $(aws sso-admin list-permission-sets \\
+    --instance-arn "$INSTANCE_ARN" --query 'PermissionSets[]' --output text); do
+  name=$(aws sso-admin describe-permission-set \\
+    --instance-arn "$INSTANCE_ARN" --permission-set-arn "$arn" \\
+    --query 'PermissionSet.Name' --output text)
+  if [ "$name" = "$PS_NAME" ]; then PS_ARN="$arn"; break; fi
+done
+if [ -z "$PS_ARN" ]; then
+  PS_ARN=$(aws sso-admin create-permission-set \\
+    --instance-arn "$INSTANCE_ARN" --name "$PS_NAME" \\
+    --query 'PermissionSet.PermissionSetArn' --output text)
+  echo "  created permission set"
+else
+  echo "  permission set already exists"
+fi
+
+# Attach managed policies (idempotent — duplicate attaches are no-ops)
+for POLICY in __MANAGED_POLICY_ARNS__; do
+  aws sso-admin attach-managed-policy-to-permission-set \\
+    --instance-arn "$INSTANCE_ARN" --permission-set-arn "$PS_ARN" \\
+    --managed-policy-arn "$POLICY" 2>/dev/null || true
+done
+echo "  attached managed policies"
+
+# Set inline policy (always overwrites — keeps it in sync with the CLI)
+aws sso-admin put-inline-policy-to-permission-set \\
+  --instance-arn "$INSTANCE_ARN" --permission-set-arn "$PS_ARN" \\
+  --inline-policy "$INLINE_POLICY"
+echo "  set inline policy"
+
+# Look up Identity Center user — prefer email match, fall back to UserName
+USER_ID=$(aws identitystore list-users --identity-store-id "$ID_STORE_ID" \\
+  --query "Users[?Emails[?Value=='$EMAIL']].UserId | [0]" \\
+  --output text 2>/dev/null)
+if [ -z "$USER_ID" ] || [ "$USER_ID" = "None" ]; then
+  USER_ID=$(aws identitystore list-users --identity-store-id "$ID_STORE_ID" \\
+    --filters "AttributePath=UserName,AttributeValue=$EMAIL" \\
+    --query 'Users[0].UserId' --output text 2>/dev/null)
+fi
+if [ -z "$USER_ID" ] || [ "$USER_ID" = "None" ]; then
+  echo ""
+  echo "ERROR: No Identity Center user matched '$EMAIL'."
+  echo ""
+  echo "Most likely your Identity Center username is different from"
+  echo "your email. The 'Add user' form has separate Username and"
+  echo "Email fields, and lookups failed against both for this value."
+  echo ""
+  echo "Existing Identity Center users in this account:"
+  aws identitystore list-users --identity-store-id "$ID_STORE_ID" \\
+    --query 'Users[].{UserName:UserName,Email:Emails[0].Value}' \\
+    --output table
+  echo ""
+  echo "Re-run the script with EMAIL set to the UserName shown above"
+  echo "(or fix the user in Identity Center so Username == email)."
+  exit 1
+fi
+
+# Assign user to this AWS account (idempotent)
+aws sso-admin create-account-assignment \\
+  --instance-arn "$INSTANCE_ARN" --target-id "$ACCOUNT_ID" \\
+  --target-type AWS_ACCOUNT --permission-set-arn "$PS_ARN" \\
+  --principal-id "$USER_ID" --principal-type USER >/dev/null 2>&1 || true
+echo "  assigned user to account"
+
+echo ""
+echo "Done. Return to your lablink terminal and press Enter."
+__HEREDOC_TAG__
+"""
+
+
+def render_bootstrap_script(email: str) -> str:
+    """Render the CloudShell heredoc that creates the permission set and
+    assigns the user.
+
+    Inlines MANAGED_POLICY_ARNS and INLINE_POLICY from policy.py at call
+    time so the script is always in sync with the CLI's source of truth.
+    The inline policy is rendered with indentation (multi-line bash
+    variable) so no individual line is so long that a terminal will
+    soft-wrap and break the paste.
+    """
+    arn_list = " \\\n  ".join(policy.MANAGED_POLICY_ARNS)
+    # Pretty-printed JSON keeps each line short. Single-quoted bash
+    # strings can span newlines; JSON has no single quotes, so no
+    # escaping is needed.
+    inline_json = json.dumps(policy.INLINE_POLICY, indent=2)
+    return (
+        _BOOTSTRAP_SCRIPT_TEMPLATE
+        .replace("__HEREDOC_TAG__", _HEREDOC_TAG)
+        .replace("__EMAIL__", email)
+        .replace("__PS_NAME__", policy.PERMISSION_SET_NAME_DEFAULT)
+        .replace("__MANAGED_POLICY_ARNS__", arn_list)
+        .replace("__INLINE_POLICY_JSON__", inline_json)
+    )
+
+
 def _step_enable_identity_center() -> tuple[str, str]:
     """Walk the user through enabling Identity Center. Returns (start_url, region)."""
     console.print(
@@ -109,13 +245,15 @@ def _step_enable_identity_center() -> tuple[str, str]:
             "We'll set up an AWS sign-in for you so the CLI can deploy lab\n"
             "infrastructure on your behalf — no access keys, no copy-pasting\n"
             "secrets. You'll sign in through your browser each session.\n\n"
-            "First-time setup takes [bold]10–15 minutes[/bold]. You'll do "
-            "three things in the AWS web console:\n\n"
+            "First-time setup takes [bold]5–10 minutes[/bold]. You'll do "
+            "two things in the AWS web console:\n\n"
             "  [bold]1.[/bold] Turn on AWS's sign-in service "
-            "(it's called [italic]Identity Center[/italic])\n"
-            "  [bold]2.[/bold] Create a sign-in for yourself "
-            "(name, email, password)\n"
-            "  [bold]3.[/bold] Grant your sign-in permission to run lablink\n\n"
+            "(it's called [italic]Identity Center[/italic]) and "
+            "create a\n"
+            "     sign-in for yourself.\n"
+            "  [bold]2.[/bold] Paste one command into AWS's in-browser "
+            "terminal to grant\n"
+            "     your sign-in permission to run lablink.\n\n"
             "[bold yellow]Before you continue:[/bold yellow] install an "
             "authenticator app on your phone\n"
             "(Authy, Google Authenticator, 1Password, or similar). AWS "
@@ -129,14 +267,21 @@ def _step_enable_identity_center() -> tuple[str, str]:
     webbrowser.open(IDENTITY_CENTER_CONSOLE_URL)
 
     console.print(
-        "\n[bold]Step 1 of 3: Turn on the AWS sign-in service[/bold]\n"
+        "\n[bold]Step 1 of 2: Turn on the AWS sign-in service[/bold]\n"
         "In the AWS Console tab that just opened:\n"
         "  1. Click [bold]Enable[/bold]. (If asked, choose "
         "[bold]account instance[/bold] for personal accounts.)\n"
         "  2. Wait ~30 seconds while AWS sets things up.\n"
         "  3. In the left sidebar, click [bold]Users[/bold] → "
         "[bold]Add user[/bold].\n"
-        "  4. Fill in your name and email, then submit.\n"
+        "  4. Fill in the form. [bold yellow]The 'Add user' wizard has "
+        "three pages[/bold yellow] —\n"
+        "     you must click [bold]Next[/bold] all the way through and "
+        "click [bold]Add user[/bold] on the\n"
+        "     final review page, or no user will be created. "
+        "[bold]Use your email as the\n"
+        "     Username[/bold] (not just the local-part) so the next step's "
+        "lookup matches.\n"
         "  5. Check your email for an [bold]Accept invitation[/bold] link. "
         "Click it,\n"
         "     set a password, and pair your authenticator app.\n"
@@ -163,6 +308,20 @@ def _step_enable_identity_center() -> tuple[str, str]:
         default="us-east-1",
     )
     return start_url.strip(), sso_region.strip()
+
+
+def _prompt_email() -> str:
+    """Collect the email the user typed when creating their Identity Center user."""
+    while True:
+        email = typer.prompt(
+            "Email you used to create the Identity Center user"
+        )
+        if _is_valid_email(email):
+            return email.strip()
+        console.print(
+            "[red]That doesn't look like an email address.[/red] "
+            "Use the same email you typed in the [bold]Add user[/bold] form."
+        )
 
 
 def _step_create_permission_set() -> str:
@@ -218,6 +377,75 @@ def _step_create_permission_set() -> str:
     return permission_set_name.strip()
 
 
+def _save_bootstrap_script(script: str) -> Path:
+    """Save the rendered script to ~/.lablink/cloudshell-bootstrap.sh.
+
+    Provides a paste-failure fallback: the user can either upload this
+    file via CloudShell's "Actions → Upload file" menu, or `cat` it to
+    re-print a clean copy.
+    """
+    home = Path(os.environ.get("HOME", str(Path.home())))
+    out = home / ".lablink" / "cloudshell-bootstrap.sh"
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_text(script)
+    return out
+
+
+def _step_grant_permissions_cloudshell(email: str) -> None:
+    """New default step 2: user pastes a script into AWS CloudShell.
+
+    CloudShell runs as the user's console-session identity, so the
+    `aws ...` calls in the script work with no extra setup. The script
+    creates the permission set, attaches policies, and assigns the
+    user to the current AWS account — replacing what used to be 14
+    manual console clicks across two separate flows.
+
+    The script is also saved to ~/.lablink/cloudshell-bootstrap.sh as
+    a fallback for terminals that mangle multi-line paste (some Windows
+    terminals, certain SSH setups, mouse-select-only environments).
+    The user can then upload that file via CloudShell's
+    "Actions → Upload file" menu instead of copy-pasting.
+    """
+    script = render_bootstrap_script(email)
+    script_path = _save_bootstrap_script(script)
+
+    console.print(
+        "\n[bold]Step 2 of 2: Grant your sign-in permission to run "
+        "lablink[/bold]\n"
+        "We'll use AWS [bold]CloudShell[/bold] — a free terminal in your "
+        "browser that\n"
+        "automatically uses your AWS Console sign-in. No local AWS CLI "
+        "setup needed.\n\n"
+        "  1. In the AWS Console (still open in your browser), click the "
+        "[bold]CloudShell[/bold]\n"
+        "     icon in the top-right toolbar (it looks like "
+        "[bold]>_[/bold]).\n"
+        "  2. Wait ~10 seconds for the terminal to start.\n"
+        "  3. [bold]Copy the script printed below[/bold] and paste it "
+        "into CloudShell,\n"
+        "     then press Enter.\n"
+        "  4. The script takes ~30 seconds. Wait until you see "
+        "[green]Done.[/green]\n"
+    )
+
+    # Print rule + plain script + rule. No Panel: vertical bars (│) on
+    # every line of a Rich Panel get included in the user's clipboard
+    # and break the bash heredoc. ``highlight=False, markup=False`` keeps
+    # Rich from interpreting any character in the script body.
+    console.rule("[bold cyan]Begin script — copy from below[/bold cyan]")
+    console.print(script, highlight=False, markup=False)
+    console.rule("[bold cyan]End script[/bold cyan]")
+
+    console.print(
+        f"\n[dim]Paste mangled? The same script was saved to "
+        f"[bold]{script_path}[/bold].\n"
+        "In CloudShell, click [bold]Actions → Upload file[/bold], pick that "
+        "file, then run\n"
+        "[bold]bash ~/cloudshell-bootstrap.sh[/bold] in CloudShell.[/dim]\n"
+    )
+    input("Press Enter once you see Done. in CloudShell...")
+
+
 def _step_assign_user(permission_set_name: str) -> None:
     console.print(
         f"\nLast step — assign your user to your AWS account with the "
@@ -242,19 +470,33 @@ def _step_assign_user(permission_set_name: str) -> None:
     input("Press Enter when done...")
 
 
-def run_bootstrap(*, deployment_region: str) -> SSOBootstrapResult:
+def run_bootstrap(
+    *,
+    deployment_region: str,
+    manual: bool = False,
+) -> SSOBootstrapResult:
     """Run the full first-time bootstrap flow.
 
-    Each step's effect on AWS (Identity Center enabled, user created,
-    permission set created, user assigned) persists in AWS regardless
-    of whether the CLI exits. So if the user Ctrl-Cs partway through,
-    re-running `lablink login` simply walks them through the same
-    console steps again — they confirm what's already there and paste
-    the URL once more. No local state needs to be remembered.
+    Default flow uses CloudShell — the user pastes one script that does
+    permission-set creation and user assignment in ~30 seconds. The
+    ``manual`` mode preserves the original click-through-the-console
+    flow as an escape hatch (CloudShell-unavailable regions, paranoid
+    auditors, debugging).
+
+    All AWS-side state created by the bootstrap (Identity Center
+    enabled, user created, permission set, assignment) persists across
+    runs, so if the user Ctrl-Cs partway through they can simply
+    re-run `lablink login` and re-confirm what's already in place.
     """
     start_url, sso_region = _step_enable_identity_center()
-    permission_set_name = _step_create_permission_set()
-    _step_assign_user(permission_set_name)
+
+    if manual:
+        permission_set_name = _step_create_permission_set()
+        _step_assign_user(permission_set_name)
+    else:
+        email = _prompt_email()
+        _step_grant_permissions_cloudshell(email)
+        permission_set_name = policy.PERMISSION_SET_NAME_DEFAULT
 
     result = SSOBootstrapResult(
         start_url=start_url,

--- a/packages/cli/src/lablink_cli/auth/bootstrap.py
+++ b/packages/cli/src/lablink_cli/auth/bootstrap.py
@@ -10,11 +10,10 @@ and writes ~/.aws/config.
 from __future__ import annotations
 
 import configparser
-import json
 import os
 import re
 import webbrowser
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass
 from pathlib import Path
 
 import typer
@@ -48,53 +47,6 @@ class SSOBootstrapResult:
     sso_region: str
     permission_set_name: str
     deployment_region: str
-
-
-@dataclass
-class BootstrapState:
-    """Bootstrap progress, persisted to ~/.lablink/bootstrap-state.json.
-
-    Resumability is purely file-based: instances do not hold a file
-    handle. `load` / `save` / `clear` operate on the well-known path
-    each time, so a Ctrl-C between steps simply leaves the file behind
-    for the next invocation to pick up.
-    """
-
-    sso_start_url: str
-    sso_region: str
-    permission_set_name: str
-    steps_complete: list[str] = field(default_factory=list)
-
-    @classmethod
-    def path(cls) -> Path:
-        """Return the on-disk location of the persisted state."""
-        home = Path(os.environ.get("HOME", str(Path.home())))
-        return home / ".lablink" / "bootstrap-state.json"
-
-    @classmethod
-    def load(cls) -> "BootstrapState | None":
-        """Read state from disk. Returns None if missing or corrupt."""
-        path = cls.path()
-        if not path.exists():
-            return None
-        try:
-            data = json.loads(path.read_text())
-            return cls(**data)
-        except (json.JSONDecodeError, TypeError, OSError):
-            return None
-
-    def save(self) -> None:
-        """Persist this state to disk, creating parent dirs as needed."""
-        path = self.path()
-        path.parent.mkdir(parents=True, exist_ok=True)
-        path.write_text(json.dumps(asdict(self), indent=2))
-
-    @classmethod
-    def clear(cls) -> None:
-        """Remove the persisted state file if it exists."""
-        path = cls.path()
-        if path.exists():
-            path.unlink()
 
 
 def _is_valid_sso_start_url(url: str) -> bool:
@@ -278,40 +230,24 @@ def _step_assign_user(permission_set_name: str) -> None:
 
 
 def run_bootstrap(*, deployment_region: str) -> SSOBootstrapResult:
-    """Run the full first-time bootstrap flow with resumability."""
-    state = BootstrapState.load()
+    """Run the full first-time bootstrap flow.
 
-    if state is None:
-        start_url, sso_region = _step_enable_identity_center()
-        state = BootstrapState(
-            sso_start_url=start_url,
-            sso_region=sso_region,
-            permission_set_name=policy.PERMISSION_SET_NAME_DEFAULT,
-            steps_complete=["enable"],
-        )
-        state.save()
-    else:
-        console.print(
-            "[dim]Resuming bootstrap from a previous run...[/dim]"
-        )
-
-    if "permission_set" not in state.steps_complete:
-        permission_set_name = _step_create_permission_set()
-        state.permission_set_name = permission_set_name
-        state.steps_complete.append("permission_set")
-        state.save()
-
-    if "assign" not in state.steps_complete:
-        _step_assign_user(state.permission_set_name)
-        state.steps_complete.append("assign")
-        state.save()
+    Each step's effect on AWS (Identity Center enabled, user created,
+    permission set created, user assigned) persists in AWS regardless
+    of whether the CLI exits. So if the user Ctrl-Cs partway through,
+    re-running `lablink login` simply walks them through the same
+    console steps again — they confirm what's already there and paste
+    the URL once more. No local state needs to be remembered.
+    """
+    start_url, sso_region = _step_enable_identity_center()
+    permission_set_name = _step_create_permission_set()
+    _step_assign_user(permission_set_name)
 
     result = SSOBootstrapResult(
-        start_url=state.sso_start_url,
-        sso_region=state.sso_region,
-        permission_set_name=state.permission_set_name,
+        start_url=start_url,
+        sso_region=sso_region,
+        permission_set_name=permission_set_name,
         deployment_region=deployment_region,
     )
     _write_aws_config(result)
-    BootstrapState.clear()
     return result

--- a/packages/cli/src/lablink_cli/auth/bootstrap.py
+++ b/packages/cli/src/lablink_cli/auth/bootstrap.py
@@ -105,48 +105,61 @@ def _step_enable_identity_center() -> tuple[str, str]:
     """Walk the user through enabling Identity Center. Returns (start_url, region)."""
     console.print(
         Panel(
-            "Welcome to LabLink. It looks like this is your first login.\n"
-            "Setup takes about 5 minutes and only happens once.\n\n"
-            "You will:\n"
-            "  1. Enable AWS Identity Center in your AWS account\n"
-            "  2. Create yourself a user (your name, email, password)\n"
-            "  3. Attach the LabLink permission set to your user\n\n"
-            "You'll need an authenticator app on your phone (Authy, Google\n"
-            "Authenticator, 1Password) for the password setup step — Identity\n"
-            "Center enforces MFA.",
+            "Welcome to LabLink. This is your first sign-in.\n\n"
+            "We'll set up an AWS sign-in for you so the CLI can deploy lab\n"
+            "infrastructure on your behalf — no access keys, no copy-pasting\n"
+            "secrets. You'll sign in through your browser each session.\n\n"
+            "First-time setup takes [bold]10–15 minutes[/bold]. You'll do "
+            "three things in the AWS web console:\n\n"
+            "  [bold]1.[/bold] Turn on AWS's sign-in service "
+            "(it's called [italic]Identity Center[/italic])\n"
+            "  [bold]2.[/bold] Create a sign-in for yourself "
+            "(name, email, password)\n"
+            "  [bold]3.[/bold] Grant your sign-in permission to run lablink\n\n"
+            "[bold yellow]Before you continue:[/bold yellow] install an "
+            "authenticator app on your phone\n"
+            "(Authy, Google Authenticator, 1Password, or similar). AWS "
+            "requires\ntwo-factor authentication and you'll pair the app "
+            "partway through.",
             title="First-time setup",
             border_style="cyan",
         )
     )
-    input("Press Enter to open the AWS Console in your browser...")
+    input("Press Enter when you're ready to open the AWS Console...")
     webbrowser.open(IDENTITY_CENTER_CONSOLE_URL)
 
     console.print(
-        "\nIn the AWS Console:\n"
+        "\n[bold]Step 1 of 3: Turn on the AWS sign-in service[/bold]\n"
+        "In the AWS Console tab that just opened:\n"
         "  1. Click [bold]Enable[/bold]. (If asked, choose "
-        "[bold]account instance[/bold] for personal accounts — either works.)\n"
-        "  2. Wait ~30 seconds for it to provision.\n"
+        "[bold]account instance[/bold] for personal accounts.)\n"
+        "  2. Wait ~30 seconds while AWS sets things up.\n"
         "  3. In the left sidebar, click [bold]Users[/bold] → "
         "[bold]Add user[/bold].\n"
-        "  4. Fill in your name + email and submit.\n"
-        "  5. Check your email for the [bold]Accept invitation[/bold] link; "
-        "set a password and MFA.\n"
-        "  6. Return to the Identity Center home (the page you opened in step 1).\n"
-        "  7. Copy the [bold]SSO Start URL[/bold] from the "
-        "[bold]AWS access portal URLs[/bold] section on the dashboard.\n"
+        "  4. Fill in your name and email, then submit.\n"
+        "  5. Check your email for an [bold]Accept invitation[/bold] link. "
+        "Click it,\n"
+        "     set a password, and pair your authenticator app.\n"
+        "  6. Return to the Identity Center home page (the page you opened "
+        "in step 1).\n"
+        "  7. On the dashboard, find the [bold]AWS access portal URLs[/bold] "
+        "section\n"
+        "     and copy the link shown there — we'll call this your "
+        "[bold]sign-in link[/bold]\n"
+        "     (AWS labels it the [italic]SSO Start URL[/italic]).\n"
     )
 
     while True:
-        start_url = typer.prompt("SSO Start URL")
+        start_url = typer.prompt("Paste your sign-in link here")
         if _is_valid_sso_start_url(start_url):
             break
         console.print(
-            "[red]That doesn't look like an SSO Start URL.[/red] "
-            "Expected something like https://d-9067abc123.awsapps.com/start"
+            "[red]That doesn't look like an AWS sign-in link.[/red] "
+            "Expected something like [dim]https://d-9067abc123.awsapps.com/start[/dim]"
         )
 
     sso_region = typer.prompt(
-        "AWS region where Identity Center is enabled",
+        "AWS region (shown in the top-right corner of the AWS Console)",
         default="us-east-1",
     )
     return start_url.strip(), sso_region.strip()

--- a/packages/cli/src/lablink_cli/auth/credentials.py
+++ b/packages/cli/src/lablink_cli/auth/credentials.py
@@ -78,10 +78,10 @@ def _read_sso_start_url() -> str | None:
 
 def _token_is_valid() -> bool:
     """Return True if the cached SSO token exists and has not expired."""
-    start_url = _read_sso_start_url()
-    if start_url is None:
+    if _read_sso_start_url() is None:
+        # No [sso-session lablink] block → no cache to check.
         return False
-    cache_path = sso_cache_path(start_url)
+    cache_path = sso_cache_path(SSO_SESSION_NAME)
     if not cache_path.exists():
         return False
     try:

--- a/packages/cli/src/lablink_cli/auth/credentials.py
+++ b/packages/cli/src/lablink_cli/auth/credentials.py
@@ -38,7 +38,8 @@ class SSOTokenExpiredError(AuthError):
     """SSO token exists but is past expiresAt."""
 
 
-def _has_sso_profile() -> bool:
+def has_sso_profile() -> bool:
+    """Return True if ~/.aws/config has a [profile lablink] block."""
     cfg_path = aws_config_path()
     if not cfg_path.exists():
         return False
@@ -101,7 +102,7 @@ def _token_is_valid() -> bool:
 
 def is_logged_in() -> bool:
     """Return True if a valid SSO token cache is present."""
-    if not _has_sso_profile():
+    if not has_sso_profile():
         return False
     return _token_is_valid()
 
@@ -113,7 +114,7 @@ def get_session(region: str | None = None) -> boto3.Session:
         NotLoggedInError: when no SSO profile, env vars, or default creds exist.
         SSOTokenExpiredError: when the SSO profile exists but its token is expired.
     """
-    if _has_sso_profile():
+    if has_sso_profile():
         if not _token_is_valid():
             raise SSOTokenExpiredError(
                 "Your AWS session has expired. Run `lablink login` and try again."
@@ -139,6 +140,6 @@ def subprocess_env() -> dict[str, str]:
     ~/.aws/credentials), do nothing — those mechanisms work without help.
     """
     env = os.environ.copy()
-    if _has_sso_profile():
+    if has_sso_profile():
         env["AWS_PROFILE"] = PROFILE_NAME
     return env

--- a/packages/cli/src/lablink_cli/auth/credentials.py
+++ b/packages/cli/src/lablink_cli/auth/credentials.py
@@ -1,0 +1,129 @@
+"""LabLink AWS credential resolution.
+
+Resolution order:
+  1. Identity Center profile `lablink` from ~/.aws/config (preferred)
+  2. AWS_ACCESS_KEY_ID + AWS_SECRET_ACCESS_KEY environment variables
+  3. ~/.aws/credentials default profile
+  4. Fail with NotLoggedInError pointing at `lablink login`
+"""
+
+from __future__ import annotations
+
+import configparser
+import datetime as dt
+import json
+import os
+
+import boto3
+
+from lablink_cli.auth.utils import (
+    aws_config_path,
+    aws_credentials_path,
+    sso_cache_path,
+)
+
+PROFILE_NAME = "lablink"
+SSO_SESSION_NAME = "lablink"
+
+
+class AuthError(Exception):
+    """Base class for lablink auth errors."""
+
+
+class NotLoggedInError(AuthError):
+    """No usable AWS credentials found."""
+
+
+class SSOTokenExpiredError(AuthError):
+    """SSO token exists but is past expiresAt."""
+
+
+def _has_sso_profile() -> bool:
+    cfg_path = aws_config_path()
+    if not cfg_path.exists():
+        return False
+    parser = configparser.ConfigParser()
+    parser.read(cfg_path)
+    return f"profile {PROFILE_NAME}" in parser.sections()
+
+
+def _has_env_credentials() -> bool:
+    return bool(
+        os.environ.get("AWS_ACCESS_KEY_ID")
+        and os.environ.get("AWS_SECRET_ACCESS_KEY")
+    )
+
+
+def _has_default_credentials_file() -> bool:
+    """Return True if ~/.aws/credentials exists with a usable default profile."""
+    creds_path = aws_credentials_path()
+    if not creds_path.exists():
+        return False
+    parser = configparser.ConfigParser()
+    parser.read(creds_path)
+    return "default" in parser.sections()
+
+
+def _read_sso_start_url() -> str | None:
+    cfg_path = aws_config_path()
+    if not cfg_path.exists():
+        return None
+    parser = configparser.ConfigParser()
+    parser.read(cfg_path)
+    section = f"sso-session {SSO_SESSION_NAME}"
+    if section not in parser.sections():
+        return None
+    return parser.get(section, "sso_start_url", fallback=None)
+
+
+def _token_is_valid() -> bool:
+    """Return True if the cached SSO token exists and has not expired."""
+    start_url = _read_sso_start_url()
+    if start_url is None:
+        return False
+    cache_path = sso_cache_path(start_url)
+    if not cache_path.exists():
+        return False
+    try:
+        data = json.loads(cache_path.read_text())
+    except (OSError, json.JSONDecodeError):
+        return False
+    expires_at = data.get("expiresAt")
+    if not expires_at:
+        return False
+    try:
+        # AWS writes UTC ISO-8601 with "Z" suffix.
+        expiry = dt.datetime.fromisoformat(expires_at.replace("Z", "+00:00"))
+    except ValueError:
+        return False
+    return expiry > dt.datetime.now(dt.timezone.utc)
+
+
+def is_logged_in() -> bool:
+    """Return True if a valid SSO token cache is present."""
+    if not _has_sso_profile():
+        return False
+    return _token_is_valid()
+
+
+def get_session(region: str | None = None) -> boto3.Session:
+    """Resolve AWS credentials and return a boto3.Session.
+
+    Raises:
+        NotLoggedInError: when no SSO profile, env vars, or default creds exist.
+        SSOTokenExpiredError: when the SSO profile exists but its token is expired.
+    """
+    if _has_sso_profile():
+        if not _token_is_valid():
+            raise SSOTokenExpiredError(
+                "Your AWS session has expired. Run `lablink login` and try again."
+            )
+        return boto3.Session(profile_name=PROFILE_NAME, region_name=region)
+
+    if _has_env_credentials() or _has_default_credentials_file():
+        return boto3.Session(region_name=region)
+
+    raise NotLoggedInError(
+        "No AWS credentials found. Run `lablink login` to sign in via "
+        "AWS Identity Center."
+    )

--- a/packages/cli/src/lablink_cli/auth/credentials.py
+++ b/packages/cli/src/lablink_cli/auth/credentials.py
@@ -127,3 +127,18 @@ def get_session(region: str | None = None) -> boto3.Session:
         "No AWS credentials found. Run `lablink login` to sign in via "
         "AWS Identity Center."
     )
+
+
+def subprocess_env() -> dict[str, str]:
+    """Build env vars for subprocesses (e.g. terraform) that need AWS credentials.
+
+    Tools like Terraform's S3 backend don't auto-detect SSO profiles from
+    ~/.aws/config — they only check env vars, ~/.aws/credentials, and IMDS.
+    When the lablink SSO profile exists, set AWS_PROFILE=lablink so Terraform
+    picks it up. When the user is on legacy access-key creds (env vars or
+    ~/.aws/credentials), do nothing — those mechanisms work without help.
+    """
+    env = os.environ.copy()
+    if _has_sso_profile():
+        env["AWS_PROFILE"] = PROFILE_NAME
+    return env

--- a/packages/cli/src/lablink_cli/auth/policy.py
+++ b/packages/cli/src/lablink_cli/auth/policy.py
@@ -1,0 +1,99 @@
+"""LabLink permission set — single source of truth.
+
+The contents here are what `lablink login` displays during the
+first-time Identity Center bootstrap and what `lablink doctor` audits
+against the live SSO session.
+
+When `lablink-template` adds a Terraform resource that needs a service
+not currently in MANAGED_POLICY_ARNS or INLINE_POLICY, update this
+file. `lablink doctor` will flag the gap; the operator runs
+`lablink login --update-policy` to refresh their permission set.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+# AWS-managed policies attached to the lablink permission set.
+# Each maps to one or more Terraform resource types in
+# lablink-template/lablink-infrastructure/*.tf.
+MANAGED_POLICY_ARNS: list[str] = [
+    "arn:aws:iam::aws:policy/AmazonEC2FullAccess",
+    "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess",
+    "arn:aws:iam::aws:policy/AmazonRoute53FullAccess",
+    "arn:aws:iam::aws:policy/IAMFullAccess",
+    "arn:aws:iam::aws:policy/CloudWatchFullAccess",
+    "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess",
+    "arn:aws:iam::aws:policy/AWSCloudTrail_FullAccess",
+    "arn:aws:iam::aws:policy/AmazonSNSFullAccess",
+]
+
+# Inline policy attached to the same permission set, scoping
+# resource-level access where AWS supports it.
+INLINE_POLICY: dict[str, Any] = {
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "STS",
+            "Effect": "Allow",
+            "Action": ["sts:GetCallerIdentity"],
+            "Resource": "*",
+        },
+        {
+            "Sid": "TerraformStateBucket",
+            "Effect": "Allow",
+            "Action": ["s3:*"],
+            "Resource": [
+                "arn:aws:s3:::lablink-tf-state-*",
+                "arn:aws:s3:::lablink-tf-state-*/*",
+            ],
+        },
+        {
+            "Sid": "CloudTrailLogsBucket",
+            "Effect": "Allow",
+            "Action": ["s3:*"],
+            "Resource": [
+                "arn:aws:s3:::*-cloudtrail-bucket-*",
+                "arn:aws:s3:::*-cloudtrail-bucket-*/*",
+            ],
+        },
+        {
+            "Sid": "TerraformLockTable",
+            "Effect": "Allow",
+            "Action": ["dynamodb:*"],
+            "Resource": "arn:aws:dynamodb:*:*:table/lock-table",
+        },
+        {
+            "Sid": "Budgets",
+            "Effect": "Allow",
+            "Action": ["budgets:*"],
+            "Resource": "*",
+        },
+    ],
+}
+
+# Representative read-only actions used by `lablink doctor` to dry-run
+# the live permission set via iam.simulate_principal_policy. One per
+# managed policy + one per inline statement.
+AUDIT_ACTIONS: list[str] = [
+    "ec2:DescribeInstances",
+    "elasticloadbalancing:DescribeLoadBalancers",
+    "route53:ListHostedZones",
+    "iam:GetRole",
+    "cloudwatch:DescribeAlarms",
+    "logs:DescribeLogGroups",
+    "cloudtrail:DescribeTrails",
+    "sns:ListTopics",
+    "sts:GetCallerIdentity",
+    "s3:ListBucket",
+    "dynamodb:DescribeTable",
+    "budgets:DescribeBudgets",
+]
+
+PERMISSION_SET_NAME_DEFAULT = "lablink"
+
+
+def render_inline_policy_json() -> str:
+    """Return the inline policy as a pretty-printed JSON string for clipboard."""
+    return json.dumps(INLINE_POLICY, indent=2)

--- a/packages/cli/src/lablink_cli/auth/policy.py
+++ b/packages/cli/src/lablink_cli/auth/policy.py
@@ -91,6 +91,20 @@ AUDIT_ACTIONS: list[str] = [
     "budgets:DescribeBudgets",
 ]
 
+# Resource overrides for actions whose inline policy entries are scoped
+# to specific resources. simulate_principal_policy without ResourceArns
+# evaluates against "*", which would falsely report scoped actions as
+# denied. For these, the audit must simulate against the actual resource.
+AUDIT_RESOURCE_OVERRIDES: dict[str, list[str]] = {
+    "s3:ListBucket": [
+        "arn:aws:s3:::lablink-tf-state-*",
+        "arn:aws:s3:::*-cloudtrail-bucket-*",
+    ],
+    "dynamodb:DescribeTable": [
+        "arn:aws:dynamodb:*:*:table/lock-table",
+    ],
+}
+
 PERMISSION_SET_NAME_DEFAULT = "lablink"
 
 

--- a/packages/cli/src/lablink_cli/auth/policy.py
+++ b/packages/cli/src/lablink_cli/auth/policy.py
@@ -105,6 +105,25 @@ AUDIT_RESOURCE_OVERRIDES: dict[str, list[str]] = {
     ],
 }
 
+# Maps each audit action back to the policy that grants it. Used by the
+# post-login verifier so we can report "missing CloudWatchFullAccess"
+# instead of "missing cloudwatch:DescribeAlarms". Inline-policy actions
+# map to the literal "<inline>" sentinel.
+ACTION_TO_POLICY_NAME: dict[str, str] = {
+    "ec2:DescribeInstances": "AmazonEC2FullAccess",
+    "elasticloadbalancing:DescribeLoadBalancers": "ElasticLoadBalancingFullAccess",
+    "route53:ListHostedZones": "AmazonRoute53FullAccess",
+    "iam:GetRole": "IAMFullAccess",
+    "cloudwatch:DescribeAlarms": "CloudWatchFullAccess",
+    "logs:DescribeLogGroups": "CloudWatchLogsFullAccess",
+    "cloudtrail:DescribeTrails": "AWSCloudTrail_FullAccess",
+    "sns:ListTopics": "AmazonSNSFullAccess",
+    "sts:GetCallerIdentity": "<inline>",
+    "s3:ListBucket": "<inline>",
+    "dynamodb:DescribeTable": "<inline>",
+    "budgets:DescribeBudgets": "<inline>",
+}
+
 PERMISSION_SET_NAME_DEFAULT = "lablink"
 
 

--- a/packages/cli/src/lablink_cli/auth/sso_flow.py
+++ b/packages/cli/src/lablink_cli/auth/sso_flow.py
@@ -109,8 +109,16 @@ def select_account(*, sso_config: SSOConfig, access_token: str) -> str:
 
     if not accounts:
         raise credentials.AuthError(
-            "Your Identity Center user has no AWS accounts assigned. "
-            "Did you assign your user to an account during bootstrap?"
+            "Your Identity Center user has no AWS accounts assigned.\n"
+            "The 'Assign user to AWS account' step in the bootstrap was "
+            "skipped or didn't apply.\n"
+            "To fix:\n"
+            "  1. Open the AWS Identity Center console.\n"
+            "  2. Go to AWS accounts, select your account, click "
+            "'Assign users or groups'.\n"
+            "  3. Pick your user and the 'lablink' permission set, then "
+            "submit.\n"
+            "  4. Re-run `lablink login`."
         )
 
     if len(accounts) == 1:
@@ -147,8 +155,11 @@ def resolve_role(
 
     if not roles:
         raise credentials.AuthError(
-            "No permission sets are assigned to your user for this account. "
-            "Re-run bootstrap to assign one."
+            "No permission sets are assigned to your user for this account.\n"
+            "In the AWS Identity Center console, go to AWS accounts, select "
+            "your account, click 'Assign users or groups', and assign your "
+            "user with the 'lablink' permission set. Then re-run "
+            "`lablink login`."
         )
 
     if preferred_role_name:

--- a/packages/cli/src/lablink_cli/auth/sso_flow.py
+++ b/packages/cli/src/lablink_cli/auth/sso_flow.py
@@ -1,0 +1,172 @@
+"""SSO login by wrapping the official `aws sso login` command.
+
+We delegate the OIDC device-authorization flow to AWS CLI v2 rather
+than implementing it ourselves. AWS CLI is already a documented
+prerequisite for LabLink, so requiring it here doesn't add a new
+install burden, and the official tool handles edge cases (proxy
+config, MFA prompts, browser fallbacks) that we'd otherwise have to
+reproduce.
+
+After `aws sso login` finishes, this module reads the access token
+that AWS CLI cached at ~/.aws/sso/cache/<sha1>.json and uses it with
+boto3 sso clients to discover the user's accounts and permission sets.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import subprocess
+from dataclasses import dataclass
+
+import boto3
+import typer
+from rich.console import Console
+
+from lablink_cli.auth import credentials
+from lablink_cli.auth.utils import sso_cache_path
+
+console = Console()
+
+AWS_CLI_INSTALL_URL = (
+    "https://docs.aws.amazon.com/cli/latest/userguide/getting-started-install.html"
+)
+
+
+@dataclass
+class SSOConfig:
+    start_url: str
+    region: str
+
+
+class AWSCLINotFoundError(credentials.AuthError):
+    """AWS CLI v2 is required but not installed."""
+
+
+class LoginFailedError(credentials.AuthError):
+    """`aws sso login` exited non-zero or didn't produce a cached token."""
+
+
+def _ensure_aws_cli_installed() -> None:
+    """Raise AWSCLINotFoundError if `aws` is not on PATH."""
+    if shutil.which("aws") is None:
+        raise AWSCLINotFoundError(
+            "AWS CLI v2 is required for `lablink login`.\n"
+            f"Install it from {AWS_CLI_INSTALL_URL}"
+        )
+
+
+def _read_cached_access_token(start_url: str) -> str:
+    """Read the SSO access token AWS CLI cached after `aws sso login`."""
+    cache_path = sso_cache_path(start_url)
+    if not cache_path.exists():
+        raise LoginFailedError(
+            f"Expected SSO token cache at {cache_path} but it does not exist. "
+            "Did `aws sso login` complete successfully?"
+        )
+    try:
+        data = json.loads(cache_path.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        raise LoginFailedError(
+            f"Could not read SSO token cache at {cache_path}: {e}"
+        ) from e
+    token = data.get("accessToken")
+    if not token:
+        raise LoginFailedError(
+            f"SSO token cache at {cache_path} has no accessToken field."
+        )
+    return token
+
+
+def login(sso_config: SSOConfig) -> str:
+    """Run `aws sso login --sso-session lablink` and return the cached token.
+
+    Raises:
+        AWSCLINotFoundError: when the `aws` binary is not on PATH.
+        LoginFailedError: when `aws sso login` exits non-zero or doesn't
+            produce a readable cached token.
+    """
+    _ensure_aws_cli_installed()
+
+    console.print("\n[dim]Running `aws sso login --sso-session lablink`...[/dim]")
+    result = subprocess.run(
+        ["aws", "sso", "login", "--sso-session", "lablink"],
+        check=False,
+    )
+    if result.returncode != 0:
+        raise LoginFailedError(
+            f"`aws sso login` failed with exit code {result.returncode}."
+        )
+
+    return _read_cached_access_token(sso_config.start_url)
+
+
+def select_account(*, sso_config: SSOConfig, access_token: str) -> str:
+    """Pick the AWS account to use. Auto-selects when only one is visible."""
+    sso = boto3.client("sso", region_name=sso_config.region)
+    accounts = sso.list_accounts(accessToken=access_token).get("accountList", [])
+
+    if not accounts:
+        raise credentials.AuthError(
+            "Your Identity Center user has no AWS accounts assigned. "
+            "Did you assign your user to an account during bootstrap?"
+        )
+
+    if len(accounts) == 1:
+        return accounts[0]["accountId"]
+
+    console.print("\nMultiple AWS accounts available. Choose one:")
+    for i, acct in enumerate(accounts, start=1):
+        console.print(
+            f"  [bold]{i}[/bold]. {acct['accountName']} ({acct['accountId']})"
+        )
+    while True:
+        choice = typer.prompt("Account number")
+        try:
+            idx = int(choice)
+            if 1 <= idx <= len(accounts):
+                return accounts[idx - 1]["accountId"]
+        except ValueError:
+            pass
+        console.print("[red]Invalid choice. Try again.[/red]")
+
+
+def resolve_role(
+    *,
+    sso_config: SSOConfig,
+    access_token: str,
+    account_id: str,
+    preferred_role_name: str | None = None,
+) -> str:
+    """Pick the role/permission-set to use within the chosen account."""
+    sso = boto3.client("sso", region_name=sso_config.region)
+    roles = sso.list_account_roles(
+        accessToken=access_token, accountId=account_id
+    ).get("roleList", [])
+
+    if not roles:
+        raise credentials.AuthError(
+            "No permission sets are assigned to your user for this account. "
+            "Re-run bootstrap to assign one."
+        )
+
+    if preferred_role_name:
+        for r in roles:
+            if r["roleName"] == preferred_role_name:
+                return preferred_role_name
+
+    if len(roles) == 1:
+        return roles[0]["roleName"]
+
+    console.print("\nMultiple permission sets available. Choose one:")
+    for i, role in enumerate(roles, start=1):
+        console.print(f"  [bold]{i}[/bold]. {role['roleName']}")
+    while True:
+        choice = typer.prompt("Permission set number")
+        try:
+            idx = int(choice)
+            if 1 <= idx <= len(roles):
+                return roles[idx - 1]["roleName"]
+        except ValueError:
+            pass
+        console.print("[red]Invalid choice. Try again.[/red]")

--- a/packages/cli/src/lablink_cli/auth/sso_flow.py
+++ b/packages/cli/src/lablink_cli/auth/sso_flow.py
@@ -24,6 +24,7 @@ import typer
 from rich.console import Console
 
 from lablink_cli.auth import credentials
+from lablink_cli.auth.credentials import SSO_SESSION_NAME
 from lablink_cli.auth.utils import sso_cache_path
 
 console = Console()
@@ -56,9 +57,9 @@ def _ensure_aws_cli_installed() -> None:
         )
 
 
-def _read_cached_access_token(start_url: str) -> str:
+def _read_cached_access_token() -> str:
     """Read the SSO access token AWS CLI cached after `aws sso login`."""
-    cache_path = sso_cache_path(start_url)
+    cache_path = sso_cache_path(SSO_SESSION_NAME)
     if not cache_path.exists():
         raise LoginFailedError(
             f"Expected SSO token cache at {cache_path} but it does not exist. "
@@ -98,7 +99,7 @@ def login(sso_config: SSOConfig) -> str:
             f"`aws sso login` failed with exit code {result.returncode}."
         )
 
-    return _read_cached_access_token(sso_config.start_url)
+    return _read_cached_access_token()
 
 
 def select_account(*, sso_config: SSOConfig, access_token: str) -> str:

--- a/packages/cli/src/lablink_cli/auth/sso_flow.py
+++ b/packages/cli/src/lablink_cli/auth/sso_flow.py
@@ -116,7 +116,7 @@ def select_account(*, sso_config: SSOConfig, access_token: str) -> str:
             "  1. Open the AWS Identity Center console.\n"
             "  2. Go to AWS accounts, select your account, click "
             "'Assign users or groups'.\n"
-            "  3. Pick your user and the 'lablink' permission set, then "
+            "  3. Pick your user and the correct permission set, then "
             "submit.\n"
             "  4. Re-run `lablink login`."
         )

--- a/packages/cli/src/lablink_cli/auth/utils.py
+++ b/packages/cli/src/lablink_cli/auth/utils.py
@@ -26,8 +26,14 @@ def aws_credentials_path() -> Path:
     return Path(os.environ.get("HOME", str(Path.home()))) / ".aws" / "credentials"
 
 
-def sso_cache_path(start_url: str) -> Path:
-    """Return the AWS-CLI-compatible cache path for an SSO access token."""
+def sso_cache_path(sso_session_name: str) -> Path:
+    """Return the AWS-CLI-compatible cache path for an SSO access token.
+
+    AWS CLI v2 hashes the sso-session name (modern `[sso-session NAME]`
+    config) to derive the cache filename, not the start URL. Earlier
+    legacy configs used the start URL — but since we always write
+    `[sso-session lablink]` blocks, we always pass the session name.
+    """
     home = Path(os.environ.get("HOME", str(Path.home())))
-    digest = hashlib.sha1(start_url.encode("utf-8")).hexdigest()
+    digest = hashlib.sha1(sso_session_name.encode("utf-8")).hexdigest()
     return home / ".aws" / "sso" / "cache" / f"{digest}.json"

--- a/packages/cli/src/lablink_cli/auth/utils.py
+++ b/packages/cli/src/lablink_cli/auth/utils.py
@@ -22,7 +22,14 @@ def aws_config_path() -> Path:
 
 
 def aws_credentials_path() -> Path:
-    """Return the path to ~/.aws/credentials."""
+    """Return the path to ~/.aws/credentials, honoring AWS_SHARED_CREDENTIALS_FILE.
+
+    Matches boto3 / AWS CLI v2 resolution: the env var, when set, points at
+    the credentials file directly; otherwise fall back to ``$HOME/.aws/credentials``.
+    """
+    explicit = os.environ.get("AWS_SHARED_CREDENTIALS_FILE")
+    if explicit:
+        return Path(explicit)
     return Path(os.environ.get("HOME", str(Path.home()))) / ".aws" / "credentials"
 
 

--- a/packages/cli/src/lablink_cli/auth/utils.py
+++ b/packages/cli/src/lablink_cli/auth/utils.py
@@ -1,0 +1,33 @@
+"""Shared path/utility helpers for the auth module.
+
+Resolves locations of AWS CLI-compatible config and SSO token caches
+in one place so other auth modules (credentials, sso_flow, bootstrap,
+login) can read and write the same files without redefining the
+resolution logic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from pathlib import Path
+
+
+def aws_config_path() -> Path:
+    """Return the path to ~/.aws/config, honoring AWS_CONFIG_FILE."""
+    explicit = os.environ.get("AWS_CONFIG_FILE")
+    if explicit:
+        return Path(explicit)
+    return Path(os.environ.get("HOME", str(Path.home()))) / ".aws" / "config"
+
+
+def aws_credentials_path() -> Path:
+    """Return the path to ~/.aws/credentials."""
+    return Path(os.environ.get("HOME", str(Path.home()))) / ".aws" / "credentials"
+
+
+def sso_cache_path(start_url: str) -> Path:
+    """Return the AWS-CLI-compatible cache path for an SSO access token."""
+    home = Path(os.environ.get("HOME", str(Path.home())))
+    digest = hashlib.sha1(start_url.encode("utf-8")).hexdigest()
+    return home / ".aws" / "sso" / "cache" / f"{digest}.json"

--- a/packages/cli/src/lablink_cli/commands/cleanup.py
+++ b/packages/cli/src/lablink_cli/commands/cleanup.py
@@ -11,8 +11,8 @@ from rich.panel import Panel
 
 from lablink_allocator_service.conf.structured_config import Config
 
+from lablink_cli.auth.credentials import get_session
 from lablink_cli.commands.setup import (
-    _get_session,
     check_credentials,
     resolve_bucket_name,
 )
@@ -481,7 +481,7 @@ def run_cleanup(
     )
     console.print()
 
-    session = _get_session(region)
+    session = get_session(region=region)
     check_credentials(session)
     ec2 = session.client("ec2")
 

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -13,7 +13,8 @@ from rich.panel import Panel
 
 from lablink_allocator_service.conf.structured_config import Config
 
-from lablink_cli.commands.setup import check_credentials, _get_session
+from lablink_cli.auth.credentials import get_session
+from lablink_cli.commands.setup import check_credentials
 from lablink_cli.commands.status import check_health_endpoint
 from lablink_cli.commands.utils import (
     get_allocator_url,
@@ -166,12 +167,11 @@ def _terraform_init(
     reconfigure = (deploy_dir / ".terraform").exists()
 
     # Resolve bucket name from AWS account
-    import boto3
+    from lablink_cli.auth.credentials import get_session
 
     account_id = (
-        boto3.client(
-            "sts", region_name=cfg.app.region
-        )
+        get_session(region=cfg.app.region)
+        .client("sts")
         .get_caller_identity()["Account"]
     )
     bucket_name = f"lablink-tf-state-{account_id}"
@@ -308,7 +308,7 @@ def run_deploy(
     console.print()
 
     # Validate AWS credentials
-    check_credentials(_get_session(cfg.app.region))
+    check_credentials(get_session(region=cfg.app.region))
 
     # Prepare working directory
     deploy_dir = _prepare_working_dir(
@@ -654,7 +654,7 @@ def _terraform_destroy(
 
 def run_destroy(cfg: Config, *, yes: bool = False) -> None:
     """Destroy LabLink infrastructure. ``yes=True`` skips confirmation prompts."""
-    check_credentials(_get_session(cfg.app.region))
+    check_credentials(get_session(region=cfg.app.region))
 
     deploy_dir = get_deploy_dir(cfg)
 

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -124,6 +124,8 @@ def _run_terraform(
     check: bool = True,
 ) -> int:
     """Run a terraform command with live-streamed output."""
+    from lablink_cli.auth.credentials import subprocess_env
+
     cmd = ["terraform"] + args
     console.print(
         f"  [dim]$ {' '.join(cmd)}[/dim]"
@@ -132,6 +134,7 @@ def _run_terraform(
     proc = subprocess.Popen(
         cmd,
         cwd=cwd,
+        env=subprocess_env(),
         stdout=subprocess.PIPE,
         stderr=subprocess.STDOUT,
         text=True,

--- a/packages/cli/src/lablink_cli/commands/doctor.py
+++ b/packages/cli/src/lablink_cli/commands/doctor.py
@@ -126,7 +126,7 @@ def _check_lablink_permissions(region: str | None) -> dict:
         NotLoggedInError,
         SSOTokenExpiredError,
     )
-    from lablink_cli.auth.policy import AUDIT_ACTIONS
+    from lablink_cli.auth.policy import AUDIT_ACTIONS, AUDIT_RESOURCE_OVERRIDES
 
     result = {"check": "LabLink permissions", "status": "fail"}
     try:
@@ -159,13 +159,35 @@ def _check_lablink_permissions(region: str | None) -> dict:
         )
 
         iam = session.client("iam")
-        evaluation = iam.simulate_principal_policy(
-            PolicySourceArn=principal_arn,
-            ActionNames=AUDIT_ACTIONS,
-        )
+
+        # Group actions by resource scope so we can simulate scoped
+        # actions against their actual resources (otherwise AWS evaluates
+        # them against "*" and falsely reports them as denied).
+        unscoped_actions = [
+            a for a in AUDIT_ACTIONS if a not in AUDIT_RESOURCE_OVERRIDES
+        ]
+        eval_results = []
+        if unscoped_actions:
+            eval_results.extend(
+                iam.simulate_principal_policy(
+                    PolicySourceArn=principal_arn,
+                    ActionNames=unscoped_actions,
+                ).get("EvaluationResults", [])
+            )
+        for action, resource_arns in AUDIT_RESOURCE_OVERRIDES.items():
+            if action not in AUDIT_ACTIONS:
+                continue
+            eval_results.extend(
+                iam.simulate_principal_policy(
+                    PolicySourceArn=principal_arn,
+                    ActionNames=[action],
+                    ResourceArns=resource_arns,
+                ).get("EvaluationResults", [])
+            )
+
         denied = [
             r["EvalActionName"]
-            for r in evaluation.get("EvaluationResults", [])
+            for r in eval_results
             if r.get("EvalDecision") != "allowed"
         ]
 

--- a/packages/cli/src/lablink_cli/commands/doctor.py
+++ b/packages/cli/src/lablink_cli/commands/doctor.py
@@ -63,30 +63,53 @@ def _check_terraform() -> dict:
 
 
 def _check_aws_credentials(region: str | None) -> dict:
-    """Check AWS credentials are valid."""
-    result = {"check": "AWS credentials", "status": "fail"}
+    """Check AWS credentials are valid.
 
+    Validates inline via sts:GetCallerIdentity rather than calling
+    setup.check_credentials, because the latter raises SystemExit on
+    failure — which would exit `lablink doctor` instead of continuing
+    with the remaining checks.
+    """
+    result = {"check": "AWS credentials", "status": "fail"}
     try:
-        from lablink_cli.commands.setup import (
-            _get_session,
-            check_credentials,
+        from botocore.exceptions import ClientError
+
+        from lablink_cli.auth.credentials import (
+            NotLoggedInError,
+            SSOTokenExpiredError,
+            get_session,
         )
 
-        session = _get_session(region or "us-east-1")
-        identity = check_credentials(session)
+        try:
+            session = get_session(region=region or "us-east-1")
+        except NotLoggedInError:
+            result["detail"] = (
+                "Not signed in. Run [bold]lablink login[/bold] to sign in "
+                "via AWS Identity Center."
+            )
+            return result
+        except SSOTokenExpiredError:
+            result["detail"] = (
+                "SSO session expired. Run [bold]lablink login[/bold] to "
+                "refresh."
+            )
+            return result
+
+        try:
+            identity = session.client("sts").get_caller_identity()
+        except ClientError as e:
+            result["detail"] = (
+                f"Credentials present but rejected by STS: {e}. "
+                "Run [bold]lablink login[/bold] to refresh."
+            )
+            return result
+
         result["status"] = "pass"
         result["detail"] = (
-            f"Account: {identity['account']}, "
-            f"Identity: {identity['arn']}"
-        )
-    except SystemExit:
-        result["detail"] = (
-            "Invalid or missing. Run 'aws configure' "
-            "or set AWS_ACCESS_KEY_ID / AWS_SECRET_ACCESS_KEY"
+            f"Account: {identity['Account']}, ARN: {identity['Arn']}"
         )
     except Exception as e:
-        result["detail"] = str(e)
-
+        result["detail"] = f"Unexpected error: {e}"
     return result
 
 
@@ -154,9 +177,9 @@ def _check_s3_bucket(cfg) -> dict:
         return result
 
     try:
-        from lablink_cli.commands.setup import _get_session
+        from lablink_cli.auth.credentials import get_session
 
-        session = _get_session(cfg.app.region)
+        session = get_session(region=cfg.app.region)
         s3 = session.client("s3")
         s3.head_bucket(Bucket=bucket_name)
         result["status"] = "pass"

--- a/packages/cli/src/lablink_cli/commands/doctor.py
+++ b/packages/cli/src/lablink_cli/commands/doctor.py
@@ -11,6 +11,8 @@ from rich.console import Console
 from rich.panel import Panel
 from rich.table import Table
 
+from lablink_cli.auth.credentials import get_session
+
 console = Console()
 
 DEFAULT_CONFIG = Path.home() / ".lablink" / "config.yaml"
@@ -77,7 +79,6 @@ def _check_aws_credentials(region: str | None) -> dict:
         from lablink_cli.auth.credentials import (
             NotLoggedInError,
             SSOTokenExpiredError,
-            get_session,
         )
 
         try:
@@ -111,6 +112,81 @@ def _check_aws_credentials(region: str | None) -> dict:
     except Exception as e:
         result["detail"] = f"Unexpected error: {e}"
     return result
+
+
+def _check_lablink_permissions(region: str | None) -> dict:
+    """Audit the live SSO role's permissions against AUDIT_ACTIONS.
+
+    Uses iam:SimulatePrincipalPolicy to dry-run each known lablink action
+    and report any denials with a hint to run `lablink login --update-policy`.
+    Marked 'warn' (skipped) when the caller isn't on a lablink Identity
+    Center role — env-var users haven't opted in to the permission audit.
+    """
+    from lablink_cli.auth.credentials import (
+        NotLoggedInError,
+        SSOTokenExpiredError,
+    )
+    from lablink_cli.auth.policy import AUDIT_ACTIONS
+
+    result = {"check": "LabLink permissions", "status": "fail"}
+    try:
+        try:
+            session = get_session(region=region or "us-east-1")
+        except (NotLoggedInError, SSOTokenExpiredError):
+            result["status"] = "warn"
+            result["detail"] = (
+                "Not signed in via Identity Center; skipping permission audit."
+            )
+            return result
+
+        identity = session.client("sts").get_caller_identity()
+        arn = identity.get("Arn", "")
+        if "assumed-role" not in arn or "lablink" not in arn.lower():
+            result["status"] = "warn"
+            result["detail"] = (
+                "Not on a lablink Identity Center role; "
+                "skipping permission audit."
+            )
+            return result
+
+        # Convert SSO assumed-role ARN to the underlying IAM role ARN:
+        # arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_lablink_HASH/USER
+        # → arn:aws:iam::ACCOUNT:role/AWSReservedSSO_lablink_HASH
+        principal_arn = (
+            arn.replace(":sts:", ":iam:")
+            .replace("assumed-role", "role")
+            .rsplit("/", 1)[0]
+        )
+
+        iam = session.client("iam")
+        evaluation = iam.simulate_principal_policy(
+            PolicySourceArn=principal_arn,
+            ActionNames=AUDIT_ACTIONS,
+        )
+        denied = [
+            r["EvalActionName"]
+            for r in evaluation.get("EvaluationResults", [])
+            if r.get("EvalDecision") != "allowed"
+        ]
+
+        if not denied:
+            result["status"] = "pass"
+            result["detail"] = (
+                f"All {len(AUDIT_ACTIONS)} required actions allowed."
+            )
+            return result
+
+        result["status"] = "fail"
+        result["detail"] = (
+            "Permission set is missing actions: "
+            + ", ".join(denied)
+            + ". Run [bold]lablink login --update-policy[/bold] to refresh."
+        )
+        return result
+    except Exception as e:
+        result["status"] = "warn"
+        result["detail"] = f"Permission audit unavailable: {e}"
+        return result
 
 
 def _check_config_exists() -> dict:
@@ -177,8 +253,6 @@ def _check_s3_bucket(cfg) -> dict:
         return result
 
     try:
-        from lablink_cli.auth.credentials import get_session
-
         session = get_session(region=cfg.app.region)
         s3 = session.client("s3")
         s3.head_bucket(Bucket=bucket_name)
@@ -249,10 +323,13 @@ def run_doctor() -> None:
     region = cfg.app.region if cfg else None
     checks.append(_check_aws_credentials(region))
 
-    # 5. S3 state bucket
+    # 5. LabLink permission audit (SSO users only)
+    checks.append(_check_lablink_permissions(region))
+
+    # 6. S3 state bucket
     checks.append(_check_s3_bucket(cfg))
 
-    # 6. AMI for region
+    # 7. AMI for region
     checks.append(_check_ami(cfg))
 
     # Display results

--- a/packages/cli/src/lablink_cli/commands/doctor.py
+++ b/packages/cli/src/lablink_cli/commands/doctor.py
@@ -258,6 +258,11 @@ def _check_config_valid() -> tuple[dict, object | None]:
 
 def _check_s3_bucket(cfg) -> dict:
     """Check that the S3 bucket for Terraform state exists."""
+    from lablink_cli.auth.credentials import (
+        NotLoggedInError,
+        SSOTokenExpiredError,
+    )
+
     result = {"check": "S3 state bucket", "status": "fail"}
 
     if cfg is None:
@@ -276,8 +281,13 @@ def _check_s3_bucket(cfg) -> dict:
 
     try:
         session = get_session(region=cfg.app.region)
-        s3 = session.client("s3")
-        s3.head_bucket(Bucket=bucket_name)
+    except (NotLoggedInError, SSOTokenExpiredError):
+        result["status"] = "warn"
+        result["detail"] = "Skipped (not signed in)"
+        return result
+
+    try:
+        session.client("s3").head_bucket(Bucket=bucket_name)
         result["status"] = "pass"
         result["detail"] = bucket_name
     except Exception:

--- a/packages/cli/src/lablink_cli/commands/login.py
+++ b/packages/cli/src/lablink_cli/commands/login.py
@@ -15,6 +15,7 @@ from rich.panel import Panel
 from lablink_cli.auth import policy
 from lablink_cli.auth.bootstrap import (
     CREATE_PERMISSION_SET_URL,
+    BootstrapState,
     SSOBootstrapResult,
     copy_to_clipboard,
     run_bootstrap,
@@ -125,6 +126,7 @@ def run_steady_state() -> None:
 def run_login(
     deployment_region: str | None = None,
     update_policy: bool = False,
+    reset_bootstrap: bool = False,
 ) -> None:
     """Top-level login orchestrator."""
     if update_policy:
@@ -142,6 +144,18 @@ def run_login(
         )
         webbrowser.open(CREATE_PERMISSION_SET_URL)
         return
+
+    if reset_bootstrap:
+        state_path = BootstrapState.path()
+        if state_path.exists():
+            BootstrapState.clear()
+            console.print(
+                f"[dim]Discarded in-progress bootstrap state at {state_path}.[/dim]"
+            )
+        else:
+            console.print(
+                "[dim]No in-progress bootstrap state to reset.[/dim]"
+            )
 
     if is_logged_in():
         expiry = _token_expiry_human()

--- a/packages/cli/src/lablink_cli/commands/login.py
+++ b/packages/cli/src/lablink_cli/commands/login.py
@@ -1,0 +1,172 @@
+"""`lablink login` — orchestrate Identity Center bootstrap + SSO sign-in."""
+
+from __future__ import annotations
+
+import configparser
+import datetime as dt
+import json
+import webbrowser
+
+import boto3
+import typer
+from rich.console import Console
+from rich.panel import Panel
+
+from lablink_cli.auth import policy
+from lablink_cli.auth.bootstrap import (
+    CREATE_PERMISSION_SET_URL,
+    SSOBootstrapResult,
+    _copy_to_clipboard,
+    run_bootstrap,
+)
+from lablink_cli.auth.credentials import (
+    PROFILE_NAME,
+    SSO_SESSION_NAME,
+    is_logged_in,
+)
+from lablink_cli.auth.sso_flow import (
+    SSOConfig,
+    login as sso_login,
+    resolve_role,
+    select_account,
+)
+from lablink_cli.auth.utils import aws_config_path, sso_cache_path
+
+console = Console()
+
+
+def _has_sso_profile() -> bool:
+    cfg_path = aws_config_path()
+    if not cfg_path.exists():
+        return False
+    parser = configparser.ConfigParser()
+    parser.read(cfg_path)
+    return f"profile {PROFILE_NAME}" in parser.sections()
+
+
+def _read_sso_config() -> SSOConfig:
+    parser = configparser.ConfigParser()
+    parser.read(aws_config_path())
+    section = f"sso-session {SSO_SESSION_NAME}"
+    return SSOConfig(
+        start_url=parser.get(section, "sso_start_url"),
+        region=parser.get(section, "sso_region"),
+    )
+
+
+def _read_profile_field(field: str) -> str | None:
+    parser = configparser.ConfigParser()
+    parser.read(aws_config_path())
+    section = f"profile {PROFILE_NAME}"
+    if section not in parser.sections():
+        return None
+    return parser.get(section, field, fallback=None)
+
+
+def _write_profile_field(field: str, value: str) -> None:
+    cfg_path = aws_config_path()
+    parser = configparser.ConfigParser()
+    parser.read(cfg_path)
+    section = f"profile {PROFILE_NAME}"
+    if section not in parser.sections():
+        parser.add_section(section)
+    parser.set(section, field, value)
+    with open(cfg_path, "w") as fp:
+        parser.write(fp)
+
+
+def _token_expiry_human() -> str:
+    """Return a human-readable 'in 4h 12m' for the cached SSO token."""
+    sso_config = _read_sso_config()
+    cache_path = sso_cache_path(sso_config.start_url)
+
+    try:
+        data = json.loads(cache_path.read_text())
+        expiry = dt.datetime.fromisoformat(
+            data["expiresAt"].replace("Z", "+00:00")
+        )
+    except (OSError, KeyError, ValueError):
+        return "unknown"
+
+    delta = expiry - dt.datetime.now(dt.timezone.utc)
+    seconds = max(0, int(delta.total_seconds()))
+    hours, rem = divmod(seconds, 3600)
+    minutes = rem // 60
+    return f"{hours}h {minutes}m"
+
+
+def run_steady_state() -> None:
+    """Run the SSO device-code flow against the existing [sso-session lablink]."""
+    sso_config = _read_sso_config()
+
+    access_token = sso_login(sso_config)
+
+    account_id = _read_profile_field("sso_account_id")
+    if not account_id:
+        account_id = select_account(
+            sso_config=sso_config, access_token=access_token
+        )
+        _write_profile_field("sso_account_id", account_id)
+
+    role = _read_profile_field("sso_role_name") or "lablink"
+    resolved_role = resolve_role(
+        sso_config=sso_config,
+        access_token=access_token,
+        account_id=account_id,
+        preferred_role_name=role,
+    )
+    if resolved_role != role:
+        _write_profile_field("sso_role_name", resolved_role)
+
+    sts = boto3.Session(profile_name=PROFILE_NAME).client("sts")
+    identity = sts.get_caller_identity()
+    expiry_human = _token_expiry_human()
+
+    console.print(
+        "\n[green]✓[/green] Signed in via Identity Center"
+    )
+    console.print(f"[green]✓[/green] AWS Account: [bold]{account_id}[/bold]")
+    console.print(f"[green]✓[/green] Permission set: [bold]{resolved_role}[/bold]")
+    console.print(f"[green]✓[/green] Token valid for: [bold]{expiry_human}[/bold]")
+    console.print(f"[dim]ARN: {identity.get('Arn', '')}[/dim]\n")
+
+
+def run_login(
+    deployment_region: str | None = None,
+    update_policy: bool = False,
+) -> None:
+    """Top-level login orchestrator."""
+    if update_policy:
+        payload = policy.render_inline_policy_json()
+        _copy_to_clipboard(payload)
+        console.print(
+            Panel(
+                "Permission set policy JSON copied to your clipboard.\n\n"
+                "Open the AWS Console, navigate to your [bold]lablink[/bold]\n"
+                "permission set, and replace its inline policy with the\n"
+                "clipboard contents.",
+                title="Update policy",
+                border_style="cyan",
+            )
+        )
+        webbrowser.open(CREATE_PERMISSION_SET_URL)
+        return
+
+    if is_logged_in():
+        expiry = _token_expiry_human()
+        console.print(
+            f"Already signed in, valid for [bold]{expiry}[/bold]."
+        )
+        if not typer.confirm("Re-login?", default=False):
+            return
+
+    if not _has_sso_profile():
+        result: SSOBootstrapResult = run_bootstrap(
+            deployment_region=deployment_region or "us-east-1"
+        )
+        console.print(
+            f"\n[green]✓[/green] Identity Center configured "
+            f"({result.start_url})\n"
+        )
+
+    run_steady_state()

--- a/packages/cli/src/lablink_cli/commands/login.py
+++ b/packages/cli/src/lablink_cli/commands/login.py
@@ -16,12 +16,13 @@ from lablink_cli.auth import policy
 from lablink_cli.auth.bootstrap import (
     CREATE_PERMISSION_SET_URL,
     SSOBootstrapResult,
-    _copy_to_clipboard,
+    copy_to_clipboard,
     run_bootstrap,
 )
 from lablink_cli.auth.credentials import (
     PROFILE_NAME,
     SSO_SESSION_NAME,
+    has_sso_profile,
     is_logged_in,
 )
 from lablink_cli.auth.sso_flow import (
@@ -33,15 +34,6 @@ from lablink_cli.auth.sso_flow import (
 from lablink_cli.auth.utils import aws_config_path, sso_cache_path
 
 console = Console()
-
-
-def _has_sso_profile() -> bool:
-    cfg_path = aws_config_path()
-    if not cfg_path.exists():
-        return False
-    parser = configparser.ConfigParser()
-    parser.read(cfg_path)
-    return f"profile {PROFILE_NAME}" in parser.sections()
 
 
 def _read_sso_config() -> SSOConfig:
@@ -137,7 +129,7 @@ def run_login(
     """Top-level login orchestrator."""
     if update_policy:
         payload = policy.render_inline_policy_json()
-        _copy_to_clipboard(payload)
+        copy_to_clipboard(payload)
         console.print(
             Panel(
                 "Permission set policy JSON copied to your clipboard.\n\n"
@@ -159,7 +151,7 @@ def run_login(
         if not typer.confirm("Re-login?", default=False):
             return
 
-    if not _has_sso_profile():
+    if not has_sso_profile():
         result: SSOBootstrapResult = run_bootstrap(
             deployment_region=deployment_region or "us-east-1"
         )

--- a/packages/cli/src/lablink_cli/commands/login.py
+++ b/packages/cli/src/lablink_cli/commands/login.py
@@ -77,8 +77,7 @@ def _write_profile_field(field: str, value: str) -> None:
 
 def _token_expiry_human() -> str:
     """Return a human-readable 'in 4h 12m' for the cached SSO token."""
-    sso_config = _read_sso_config()
-    cache_path = sso_cache_path(sso_config.start_url)
+    cache_path = sso_cache_path(SSO_SESSION_NAME)
 
     try:
         data = json.loads(cache_path.read_text())

--- a/packages/cli/src/lablink_cli/commands/login.py
+++ b/packages/cli/src/lablink_cli/commands/login.py
@@ -15,7 +15,6 @@ from rich.panel import Panel
 from lablink_cli.auth import policy
 from lablink_cli.auth.bootstrap import (
     CREATE_PERMISSION_SET_URL,
-    BootstrapState,
     SSOBootstrapResult,
     copy_to_clipboard,
     run_bootstrap,
@@ -126,7 +125,6 @@ def run_steady_state() -> None:
 def run_login(
     deployment_region: str | None = None,
     update_policy: bool = False,
-    reset_bootstrap: bool = False,
 ) -> None:
     """Top-level login orchestrator."""
     if update_policy:
@@ -136,7 +134,7 @@ def run_login(
             Panel(
                 "Permission set policy JSON copied to your clipboard.\n\n"
                 "Open the AWS Console, navigate to your [bold]lablink[/bold]\n"
-                "permission set, and repla  ce its inline policy with the\n"
+                "permission set, and replace its inline policy with the\n"
                 "clipboard contents.",
                 title="Update policy",
                 border_style="cyan",
@@ -144,18 +142,6 @@ def run_login(
         )
         webbrowser.open(CREATE_PERMISSION_SET_URL)
         return
-
-    if reset_bootstrap:
-        state_path = BootstrapState.path()
-        if state_path.exists():
-            BootstrapState.clear()
-            console.print(
-                f"[dim]Discarded in-progress bootstrap state at {state_path}.[/dim]"
-            )
-        else:
-            console.print(
-                "[dim]No in-progress bootstrap state to reset.[/dim]"
-            )
 
     if is_logged_in():
         expiry = _token_expiry_human()
@@ -166,9 +152,16 @@ def run_login(
             return
 
     if not has_sso_profile():
-        result: SSOBootstrapResult = run_bootstrap(
-            deployment_region=deployment_region or "us-east-1"
-        )
+        try:
+            result: SSOBootstrapResult = run_bootstrap(
+                deployment_region=deployment_region or "us-east-1"
+            )
+        except KeyboardInterrupt:
+            console.print(
+                "\n[yellow]Bootstrap interrupted.[/yellow] "
+                "Re-run [bold]lablink login[/bold] to start over."
+            )
+            raise typer.Exit(1) from None
         console.print(
             f"\n[green]✓[/green] Identity Center configured "
             f"({result.start_url})\n"

--- a/packages/cli/src/lablink_cli/commands/login.py
+++ b/packages/cli/src/lablink_cli/commands/login.py
@@ -136,7 +136,7 @@ def run_login(
             Panel(
                 "Permission set policy JSON copied to your clipboard.\n\n"
                 "Open the AWS Console, navigate to your [bold]lablink[/bold]\n"
-                "permission set, and replace its inline policy with the\n"
+                "permission set, and repla  ce its inline policy with the\n"
                 "clipboard contents.",
                 title="Update policy",
                 border_style="cyan",

--- a/packages/cli/src/lablink_cli/commands/login.py
+++ b/packages/cli/src/lablink_cli/commands/login.py
@@ -122,9 +122,124 @@ def run_steady_state() -> None:
     console.print(f"[dim]ARN: {identity.get('Arn', '')}[/dim]\n")
 
 
+def _verify_permission_set() -> list[str]:
+    """Return policy names that are missing from the active SSO role.
+
+    Uses iam:SimulatePrincipalPolicy against AUDIT_ACTIONS so the check
+    works regardless of which managed policy grants which action. Empty
+    list = everything is in place.
+    """
+    from botocore.exceptions import ClientError
+
+    session = boto3.Session(profile_name=PROFILE_NAME)
+    arn = session.client("sts").get_caller_identity().get("Arn", "")
+    # arn:aws:sts::ACCOUNT:assumed-role/AWSReservedSSO_lablink_HASH/USER
+    # → arn:aws:iam::ACCOUNT:role/AWSReservedSSO_lablink_HASH
+    principal_arn = (
+        arn.replace(":sts:", ":iam:")
+        .replace("assumed-role", "role")
+        .rsplit("/", 1)[0]
+    )
+
+    iam = session.client("iam")
+    unscoped = [
+        a for a in policy.AUDIT_ACTIONS
+        if a not in policy.AUDIT_RESOURCE_OVERRIDES
+    ]
+    eval_results = []
+    try:
+        if unscoped:
+            eval_results.extend(
+                iam.simulate_principal_policy(
+                    PolicySourceArn=principal_arn,
+                    ActionNames=unscoped,
+                ).get("EvaluationResults", [])
+            )
+        for action, resource_arns in policy.AUDIT_RESOURCE_OVERRIDES.items():
+            if action not in policy.AUDIT_ACTIONS:
+                continue
+            eval_results.extend(
+                iam.simulate_principal_policy(
+                    PolicySourceArn=principal_arn,
+                    ActionNames=[action],
+                    ResourceArns=resource_arns,
+                ).get("EvaluationResults", [])
+            )
+    except ClientError as e:
+        if e.response.get("Error", {}).get("Code") == "AccessDenied":
+            # The simulate call itself needs iam:SimulatePrincipalPolicy,
+            # which is part of IAMFullAccess. If we can't even simulate,
+            # IAMFullAccess (or similar IAM read perms) is missing.
+            return ["IAMFullAccess"]
+        raise
+
+    denied_actions = [
+        r["EvalActionName"]
+        for r in eval_results
+        if r.get("EvalDecision") != "allowed"
+    ]
+    if not denied_actions:
+        return []
+
+    # Map denied actions back to policy names; dedupe while preserving order.
+    seen: set[str] = set()
+    missing: list[str] = []
+    for action in denied_actions:
+        name = policy.ACTION_TO_POLICY_NAME.get(action, action)
+        if name not in seen:
+            seen.add(name)
+            missing.append(name)
+    return missing
+
+
+def _run_verifier_with_retry(*, max_attempts: int = 3) -> None:
+    """Run _verify_permission_set with a small retry loop.
+
+    On failure, lists missing policies and waits for the user to fix
+    them in the AWS Console, then re-runs. Exits with a hint if the
+    user hits the retry cap.
+    """
+    for attempt in range(1, max_attempts + 1):
+        missing = _verify_permission_set()
+        if not missing:
+            console.print(
+                "[green]✓[/green] Permission set has every required policy.\n"
+            )
+            return
+
+        console.print(
+            f"\n[yellow]Permission set is missing {len(missing)} "
+            f"policy/policies:[/yellow]"
+        )
+        for name in missing:
+            if name == "<inline>":
+                console.print(
+                    "  • [bold]inline policy[/bold] — run "
+                    "[bold]lablink login --update-policy[/bold] to refresh."
+                )
+            else:
+                console.print(f"  • [bold]{name}[/bold]")
+
+        if attempt == max_attempts:
+            console.print(
+                "\n[yellow]Reached retry limit.[/yellow] Fix the policies above "
+                "and run [bold]lablink doctor[/bold] when ready."
+            )
+            return
+
+        console.print(
+            "\nIn the AWS Console, attach the missing policy/policies to your "
+            "[bold]lablink[/bold] permission set, then press Enter to "
+            "re-check.\n"
+            f"[dim]Attempt {attempt} of {max_attempts}.[/dim]"
+        )
+        input()
+
+
 def run_login(
     deployment_region: str | None = None,
     update_policy: bool = False,
+    manual: bool = False,
 ) -> None:
     """Top-level login orchestrator."""
     if update_policy:
@@ -151,10 +266,12 @@ def run_login(
         if not typer.confirm("Re-login?", default=False):
             return
 
+    bootstrapped = False
     if not has_sso_profile():
         try:
             result: SSOBootstrapResult = run_bootstrap(
-                deployment_region=deployment_region or "us-east-1"
+                deployment_region=deployment_region or "us-east-1",
+                manual=manual,
             )
         except KeyboardInterrupt:
             console.print(
@@ -166,5 +283,13 @@ def run_login(
             f"\n[green]✓[/green] Identity Center configured "
             f"({result.start_url})\n"
         )
+        bootstrapped = True
 
     run_steady_state()
+
+    # Verify the permission set has every policy lablink needs. This is
+    # most useful right after a fresh bootstrap (typo'd email, paste
+    # mangled, manual flow forgot a policy) but cheap enough to run on
+    # every login — catches policy drift if AWS removed something.
+    if bootstrapped or manual:
+        _run_verifier_with_retry()

--- a/packages/cli/src/lablink_cli/commands/logs.py
+++ b/packages/cli/src/lablink_cli/commands/logs.py
@@ -107,6 +107,8 @@ def _ssh_via_instance_connect(
     command: str,
 ) -> str | None:
     """Try SSH via ec2-instance-connect. Returns stdout or None."""
+    from lablink_cli.auth.credentials import subprocess_env
+
     try:
         result = subprocess.run(
             [
@@ -124,6 +126,7 @@ def _ssh_via_instance_connect(
                 "--",
                 command,
             ],
+            env=subprocess_env(),
             capture_output=True,
             text=True,
             timeout=30,

--- a/packages/cli/src/lablink_cli/commands/setup.py
+++ b/packages/cli/src/lablink_cli/commands/setup.py
@@ -41,27 +41,13 @@ def check_credentials(session: boto3.Session) -> dict:
         )
         console.print()
         console.print(
-            "  To create access keys, visit:"
+            "  Run [bold]lablink login[/bold] to sign in via "
+            "AWS Identity Center (no access keys required)."
         )
         console.print(
-            "  [link=https://console.aws.amazon.com/iam/"
-            "home#/security_credentials]"
-            "https://console.aws.amazon.com/iam/"
-            "home#/security_credentials"
-            "[/link]"
-        )
-        console.print()
-        console.print(
-            "  Then configure them with one of:"
-        )
-        console.print(
-            '  [dim]1. Run: [bold]aws configure[/bold]'
-            "[/dim]"
-        )
-        console.print(
-            "  [dim]2. Set environment variables: "
-            "[bold]AWS_ACCESS_KEY_ID[/bold] and "
-            "[bold]AWS_SECRET_ACCESS_KEY[/bold][/dim]"
+            "  [dim]Existing access-key users: ensure "
+            "AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY env vars are "
+            "set, or that ~/.aws/credentials has a default profile.[/dim]"
         )
         console.print()
         console.print(f"  [dim]Error: {e}[/dim]")

--- a/packages/cli/src/lablink_cli/commands/setup.py
+++ b/packages/cli/src/lablink_cli/commands/setup.py
@@ -17,12 +17,9 @@ from rich.table import Table
 
 from lablink_allocator_service.conf.structured_config import Config
 
+from lablink_cli.auth.credentials import get_session
+
 console = Console()
-
-
-def _get_session(region: str) -> boto3.Session:
-    """Create a boto3 session for the given region."""
-    return boto3.Session(region_name=region)
 
 
 # ------------------------------------------------------------------
@@ -266,7 +263,7 @@ def run_setup(cfg: Config, config_path: Path | None = None) -> None:
 
     # Step 1: Credentials
     console.print("[bold]Step 1/3:[/bold] Checking AWS credentials")
-    session = _get_session(region)
+    session = get_session(region=region)
     identity = check_credentials(session)
     console.print(
         f"  [green]authenticated[/green] "

--- a/packages/cli/src/lablink_cli/commands/status.py
+++ b/packages/cli/src/lablink_cli/commands/status.py
@@ -10,7 +10,6 @@ from pathlib import Path
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
-import boto3
 from botocore.exceptions import ClientError
 from rich.console import Console
 from rich.panel import Panel

--- a/packages/cli/src/lablink_cli/commands/status.py
+++ b/packages/cli/src/lablink_cli/commands/status.py
@@ -282,9 +282,9 @@ def estimate_costs(cfg: Config) -> list[dict]:
 
     # Try AWS Pricing API (only available in us-east-1)
     try:
-        pricing = boto3.client(
-            "pricing", region_name="us-east-1"
-        )
+        from lablink_cli.auth.credentials import get_session
+
+        pricing = get_session(region="us-east-1").client("pricing")
         use_api = True
     except Exception:
         use_api = False

--- a/packages/cli/src/lablink_cli/commands/utils.py
+++ b/packages/cli/src/lablink_cli/commands/utils.py
@@ -54,13 +54,13 @@ def query_ec2_instances(
     Returns:
         List of VM info dicts.
     """
-    from lablink_cli.commands.setup import _get_session
+    from lablink_cli.auth.credentials import get_session
 
     if states is None:
         states = ["running"]
 
     try:
-        session = _get_session(region)
+        session = get_session(region=region)
         ec2 = session.client("ec2")
     except Exception:
         return []

--- a/packages/cli/src/lablink_cli/commands/utils.py
+++ b/packages/cli/src/lablink_cli/commands/utils.py
@@ -115,11 +115,18 @@ def list_all_vms(cfg: Config) -> list[dict]:
 
 
 def get_terraform_outputs(deploy_dir: Path) -> dict[str, str]:
-    """Read terraform outputs as a dict."""
+    """Read terraform outputs as a dict.
+
+    Uses subprocess_env() so terraform inherits AWS_PROFILE=lablink
+    (when SSO is configured) and can read state from S3 backend.
+    """
+    from lablink_cli.auth.credentials import subprocess_env
+
     try:
         result = subprocess.run(
             ["terraform", "output", "-json"],
             cwd=deploy_dir,
+            env=subprocess_env(),
             capture_output=True,
             text=True,
             check=True,

--- a/packages/cli/tests/test_auth_bootstrap.py
+++ b/packages/cli/tests/test_auth_bootstrap.py
@@ -3,8 +3,7 @@
 from __future__ import annotations
 
 import configparser
-import json
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 
@@ -133,7 +132,10 @@ def test_clear_state_removes_file(fake_home):
 def test_copy_to_clipboard_falls_back_to_file_when_pyperclip_unavailable(
     fake_home,
 ):
-    with patch("lablink_cli.auth.bootstrap._pyperclip_copy", side_effect=Exception("no clip")):
+    with patch(
+        "lablink_cli.auth.bootstrap._pyperclip_copy",
+        side_effect=Exception("no clip"),
+    ):
         path = bootstrap._copy_to_clipboard("policy json contents")
 
     # Fallback writes the JSON to a file in ~/.lablink and returns the path

--- a/packages/cli/tests/test_auth_bootstrap.py
+++ b/packages/cli/tests/test_auth_bootstrap.py
@@ -1,0 +1,215 @@
+"""Tests for auth.bootstrap — first-time Identity Center setup."""
+
+from __future__ import annotations
+
+import configparser
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lablink_cli.auth import bootstrap
+
+
+@pytest.fixture()
+def fake_home(tmp_path, monkeypatch):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / ".aws" / "config"))
+    return tmp_path
+
+
+def test_extract_region_from_start_url():
+    url = "https://d-9067abc123.awsapps.com/start"
+    # Default fallback when the URL doesn't carry region info.
+    assert bootstrap._extract_region_from_url(url) is None
+
+
+def test_validate_start_url_accepts_well_formed():
+    assert bootstrap._is_valid_sso_start_url(
+        "https://d-9067abc123.awsapps.com/start"
+    )
+    assert bootstrap._is_valid_sso_start_url(
+        "https://my-org.awsapps.com/start"
+    )
+
+
+def test_validate_start_url_rejects_garbage():
+    assert not bootstrap._is_valid_sso_start_url("not-a-url")
+    assert not bootstrap._is_valid_sso_start_url("https://example.com/")
+    assert not bootstrap._is_valid_sso_start_url("")
+
+
+def test_write_aws_config_creates_sso_session_and_profile_blocks(fake_home):
+    cfg = bootstrap.SSOBootstrapResult(
+        start_url="https://d-test.awsapps.com/start",
+        sso_region="us-east-1",
+        permission_set_name="lablink",
+        deployment_region="us-west-2",
+    )
+    bootstrap._write_aws_config(cfg)
+
+    config_path = fake_home / ".aws" / "config"
+    assert config_path.exists()
+    parser = configparser.ConfigParser()
+    parser.read(config_path)
+
+    assert "sso-session lablink" in parser.sections()
+    assert (
+        parser.get("sso-session lablink", "sso_start_url")
+        == "https://d-test.awsapps.com/start"
+    )
+    assert parser.get("sso-session lablink", "sso_region") == "us-east-1"
+
+    assert "profile lablink" in parser.sections()
+    assert parser.get("profile lablink", "sso_session") == "lablink"
+    assert parser.get("profile lablink", "sso_role_name") == "lablink"
+    assert parser.get("profile lablink", "region") == "us-west-2"
+
+
+def test_write_aws_config_preserves_other_profiles(fake_home):
+    """Bootstrap must not clobber unrelated [profile X] blocks."""
+    config_path = fake_home / ".aws" / "config"
+    config_path.parent.mkdir(parents=True, exist_ok=True)
+    config_path.write_text(
+        "[profile work]\n"
+        "region = eu-west-1\n"
+        "aws_access_key_id = AKIATEST\n"
+    )
+
+    cfg = bootstrap.SSOBootstrapResult(
+        start_url="https://d-test.awsapps.com/start",
+        sso_region="us-east-1",
+        permission_set_name="lablink",
+        deployment_region="us-east-1",
+    )
+    bootstrap._write_aws_config(cfg)
+
+    parser = configparser.ConfigParser()
+    parser.read(config_path)
+    assert "profile work" in parser.sections()
+    assert parser.get("profile work", "region") == "eu-west-1"
+    assert "profile lablink" in parser.sections()
+
+
+def test_state_file_round_trip(fake_home):
+    state = bootstrap.BootstrapState(
+        sso_start_url="https://d-test.awsapps.com/start",
+        sso_region="us-east-1",
+        permission_set_name="lablink",
+        steps_complete=["enable", "permission_set"],
+    )
+    state.save()
+    loaded = bootstrap.BootstrapState.load()
+    assert loaded == state
+    # Confirm state was written under the fake HOME, not real ~/.lablink
+    assert (fake_home / ".lablink" / "bootstrap-state.json").exists()
+
+
+def test_load_state_returns_none_when_missing(fake_home):
+    assert not (fake_home / ".lablink" / "bootstrap-state.json").exists()
+    assert bootstrap.BootstrapState.load() is None
+
+
+def test_load_state_returns_none_when_corrupt(fake_home):
+    state_path = fake_home / ".lablink" / "bootstrap-state.json"
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    state_path.write_text("not valid json {{{")
+    assert bootstrap.BootstrapState.load() is None
+
+
+def test_clear_state_removes_file(fake_home):
+    state = bootstrap.BootstrapState(
+        sso_start_url="x", sso_region="y", permission_set_name="z",
+        steps_complete=["enable"],
+    )
+    state.save()
+    state_file = fake_home / ".lablink" / "bootstrap-state.json"
+    assert state_file.exists()
+    bootstrap.BootstrapState.clear()
+    assert not state_file.exists()
+    assert bootstrap.BootstrapState.load() is None
+
+
+def test_copy_to_clipboard_falls_back_to_file_when_pyperclip_unavailable(
+    fake_home,
+):
+    with patch("lablink_cli.auth.bootstrap._pyperclip_copy", side_effect=Exception("no clip")):
+        path = bootstrap._copy_to_clipboard("policy json contents")
+
+    # Fallback writes the JSON to a file in ~/.lablink and returns the path
+    assert path is not None
+    assert path.exists()
+    assert path.read_text() == "policy json contents"
+    # And the path is inside the fake HOME, not the real one
+    assert fake_home in path.parents
+
+
+def test_run_bootstrap_writes_config_after_user_completes_console_steps(
+    fake_home, monkeypatch
+):
+    """Smoke test: run_bootstrap fully drives the flow with mocked I/O."""
+    # User pastes a valid SSO Start URL, hits Enter for region default,
+    # accepts default permission-set name, and presses Enter at each prompt.
+    inputs = iter(
+        [
+            "",  # Press Enter to open Identity Center console
+            "https://d-9067abc123.awsapps.com/start",  # SSO Start URL
+            "us-east-1",  # SSO region
+            "",  # Press Enter to open create permission set page
+            "lablink",  # Permission set name
+            "",  # Press Enter once permission set created
+            "",  # Press Enter to open assign user page
+            "",  # Press Enter once assigned
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: next(inputs))
+    monkeypatch.setattr(
+        "lablink_cli.auth.bootstrap.typer.prompt",
+        lambda *a, **kw: next(inputs),
+    )
+    monkeypatch.setattr(
+        "lablink_cli.auth.bootstrap.webbrowser.open", lambda *a, **kw: True
+    )
+    monkeypatch.setattr(
+        "lablink_cli.auth.bootstrap._copy_to_clipboard", lambda payload: None
+    )
+
+    result = bootstrap.run_bootstrap(deployment_region="us-east-1")
+
+    assert result.start_url == "https://d-9067abc123.awsapps.com/start"
+    assert result.sso_region == "us-east-1"
+    assert result.permission_set_name == "lablink"
+
+    config_path = fake_home / ".aws" / "config"
+    assert config_path.exists()
+    parser = configparser.ConfigParser()
+    parser.read(config_path)
+    assert "sso-session lablink" in parser.sections()
+
+
+def test_run_bootstrap_resumes_from_saved_state(fake_home, monkeypatch):
+    """If state shows enable+permission_set complete, only assign + write is needed."""
+    state_file = fake_home / ".lablink" / "bootstrap-state.json"
+    bootstrap.BootstrapState(
+        sso_start_url="https://d-9067abc123.awsapps.com/start",
+        sso_region="us-east-1",
+        permission_set_name="lablink",
+        steps_complete=["enable", "permission_set"],
+    ).save()
+    assert state_file.exists()
+
+    inputs = iter(
+        [
+            "",  # Press Enter to open assign user page
+            "",  # Press Enter once assigned
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: next(inputs))
+    monkeypatch.setattr(
+        "lablink_cli.auth.bootstrap.webbrowser.open", lambda *a, **kw: True
+    )
+
+    result = bootstrap.run_bootstrap(deployment_region="us-east-1")
+    assert result.start_url == "https://d-9067abc123.awsapps.com/start"
+    # State should be cleared after completion
+    assert bootstrap.BootstrapState.load() is None

--- a/packages/cli/tests/test_auth_bootstrap.py
+++ b/packages/cli/tests/test_auth_bootstrap.py
@@ -17,12 +17,6 @@ def fake_home(tmp_path, monkeypatch):
     return tmp_path
 
 
-def test_extract_region_from_start_url():
-    url = "https://d-9067abc123.awsapps.com/start"
-    # Default fallback when the URL doesn't carry region info.
-    assert bootstrap._extract_region_from_url(url) is None
-
-
 def test_validate_start_url_accepts_well_formed():
     assert bootstrap._is_valid_sso_start_url(
         "https://d-9067abc123.awsapps.com/start"

--- a/packages/cli/tests/test_auth_bootstrap.py
+++ b/packages/cli/tests/test_auth_bootstrap.py
@@ -136,7 +136,7 @@ def test_copy_to_clipboard_falls_back_to_file_when_pyperclip_unavailable(
         "lablink_cli.auth.bootstrap._pyperclip_copy",
         side_effect=Exception("no clip"),
     ):
-        path = bootstrap._copy_to_clipboard("policy json contents")
+        path = bootstrap.copy_to_clipboard("policy json contents")
 
     # Fallback writes the JSON to a file in ~/.lablink and returns the path
     assert path is not None
@@ -173,7 +173,7 @@ def test_run_bootstrap_writes_config_after_user_completes_console_steps(
         "lablink_cli.auth.bootstrap.webbrowser.open", lambda *a, **kw: True
     )
     monkeypatch.setattr(
-        "lablink_cli.auth.bootstrap._copy_to_clipboard", lambda payload: None
+        "lablink_cli.auth.bootstrap.copy_to_clipboard", lambda payload: None
     )
 
     result = bootstrap.run_bootstrap(deployment_region="us-east-1")

--- a/packages/cli/tests/test_auth_bootstrap.py
+++ b/packages/cli/tests/test_auth_bootstrap.py
@@ -84,45 +84,6 @@ def test_write_aws_config_preserves_other_profiles(fake_home):
     assert "profile lablink" in parser.sections()
 
 
-def test_state_file_round_trip(fake_home):
-    state = bootstrap.BootstrapState(
-        sso_start_url="https://d-test.awsapps.com/start",
-        sso_region="us-east-1",
-        permission_set_name="lablink",
-        steps_complete=["enable", "permission_set"],
-    )
-    state.save()
-    loaded = bootstrap.BootstrapState.load()
-    assert loaded == state
-    # Confirm state was written under the fake HOME, not real ~/.lablink
-    assert (fake_home / ".lablink" / "bootstrap-state.json").exists()
-
-
-def test_load_state_returns_none_when_missing(fake_home):
-    assert not (fake_home / ".lablink" / "bootstrap-state.json").exists()
-    assert bootstrap.BootstrapState.load() is None
-
-
-def test_load_state_returns_none_when_corrupt(fake_home):
-    state_path = fake_home / ".lablink" / "bootstrap-state.json"
-    state_path.parent.mkdir(parents=True, exist_ok=True)
-    state_path.write_text("not valid json {{{")
-    assert bootstrap.BootstrapState.load() is None
-
-
-def test_clear_state_removes_file(fake_home):
-    state = bootstrap.BootstrapState(
-        sso_start_url="x", sso_region="y", permission_set_name="z",
-        steps_complete=["enable"],
-    )
-    state.save()
-    state_file = fake_home / ".lablink" / "bootstrap-state.json"
-    assert state_file.exists()
-    bootstrap.BootstrapState.clear()
-    assert not state_file.exists()
-    assert bootstrap.BootstrapState.load() is None
-
-
 def test_copy_to_clipboard_falls_back_to_file_when_pyperclip_unavailable(
     fake_home,
 ):
@@ -183,29 +144,3 @@ def test_run_bootstrap_writes_config_after_user_completes_console_steps(
     assert "sso-session lablink" in parser.sections()
 
 
-def test_run_bootstrap_resumes_from_saved_state(fake_home, monkeypatch):
-    """If state shows enable+permission_set complete, only assign + write is needed."""
-    state_file = fake_home / ".lablink" / "bootstrap-state.json"
-    bootstrap.BootstrapState(
-        sso_start_url="https://d-9067abc123.awsapps.com/start",
-        sso_region="us-east-1",
-        permission_set_name="lablink",
-        steps_complete=["enable", "permission_set"],
-    ).save()
-    assert state_file.exists()
-
-    inputs = iter(
-        [
-            "",  # Press Enter to open assign user page
-            "",  # Press Enter once assigned
-        ]
-    )
-    monkeypatch.setattr("builtins.input", lambda *a, **kw: next(inputs))
-    monkeypatch.setattr(
-        "lablink_cli.auth.bootstrap.webbrowser.open", lambda *a, **kw: True
-    )
-
-    result = bootstrap.run_bootstrap(deployment_region="us-east-1")
-    assert result.start_url == "https://d-9067abc123.awsapps.com/start"
-    # State should be cleared after completion
-    assert bootstrap.BootstrapState.load() is None

--- a/packages/cli/tests/test_auth_bootstrap.py
+++ b/packages/cli/tests/test_auth_bootstrap.py
@@ -32,6 +32,49 @@ def test_validate_start_url_rejects_garbage():
     assert not bootstrap._is_valid_sso_start_url("")
 
 
+def test_email_validator_accepts_well_formed_addresses():
+    assert bootstrap._is_valid_email("alice@example.com")
+    assert bootstrap._is_valid_email("a.b+tag@sub.example.org")
+
+
+def test_email_validator_rejects_garbage():
+    assert not bootstrap._is_valid_email("not-an-email")
+    assert not bootstrap._is_valid_email("missing@tld")
+    assert not bootstrap._is_valid_email("")
+    assert not bootstrap._is_valid_email("two@@signs.com")
+
+
+def test_render_bootstrap_script_inlines_policy_data():
+    """The CloudShell heredoc must always reflect the live policy data."""
+    from lablink_cli.auth import policy as policy_mod
+
+    script = bootstrap.render_bootstrap_script("alice@example.com")
+
+    # Email is substituted into the script as a literal.
+    assert 'EMAIL="alice@example.com"' in script
+
+    # Every managed policy ARN appears in the for-loop.
+    for arn in policy_mod.MANAGED_POLICY_ARNS:
+        assert arn in script
+
+    # Inline policy is embedded as multi-line indented JSON inside a
+    # single-quoted bash variable. Multi-line keeps each line short
+    # enough that terminals don't soft-wrap and break the paste.
+    import json
+    inline_indented = json.dumps(policy_mod.INLINE_POLICY, indent=2)
+    assert inline_indented in script
+    # And it's wrapped as a bash variable, not a CLI arg.
+    assert "INLINE_POLICY='" in script
+    assert '--inline-policy "$INLINE_POLICY"' in script
+
+    # Permission set name comes from the canonical default, not hardcoded.
+    assert f'PS_NAME="{policy_mod.PERMISSION_SET_NAME_DEFAULT}"' in script
+
+    # Heredoc opens and closes with the right tag.
+    assert "bash <<'LABLINK_SETUP'" in script
+    assert script.rstrip().endswith("LABLINK_SETUP")
+
+
 def test_write_aws_config_creates_sso_session_and_profile_blocks(fake_home):
     cfg = bootstrap.SSOBootstrapResult(
         start_url="https://d-test.awsapps.com/start",
@@ -101,12 +144,41 @@ def test_copy_to_clipboard_falls_back_to_file_when_pyperclip_unavailable(
     assert fake_home in path.parents
 
 
-def test_run_bootstrap_writes_config_after_user_completes_console_steps(
-    fake_home, monkeypatch
-):
-    """Smoke test: run_bootstrap fully drives the flow with mocked I/O."""
-    # User pastes a valid SSO Start URL, hits Enter for region default,
-    # accepts default permission-set name, and presses Enter at each prompt.
+def test_run_bootstrap_default_uses_cloudshell_flow(fake_home, monkeypatch):
+    """Smoke test: default run_bootstrap drives the CloudShell flow with mocked I/O."""
+    inputs = iter(
+        [
+            "",  # Press Enter to open Identity Center console
+            "https://d-9067abc123.awsapps.com/start",  # SSO Start URL
+            "us-east-1",  # SSO region
+            "alice@example.com",  # Email for Identity Center user
+            "",  # Press Enter once CloudShell script prints "Done."
+        ]
+    )
+    monkeypatch.setattr("builtins.input", lambda *a, **kw: next(inputs))
+    monkeypatch.setattr(
+        "lablink_cli.auth.bootstrap.typer.prompt",
+        lambda *a, **kw: next(inputs),
+    )
+    monkeypatch.setattr(
+        "lablink_cli.auth.bootstrap.webbrowser.open", lambda *a, **kw: True
+    )
+
+    result = bootstrap.run_bootstrap(deployment_region="us-east-1")
+
+    assert result.start_url == "https://d-9067abc123.awsapps.com/start"
+    assert result.sso_region == "us-east-1"
+    assert result.permission_set_name == "lablink"
+
+    config_path = fake_home / ".aws" / "config"
+    assert config_path.exists()
+    parser = configparser.ConfigParser()
+    parser.read(config_path)
+    assert "sso-session lablink" in parser.sections()
+
+
+def test_run_bootstrap_manual_uses_console_clickthrough(fake_home, monkeypatch):
+    """--manual mode runs the original 8-policy + assign-user flow."""
     inputs = iter(
         [
             "",  # Press Enter to open Identity Center console
@@ -131,16 +203,7 @@ def test_run_bootstrap_writes_config_after_user_completes_console_steps(
         "lablink_cli.auth.bootstrap.copy_to_clipboard", lambda payload: None
     )
 
-    result = bootstrap.run_bootstrap(deployment_region="us-east-1")
-
-    assert result.start_url == "https://d-9067abc123.awsapps.com/start"
-    assert result.sso_region == "us-east-1"
+    result = bootstrap.run_bootstrap(deployment_region="us-east-1", manual=True)
     assert result.permission_set_name == "lablink"
-
-    config_path = fake_home / ".aws" / "config"
-    assert config_path.exists()
-    parser = configparser.ConfigParser()
-    parser.read(config_path)
-    assert "sso-session lablink" in parser.sections()
 
 

--- a/packages/cli/tests/test_auth_credentials.py
+++ b/packages/cli/tests/test_auth_credentials.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest

--- a/packages/cli/tests/test_auth_credentials.py
+++ b/packages/cli/tests/test_auth_credentials.py
@@ -108,6 +108,34 @@ def test_is_logged_in_false_when_no_sso_profile(tmp_path, monkeypatch):
     assert credentials.is_logged_in() is False
 
 
+def test_get_session_honors_aws_shared_credentials_file(tmp_path, monkeypatch):
+    """Setting AWS_SHARED_CREDENTIALS_FILE points credential discovery there."""
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+    (aws_dir / "config").write_text("")  # no SSO profile
+
+    # Default path is empty; alternate path has a usable [default] profile.
+    alt_creds = tmp_path / "alt-credentials"
+    alt_creds.write_text(
+        "[default]\n"
+        "aws_access_key_id = AKIATEST\n"
+        "aws_secret_access_key = secrettest\n"
+    )
+
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_dir / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(alt_creds))
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    with patch("lablink_cli.auth.credentials.boto3.Session") as mock_session_cls:
+        mock_session_cls.return_value = MagicMock()
+        # Should resolve via the alt path instead of raising NotLoggedInError.
+        credentials.get_session(region="us-east-1")
+        kwargs = mock_session_cls.call_args.kwargs
+        assert "profile_name" not in kwargs
+
+
 def test_get_session_raises_sso_token_expired_when_token_stale(tmp_path, monkeypatch):
     """Profile exists but cached token is past expiresAt → SSOTokenExpiredError."""
     aws_dir = tmp_path / ".aws"

--- a/packages/cli/tests/test_auth_credentials.py
+++ b/packages/cli/tests/test_auth_credentials.py
@@ -1,0 +1,130 @@
+"""Tests for auth.credentials.get_session and friends."""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lablink_cli.auth import credentials
+
+
+def test_get_session_uses_sso_profile_when_present(tmp_path, monkeypatch):
+    """If ~/.aws/config has a [profile lablink] block, get_session uses it."""
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+    (aws_dir / "config").write_text(
+        "[sso-session lablink]\n"
+        "sso_start_url = https://d-test.awsapps.com/start\n"
+        "sso_region = us-east-1\n"
+        "sso_registration_scopes = sso:account:access\n"
+        "\n"
+        "[profile lablink]\n"
+        "sso_session = lablink\n"
+        "sso_account_id = 123456789012\n"
+        "sso_role_name = lablink\n"
+        "region = us-east-1\n"
+    )
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_dir / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    # Clear any AWS_* creds env vars so we genuinely test the SSO branch.
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    with patch("lablink_cli.auth.credentials.boto3.Session") as mock_session_cls:
+        mock_session = MagicMock()
+        mock_session_cls.return_value = mock_session
+
+        with patch("lablink_cli.auth.credentials._token_is_valid", return_value=True):
+            result = credentials.get_session(region="us-east-1")
+
+        # Must construct with profile_name="lablink"
+        mock_session_cls.assert_called_once()
+        kwargs = mock_session_cls.call_args.kwargs
+        assert kwargs.get("profile_name") == "lablink"
+        assert kwargs.get("region_name") == "us-east-1"
+        assert result is mock_session
+
+
+def test_get_session_falls_back_to_env_vars_when_no_sso_profile(tmp_path, monkeypatch):
+    """No SSO profile, env vars set → boto3.Session() with no profile_name."""
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+    (aws_dir / "config").write_text("")  # empty config
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_dir / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "AKIATEST")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "secrettest")
+
+    with patch("lablink_cli.auth.credentials.boto3.Session") as mock_session_cls:
+        mock_session_cls.return_value = MagicMock()
+        credentials.get_session(region="us-east-1")
+        kwargs = mock_session_cls.call_args.kwargs
+        assert "profile_name" not in kwargs
+        assert kwargs.get("region_name") == "us-east-1"
+
+
+def test_get_session_raises_not_logged_in_when_nothing_available(tmp_path, monkeypatch):
+    """No SSO profile, no env vars, no ~/.aws/credentials → NotLoggedInError."""
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+    (aws_dir / "config").write_text("")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_dir / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+
+    with pytest.raises(credentials.NotLoggedInError) as exc_info:
+        credentials.get_session(region="us-east-1")
+
+    assert "lablink login" in str(exc_info.value)
+
+
+def test_is_logged_in_true_when_sso_profile_with_valid_token(tmp_path, monkeypatch):
+    """is_logged_in returns True when SSO profile exists and token is fresh."""
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+    (aws_dir / "config").write_text(
+        "[sso-session lablink]\n"
+        "sso_start_url = https://d-test.awsapps.com/start\n"
+        "sso_region = us-east-1\n"
+        "[profile lablink]\n"
+        "sso_session = lablink\n"
+        "region = us-east-1\n"
+    )
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_dir / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    with patch("lablink_cli.auth.credentials._token_is_valid", return_value=True):
+        assert credentials.is_logged_in() is True
+
+
+def test_is_logged_in_false_when_no_sso_profile(tmp_path, monkeypatch):
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+    (aws_dir / "config").write_text("")
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_dir / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    assert credentials.is_logged_in() is False
+
+
+def test_get_session_raises_sso_token_expired_when_token_stale(tmp_path, monkeypatch):
+    """Profile exists but cached token is past expiresAt → SSOTokenExpiredError."""
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+    (aws_dir / "config").write_text(
+        "[sso-session lablink]\n"
+        "sso_start_url = https://d-test.awsapps.com/start\n"
+        "sso_region = us-east-1\n"
+        "[profile lablink]\n"
+        "sso_session = lablink\n"
+        "region = us-east-1\n"
+    )
+    monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_dir / "config"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    with patch("lablink_cli.auth.credentials._token_is_valid", return_value=False):
+        with pytest.raises(credentials.SSOTokenExpiredError) as exc_info:
+            credentials.get_session(region="us-east-1")
+        assert "lablink login" in str(exc_info.value)

--- a/packages/cli/tests/test_auth_policy.py
+++ b/packages/cli/tests/test_auth_policy.py
@@ -1,0 +1,79 @@
+"""Tests for the lablink permission-set policy module."""
+
+from __future__ import annotations
+
+import json
+
+from lablink_cli.auth import policy
+
+
+def test_managed_policy_arns_cover_required_services():
+    arns = policy.MANAGED_POLICY_ARNS
+    assert "arn:aws:iam::aws:policy/AmazonEC2FullAccess" in arns
+    assert "arn:aws:iam::aws:policy/ElasticLoadBalancingFullAccess" in arns
+    assert "arn:aws:iam::aws:policy/AmazonRoute53FullAccess" in arns
+    assert "arn:aws:iam::aws:policy/IAMFullAccess" in arns
+    assert "arn:aws:iam::aws:policy/CloudWatchFullAccess" in arns
+    assert "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess" in arns
+    assert "arn:aws:iam::aws:policy/AWSCloudTrail_FullAccess" in arns
+    assert "arn:aws:iam::aws:policy/AmazonSNSFullAccess" in arns
+
+
+def test_inline_policy_is_valid_iam_policy_json():
+    doc = policy.INLINE_POLICY
+    assert doc["Version"] == "2012-10-17"
+    assert isinstance(doc["Statement"], list)
+    assert len(doc["Statement"]) > 0
+    for stmt in doc["Statement"]:
+        assert "Sid" in stmt
+        assert stmt["Effect"] == "Allow"
+        assert "Action" in stmt
+        assert "Resource" in stmt
+
+
+def test_inline_policy_scopes_terraform_state_bucket():
+    statements = {s["Sid"]: s for s in policy.INLINE_POLICY["Statement"]}
+    s3 = statements["TerraformStateBucket"]
+    assert "arn:aws:s3:::lablink-tf-state-*" in s3["Resource"]
+    assert "arn:aws:s3:::lablink-tf-state-*/*" in s3["Resource"]
+
+
+def test_inline_policy_scopes_cloudtrail_bucket():
+    statements = {s["Sid"]: s for s in policy.INLINE_POLICY["Statement"]}
+    ct = statements["CloudTrailLogsBucket"]
+    assert "arn:aws:s3:::*-cloudtrail-bucket-*" in ct["Resource"]
+
+
+def test_inline_policy_scopes_dynamodb_lock_table():
+    statements = {s["Sid"]: s for s in policy.INLINE_POLICY["Statement"]}
+    ddb = statements["TerraformLockTable"]
+    assert ddb["Resource"] == "arn:aws:dynamodb:*:*:table/lock-table"
+
+
+def test_inline_policy_includes_sts_get_caller_identity():
+    statements = {s["Sid"]: s for s in policy.INLINE_POLICY["Statement"]}
+    sts = statements["STS"]
+    assert "sts:GetCallerIdentity" in sts["Action"]
+
+
+def test_inline_policy_includes_budgets():
+    statements = {s["Sid"]: s for s in policy.INLINE_POLICY["Statement"]}
+    budgets = statements["Budgets"]
+    assert "budgets:*" in budgets["Action"]
+
+
+def test_render_inline_policy_returns_valid_json_string():
+    rendered = policy.render_inline_policy_json()
+    parsed = json.loads(rendered)
+    assert parsed == policy.INLINE_POLICY
+
+
+def test_audit_actions_lists_one_action_per_managed_policy():
+    """The audit dry-run uses one representative action per managed policy."""
+    actions = policy.AUDIT_ACTIONS
+    assert isinstance(actions, list)
+    # One per managed policy + at least one per inline statement
+    assert len(actions) >= len(policy.MANAGED_POLICY_ARNS)
+    for action in actions:
+        assert isinstance(action, str)
+        assert ":" in action  # service:action format

--- a/packages/cli/tests/test_auth_sso_flow.py
+++ b/packages/cli/tests/test_auth_sso_flow.py
@@ -1,0 +1,161 @@
+"""Tests for the SSO login wrapper around `aws sso login`."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from lablink_cli.auth import sso_flow
+
+
+@pytest.fixture()
+def sso_config():
+    return sso_flow.SSOConfig(
+        start_url="https://d-test.awsapps.com/start",
+        region="us-east-1",
+    )
+
+
+def _write_token_cache(tmp_path, start_url: str, payload: dict) -> None:
+    """Helper: write an AWS-CLI-style token cache file at the expected path."""
+    import hashlib
+
+    cache_dir = tmp_path / ".aws" / "sso" / "cache"
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    digest = hashlib.sha1(start_url.encode("utf-8")).hexdigest()
+    (cache_dir / f"{digest}.json").write_text(json.dumps(payload))
+
+
+def test_ensure_aws_cli_installed_passes_when_aws_on_path():
+    with patch("lablink_cli.auth.sso_flow.shutil.which", return_value="/usr/local/bin/aws"):
+        sso_flow._ensure_aws_cli_installed()
+
+
+def test_ensure_aws_cli_installed_raises_when_aws_missing():
+    with patch("lablink_cli.auth.sso_flow.shutil.which", return_value=None):
+        with pytest.raises(sso_flow.AWSCLINotFoundError) as exc:
+            sso_flow._ensure_aws_cli_installed()
+    assert "AWS CLI" in str(exc.value)
+
+
+def test_login_runs_aws_sso_login_and_returns_cached_token(
+    tmp_path, sso_config, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _write_token_cache(
+        tmp_path,
+        sso_config.start_url,
+        {"accessToken": "TOKEN-XYZ", "expiresAt": "2099-01-01T00:00:00Z"},
+    )
+
+    with (
+        patch(
+            "lablink_cli.auth.sso_flow.shutil.which",
+            return_value="/usr/local/bin/aws",
+        ),
+        patch(
+            "lablink_cli.auth.sso_flow.subprocess.run",
+            return_value=MagicMock(returncode=0),
+        ) as mock_run,
+    ):
+        token = sso_flow.login(sso_config)
+
+    assert token == "TOKEN-XYZ"
+    args = mock_run.call_args.args[0]
+    assert args == ["aws", "sso", "login", "--sso-session", "lablink"]
+
+
+def test_login_raises_when_aws_cli_missing(sso_config):
+    with patch("lablink_cli.auth.sso_flow.shutil.which", return_value=None):
+        with pytest.raises(sso_flow.AWSCLINotFoundError):
+            sso_flow.login(sso_config)
+
+
+def test_login_raises_login_failed_on_nonzero_exit(
+    tmp_path, sso_config, monkeypatch
+):
+    monkeypatch.setenv("HOME", str(tmp_path))
+    with (
+        patch(
+            "lablink_cli.auth.sso_flow.shutil.which",
+            return_value="/usr/local/bin/aws",
+        ),
+        patch(
+            "lablink_cli.auth.sso_flow.subprocess.run",
+            return_value=MagicMock(returncode=1),
+        ),
+    ):
+        with pytest.raises(sso_flow.LoginFailedError) as exc:
+            sso_flow.login(sso_config)
+    assert "exit code 1" in str(exc.value)
+
+
+def test_login_raises_login_failed_when_token_cache_missing(
+    tmp_path, sso_config, monkeypatch
+):
+    """aws sso login returned 0 but no cache file was written."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    with (
+        patch(
+            "lablink_cli.auth.sso_flow.shutil.which",
+            return_value="/usr/local/bin/aws",
+        ),
+        patch(
+            "lablink_cli.auth.sso_flow.subprocess.run",
+            return_value=MagicMock(returncode=0),
+        ),
+    ):
+        with pytest.raises(sso_flow.LoginFailedError) as exc:
+            sso_flow.login(sso_config)
+    assert "does not exist" in str(exc.value)
+
+
+def test_select_account_auto_picks_when_single_account(sso_config):
+    mock_sso = MagicMock()
+    mock_sso.list_accounts.return_value = {
+        "accountList": [
+            {"accountId": "111111111111", "accountName": "OnlyAcct"},
+        ],
+    }
+    with patch("lablink_cli.auth.sso_flow.boto3.client", return_value=mock_sso):
+        account_id = sso_flow.select_account(
+            sso_config=sso_config, access_token="TOKEN"
+        )
+    assert account_id == "111111111111"
+
+
+def test_select_account_prompts_when_multiple(sso_config):
+    mock_sso = MagicMock()
+    mock_sso.list_accounts.return_value = {
+        "accountList": [
+            {"accountId": "111111111111", "accountName": "Alpha"},
+            {"accountId": "222222222222", "accountName": "Beta"},
+        ],
+    }
+    with patch("lablink_cli.auth.sso_flow.boto3.client", return_value=mock_sso):
+        with patch("lablink_cli.auth.sso_flow.typer.prompt", return_value="2"):
+            account_id = sso_flow.select_account(
+                sso_config=sso_config, access_token="TOKEN"
+            )
+    assert account_id == "222222222222"
+
+
+def test_resolve_role_returns_lablink_when_present(sso_config):
+    mock_sso = MagicMock()
+    mock_sso.list_account_roles.return_value = {
+        "roleList": [
+            {"roleName": "OtherRole", "accountId": "111111111111"},
+            {"roleName": "lablink", "accountId": "111111111111"},
+        ],
+    }
+    with patch("lablink_cli.auth.sso_flow.boto3.client", return_value=mock_sso):
+        role = sso_flow.resolve_role(
+            sso_config=sso_config,
+            access_token="TOKEN",
+            account_id="111111111111",
+            preferred_role_name="lablink",
+        )
+    assert role == "lablink"

--- a/packages/cli/tests/test_auth_sso_flow.py
+++ b/packages/cli/tests/test_auth_sso_flow.py
@@ -18,13 +18,16 @@ def sso_config():
     )
 
 
-def _write_token_cache(tmp_path, start_url: str, payload: dict) -> None:
-    """Helper: write an AWS-CLI-style token cache file at the expected path."""
+def _write_token_cache(tmp_path, sso_session_name: str, payload: dict) -> None:
+    """Helper: write an AWS-CLI-style token cache file at the expected path.
+
+    AWS CLI v2 hashes the sso-session name (modern config), not the start URL.
+    """
     import hashlib
 
     cache_dir = tmp_path / ".aws" / "sso" / "cache"
     cache_dir.mkdir(parents=True, exist_ok=True)
-    digest = hashlib.sha1(start_url.encode("utf-8")).hexdigest()
+    digest = hashlib.sha1(sso_session_name.encode("utf-8")).hexdigest()
     (cache_dir / f"{digest}.json").write_text(json.dumps(payload))
 
 
@@ -49,7 +52,7 @@ def test_login_runs_aws_sso_login_and_returns_cached_token(
     monkeypatch.setenv("HOME", str(tmp_path))
     _write_token_cache(
         tmp_path,
-        sso_config.start_url,
+        "lablink",
         {"accessToken": "TOKEN-XYZ", "expiresAt": "2099-01-01T00:00:00Z"},
     )
 

--- a/packages/cli/tests/test_auth_sso_flow.py
+++ b/packages/cli/tests/test_auth_sso_flow.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import json
-import subprocess
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -30,7 +29,10 @@ def _write_token_cache(tmp_path, start_url: str, payload: dict) -> None:
 
 
 def test_ensure_aws_cli_installed_passes_when_aws_on_path():
-    with patch("lablink_cli.auth.sso_flow.shutil.which", return_value="/usr/local/bin/aws"):
+    with patch(
+        "lablink_cli.auth.sso_flow.shutil.which",
+        return_value="/usr/local/bin/aws",
+    ):
         sso_flow._ensure_aws_cli_installed()
 
 

--- a/packages/cli/tests/test_cleanup_full.py
+++ b/packages/cli/tests/test_cleanup_full.py
@@ -56,7 +56,7 @@ class TestRunCleanup:
     @patch("lablink_cli.commands.cleanup.cleanup_security_groups")
     @patch("lablink_cli.commands.cleanup.cleanup_ec2_instances")
     @patch("lablink_cli.commands.cleanup.check_credentials")
-    @patch("lablink_cli.commands.cleanup._get_session")
+    @patch("lablink_cli.commands.cleanup.get_session")
     def test_dry_run(
         self,
         mock_session,
@@ -108,7 +108,7 @@ class TestRunCleanup:
     @patch("lablink_cli.commands.cleanup.cleanup_security_groups")
     @patch("lablink_cli.commands.cleanup.cleanup_ec2_instances")
     @patch("lablink_cli.commands.cleanup.check_credentials")
-    @patch("lablink_cli.commands.cleanup._get_session")
+    @patch("lablink_cli.commands.cleanup.get_session")
     def test_s3_and_dynamo_always_called(
         self,
         mock_session,

--- a/packages/cli/tests/test_deploy.py
+++ b/packages/cli/tests/test_deploy.py
@@ -303,7 +303,7 @@ def _patch_deploy_deps(deploy_dir):
             return_value=deploy_dir,
         ),
         patch("lablink_cli.commands.deploy.check_credentials"),
-        patch("lablink_cli.commands.deploy._get_session"),
+        patch("lablink_cli.commands.deploy.get_session"),
         patch(
             "lablink_cli.commands.deploy._prompt_passwords",
             return_value={
@@ -439,7 +439,7 @@ def _patch_destroy_deps(deploy_dir, stack):
             patch("lablink_cli.commands.deploy.check_credentials")
         ),
         "get_session": stack.enter_context(
-            patch("lablink_cli.commands.deploy._get_session")
+            patch("lablink_cli.commands.deploy.get_session")
         ),
         "get_deploy_dir": stack.enter_context(
             patch(

--- a/packages/cli/tests/test_doctor_full.py
+++ b/packages/cli/tests/test_doctor_full.py
@@ -19,37 +19,39 @@ from lablink_cli.commands.doctor import (
 # _check_aws_credentials
 # ------------------------------------------------------------------
 class TestCheckAwsCredentials:
-    @patch("lablink_cli.commands.setup.check_credentials")
-    @patch("lablink_cli.commands.setup._get_session")
-    def test_valid(self, mock_session, mock_check):
-        mock_check.return_value = {
-            "account": "123456789012",
-            "arn": "arn:aws:iam::123456789012:user/test",
+    @patch("lablink_cli.auth.credentials.get_session")
+    def test_valid(self, mock_get_session):
+        mock_sts = MagicMock()
+        mock_sts.get_caller_identity.return_value = {
+            "Account": "123456789012",
+            "Arn": "arn:aws:iam::123456789012:user/test",
         }
+        mock_get_session.return_value.client.return_value = mock_sts
         result = _check_aws_credentials("us-east-1")
         assert result["status"] == "pass"
 
-    @patch("lablink_cli.commands.setup.check_credentials")
-    @patch("lablink_cli.commands.setup._get_session")
-    def test_invalid_exits(self, mock_session, mock_check):
-        mock_check.side_effect = SystemExit(1)
+    @patch("lablink_cli.auth.credentials.get_session")
+    def test_invalid_exits(self, mock_get_session):
+        from lablink_cli.auth.credentials import NotLoggedInError
+
+        mock_get_session.side_effect = NotLoggedInError("not logged in")
         result = _check_aws_credentials("us-east-1")
         assert result["status"] == "fail"
 
-    @patch("lablink_cli.commands.setup.check_credentials")
-    @patch("lablink_cli.commands.setup._get_session")
-    def test_exception(self, mock_session, mock_check):
-        mock_check.side_effect = Exception("network error")
+    @patch("lablink_cli.auth.credentials.get_session")
+    def test_exception(self, mock_get_session):
+        mock_get_session.side_effect = Exception("network error")
         result = _check_aws_credentials("us-east-1")
         assert result["status"] == "fail"
         assert "network error" in result["detail"]
 
-    @patch("lablink_cli.commands.setup.check_credentials")
-    @patch("lablink_cli.commands.setup._get_session")
-    def test_default_region(self, mock_session, mock_check):
-        mock_check.side_effect = SystemExit(1)
+    @patch("lablink_cli.auth.credentials.get_session")
+    def test_default_region(self, mock_get_session):
+        from lablink_cli.auth.credentials import NotLoggedInError
+
+        mock_get_session.side_effect = NotLoggedInError("not logged in")
         _check_aws_credentials(None)
-        mock_session.assert_called_once_with("us-east-1")
+        mock_get_session.assert_called_once_with(region="us-east-1")
 
 
 # ------------------------------------------------------------------
@@ -141,7 +143,7 @@ class TestCheckS3Bucket:
         result = _check_s3_bucket(cfg)
         assert result["status"] == "fail"
 
-    @patch("lablink_cli.commands.setup._get_session")
+    @patch("lablink_cli.auth.credentials.get_session")
     def test_bucket_exists(self, mock_session):
         cfg = MagicMock()
         cfg.bucket_name = "my-bucket"
@@ -153,7 +155,7 @@ class TestCheckS3Bucket:
         result = _check_s3_bucket(cfg)
         assert result["status"] == "pass"
 
-    @patch("lablink_cli.commands.setup._get_session")
+    @patch("lablink_cli.auth.credentials.get_session")
     def test_bucket_not_found(self, mock_session):
         cfg = MagicMock()
         cfg.bucket_name = "my-bucket"

--- a/packages/cli/tests/test_doctor_full.py
+++ b/packages/cli/tests/test_doctor_full.py
@@ -19,7 +19,7 @@ from lablink_cli.commands.doctor import (
 # _check_aws_credentials
 # ------------------------------------------------------------------
 class TestCheckAwsCredentials:
-    @patch("lablink_cli.auth.credentials.get_session")
+    @patch("lablink_cli.commands.doctor.get_session")
     def test_valid(self, mock_get_session):
         mock_sts = MagicMock()
         mock_sts.get_caller_identity.return_value = {
@@ -30,7 +30,7 @@ class TestCheckAwsCredentials:
         result = _check_aws_credentials("us-east-1")
         assert result["status"] == "pass"
 
-    @patch("lablink_cli.auth.credentials.get_session")
+    @patch("lablink_cli.commands.doctor.get_session")
     def test_invalid_exits(self, mock_get_session):
         from lablink_cli.auth.credentials import NotLoggedInError
 
@@ -38,14 +38,14 @@ class TestCheckAwsCredentials:
         result = _check_aws_credentials("us-east-1")
         assert result["status"] == "fail"
 
-    @patch("lablink_cli.auth.credentials.get_session")
+    @patch("lablink_cli.commands.doctor.get_session")
     def test_exception(self, mock_get_session):
         mock_get_session.side_effect = Exception("network error")
         result = _check_aws_credentials("us-east-1")
         assert result["status"] == "fail"
         assert "network error" in result["detail"]
 
-    @patch("lablink_cli.auth.credentials.get_session")
+    @patch("lablink_cli.commands.doctor.get_session")
     def test_default_region(self, mock_get_session):
         from lablink_cli.auth.credentials import NotLoggedInError
 
@@ -143,7 +143,7 @@ class TestCheckS3Bucket:
         result = _check_s3_bucket(cfg)
         assert result["status"] == "fail"
 
-    @patch("lablink_cli.auth.credentials.get_session")
+    @patch("lablink_cli.commands.doctor.get_session")
     def test_bucket_exists(self, mock_session):
         cfg = MagicMock()
         cfg.bucket_name = "my-bucket"
@@ -155,7 +155,7 @@ class TestCheckS3Bucket:
         result = _check_s3_bucket(cfg)
         assert result["status"] == "pass"
 
-    @patch("lablink_cli.auth.credentials.get_session")
+    @patch("lablink_cli.commands.doctor.get_session")
     def test_bucket_not_found(self, mock_session):
         cfg = MagicMock()
         cfg.bucket_name = "my-bucket"
@@ -174,6 +174,7 @@ class TestCheckS3Bucket:
 class TestRunDoctor:
     @patch("lablink_cli.commands.doctor._check_ami")
     @patch("lablink_cli.commands.doctor._check_s3_bucket")
+    @patch("lablink_cli.commands.doctor._check_lablink_permissions")
     @patch("lablink_cli.commands.doctor._check_aws_credentials")
     @patch("lablink_cli.commands.doctor._check_config_valid")
     @patch("lablink_cli.commands.doctor._check_config_exists")
@@ -184,6 +185,7 @@ class TestRunDoctor:
         mock_cfg_exists,
         mock_cfg_valid,
         mock_aws,
+        mock_perms,
         mock_s3,
         mock_ami,
     ):
@@ -198,6 +200,9 @@ class TestRunDoctor:
             mock_cfg,
         )
         mock_aws.return_value = {"check": "AWS", "status": "pass", "detail": "ok"}
+        mock_perms.return_value = {
+            "check": "LabLink permissions", "status": "pass", "detail": "ok"
+        }
         mock_s3.return_value = {"check": "S3", "status": "pass", "detail": "ok"}
         mock_ami.return_value = {"check": "AMI", "status": "pass", "detail": "ok"}
 
@@ -206,6 +211,7 @@ class TestRunDoctor:
 
     @patch("lablink_cli.commands.doctor._check_ami")
     @patch("lablink_cli.commands.doctor._check_s3_bucket")
+    @patch("lablink_cli.commands.doctor._check_lablink_permissions")
     @patch("lablink_cli.commands.doctor._check_aws_credentials")
     @patch("lablink_cli.commands.doctor._check_config_valid")
     @patch("lablink_cli.commands.doctor._check_config_exists")
@@ -216,6 +222,7 @@ class TestRunDoctor:
         mock_cfg_exists,
         mock_cfg_valid,
         mock_aws,
+        mock_perms,
         mock_s3,
         mock_ami,
     ):
@@ -228,6 +235,9 @@ class TestRunDoctor:
             None,
         )
         mock_aws.return_value = {"check": "AWS", "status": "fail", "detail": ""}
+        mock_perms.return_value = {
+            "check": "LabLink permissions", "status": "warn", "detail": "skipped"
+        }
         mock_s3.return_value = {"check": "S3", "status": "warn", "detail": ""}
         mock_ami.return_value = {"check": "AMI", "status": "warn", "detail": ""}
 

--- a/packages/cli/tests/test_doctor_full.py
+++ b/packages/cli/tests/test_doctor_full.py
@@ -167,6 +167,33 @@ class TestCheckS3Bucket:
         result = _check_s3_bucket(cfg)
         assert result["status"] == "fail"
 
+    @patch("lablink_cli.commands.doctor.get_session")
+    def test_skipped_when_not_logged_in(self, mock_session):
+        """A NotLoggedInError must not be misreported as a missing bucket."""
+        from lablink_cli.auth.credentials import NotLoggedInError
+
+        cfg = MagicMock()
+        cfg.bucket_name = "my-bucket"
+        cfg.app.region = "us-east-1"
+        mock_session.side_effect = NotLoggedInError("not signed in")
+
+        result = _check_s3_bucket(cfg)
+        assert result["status"] == "warn"
+        assert "not signed in" in result["detail"].lower()
+
+    @patch("lablink_cli.commands.doctor.get_session")
+    def test_skipped_when_sso_token_expired(self, mock_session):
+        from lablink_cli.auth.credentials import SSOTokenExpiredError
+
+        cfg = MagicMock()
+        cfg.bucket_name = "my-bucket"
+        cfg.app.region = "us-east-1"
+        mock_session.side_effect = SSOTokenExpiredError("expired")
+
+        result = _check_s3_bucket(cfg)
+        assert result["status"] == "warn"
+        assert "not signed in" in result["detail"].lower()
+
 
 # ------------------------------------------------------------------
 # run_doctor (integration-level)

--- a/packages/cli/tests/test_doctor_permission_audit.py
+++ b/packages/cli/tests/test_doctor_permission_audit.py
@@ -1,0 +1,102 @@
+"""Tests for the proactive permission audit in `lablink doctor`."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from lablink_cli.commands.doctor import _check_lablink_permissions
+
+
+def test_audit_returns_pass_when_all_actions_allowed():
+    fake_session = MagicMock()
+    fake_iam = MagicMock()
+    fake_session.client.side_effect = lambda svc: (
+        MagicMock(
+            get_caller_identity=lambda: {
+                "Arn": (
+                    "arn:aws:sts::123456789012:assumed-role/"
+                    "AWSReservedSSO_lablink_abc/alice"
+                ),
+            }
+        )
+        if svc == "sts"
+        else fake_iam
+    )
+    fake_iam.simulate_principal_policy.return_value = {
+        "EvaluationResults": [
+            {"EvalActionName": "ec2:DescribeInstances", "EvalDecision": "allowed"},
+            {"EvalActionName": "iam:GetRole", "EvalDecision": "allowed"},
+        ]
+    }
+    with patch(
+        "lablink_cli.commands.doctor.get_session", return_value=fake_session,
+        create=True,
+    ):
+        result = _check_lablink_permissions(region="us-east-1")
+
+    assert result["status"] == "pass"
+
+
+def test_audit_reports_denied_actions_with_update_policy_hint():
+    fake_session = MagicMock()
+    fake_iam = MagicMock()
+    fake_session.client.side_effect = lambda svc: (
+        MagicMock(
+            get_caller_identity=lambda: {
+                "Arn": (
+                    "arn:aws:sts::123456789012:assumed-role/"
+                    "AWSReservedSSO_lablink_abc/alice"
+                ),
+            }
+        )
+        if svc == "sts"
+        else fake_iam
+    )
+    fake_iam.simulate_principal_policy.return_value = {
+        "EvaluationResults": [
+            {"EvalActionName": "ec2:DescribeInstances", "EvalDecision": "allowed"},
+            {
+                "EvalActionName": "budgets:DescribeBudgets",
+                "EvalDecision": "implicitDeny",
+            },
+        ]
+    }
+    with patch(
+        "lablink_cli.commands.doctor.get_session", return_value=fake_session,
+        create=True,
+    ):
+        result = _check_lablink_permissions(region="us-east-1")
+
+    assert result["status"] == "fail"
+    assert "budgets:DescribeBudgets" in result["detail"]
+    assert "lablink login --update-policy" in result["detail"]
+
+
+def test_audit_skipped_when_not_on_lablink_sso_role():
+    """If the user has env-var creds (no SSO profile), warn and skip the audit."""
+    fake_session = MagicMock()
+    fake_session.client.return_value.get_caller_identity.return_value = {
+        "Arn": "arn:aws:iam::123456789012:user/alice",  # IAM user, not SSO
+    }
+    with patch(
+        "lablink_cli.commands.doctor.get_session", return_value=fake_session,
+        create=True,
+    ):
+        result = _check_lablink_permissions(region="us-east-1")
+    assert result["status"] == "warn"
+    assert "Identity Center" in result["detail"]
+
+
+def test_audit_skipped_when_not_logged_in():
+    """If get_session raises NotLoggedInError, the audit is warn-skipped."""
+    from lablink_cli.auth.credentials import NotLoggedInError
+
+    with patch(
+        "lablink_cli.commands.doctor.get_session",
+        side_effect=NotLoggedInError("not signed in"),
+        create=True,
+    ):
+        result = _check_lablink_permissions(region="us-east-1")
+    assert result["status"] == "warn"
+    detail = result["detail"]
+    assert "Not signed in" in detail or "not signed in" in detail.lower()

--- a/packages/cli/tests/test_login.py
+++ b/packages/cli/tests/test_login.py
@@ -1,0 +1,86 @@
+"""Tests for the `lablink login` command."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from typer.testing import CliRunner
+
+from lablink_cli.app import app
+
+runner = CliRunner()
+
+
+def test_login_runs_bootstrap_when_no_sso_profile():
+    with (
+        patch("lablink_cli.commands.login.is_logged_in", return_value=False),
+        patch(
+            "lablink_cli.commands.login._has_sso_profile", return_value=False
+        ),
+        patch("lablink_cli.commands.login.run_bootstrap") as mock_bootstrap,
+        patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
+    ):
+        mock_bootstrap.return_value = MagicMock(
+            start_url="https://d-test.awsapps.com/start",
+            sso_region="us-east-1",
+            permission_set_name="lablink",
+            deployment_region="us-east-1",
+        )
+        result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 0
+    mock_bootstrap.assert_called_once()
+    mock_steady.assert_called_once()
+
+
+def test_login_skips_bootstrap_when_sso_profile_exists():
+    with (
+        patch("lablink_cli.commands.login.is_logged_in", return_value=False),
+        patch("lablink_cli.commands.login._has_sso_profile", return_value=True),
+        patch("lablink_cli.commands.login.run_bootstrap") as mock_bootstrap,
+        patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
+    ):
+        result = runner.invoke(app, ["login"])
+
+    assert result.exit_code == 0
+    mock_bootstrap.assert_not_called()
+    mock_steady.assert_called_once()
+
+
+def test_login_already_logged_in_prompts_before_relogin():
+    with (
+        patch("lablink_cli.commands.login.is_logged_in", return_value=True),
+        patch("lablink_cli.commands.login._token_expiry_human", return_value="4h 12m"),
+        patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
+    ):
+        # User answers "n" — should not re-login
+        result = runner.invoke(app, ["login"], input="n\n")
+
+    assert result.exit_code == 0
+    assert "Already signed in" in result.stdout
+    mock_steady.assert_not_called()
+
+
+def test_login_already_logged_in_relogs_when_user_confirms():
+    with (
+        patch("lablink_cli.commands.login.is_logged_in", return_value=True),
+        patch("lablink_cli.commands.login._token_expiry_human", return_value="4h 12m"),
+        patch("lablink_cli.commands.login._has_sso_profile", return_value=True),
+        patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
+    ):
+        result = runner.invoke(app, ["login"], input="y\n")
+
+    assert result.exit_code == 0
+    mock_steady.assert_called_once()
+
+
+def test_login_update_policy_flag_reprints_deeplink():
+    with (
+        patch("lablink_cli.commands.login._copy_to_clipboard") as mock_copy,
+        patch("lablink_cli.commands.login.webbrowser.open"),
+    ):
+        result = runner.invoke(app, ["login", "--update-policy"])
+
+    assert result.exit_code == 0
+    assert "Permission set" in result.stdout
+    mock_copy.assert_called_once()

--- a/packages/cli/tests/test_login.py
+++ b/packages/cli/tests/test_login.py
@@ -84,3 +84,49 @@ def test_login_update_policy_flag_reprints_deeplink():
     assert result.exit_code == 0
     assert "Permission set" in result.stdout
     mock_copy.assert_called_once()
+
+
+def test_login_reset_bootstrap_clears_state_before_running(tmp_path, monkeypatch):
+    """--reset-bootstrap clears bootstrap-state.json before bootstrap runs."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+    state_file = tmp_path / ".lablink" / "bootstrap-state.json"
+    state_file.parent.mkdir(parents=True, exist_ok=True)
+    state_file.write_text(
+        '{"sso_start_url": "https://typo.awsapps.com/start", '
+        '"sso_region": "us-east-1", "permission_set_name": "lablink", '
+        '"steps_complete": ["enable"]}'
+    )
+
+    with (
+        patch("lablink_cli.commands.login.is_logged_in", return_value=False),
+        patch("lablink_cli.commands.login.has_sso_profile", return_value=False),
+        patch("lablink_cli.commands.login.run_bootstrap") as mock_bootstrap,
+        patch("lablink_cli.commands.login.run_steady_state"),
+    ):
+        mock_bootstrap.return_value = MagicMock(
+            start_url="https://d-test.awsapps.com/start",
+            sso_region="us-east-1",
+            permission_set_name="lablink",
+            deployment_region="us-east-1",
+        )
+        result = runner.invoke(app, ["login", "--reset-bootstrap"])
+
+    assert result.exit_code == 0
+    # State file should be gone — run_bootstrap will start from a clean slate.
+    assert not state_file.exists()
+    mock_bootstrap.assert_called_once()
+
+
+def test_login_reset_bootstrap_is_noop_when_no_state(tmp_path, monkeypatch):
+    """--reset-bootstrap with no existing state file just prints a notice."""
+    monkeypatch.setenv("HOME", str(tmp_path))
+
+    with (
+        patch("lablink_cli.commands.login.is_logged_in", return_value=False),
+        patch("lablink_cli.commands.login.has_sso_profile", return_value=True),
+        patch("lablink_cli.commands.login.run_steady_state"),
+    ):
+        result = runner.invoke(app, ["login", "--reset-bootstrap"])
+
+    assert result.exit_code == 0
+    assert "No in-progress bootstrap state" in result.stdout

--- a/packages/cli/tests/test_login.py
+++ b/packages/cli/tests/test_login.py
@@ -15,7 +15,7 @@ def test_login_runs_bootstrap_when_no_sso_profile():
     with (
         patch("lablink_cli.commands.login.is_logged_in", return_value=False),
         patch(
-            "lablink_cli.commands.login._has_sso_profile", return_value=False
+            "lablink_cli.commands.login.has_sso_profile", return_value=False
         ),
         patch("lablink_cli.commands.login.run_bootstrap") as mock_bootstrap,
         patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
@@ -36,7 +36,7 @@ def test_login_runs_bootstrap_when_no_sso_profile():
 def test_login_skips_bootstrap_when_sso_profile_exists():
     with (
         patch("lablink_cli.commands.login.is_logged_in", return_value=False),
-        patch("lablink_cli.commands.login._has_sso_profile", return_value=True),
+        patch("lablink_cli.commands.login.has_sso_profile", return_value=True),
         patch("lablink_cli.commands.login.run_bootstrap") as mock_bootstrap,
         patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
     ):
@@ -65,7 +65,7 @@ def test_login_already_logged_in_relogs_when_user_confirms():
     with (
         patch("lablink_cli.commands.login.is_logged_in", return_value=True),
         patch("lablink_cli.commands.login._token_expiry_human", return_value="4h 12m"),
-        patch("lablink_cli.commands.login._has_sso_profile", return_value=True),
+        patch("lablink_cli.commands.login.has_sso_profile", return_value=True),
         patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
     ):
         result = runner.invoke(app, ["login"], input="y\n")
@@ -76,7 +76,7 @@ def test_login_already_logged_in_relogs_when_user_confirms():
 
 def test_login_update_policy_flag_reprints_deeplink():
     with (
-        patch("lablink_cli.commands.login._copy_to_clipboard") as mock_copy,
+        patch("lablink_cli.commands.login.copy_to_clipboard") as mock_copy,
         patch("lablink_cli.commands.login.webbrowser.open"),
     ):
         result = runner.invoke(app, ["login", "--update-policy"])

--- a/packages/cli/tests/test_login.py
+++ b/packages/cli/tests/test_login.py
@@ -86,47 +86,20 @@ def test_login_update_policy_flag_reprints_deeplink():
     mock_copy.assert_called_once()
 
 
-def test_login_reset_bootstrap_clears_state_before_running(tmp_path, monkeypatch):
-    """--reset-bootstrap clears bootstrap-state.json before bootstrap runs."""
-    monkeypatch.setenv("HOME", str(tmp_path))
-    state_file = tmp_path / ".lablink" / "bootstrap-state.json"
-    state_file.parent.mkdir(parents=True, exist_ok=True)
-    state_file.write_text(
-        '{"sso_start_url": "https://typo.awsapps.com/start", '
-        '"sso_region": "us-east-1", "permission_set_name": "lablink", '
-        '"steps_complete": ["enable"]}'
-    )
-
+def test_login_keyboard_interrupt_during_bootstrap_prints_hint():
+    """Ctrl-C during bootstrap exits with a friendly 're-run lablink login' hint."""
     with (
         patch("lablink_cli.commands.login.is_logged_in", return_value=False),
         patch("lablink_cli.commands.login.has_sso_profile", return_value=False),
-        patch("lablink_cli.commands.login.run_bootstrap") as mock_bootstrap,
-        patch("lablink_cli.commands.login.run_steady_state"),
+        patch(
+            "lablink_cli.commands.login.run_bootstrap",
+            side_effect=KeyboardInterrupt,
+        ),
+        patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
     ):
-        mock_bootstrap.return_value = MagicMock(
-            start_url="https://d-test.awsapps.com/start",
-            sso_region="us-east-1",
-            permission_set_name="lablink",
-            deployment_region="us-east-1",
-        )
-        result = runner.invoke(app, ["login", "--reset-bootstrap"])
+        result = runner.invoke(app, ["login"])
 
-    assert result.exit_code == 0
-    # State file should be gone — run_bootstrap will start from a clean slate.
-    assert not state_file.exists()
-    mock_bootstrap.assert_called_once()
-
-
-def test_login_reset_bootstrap_is_noop_when_no_state(tmp_path, monkeypatch):
-    """--reset-bootstrap with no existing state file just prints a notice."""
-    monkeypatch.setenv("HOME", str(tmp_path))
-
-    with (
-        patch("lablink_cli.commands.login.is_logged_in", return_value=False),
-        patch("lablink_cli.commands.login.has_sso_profile", return_value=True),
-        patch("lablink_cli.commands.login.run_steady_state"),
-    ):
-        result = runner.invoke(app, ["login", "--reset-bootstrap"])
-
-    assert result.exit_code == 0
-    assert "No in-progress bootstrap state" in result.stdout
+    assert result.exit_code == 1
+    assert "Bootstrap interrupted" in result.stdout
+    assert "Re-run" in result.stdout and "lablink login" in result.stdout
+    mock_steady.assert_not_called()

--- a/packages/cli/tests/test_login.py
+++ b/packages/cli/tests/test_login.py
@@ -19,6 +19,7 @@ def test_login_runs_bootstrap_when_no_sso_profile():
         ),
         patch("lablink_cli.commands.login.run_bootstrap") as mock_bootstrap,
         patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
+        patch("lablink_cli.commands.login._run_verifier_with_retry"),
     ):
         mock_bootstrap.return_value = MagicMock(
             start_url="https://d-test.awsapps.com/start",
@@ -39,6 +40,7 @@ def test_login_skips_bootstrap_when_sso_profile_exists():
         patch("lablink_cli.commands.login.has_sso_profile", return_value=True),
         patch("lablink_cli.commands.login.run_bootstrap") as mock_bootstrap,
         patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
+        patch("lablink_cli.commands.login._run_verifier_with_retry"),
     ):
         result = runner.invoke(app, ["login"])
 
@@ -67,6 +69,7 @@ def test_login_already_logged_in_relogs_when_user_confirms():
         patch("lablink_cli.commands.login._token_expiry_human", return_value="4h 12m"),
         patch("lablink_cli.commands.login.has_sso_profile", return_value=True),
         patch("lablink_cli.commands.login.run_steady_state") as mock_steady,
+        patch("lablink_cli.commands.login._run_verifier_with_retry"),
     ):
         result = runner.invoke(app, ["login"], input="y\n")
 
@@ -103,3 +106,97 @@ def test_login_keyboard_interrupt_during_bootstrap_prints_hint():
     assert "Bootstrap interrupted" in result.stdout
     assert "Re-run" in result.stdout and "lablink login" in result.stdout
     mock_steady.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# _verify_permission_set
+# ------------------------------------------------------------------
+def _fake_sso_session(arn="arn:aws:sts::123456789012:assumed-role/"
+                          "AWSReservedSSO_lablink_abc/alice"):
+    """Build a MagicMock boto3 session with sts.get_caller_identity wired."""
+    fake_session = MagicMock()
+    fake_iam = MagicMock()
+    fake_session.client.side_effect = lambda svc: (
+        MagicMock(get_caller_identity=lambda: {"Arn": arn})
+        if svc == "sts" else fake_iam
+    )
+    return fake_session, fake_iam
+
+
+def test_verifier_returns_empty_list_when_all_actions_allowed():
+    from lablink_cli.commands.login import _verify_permission_set
+    from lablink_cli.auth.policy import AUDIT_ACTIONS
+
+    fake_session, fake_iam = _fake_sso_session()
+    fake_iam.simulate_principal_policy.return_value = {
+        "EvaluationResults": [
+            {"EvalActionName": a, "EvalDecision": "allowed"}
+            for a in AUDIT_ACTIONS
+        ]
+    }
+    with patch(
+        "lablink_cli.commands.login.boto3.Session", return_value=fake_session
+    ):
+        assert _verify_permission_set() == []
+
+
+def test_verifier_maps_denied_actions_to_friendly_policy_names():
+    from lablink_cli.commands.login import _verify_permission_set
+
+    fake_session, fake_iam = _fake_sso_session()
+    fake_iam.simulate_principal_policy.return_value = {
+        "EvaluationResults": [
+            {
+                "EvalActionName": "cloudwatch:DescribeAlarms",
+                "EvalDecision": "implicitDeny",
+            },
+            {"EvalActionName": "ec2:DescribeInstances", "EvalDecision": "allowed"},
+        ]
+    }
+    with patch(
+        "lablink_cli.commands.login.boto3.Session", return_value=fake_session
+    ):
+        missing = _verify_permission_set()
+
+    assert "CloudWatchFullAccess" in missing
+    assert "AmazonEC2FullAccess" not in missing
+
+
+def test_verifier_treats_simulate_access_denied_as_missing_iam_full_access():
+    """When IAMFullAccess is missing, simulate_principal_policy itself fails."""
+    from botocore.exceptions import ClientError
+
+    from lablink_cli.commands.login import _verify_permission_set
+
+    fake_session, fake_iam = _fake_sso_session()
+    fake_iam.simulate_principal_policy.side_effect = ClientError(
+        {"Error": {"Code": "AccessDenied", "Message": "denied"}},
+        "SimulatePrincipalPolicy",
+    )
+    with patch(
+        "lablink_cli.commands.login.boto3.Session", return_value=fake_session
+    ):
+        assert _verify_permission_set() == ["IAMFullAccess"]
+
+
+def test_verifier_dedupes_when_multiple_actions_map_to_inline_policy():
+    from lablink_cli.commands.login import _verify_permission_set
+
+    fake_session, fake_iam = _fake_sso_session()
+    fake_iam.simulate_principal_policy.return_value = {
+        "EvaluationResults": [
+            {"EvalActionName": a, "EvalDecision": "implicitDeny"}
+            for a in (
+                "sts:GetCallerIdentity",
+                "s3:ListBucket",
+                "dynamodb:DescribeTable",
+            )
+        ]
+    }
+    with patch(
+        "lablink_cli.commands.login.boto3.Session", return_value=fake_session
+    ):
+        missing = _verify_permission_set()
+
+    # Three inline-policy actions denied → reported once.
+    assert missing == ["<inline>"]

--- a/packages/cli/tests/test_setup_full.py
+++ b/packages/cli/tests/test_setup_full.py
@@ -13,7 +13,7 @@ class TestRunSetup:
     @patch("lablink_cli.commands.setup.create_dynamodb_table")
     @patch("lablink_cli.commands.setup.create_s3_bucket")
     @patch("lablink_cli.commands.setup.check_credentials")
-    @patch("lablink_cli.commands.setup._get_session")
+    @patch("lablink_cli.commands.setup.get_session")
     def test_basic_setup(
         self,
         mock_session,
@@ -44,7 +44,7 @@ class TestRunSetup:
     @patch("lablink_cli.commands.setup.create_dynamodb_table")
     @patch("lablink_cli.commands.setup.create_s3_bucket")
     @patch("lablink_cli.commands.setup.check_credentials")
-    @patch("lablink_cli.commands.setup._get_session")
+    @patch("lablink_cli.commands.setup.get_session")
     def test_with_dns(
         self,
         mock_session,
@@ -73,7 +73,7 @@ class TestRunSetup:
     @patch("lablink_cli.commands.setup.create_dynamodb_table")
     @patch("lablink_cli.commands.setup.create_s3_bucket")
     @patch("lablink_cli.commands.setup.check_credentials")
-    @patch("lablink_cli.commands.setup._get_session")
+    @patch("lablink_cli.commands.setup.get_session")
     def test_default_config_path(
         self,
         mock_session,

--- a/packages/cli/tests/test_status.py
+++ b/packages/cli/tests/test_status.py
@@ -142,8 +142,8 @@ class TestEstimateCosts:
         mock_cfg.ssl.provider = "none"
         mock_cfg.monitoring.enabled = False
 
-        with patch("lablink_cli.commands.status.boto3") as mock_boto:
-            mock_boto.client.side_effect = Exception("no creds")
+        with patch("lablink_cli.auth.credentials.get_session") as mock_get_session:
+            mock_get_session.side_effect = Exception("no creds")
             costs = estimate_costs(mock_cfg)
 
         # Should have allocator EC2, EBS, EIP at minimum
@@ -157,8 +157,8 @@ class TestEstimateCosts:
         mock_cfg.ssl.provider = "none"
         mock_cfg.monitoring.enabled = False
 
-        with patch("lablink_cli.commands.status.boto3") as mock_boto:
-            mock_boto.client.side_effect = Exception("no creds")
+        with patch("lablink_cli.auth.credentials.get_session") as mock_get_session:
+            mock_get_session.side_effect = Exception("no creds")
             costs = estimate_costs(mock_cfg)
 
         resource_names = [c["resource"] for c in costs]
@@ -169,8 +169,8 @@ class TestEstimateCosts:
         mock_cfg.ssl.provider = "acm"
         mock_cfg.monitoring.enabled = False
 
-        with patch("lablink_cli.commands.status.boto3") as mock_boto:
-            mock_boto.client.side_effect = Exception("no creds")
+        with patch("lablink_cli.auth.credentials.get_session") as mock_get_session:
+            mock_get_session.side_effect = Exception("no creds")
             costs = estimate_costs(mock_cfg)
 
         resource_names = [c["resource"] for c in costs]
@@ -181,8 +181,8 @@ class TestEstimateCosts:
         mock_cfg.ssl.provider = "none"
         mock_cfg.monitoring.enabled = True
 
-        with patch("lablink_cli.commands.status.boto3") as mock_boto:
-            mock_boto.client.side_effect = Exception("no creds")
+        with patch("lablink_cli.auth.credentials.get_session") as mock_get_session:
+            mock_get_session.side_effect = Exception("no creds")
             costs = estimate_costs(mock_cfg)
 
         resource_names = [c["resource"] for c in costs]
@@ -195,8 +195,8 @@ class TestEstimateCosts:
         mock_cfg.monitoring.enabled = False
         mock_cfg.machine.machine_type = "g4dn.xlarge"
 
-        with patch("lablink_cli.commands.status.boto3") as mock_boto:
-            mock_boto.client.side_effect = Exception("no creds")
+        with patch("lablink_cli.auth.credentials.get_session") as mock_get_session:
+            mock_get_session.side_effect = Exception("no creds")
             costs = estimate_costs(mock_cfg)
 
         resource_names = [c["resource"] for c in costs]
@@ -207,8 +207,8 @@ class TestEstimateCosts:
         mock_cfg.ssl.provider = "acm"
         mock_cfg.monitoring.enabled = True
 
-        with patch("lablink_cli.commands.status.boto3") as mock_boto:
-            mock_boto.client.side_effect = Exception("no creds")
+        with patch("lablink_cli.auth.credentials.get_session") as mock_get_session:
+            mock_get_session.side_effect = Exception("no creds")
             costs = estimate_costs(mock_cfg)
 
         for c in costs:

--- a/packages/cli/tests/test_utils.py
+++ b/packages/cli/tests/test_utils.py
@@ -107,7 +107,7 @@ class TestParseInstances:
 # query_ec2_instances
 # ------------------------------------------------------------------
 class TestQueryEc2Instances:
-    @patch("lablink_cli.commands.utils._get_session", create=True)
+    @patch("lablink_cli.auth.credentials.get_session")
     def test_returns_instances(self, mock_get_session):
         mock_ec2 = MagicMock()
         mock_get_session.return_value.client.return_value = mock_ec2
@@ -116,7 +116,7 @@ class TestQueryEc2Instances:
         ])
 
         with patch(
-            "lablink_cli.commands.setup._get_session", mock_get_session
+            "lablink_cli.auth.credentials.get_session", mock_get_session
         ):
             result = query_ec2_instances("us-east-1", "my-tag-*")
 
@@ -129,14 +129,14 @@ class TestQueryEc2Instances:
             ]
         )
 
-    @patch("lablink_cli.commands.utils._get_session", create=True)
+    @patch("lablink_cli.auth.credentials.get_session")
     def test_custom_states(self, mock_get_session):
         mock_ec2 = MagicMock()
         mock_get_session.return_value.client.return_value = mock_ec2
         mock_ec2.describe_instances.return_value = _make_ec2_response([])
 
         with patch(
-            "lablink_cli.commands.setup._get_session", mock_get_session
+            "lablink_cli.auth.credentials.get_session", mock_get_session
         ):
             query_ec2_instances(
                 "us-east-1", "tag", states=["running", "stopped"]
@@ -146,25 +146,25 @@ class TestQueryEc2Instances:
         state_filter = call_args[1]["Filters"][1]
         assert state_filter["Values"] == ["running", "stopped"]
 
-    @patch("lablink_cli.commands.utils._get_session", create=True)
+    @patch("lablink_cli.auth.credentials.get_session")
     def test_session_error_returns_empty(self, mock_get_session):
         mock_get_session.side_effect = Exception("no credentials")
 
         with patch(
-            "lablink_cli.commands.setup._get_session", mock_get_session
+            "lablink_cli.auth.credentials.get_session", mock_get_session
         ):
             result = query_ec2_instances("us-east-1", "tag")
 
         assert result == []
 
-    @patch("lablink_cli.commands.utils._get_session", create=True)
+    @patch("lablink_cli.auth.credentials.get_session")
     def test_describe_error_returns_empty(self, mock_get_session):
         mock_ec2 = MagicMock()
         mock_get_session.return_value.client.return_value = mock_ec2
         mock_ec2.describe_instances.side_effect = Exception("API error")
 
         with patch(
-            "lablink_cli.commands.setup._get_session", mock_get_session
+            "lablink_cli.auth.credentials.get_session", mock_get_session
         ):
             result = query_ec2_instances("us-east-1", "tag")
 

--- a/packages/cli/tests/test_utils.py
+++ b/packages/cli/tests/test_utils.py
@@ -248,13 +248,18 @@ class TestGetTerraformOutputs:
             "ec2_public_ip": "10.0.0.1",
             "private_key_pem": "-----BEGIN RSA PRIVATE KEY-----",
         }
-        mock_run.assert_called_once_with(
-            ["terraform", "output", "-json"],
-            cwd=tmp_path,
-            capture_output=True,
-            text=True,
-            check=True,
-        )
+        # Assert the command, cwd, and capture flags — but not env, since
+        # subprocess_env() injects AWS_PROFILE based on the developer's
+        # local ~/.aws/config and we don't want the test to depend on that.
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        args = mock_run.call_args.args[0]
+        assert args == ["terraform", "output", "-json"]
+        assert kwargs["cwd"] == tmp_path
+        assert kwargs["capture_output"] is True
+        assert kwargs["text"] is True
+        assert kwargs["check"] is True
+        assert "env" in kwargs  # subprocess_env was used
 
     def test_subprocess_error(self, tmp_path):
         with patch("subprocess.run") as mock_run:


### PR DESCRIPTION
## Summary

- New `lablink login` command authenticates the operator to AWS via Identity Center (username + password + MFA, no IAM access keys ever)
- Adds a guided first-time bootstrap that walks the user through enabling Identity Center and creating the lablink permission set, all via console deep-links
- `lablink doctor` now proactively audits the live SSO role's permissions against the canonical policy and points users at `lablink login --update-policy` when something's missing

## Background

Today, lablink operators have to find their AWS access keys in the IAM console and configure them via `aws configure`. This PR replaces that with a near-zero-AWS-knowledge flow: the user provides only their Identity Center username and password, and the CLI handles all the AWS plumbing.

## Architecture

A new `lablink_cli/auth/` module with five focused, single-responsibility files:

| File | Responsibility |
|---|---|
| `auth/policy.py` | Permission set JSON — single source of truth (8 AWS-managed policies + a tight inline policy) |
| `auth/credentials.py` | `get_session()` — central credential resolver (SSO → env vars → fail) |
| `auth/utils.py` | Shared path helpers (`aws_config_path`, `sso_cache_path`) |
| `auth/sso_flow.py` | Wraps `aws sso login` (subprocess) and discovers accounts/roles via boto3 |
| `auth/bootstrap.py` | First-time Identity Center setup with resumable state |
| `commands/login.py` | Top-level orchestrator |

All existing AWS calls in `setup.py`, `deploy.py`, `doctor.py`, `cleanup.py`, and `utils.py` migrate to `auth.credentials.get_session()` — the legacy access-key path keeps working via a fallback in the resolver.

## Changes Made

**New files (10):**
- `auth/{__init__,policy,utils,credentials,sso_flow,bootstrap}.py`
- `commands/login.py`
- `tests/test_auth_{policy,credentials,sso_flow,bootstrap}.py`
- `tests/test_login.py`, `tests/test_doctor_permission_audit.py`

**Modified (8):**
- `pyproject.toml` — adds `pyperclip>=1.8` (clipboard fallback for the bootstrap policy paste)
- `app.py` — registers `lablink login` in the Setup help panel
- `setup.py`, `deploy.py`, `cleanup.py`, `doctor.py`, `utils.py` — migrate to `get_session()`; `_get_session` wrapper removed entirely
- Existing test files updated for the new patch targets

**Commits (8 logical commits):**
1. `dep: add new dependency pyperclip for copy-paste operations`
2. `feat: add policy specified required by the admin to deploy lablink`
3. `feat: add credentials.py to resolve sessions (get_session())`
4. `feat: add aws sso login to use the credentials for lablink`
5. `feat: add state management of SSO`
6. `feat: add new login CLI to the lablink-cli`
7. `fix: cleanup _get_session helper function and shift to the new auth module`
8. `feat: lablink doctor now checks for credentials and policies`

## Testing

- **Unit tests:** 41 new tests across the auth module, covering the OIDC flow polling state machine, credential resolution chain, bootstrap resumability, clipboard fallback, account/role selection, and the `--update-policy` UX.
- **Audit tests:** 4 new tests for the doctor permission audit (pass / fail-with-hint / not-on-SSO-role / not-logged-in).
- **Migration coverage:** ~10 existing tests in `test_setup_full`, `test_deploy`, `test_cleanup_full`, `test_doctor_full`, `test_utils` updated for the new `get_session()` patch targets.
- **Total:** 331 passed, 1 deselected (integration). All ruff checks pass.

### Manual verification (recommended before merge):

- [x] Run `lablink login` on a fresh AWS account — verify the bootstrap flow completes in ≤ 5 min
- [x] Run `lablink login` again with a valid token — verify the \"Already signed in\" prompt
- [ ] Delete `~/.aws/sso/cache/*.json` and run `lablink deploy` — verify clean \"Run lablink login\" error
- [x] Run `lablink doctor` on a lablink SSO session — verify the permission audit reports `pass`
- [x] Run `lablink doctor` with env-var credentials only — verify the audit cleanly skips with `warn`

## Design Decisions

- **Wrap `aws sso login` instead of native OIDC** — AWS CLI v2 is already a documented prerequisite, so requiring it here adds no install burden, and the official tool handles edge cases (proxies, MFA, headless fallbacks) we'd otherwise reproduce. This dropped ~140 lines of code from the original native implementation.
- **Console handoff for first-time bootstrap** — Identity Center can't be enabled programmatically without admin keys (which the user wanted to avoid), so the CLI opens deep-links to the AWS console and prompts the user to paste back the SSO Start URL. One-time, ~5-min flow.
- **Tight scope where it's free, broad managed policies elsewhere** — S3 (`lablink-tf-state-*`), DynamoDB (`lock-table`), and CloudTrail bucket are scoped via inline policy. EC2/ELB/IAM/CloudWatch/Route53/SNS use AWS-managed `*FullAccess` policies because resource-level scoping isn't viable for those services without renaming Terraform resources.
- **Backwards compatible** — existing access-key users keep working via env-var fallback in `get_session()`. No flag day, no deprecation warning.
- **Multi-user labs out of scope for v1** — bootstrap creates one SSO user. PI manually adds students via the AWS console for now.

## Out of scope (follow-ups)

- CI/CD support (env vars + boto3 default chain for now)
- `lablink invite` for multi-user labs
- `lablink logout` as a first-class command
- Tightening IAM policy by renaming Terraform resources to `lablink-*` prefix

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)