### PR TITLE
docs: scrub remaining removed-monitoring-feature references

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -267,7 +267,7 @@ Receives and stores logs pushed from a VM.
 
 **Endpoint:** `POST /api/vm-logs`
 
-**Description:** Called by the CloudWatch agent on the client VM (via a Lambda subscription) to push `cloud-init` logs to the allocator.
+**Description:** Receives batched log lines pushed from a VM by the `log_shipper.sh` script, which tails the VM's `cloud-init` output and the client container's Docker logs.
 
 **Authentication:** Bearer Token
 
@@ -297,7 +297,7 @@ Receives and stores logs pushed from a VM.
 - **Code:** `404 Not Found` if the VM does not exist.
 - **Code:** `500 Internal Server Error` on failure.
 
-**Client Usage:** This endpoint is not called directly from any code in `packages/client`. It is part of the AWS infrastructure that forwards logs from the client VM. Logs from the client VM are sent to AWS CloudWatch, which triggers a Lambda function that then forwards the log messages to this endpoint on the allocator.
+**Client Usage:** This endpoint is not called directly from any code in `packages/client`. The `log_shipper.sh` script, installed on each VM by the Terraform user-data script, tails the VM's `cloud-init` output log and the client container's Docker logs, batches new lines, and POSTs them to this endpoint using the API token as a Bearer credential.
 
 ## Admin API Endpoints
 
@@ -513,5 +513,5 @@ Retrieves reboot tracking information for a specific VM.
 **Error Response:**
 
 - **Code:** `404 Not Found` if the VM is not found.
-- **Code:** `503 Service Unavailable` if the logs are not yet available because the CloudWatch agent is still being installed.
+- **Code:** `503 Service Unavailable` if the logs are not yet available because the VM's log shipper has not started reporting yet.
 - **Code:** `500 Internal Server Error` on failure.

--- a/docs/aws-setup.md
+++ b/docs/aws-setup.md
@@ -558,42 +558,20 @@ aws iam attach-role-policy \
 aws iam attach-role-policy \
   --role-name GitHubActionsLabLinkRole \
   --policy-arn arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess
-
-# Monitoring and logging permissions
-aws iam attach-role-policy \
-  --role-name GitHubActionsLabLinkRole \
-  --policy-arn arn:aws:iam::aws:policy/CloudWatchLogsFullAccess
-
-aws iam attach-role-policy \
-  --role-name GitHubActionsLabLinkRole \
-  --policy-arn arn:aws:iam::aws:policy/AWSCloudTrail_FullAccess
-
-# Lambda and notifications permissions
-aws iam attach-role-policy \
-  --role-name GitHubActionsLabLinkRole \
-  --policy-arn arn:aws:iam::aws:policy/AWSLambda_FullAccess
-
-aws iam attach-role-policy \
-  --role-name GitHubActionsLabLinkRole \
-  --policy-arn arn:aws:iam::aws:policy/AmazonSNSFullAccess
 ```
 
-**Note:** This approach uses 8 AWS managed policies that provide full access to the required services. While broader than strictly necessary, it ensures all Terraform operations succeed without permission errors.
+**Note:** This approach uses 4 AWS managed policies that provide full access to the required services. While broader than strictly necessary, it ensures all Terraform operations succeed without permission errors.
 
-| Policy                     | Purpose                                            |
-| -------------------------- | -------------------------------------------------- |
-| `AmazonEC2FullAccess`      | EC2 instances, security groups, key pairs, EIPs    |
-| `AmazonS3FullAccess`       | Terraform state, CloudTrail logs                   |
-| `IAMFullAccess`            | Roles, instance profiles for CloudWatch/CloudTrail |
-| `AmazonDynamoDBFullAccess` | Terraform state locking                            |
-| `CloudWatchLogsFullAccess` | Log groups, metric filters, alarms                 |
-| `AWSCloudTrail_FullAccess` | Audit logging                                      |
-| `AWSLambda_FullAccess`     | Log processing functions                           |
-| `AmazonSNSFullAccess`      | Alert notifications                                |
+| Policy                     | Purpose                                         |
+| -------------------------- | ----------------------------------------------- |
+| `AmazonEC2FullAccess`      | EC2 instances, security groups, key pairs, EIPs |
+| `AmazonS3FullAccess`       | Terraform state                                 |
+| `IAMFullAccess`            | Roles, instance profiles                        |
+| `AmazonDynamoDBFullAccess` | Terraform state locking                         |
 
 #### Option B: AWS CLI - Create Custom Policy
 
-For more restrictive permissions, create a custom policy that covers all LabLink Terraform resources including EC2, ALB, CloudTrail, CloudWatch, Lambda, SNS, and Budgets.
+For more restrictive permissions, create a custom policy that covers all LabLink Terraform resources including EC2 and ALB.
 
 Create `lablink-terraform-policy.json`:
 
@@ -716,139 +694,6 @@ Create `lablink-terraform-policy.json`:
         "acm:GetCertificate"
       ],
       "Resource": "*"
-    },
-    {
-      "Sid": "CloudWatchLogsAndAlarms",
-      "Effect": "Allow",
-      "Action": [
-        "logs:CreateLogGroup",
-        "logs:DeleteLogGroup",
-        "logs:DescribeLogGroups",
-        "logs:PutRetentionPolicy",
-        "logs:DeleteRetentionPolicy",
-        "logs:CreateLogStream",
-        "logs:DeleteLogStream",
-        "logs:PutLogEvents",
-        "logs:PutMetricFilter",
-        "logs:DeleteMetricFilter",
-        "logs:DescribeMetricFilters",
-        "logs:PutSubscriptionFilter",
-        "logs:DeleteSubscriptionFilter",
-        "logs:DescribeSubscriptionFilters",
-        "logs:TagResource",
-        "logs:UntagResource",
-        "logs:ListTagsForResource",
-        "cloudwatch:PutMetricAlarm",
-        "cloudwatch:DeleteAlarms",
-        "cloudwatch:DescribeAlarms",
-        "cloudwatch:EnableAlarmActions",
-        "cloudwatch:DisableAlarmActions",
-        "cloudwatch:TagResource",
-        "cloudwatch:UntagResource",
-        "cloudwatch:ListTagsForResource"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "CloudTrail",
-      "Effect": "Allow",
-      "Action": [
-        "cloudtrail:CreateTrail",
-        "cloudtrail:DeleteTrail",
-        "cloudtrail:DescribeTrails",
-        "cloudtrail:GetTrailStatus",
-        "cloudtrail:StartLogging",
-        "cloudtrail:StopLogging",
-        "cloudtrail:UpdateTrail",
-        "cloudtrail:PutEventSelectors",
-        "cloudtrail:GetEventSelectors",
-        "cloudtrail:AddTags",
-        "cloudtrail:RemoveTags",
-        "cloudtrail:ListTags"
-      ],
-      "Resource": "*"
-    },
-    {
-      "Sid": "CloudTrailS3Bucket",
-      "Effect": "Allow",
-      "Action": [
-        "s3:CreateBucket",
-        "s3:DeleteBucket",
-        "s3:PutBucketPolicy",
-        "s3:DeleteBucketPolicy",
-        "s3:GetBucketPolicy",
-        "s3:PutBucketAcl",
-        "s3:GetBucketAcl",
-        "s3:PutEncryptionConfiguration",
-        "s3:GetEncryptionConfiguration",
-        "s3:PutBucketVersioning",
-        "s3:GetBucketVersioning",
-        "s3:PutBucketPublicAccessBlock",
-        "s3:GetBucketPublicAccessBlock",
-        "s3:PutLifecycleConfiguration",
-        "s3:GetLifecycleConfiguration",
-        "s3:PutBucketTagging",
-        "s3:GetBucketTagging",
-        "s3:ListBucket",
-        "s3:GetObject",
-        "s3:PutObject",
-        "s3:DeleteObject"
-      ],
-      "Resource": [
-        "arn:aws:s3:::lablink-cloudtrail-*",
-        "arn:aws:s3:::lablink-cloudtrail-*/*"
-      ]
-    },
-    {
-      "Sid": "Lambda",
-      "Effect": "Allow",
-      "Action": [
-        "lambda:CreateFunction",
-        "lambda:DeleteFunction",
-        "lambda:GetFunction",
-        "lambda:GetFunctionConfiguration",
-        "lambda:UpdateFunctionCode",
-        "lambda:UpdateFunctionConfiguration",
-        "lambda:AddPermission",
-        "lambda:RemovePermission",
-        "lambda:GetPolicy",
-        "lambda:InvokeFunction",
-        "lambda:TagResource",
-        "lambda:UntagResource",
-        "lambda:ListTags"
-      ],
-      "Resource": "arn:aws:lambda:*:*:function:lablink*"
-    },
-    {
-      "Sid": "SNSNotifications",
-      "Effect": "Allow",
-      "Action": [
-        "sns:CreateTopic",
-        "sns:DeleteTopic",
-        "sns:GetTopicAttributes",
-        "sns:SetTopicAttributes",
-        "sns:Subscribe",
-        "sns:Unsubscribe",
-        "sns:ListSubscriptionsByTopic",
-        "sns:Publish",
-        "sns:TagResource",
-        "sns:UntagResource",
-        "sns:ListTagsForResource"
-      ],
-      "Resource": "arn:aws:sns:*:*:lablink*"
-    },
-    {
-      "Sid": "Budgets",
-      "Effect": "Allow",
-      "Action": [
-        "budgets:ViewBudget",
-        "budgets:CreateBudgetAction",
-        "budgets:DeleteBudgetAction",
-        "budgets:UpdateBudgetAction",
-        "budgets:ExecuteBudgetAction",
-        "budgets:ModifyBudget"
-      ],
-      "Resource": "*"
     }
   ]
 }
@@ -856,20 +701,15 @@ Create `lablink-terraform-policy.json`:
 
 **Note:** This policy covers all AWS services used by the LabLink Terraform configuration:
 
-| Service        | Purpose                                                             |
-| -------------- | ------------------------------------------------------------------- |
-| **S3**         | Terraform state storage, CloudTrail logs                            |
-| **DynamoDB**   | Terraform state locking                                             |
-| **EC2**        | Allocator and client VM instances, security groups, key pairs, EIPs |
-| **IAM**        | Instance profiles, CloudWatch agent roles, CloudTrail roles         |
-| **Route53**    | DNS records for allocator endpoints                                 |
-| **ELB**        | Application Load Balancer for HTTPS termination                     |
-| **ACM**        | SSL/TLS certificates                                                |
-| **CloudWatch** | Logs, metric filters, alarms for monitoring                         |
-| **CloudTrail** | Audit logging and compliance                                        |
-| **Lambda**     | Log processing functions                                            |
-| **SNS**        | Alert notifications                                                 |
-| **Budgets**    | Cost monitoring and alerts                                          |
+| Service      | Purpose                                                             |
+| ------------ | ------------------------------------------------------------------- |
+| **S3**       | Terraform state storage                                             |
+| **DynamoDB** | Terraform state locking                                             |
+| **EC2**      | Allocator and client VM instances, security groups, key pairs, EIPs |
+| **IAM**      | Instance profiles                                                   |
+| **Route53**  | DNS records for allocator endpoints                                 |
+| **ELB**      | Application Load Balancer for HTTPS termination                     |
+| **ACM**      | SSL/TLS certificates                                                |
 
 Attach the custom policy:
 
@@ -891,10 +731,6 @@ aws iam put-role-policy \
       - `AmazonS3FullAccess`
       - `IAMFullAccess`
       - `AmazonDynamoDBFullAccess`
-      - `CloudWatchLogsFullAccess`
-      - `AWSCloudTrail_FullAccess`
-      - `AWSLambda_FullAccess`
-      - `AmazonSNSFullAccess`
 
 5. Click **Add permissions** after selecting each policy
 
@@ -1312,92 +1148,7 @@ db_password = get_secret("lablink/db-password")
 admin_password = get_secret("lablink/admin-password")
 ```
 
-## Step 8: CloudWatch Monitoring (Optional)
-
-Set up monitoring and alerts for your infrastructure.
-
-### Terraform-Managed CloudWatch Resources
-
-When you deploy LabLink using Terraform, the following CloudWatch resources are automatically created:
-
-**CloudWatch Agent Role**: Terraform creates an IAM role (`lablink_cloud_watch_agent_role_<suffix>`) that allows client VMs to send logs and metrics to CloudWatch. This role includes permissions for:
-
-- `logs:CreateLogGroup` - Create new log groups
-- `logs:CreateLogStream` - Create log streams within groups
-- `logs:PutLogEvents` - Write log entries
-- `logs:DescribeLogStreams` - List available log streams
-- `cloudwatch:PutMetricData` - Send custom metrics
-
-**CloudTrail Logs**: CloudTrail events are automatically sent to CloudWatch Logs for security monitoring.
-
-**Metric Filters & Alarms**: Terraform creates CloudWatch metric filters to monitor:
-
-| Metric Filter        | Purpose                                        | Alarm Threshold  |
-| -------------------- | ---------------------------------------------- | ---------------- |
-| `RunInstances`       | Detect mass instance launches                  | >10 in 5 minutes |
-| `LargeInstances`     | Monitor expensive instance types (p4d, p3, g5) | Any launch       |
-| `UnauthorizedCalls`  | Track API permission failures                  | >5 in 5 minutes  |
-| `TerminateInstances` | High termination rate detection                | >10 in 5 minutes |
-
-**SNS Notifications**: Alarms send notifications to the `lablink-admin-alerts-<suffix>` SNS topic, which emails the configured admin.
-
-### Manual CloudWatch Configuration (Optional)
-
-For additional monitoring beyond what Terraform provides:
-
-### Enable CloudWatch Logs
-
-Update user data script to send logs to CloudWatch:
-
-```bash
-#!/bin/bash
-
-# Install CloudWatch agent
-wget https://s3.amazonaws.com/amazoncloudwatch-agent/ubuntu/amd64/latest/amazon-cloudwatch-agent.deb
-dpkg -i amazon-cloudwatch-agent.deb
-
-# Configure CloudWatch agent
-cat > /opt/aws/amazon-cloudwatch-agent/etc/config.json <<EOF
-{
-  "logs": {
-    "logs_collected": {
-      "files": {
-        "collect_list": [
-          {
-            "file_path": "/var/log/syslog",
-            "log_group_name": "/aws/ec2/lablink-allocator",
-            "log_stream_name": "{instance_id}/syslog"
-          }
-        ]
-      }
-    }
-  }
-}
-EOF
-
-# Start agent
-/opt/aws/amazon-cloudwatch-agent/bin/amazon-cloudwatch-agent-ctl \
-  -a fetch-config -m ec2 -s -c file:/opt/aws/amazon-cloudwatch-agent/etc/config.json
-```
-
-### Create CloudWatch Alarms
-
-```bash
-# CPU utilization alarm
-aws cloudwatch put-metric-alarm \
-  --alarm-name lablink-allocator-cpu-high \
-  --alarm-description "Alert when CPU exceeds 80%" \
-  --metric-name CPUUtilization \
-  --namespace AWS/EC2 \
-  --statistic Average \
-  --period 300 \
-  --threshold 80 \
-  --comparison-operator GreaterThanThreshold \
-  --evaluation-periods 2 \
-  --dimensions Name=InstanceId,Value=i-xxxxx
-```
-
-## Step 9: Billing Alerts
+## Step 8: Billing Alerts
 
 Set up cost monitoring to avoid unexpected charges.
 
@@ -1487,12 +1238,7 @@ After completing setup, verify:
 The following resources are created automatically by Terraform during deployment:
 
 - [ ] Application Load Balancer (ALB) with HTTPS listener
-- [ ] CloudTrail trail with S3 bucket for logs
-- [ ] CloudWatch log groups and metric filters
-- [ ] SNS topic for admin alerts
-- [ ] IAM roles for CloudWatch agent and CloudTrail
 - [ ] Security groups for allocator and ALB
-- [ ] Monthly budget with alert thresholds
 
 ## Testing Your Setup
 

--- a/docs/cost-estimation.md
+++ b/docs/cost-estimation.md
@@ -48,9 +48,8 @@ Prices: AWS Pricing API
   Client VM EC2 (g4dn.xlarge)                 $383.98  *
   EBS root volume (gp3, 20 GB)                  $1.60
   Elastic IP                                    $3.65
-  CloudWatch Logs                               $2.00
   -------------------------------------  ------------
-  Base infrastructure total                   $67.99/month
+  Base infrastructure total                   $65.99/month
   Per client VM (when running)               $383.98/month *
 
   * Client VM costs scale with usage. VMs are billed only while running.
@@ -320,39 +319,6 @@ If using resources across regions:
 **Total**: **~$20/month**
 
 ## Cost Monitoring
-
-### Set Up Billing Alerts
-
-**Step 1: Create SNS Topic**
-```bash
-aws sns create-topic --name lablink-billing-alerts
-```
-
-**Step 2: Subscribe Email**
-```bash
-aws sns subscribe \
-  --topic-arn arn:aws:sns:us-west-2:ACCOUNT_ID:lablink-billing-alerts \
-  --protocol email \
-  --notification-endpoint your-email@example.com
-```
-
-**Step 3: Create Budget**
-```bash
-aws budgets create-budget --account-id ACCOUNT_ID --budget file://budget.json
-```
-
-**`budget.json`**:
-```json
-{
-  "BudgetName": "LabLink Monthly Budget",
-  "BudgetLimit": {
-    "Amount": "100",
-    "Unit": "USD"
-  },
-  "TimeUnit": "MONTHLY",
-  "BudgetType": "COST"
-}
-```
 
 ### View Current Costs
 

--- a/docs/dns-configuration.md
+++ b/docs/dns-configuration.md
@@ -353,7 +353,6 @@ ssl:
 ### DNS Security
 - Route53 hosted zones are public by default
 - Use IAM policies to restrict who can modify DNS records
-- Enable CloudTrail logging for DNS changes
 - Consider DNSSEC for additional security (advanced)
 
 ### SSL/TLS Security

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -267,7 +267,7 @@ See [Troubleshooting → VM Spawning Issues](troubleshooting.md#vm-spawning-issu
 ### I'm getting billed unexpectedly
 
 - Check for running EC2 instances you forgot to terminate
-- Set up billing alerts (see [AWS Setup → Billing Alerts](aws-setup.md#step-9-billing-alerts))
+- Set up billing alerts (see [AWS Setup → Billing Alerts](aws-setup.md#step-8-billing-alerts))
 - Review [Cost Estimation](cost-estimation.md) guide
 
 ## Costs

--- a/docs/quickstart-template.md
+++ b/docs/quickstart-template.md
@@ -72,7 +72,6 @@ The configure script prompts for:
 
 - Instance type and AMI settings
 - DNS and SSL configuration
-- Monitoring options
 
 It generates `lablink-infrastructure/config/config.yaml` with your settings.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -169,7 +169,6 @@ OpenID Connect (OIDC) allows GitHub Actions to authenticate to AWS **without sto
 - **No stored credentials**: Nothing to leak or rotate
 - **Short-lived**: Credentials expire quickly
 - **Scoped**: Permissions limited to specific role
-- **Auditable**: CloudTrail logs all API calls
 
 #### Trust Policy
 
@@ -424,7 +423,7 @@ If you must use staging mode with potentially sensitive data:
 
 4. **Time-limited** - Switch to production mode as soon as testing is complete
 
-5. **Monitor access** - Check CloudWatch logs for unexpected connections
+5. **Monitor access** - Review allocator logs for unexpected connections
 
 ### Switching to Production Mode
 
@@ -505,7 +504,7 @@ admin_password = secrets['admin_password']
 **Pros**:
 - Encrypted at rest and in transit
 - Automatic rotation
-- Audit logs (CloudTrail)
+- Audit logging
 - Versioning
 
 **Cons**:
@@ -711,24 +710,6 @@ conn = psycopg2.connect(
 
 ## Monitoring & Auditing
 
-### CloudTrail
-
-Enable CloudTrail for AWS API auditing:
-
-```bash
-aws cloudtrail create-trail \
-  --name lablink-trail \
-  --s3-bucket-name lablink-cloudtrail-logs
-
-aws cloudtrail start-logging --name lablink-trail
-```
-
-**Logs include**:
-- EC2 instance launches/terminations
-- Security group changes
-- IAM role assumptions
-- S3 access
-
 ### VPC Flow Logs
 
 Monitor network traffic:
@@ -776,7 +757,6 @@ def request_vm():
 - [ ] Restricted SSH access to known IPs
 - [ ] Enabled S3 bucket encryption
 - [ ] Enabled EBS volume encryption
-- [ ] Set up CloudTrail logging
 - [ ] Set up billing alerts
 - [ ] Rotated SSH keys (if older than 90 days)
 - [ ] Reviewed IAM role permissions
@@ -788,7 +768,6 @@ def request_vm():
 
 | Task | Frequency |
 |------|-----------|
-| Review CloudTrail logs | Weekly |
 | Rotate SSH keys | Every 90 days |
 | Update dependencies | Monthly |
 | Review security group rules | Quarterly |
@@ -800,7 +779,7 @@ def request_vm():
 If security incident occurs:
 
 1. **Isolate**: Modify security groups to block traffic
-2. **Investigate**: Review CloudTrail, VPC Flow Logs, application logs
+2. **Investigate**: Review VPC Flow Logs and application logs
 3. **Contain**: Terminate compromised instances
 4. **Recover**: Deploy from known-good state
 5. **Learn**: Document incident, improve security


### PR DESCRIPTION
## Summary

Follow-up to #346. That PR removed the `monitoring` config schema and Terraform infra (companion: talmolab/lablink-template#50) but explicitly left CloudTrail/CloudWatch/SNS guidance in the docs as "independent AWS guidance." This PR removes that remaining documentation, since it still described infrastructure LabLink no longer creates — plus the CloudWatch-agent log-forwarding path that #279 already replaced with the self-hosted log shipper.

## Changes

### Fixed (stale descriptions)
- **`api-endpoints.md`**: `POST /api/vm-logs` is now described as receiving batched lines from `log_shipper.sh` (tails cloud-init output + the client container's Docker logs, POSTs with a Bearer token) instead of "called by the CloudWatch agent via a Lambda subscription." Also corrected the `503` reason on the log-fetch endpoint.

### Removed (infra that no longer exists)
- **`aws-setup.md`**: dropped the CloudWatch/CloudTrail/Lambda/SNS managed-policy attachments and the 6 corresponding custom-IAM-policy statements (`CloudWatchLogsAndAlarms`, `CloudTrail`, `CloudTrailS3Bucket`, `Lambda`, `SNSNotifications`, `Budgets`); trimmed the policy/service tables; deleted **Step 8: CloudWatch Monitoring** entirely and renumbered **Step 9 → Step 8 (Billing Alerts)**; removed the stale "Terraform-Managed (Automatic)" checklist items (CloudTrail trail, CloudWatch log groups/metric filters, SNS admin-alerts topic, IAM CloudWatch/CloudTrail roles, monthly budget).
- **`security.md`**: removed the `### CloudTrail` setup subsection, the OIDC "Auditable: CloudTrail" bullet, the "Set up CloudTrail logging" checklist item and "Review CloudTrail logs" recurring-task row; reworded the stale "Check CloudWatch logs" advice to "Review allocator logs"; genericized a Secrets Manager "Audit logs (CloudTrail)" pro to "Audit logging."
- **`cost-estimation.md`**: removed the `CloudWatch Logs $2.00` line from the sample output (base infra total `$67.99 → $65.99`) and the SNS-topic/AWS-Budget "Set Up Billing Alerts" block.
- **`dns-configuration.md`**, **`quickstart-template.md`**: dropped the "Enable CloudTrail logging for DNS changes" and "Monitoring options" bullets.
- **`faq.md`**: updated the billing-alerts link to the renumbered `#step-8-billing-alerts` anchor.

Generic, infra-agnostic cost-hygiene advice (one-line "set up billing alerts" mentions, the renamed Step 8 budget/cost-anomaly section, the independent VPC Flow Logs section) was intentionally kept.

## Technical Details

Two separate removed systems were referenced in docs:
1. The `monitoring:` feature — CloudWatch alarms/metric filters, SNS `lablink-admin-alerts`, CloudTrail trail, AWS Budgets, Lambda log-processor (removed in #346 + lablink-template v0.2.0).
2. CloudWatch → Lambda → allocator log-forwarding — replaced by the self-hosted `log_shipper.sh` → `/api/vm-logs` in #279.

This PR deliberately goes beyond #346's stated "Out of scope" decision, which had argued this content was independent AWS guidance worth keeping.

## Testing

- [x] `mkdocs build` succeeds; no link/anchor warnings from any edited file (3 pre-existing strict-mode warnings are unrelated: a griffe code-docstring warning and two cross-refs inside the untracked `docs/superpowers/` working docs)
- [x] No remaining stale `cloudtrail|cloudwatch|sns|lambda|metric filter|admin-alerts` references in `docs/` (excluding `docs/superpowers/`)
- [x] `aws-setup.md` Step numbering consistent and `faq.md` anchor (`#step-8-billing-alerts`) resolves

## Related

- Follow-up to #346
- Companion infra removal: talmolab/lablink-template#50
- Log-forwarding replacement context: #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)