### PR TITLE
fix(cli): SSL-aware deploy health check, zone_id auto-save, drop db password prompt

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,7 +179,7 @@ We welcome contributions! Please see:
 
 ## 📝 License
 
-[BSD-3-Clause License](LICENSE)
+[BSD-2-Clause License](LICENSE)
 
 ---
 

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -813,7 +813,7 @@ Contributors are recognized in:
 
 ## License
 
-By contributing, you agree that your contributions will be licensed under the same [BSD-3-Clause License](https://github.com/talmolab/lablink/blob/main/LICENSE) that covers the project.
+By contributing, you agree that your contributions will be licensed under the same [BSD-2-Clause License](https://github.com/talmolab/lablink/blob/main/LICENSE) that covers the project.
 
 ## Thank You!
 

--- a/packages/cli/src/lablink_cli/__init__.py
+++ b/packages/cli/src/lablink_cli/__init__.py
@@ -5,4 +5,4 @@ TEMPLATE_VERSION = "v0.2.0"
 # SHA-256 of the GitHub release tarball for TEMPLATE_VERSION.
 # Update this when bumping TEMPLATE_VERSION.
 # To compute: curl -sL <tarball_url> | sha256sum
-TEMPLATE_SHA256 = "c1d3d31ed318ea22c9ba59450779caf071b0d37af8e806ed4ee837811347311a"
+TEMPLATE_SHA256 = "93c2694915e588e3c804612639666a73354fcdaa53607734c2d26f07d08eca58"

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -159,7 +159,7 @@ def deploy(
         "--yes",
         "-y",
         help="Skip confirmation prompts. Does not bypass credential prompts "
-        "(admin/db passwords still required interactively).",
+        "(admin password still required interactively).",
     ),
 ) -> None:
     """Deploy LabLink infrastructure with Terraform."""
@@ -186,7 +186,7 @@ def destroy(
         "--yes",
         "-y",
         help="Skip confirmation prompts. Does not bypass credential prompts "
-        "(admin/db passwords still required interactively).",
+        "(admin password still required interactively).",
     ),
     verbose: bool = typer.Option(
         False,

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -311,6 +311,36 @@ def _prompt_passwords() -> dict[str, str]:
     }
 
 
+def _build_health_poll_target(cfg: Config, ec2_ip: str) -> dict:
+    """Choose the post-deploy health-check URL and timeout for this SSL config.
+
+    Caddy's `${DOMAIN} { ... }` site block matches the request Host header,
+    so for letsencrypt/cloudflare an IP-based GET to port 80 doesn't match
+    any site and never returns healthy — the spinner sits for the full
+    timeout. ACM has no listener on EC2:80 at all (ALB owns 80/443), but
+    Flask is reachable on :5000 directly. Returns the URL + max_wait that
+    actually responds for this provider.
+    """
+    provider = cfg.ssl.provider
+    domain = cfg.dns.domain if cfg.dns.enabled else ""
+
+    if provider == "none":
+        return {"url": f"http://{ec2_ip}", "max_wait": 300}
+    if provider == "acm":
+        # ALB owns 80/443; Flask is bound 0.0.0.0:5000 (SG allows 5000).
+        return {"url": f"http://{ec2_ip}:5000", "max_wait": 300}
+    # letsencrypt / cloudflare: Caddy is Host-bound to the domain. Poll the
+    # domain instead of the IP. Allow extra time for DNS propagation and
+    # (for LE) ACME cert issuance.
+    if not domain:
+        # Misconfiguration — SSL provider requires a domain — but fall back
+        # to IP polling rather than crashing. The deploy will likely fail
+        # downstream and the operator will see why.
+        return {"url": f"http://{ec2_ip}", "max_wait": 300}
+    scheme = "https" if provider == "letsencrypt" else "http"
+    return {"url": f"{scheme}://{domain}", "max_wait": 600}
+
+
 def _poll_allocator_health(
     poll_url: str,
     *,
@@ -501,16 +531,16 @@ def run_deploy(
         outputs = get_terraform_outputs(deploy_dir)
         ec2_ip = outputs.get("ec2_public_ip", "")
 
-        max_wait = 300
-
-        # Phase 1: Poll EC2 IP directly for allocator readiness.
-        # Uses port 80 (nginx) — the EC2 security group does not expose
-        # Flask's 5000 externally; nginx reverse-proxies to it internally.
+        # Phase 1: Poll the allocator for readiness. URL and timeout depend
+        # on the SSL provider — see _build_health_poll_target for the
+        # rationale per provider.
         if ec2_ip:
-            direct_url = f"http://{ec2_ip}"
+            target = _build_health_poll_target(cfg, ec2_ip)
+            direct_url = target["url"]
+            max_wait = target["max_wait"]
             console.print(
                 f"[bold]Waiting for allocator to become healthy"
-                f" (up to {max_wait // 60} min)...[/bold]"
+                f" at {direct_url} (up to {max_wait // 60} min)...[/bold]"
             )
             with phase_timer(
                 metrics,

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -279,7 +279,7 @@ def _terraform_init(
 
 
 def _prompt_passwords() -> dict[str, str]:
-    """Prompt for admin and database passwords at deploy time."""
+    """Prompt for the admin credentials at deploy time."""
     import getpass
 
     console.print(
@@ -296,18 +296,10 @@ def _prompt_passwords() -> dict[str, str]:
         console.print("  [red]Admin password is required[/red]")
         raise SystemExit(1)
 
-    db_pw = getpass.getpass("  Database password: ")
-    if not db_pw:
-        console.print(
-            "  [red]Database password is required[/red]"
-        )
-        raise SystemExit(1)
-
     console.print()
     return {
         "admin_user": admin_user,
         "admin_password": admin_pw,
-        "db_password": db_pw,
     }
 
 
@@ -443,7 +435,6 @@ def run_deploy(
     cfg_dict["app"]["admin_password"] = passwords[
         "admin_password"
     ]
-    cfg_dict["db"]["password"] = passwords["db_password"]
 
     with open(config_path, "w") as f:
         yaml.dump(

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -304,15 +304,8 @@ def _prompt_passwords() -> dict[str, str]:
 
 
 def _build_health_poll_target(cfg: Config, ec2_ip: str) -> dict:
-    """Choose the post-deploy health-check URL and timeout for this SSL config.
-
-    Caddy's `${DOMAIN} { ... }` site block matches the request Host header,
-    so for letsencrypt/cloudflare an IP-based GET to port 80 doesn't match
-    any site and never returns healthy — the spinner sits for the full
-    timeout. ACM has no listener on EC2:80 at all (ALB owns 80/443), but
-    Flask is reachable on :5000 directly. Returns the URL + max_wait that
-    actually responds for this provider.
-    """
+    """Pick the post-deploy poll URL + timeout. Caddy is Host-bound under
+    letsencrypt/cloudflare, so those must poll the domain, not the IP."""
     provider = cfg.ssl.provider
     domain = cfg.dns.domain if cfg.dns.enabled else ""
 
@@ -321,13 +314,12 @@ def _build_health_poll_target(cfg: Config, ec2_ip: str) -> dict:
     if provider == "acm":
         # ALB owns 80/443; Flask is bound 0.0.0.0:5000 (SG allows 5000).
         return {"url": f"http://{ec2_ip}:5000", "max_wait": 300}
-    # letsencrypt / cloudflare: Caddy is Host-bound to the domain. Poll the
-    # domain instead of the IP. Allow extra time for DNS propagation and
-    # (for LE) ACME cert issuance.
     if not domain:
-        # Misconfiguration — SSL provider requires a domain — but fall back
-        # to IP polling rather than crashing. The deploy will likely fail
-        # downstream and the operator will see why.
+        console.print(
+            f"  [yellow]Warning:[/yellow] ssl.provider='{provider}' "
+            f"without dns.domain — falling back to IP poll. "
+            f"The deploy will likely fail to serve at the expected URL."
+        )
         return {"url": f"http://{ec2_ip}", "max_wait": 300}
     scheme = "https" if provider == "letsencrypt" else "http"
     return {"url": f"{scheme}://{domain}", "max_wait": 600}

--- a/packages/cli/src/lablink_cli/commands/setup.py
+++ b/packages/cli/src/lablink_cli/commands/setup.py
@@ -313,9 +313,10 @@ def run_setup(cfg: Config, config_path: Path | None = None) -> None:
         )
         zone_id = create_route53_zone(session, cfg.dns.domain)
         if zone_id and not cfg.dns.zone_id:
+            cfg.dns.zone_id = zone_id
+            save_config(cfg, config_path)
             console.print(
-                f"  [dim]Tip: set dns.zone_id to "
-                f"'{zone_id}' in your config[/dim]"
+                f"  [green]saved[/green] dns.zone_id → {config_path}"
             )
         console.print()
 

--- a/packages/cli/tests/test_deploy.py
+++ b/packages/cli/tests/test_deploy.py
@@ -365,7 +365,6 @@ def _patch_deploy_deps(deploy_dir):
             return_value={
                 "admin_user": "admin",
                 "admin_password": "pw",
-                "db_password": "dbpw",
             },
         ),
         patch("lablink_cli.commands.deploy._terraform_init"),

--- a/packages/cli/tests/test_deploy.py
+++ b/packages/cli/tests/test_deploy.py
@@ -15,6 +15,7 @@ from lablink_cli.api import (
     AllocatorUnavailableError,
 )
 from lablink_cli.commands.deploy import (
+    _build_health_poll_target,
     _destroy_client_vms,
     _poll_allocator_health,
     _prepare_working_dir,
@@ -230,6 +231,61 @@ class TestTerraformDestroy:
         mock_tf_init.assert_called_once_with(deploy_dir, mock_cfg)
         mock_tf_run.assert_called_once()
         mock_rmtree.assert_called_once_with(deploy_dir)
+
+
+# ------------------------------------------------------------------
+# _build_health_poll_target
+# ------------------------------------------------------------------
+class TestBuildHealthPollTarget:
+    """SSL-aware Phase 1 health URL selection.
+
+    Regression guard for the stuck-spinner bug: deploying with SSL+domain
+    polled http://{ec2_ip} (port 80), which Caddy's Host-bound site block
+    never matched, so the poll loop ran the full timeout before failing.
+    """
+
+    def test_ssl_none_uses_ip_port_80(self, mock_cfg):
+        mock_cfg.ssl.provider = "none"
+        target = _build_health_poll_target(mock_cfg, "1.2.3.4")
+        assert target["url"] == "http://1.2.3.4"
+        assert target["max_wait"] == 300
+
+    def test_ssl_acm_uses_ip_port_5000(self, mock_cfg):
+        """ACM: ALB owns 80/443 on EC2; Flask is bound 0.0.0.0:5000."""
+        mock_cfg.ssl.provider = "acm"
+        mock_cfg.dns.enabled = True
+        mock_cfg.dns.domain = "lab.example.com"
+        target = _build_health_poll_target(mock_cfg, "1.2.3.4")
+        assert target["url"] == "http://1.2.3.4:5000"
+        assert target["max_wait"] == 300
+
+    def test_ssl_letsencrypt_polls_domain_https(self, mock_cfg):
+        """LetsEncrypt: Caddy is Host-bound; must poll via domain over HTTPS."""
+        mock_cfg.ssl.provider = "letsencrypt"
+        mock_cfg.dns.enabled = True
+        mock_cfg.dns.domain = "lab.example.com"
+        target = _build_health_poll_target(mock_cfg, "1.2.3.4")
+        assert target["url"] == "https://lab.example.com"
+        # Longer wait: DNS propagation + ACME cert issuance.
+        assert target["max_wait"] == 600
+
+    def test_ssl_cloudflare_polls_domain_http(self, mock_cfg):
+        """CloudFlare: Caddy serves plain HTTP; CF terminates SSL externally."""
+        mock_cfg.ssl.provider = "cloudflare"
+        mock_cfg.dns.enabled = True
+        mock_cfg.dns.domain = "lab.example.com"
+        target = _build_health_poll_target(mock_cfg, "1.2.3.4")
+        assert target["url"] == "http://lab.example.com"
+        assert target["max_wait"] == 600
+
+    def test_ssl_letsencrypt_without_domain_falls_back_to_ip(self, mock_cfg):
+        """Misconfigured (LE + no domain) — fall back rather than crash here."""
+        mock_cfg.ssl.provider = "letsencrypt"
+        mock_cfg.dns.enabled = False
+        mock_cfg.dns.domain = ""
+        target = _build_health_poll_target(mock_cfg, "1.2.3.4")
+        assert target["url"] == "http://1.2.3.4"
+        assert target["max_wait"] == 300
 
 
 # ------------------------------------------------------------------

--- a/packages/cli/tests/test_setup_full.py
+++ b/packages/cli/tests/test_setup_full.py
@@ -68,6 +68,8 @@ class TestRunSetup:
 
         run_setup(mock_cfg, config_path=tmp_path / "config.yaml")
         mock_route53.assert_called_once()
+        # zone_id should be auto-written back into the config
+        assert mock_cfg.dns.zone_id == "Z123"
 
     @patch("lablink_cli.config.schema.save_config")
     @patch("lablink_cli.commands.setup.create_dynamodb_table")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 readme = "README.md"
 requires-python = ">=3.10"
-license = {text = "BSD-3-Clause"}
+license = {text = "BSD-2-Clause"}
 
 # This is a workspace root for documentation and tooling
 # The actual packages are in subdirectories with their own pyproject.toml


### PR DESCRIPTION
## Summary
- Fix the deploy spinner that hung for the full timeout when SSL was enabled (Caddy is Host-bound; the IP-based poll never matched a site).
- Auto-write `dns.zone_id` back to the user's config after Route53 zone creation instead of asking them to copy it manually.
- Drop the interactive database-password prompt from `deploy` / `destroy` — only admin credentials are collected.
- Re-pin the `lablink-template` v0.2.0 SHA256 to match the published tarball.
- Sweep a few licence-string inconsistencies in `README.md`, `docs/contributing.md`, and `pyproject.toml`.

## Changes Made
- `commands/deploy.py`: new `_build_health_poll_target(cfg, ec2_ip)` selects URL + timeout per SSL provider:
  - `none` → `http://{ip}` (300 s)
  - `acm` → `http://{ip}:5000` (ALB owns 80/443; Flask is reachable directly on 5000) (300 s)
  - `letsencrypt` → `https://{domain}` (600 s — DNS propagation + ACME issuance)
  - `cloudflare` → `http://{domain}` (CF terminates SSL externally) (600 s)
  - misconfigured (SSL + no domain) → falls back to IP poll rather than crashing
- `commands/setup.py`: persists `dns.zone_id` via `save_config` after `create_route53_zone` and prints a `saved` confirmation instead of a manual-copy tip.
- `commands/deploy.py` + `app.py`: remove the `db_password` prompt and update the `--yes` help text accordingly.
- `__init__.py`: bump `TEMPLATE_SHA256` to the current v0.2.0 release hash.
- Licence string fixes in `README.md`, `docs/contributing.md`, `pyproject.toml`.

## Testing
- `tests/test_deploy.py`: new `TestBuildHealthPollTarget` covers all five provider/config branches as a regression guard for the stuck-spinner bug; `_patch_deploy_deps` no longer returns `db_password`.
- `tests/test_setup_full.py`: asserts `cfg.dns.zone_id` is auto-written after Route53 zone creation.
- No manual deploy run in this PR — verification of the health-poll URL selection is via the new unit tests.

## Design Decisions
- Picked per-provider URLs in a small helper rather than threading SSL knowledge through `_poll_allocator_health`, so the polling loop stays provider-agnostic and the SSL routing logic is easy to test in isolation.
- The misconfigured `SSL + no domain` case falls back to IP polling rather than raising — the deploy will fail downstream with a clearer error, and we'd rather not crash the CLI mid-apply.
- Auto-saving `zone_id` rewrites the user's config file. Acceptable here because `setup` is already the command that owns config bootstrap; the user explicitly invoked it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)