### PR TITLE
PR D1: manual provider + LAN-direct browser connectivity

### DIFF
--- a/packages/allocator/pyproject.toml
+++ b/packages/allocator/pyproject.toml
@@ -39,6 +39,7 @@ lablink-validate-config = "lablink_allocator_service.validate_config:main"
 
 [project.entry-points."lablink.providers"]
 aws = "lablink_allocator_service.providers.aws:AWSProvider"
+manual = "lablink_allocator_service.providers.manual:ManualProvider"
 
 [tool.setuptools.package-data]
 lablink_allocator_service = ["terraform/**/*", "conf/*.yaml"]

--- a/packages/allocator/src/lablink_allocator_service/client_session.py
+++ b/packages/allocator/src/lablink_allocator_service/client_session.py
@@ -28,7 +28,8 @@ class RotationFailed(RuntimeError):
 
 @dataclass
 class BrowserSessionTarget:
-    upstream: str  # e.g. "10.0.0.5:6080"
+    ws_url: str                       # opaque URL the page opens
+    browser_credential: str | None    # non-None ⇒ page sends HTTP Basic
 
 
 def _region() -> str:
@@ -74,14 +75,14 @@ def prepare_browser_session(
     hostname: str,
     session_id: uuid.UUID,
     browser_token: str,
-    api_token: str,
+    agent_token: str,
 ) -> BrowserSessionTarget:
     """Rotate the assigned client's VNC password and persist per-session
     columns on the VM row. Must be called inside the seat-assignment
     transaction so failures roll back.
 
-    `api_token` is the allocator's per-startup random token (main.API_TOKEN);
-    the client agent receives the same value as its API_TOKEN env via the
+    `agent_token` is the deployment agent-control token (`main.AGENT_TOKEN`);
+    the client agent receives the same value as its AGENT_TOKEN env via the
     Terraform user_data and validates it on every /api/session/start call.
     Passed explicitly rather than read from env so this function has no
     hidden global dependency for tests.
@@ -96,9 +97,10 @@ def prepare_browser_session(
     _post_rotate(
         f"http://{private_ip}:7070/api/session/start",
         {"password": password},
-        bearer=api_token,
+        bearer=agent_token,
     )
 
+    ws_url = f"proxy/{browser_token}"
     with database._cursor as cursor:
         cursor.execute(
             f"UPDATE {database.table_name} "
@@ -106,9 +108,12 @@ def prepare_browser_session(
             f"    browsertoken = %s, "
             f"    vncpassword = %s, "
             f"    upstream = %s, "
+            f"    browser_ws_url = %s, "
+            f"    browser_credential = NULL, "
             f"    sessionstartedat = NOW() "
             f"WHERE hostname = %s",
-            (str(session_id), browser_token, password, upstream, hostname),
+            (str(session_id), browser_token, password, upstream,
+             ws_url, hostname),
         )
 
-    return BrowserSessionTarget(upstream=upstream)
+    return BrowserSessionTarget(ws_url=ws_url, browser_credential=None)

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -547,6 +547,8 @@ class PostgresqlDatabase:
             f"    browsertoken = NULL, "
             f"    vncpassword = NULL, "
             f"    upstream = NULL, "
+            f"    browser_ws_url = NULL, "
+            f"    browser_credential = NULL, "
             f"    sessionstartedat = NULL "
             f"WHERE hostname = %s"
         )

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -2,6 +2,7 @@ from datetime import datetime, timezone
 import json
 import logging
 from typing import List, Optional
+from urllib.parse import urlsplit
 
 import psycopg2
 import psycopg2.pool
@@ -292,6 +293,33 @@ class PostgresqlDatabase:
             )
             row = cursor.fetchone()
         return row[0] if row else None
+
+    def get_lan_ip(self, hostname: str):
+        """LAN IP for a manual client: provider_metadata->>'lan_ip',
+        falling back to the host part of endpoint_url. None if absent."""
+        with self._cursor as cursor:
+            cursor.execute(
+                f"SELECT provider_metadata->>'lan_ip', endpoint_url "
+                f"FROM {self.table_name} WHERE hostname = %s;",
+                (hostname,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        lan_ip, endpoint_url = row
+        if lan_ip:
+            return lan_ip
+        if endpoint_url:
+            return urlsplit(endpoint_url).hostname
+        return None
+
+    def list_hosts_by_provider(self, provider: str) -> list:
+        with self._cursor as cursor:
+            cursor.execute(
+                f"SELECT hostname FROM {self.table_name} WHERE provider = %s;",
+                (provider,),
+            )
+            return [r[0] for r in cursor.fetchall()]
 
     def register_client(
         self,

--- a/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
+++ b/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
@@ -88,6 +88,8 @@ CREATE TABLE IF NOT EXISTS {VM_TABLE} (
     endpoint_url       TEXT,
     provider_metadata  JSONB NOT NULL DEFAULT '{{}}',
     client_secret_hash TEXT,
+    browser_ws_url     TEXT,
+    browser_credential TEXT,
     gpu_present        BOOLEAN,
     gpu_model          TEXT,
     last_release_time  TIMESTAMP

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -108,6 +108,12 @@ API_TOKEN = secrets.token_urlsafe(32)
 # semantics: one per allocator process, re-injected via terraform on launch.
 REGISTER_TOKEN = secrets.token_urlsafe(32)
 
+# Deployment agent-control token: allocator→client-agent (:7070) control
+# channel. Distinct from API_TOKEN (M2M, → D4) and REGISTER_TOKEN
+# (client→allocator join). Symmetric plaintext (allocator presents, agent
+# verifies); per-process like API_TOKEN/REGISTER_TOKEN.
+AGENT_TOKEN = secrets.token_urlsafe(32)
+
 # Initialize the database connection
 database = None
 
@@ -347,7 +353,7 @@ def submit_vm_details():
                 hostname=hostname,
                 session_id=session_id,
                 browser_token=browser_token,
-                api_token=API_TOKEN,
+                agent_token=AGENT_TOKEN,
             )
         except RotationFailed as exc:
             logger.warning(
@@ -479,6 +485,7 @@ def launch():
             f.write(f'region = "{cfg.app.region}"\n')
             f.write(f'startup_on_error = "{cfg.startup_script.on_error}"\n')
             f.write(f'api_token = "{API_TOKEN}"\n')
+            f.write(f'agent_token = "{AGENT_TOKEN}"\n')
             f.write(f'register_token = "{REGISTER_TOKEN}"\n')
 
         # Build the var args once; they apply to both `plan` and `apply`.

--- a/packages/allocator/src/lablink_allocator_service/providers/aws.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/aws.py
@@ -21,7 +21,7 @@ class AWSProvider:
     can_destroy_hosts = True
     can_recover_hosts = True
 
-    def __init__(self, *, region: str, terraform_dir: str):
+    def __init__(self, *, region=None, terraform_dir=None, **_):
         self._region = region
         self._terraform_dir = terraform_dir
         self.client_connectivity = AllocatorProxiedClientConnectivity()

--- a/packages/allocator/src/lablink_allocator_service/providers/connectivity/lan_direct.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/connectivity/lan_direct.py
@@ -1,0 +1,57 @@
+"""LAN-direct connectivity: student browser opens the KasmVNC WS straight
+to the client's LAN IP. No allocator proxy in the byte path."""
+from __future__ import annotations
+
+import secrets
+import uuid
+
+from lablink_allocator_service import client_session
+from lablink_allocator_service.client_session import (
+    BrowserSessionTarget,
+    RotationFailed,
+)
+from lablink_allocator_service.providers.protocol import ClientJoinMaterial
+
+
+class LANDirectClientConnectivity:
+    name = "lan_direct"
+
+    def make_join_material(
+        self, *, allocator_url: str, client_image: str,
+        register_token: str, hostname_hint: str | None = None,
+    ) -> ClientJoinMaterial:
+        return ClientJoinMaterial(
+            register_token=register_token,
+            allocator_url=allocator_url,
+            connectivity=self.name,
+            client_image=client_image,
+        )
+
+    def prepare_browser_session(
+        self, *, database, hostname: str, session_id: uuid.UUID,
+        browser_token: str, agent_token: str,
+    ) -> BrowserSessionTarget:
+        lan_ip = database.get_lan_ip(hostname)
+        if not lan_ip:
+            raise RotationFailed(
+                f"no LAN IP recorded for manual client {hostname}"
+            )
+        password = secrets.token_urlsafe(24)
+        ws_url = f"ws://{lan_ip}:6080"
+
+        client_session._post_rotate(
+            f"http://{lan_ip}:7070/api/session/start",
+            {"password": password},
+            bearer=agent_token,
+        )
+
+        with database._cursor as cursor:
+            cursor.execute(
+                f"UPDATE {database.table_name} "
+                f"SET sessionid = %s, browsertoken = %s, "
+                f"    browser_ws_url = %s, browser_credential = %s, "
+                f"    sessionstartedat = NOW() "
+                f"WHERE hostname = %s",
+                (str(session_id), browser_token, ws_url, password, hostname),
+            )
+        return BrowserSessionTarget(ws_url=ws_url, browser_credential=password)

--- a/packages/allocator/src/lablink_allocator_service/providers/manual.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/manual.py
@@ -1,0 +1,52 @@
+"""ManualProvider — BYO hosts the instructor registers; LabLink never
+provisions/destroys/recovers them. LAN-agnostic: LAN lives only in the
+injected ClientConnectivity, never here."""
+from __future__ import annotations
+
+from lablink_allocator_service.providers.connectivity.lan_direct import (
+    LANDirectClientConnectivity,
+)
+from lablink_allocator_service.providers.protocol import ClientHandle
+
+
+def _db():
+    from lablink_allocator_service import main
+    return main.database
+
+
+class ManualProvider:
+    name = "manual"
+    can_provision_hosts = False
+    can_destroy_hosts = False
+    can_recover_hosts = False
+
+    def __init__(self, *, region=None, terraform_dir=None,
+                 client_connectivity=None, **_):
+        self.client_connectivity = (
+            client_connectivity
+            if client_connectivity is not None
+            else LANDirectClientConnectivity()
+        )
+
+    def provision_hosts(self, count, spec):
+        raise NotImplementedError(
+            "ManualProvider doesn't provision — instructor brings the "
+            "machines. Use 'lablink launch' for the registration command."
+        )
+
+    def destroy_hosts(self, handles):
+        raise NotImplementedError(
+            "ManualProvider cannot destroy BYO machines."
+        )
+
+    def recover_hosts(self, handles):
+        raise NotImplementedError(
+            "ManualProvider cannot recover BYO machines; the box rejoins "
+            "via docker --restart + idempotent re-registration."
+        )
+
+    def list_hosts(self):
+        return [
+            ClientHandle(id=h, hostname=h)
+            for h in _db().list_hosts_by_provider(self.name)
+        ]

--- a/packages/allocator/src/lablink_allocator_service/providers/registry.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/registry.py
@@ -7,6 +7,7 @@ import logging
 from importlib.metadata import entry_points
 
 from lablink_allocator_service.providers.aws import AWSProvider
+from lablink_allocator_service.providers.manual import ManualProvider
 from lablink_allocator_service.providers.protocol import ComputeProvider
 
 logger = logging.getLogger(__name__)
@@ -15,7 +16,7 @@ DEFAULT_PROVIDER = "aws"
 
 # Built-in fallback so the allocator works in editable/test installs where
 # entry-point metadata may not be regenerated.
-_BUILTIN: dict[str, type] = {"aws": AWSProvider}
+_BUILTIN: dict[str, type] = {"aws": AWSProvider, "manual": ManualProvider}
 
 
 def _discover() -> dict[str, type]:

--- a/packages/allocator/src/lablink_allocator_service/routes/desktop.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/desktop.py
@@ -67,6 +67,10 @@ def desktop():
 
     # Direct ws(s):// target: render an in-page bootstrap so the
     # per-session credential is NEVER placed in a logged query string.
+    # The credential is set in same-origin localStorage for noVNC to
+    # read; short-lived (rotated each session) but readable by any
+    # same-origin JS — relies on the allocator origin's CSP/XSS
+    # hygiene. Revisit CSP before the LAN-direct path goes live.
     parts = urlsplit(ws_url)
     host = parts.hostname or ""
     port = parts.port or 6080

--- a/packages/allocator/src/lablink_allocator_service/routes/desktop.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/desktop.py
@@ -2,11 +2,14 @@
 
 Reads the signed lablink_session cookie minted by /api/request_vm,
 looks up the assigned VM by session_id, and renders the noVNC viewer
-configured with a WebSocket URL pointing at /proxy/<browser_token>.
+configured from the persisted browser_ws_url and browser_credential.
 
 If the cookie is missing, invalid, or the bound VM is no longer
 running, redirect to / so the student can submit their email again.
 """
+import json
+from urllib.parse import urlsplit
+
 from flask import Blueprint, current_app, redirect, request
 from psycopg2 import sql
 
@@ -39,7 +42,7 @@ def desktop():
         with conn.cursor() as cur:
             cur.execute(
                 sql.SQL(
-                    "SELECT browsertoken FROM {table} "
+                    "SELECT browser_ws_url, browser_credential FROM {table} "
                     "WHERE sessionid = %s AND status = 'running'"
                 ).format(table=table),
                 (session_id,),
@@ -51,18 +54,32 @@ def desktop():
     if row is None or row[0] is None:
         return redirect("/", code=302)
 
-    # Redirect into KasmVNC's bundled noVNC viewer (served via nginx at
-    # /static/novnc/ from /usr/share/kasmvnc/www/). Kasm's noVNC is the
-    # only viewer that's protocol-compatible with kasmvncserver — the
-    # Debian `novnc` package sends RFB extension messages KasmVNC rejects.
-    # autoconnect=1 + resize=remote tells the viewer to open the WS
-    # immediately on load and follow window resizes; `path` is relative
-    # to location.host, so the viewer connects to /proxy/<token> at the
-    # current origin, which nginx then upgrades and proxies to KasmVNC
-    # with the Basic Auth header attached server-side.
-    browser_token = row[0]
-    return redirect(
-        f"/static/novnc/vnc.html?path=proxy/{browser_token}"
-        f"&autoconnect=1&resize=remote",
-        code=302,
+    ws_url, credential = row[0], row[1]
+
+    # Proxied path (relative, server-side credential): byte-identical to
+    # the historical viewer URL — AWS regression-locked.
+    if ws_url.startswith("proxy/"):
+        return redirect(
+            f"/static/novnc/vnc.html?path={ws_url}"
+            f"&autoconnect=1&resize=remote",
+            code=302,
+        )
+
+    # Direct ws(s):// target: render an in-page bootstrap so the
+    # per-session credential is NEVER placed in a logged query string.
+    parts = urlsplit(ws_url)
+    host = parts.hostname or ""
+    port = parts.port or 6080
+    encrypt = "1" if parts.scheme == "wss" else "0"
+    cred_js = "" if credential is None else (
+        f"localStorage.setItem('lablink_cred', {json.dumps(credential)});"
+    )
+    return (
+        "<!doctype html><meta charset=utf-8>"
+        '<body style="margin:0">'
+        f"<script>{cred_js}"
+        f'location.replace("/static/novnc/vnc.html"'
+        f'+"?host={host}&port={port}&encrypt={encrypt}"'
+        f'+"&autoconnect=1&resize=remote");</script>',
+        200,
     )

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -75,6 +75,7 @@ def register_client():
     return jsonify(
         client_id=client_id,
         client_secret=client_secret,
+        agent_token=main.AGENT_TOKEN,
         register_token=jm.register_token,
         allocator_url=jm.allocator_url,
         connectivity=jm.connectivity,

--- a/packages/allocator/src/lablink_allocator_service/terraform/main.tf
+++ b/packages/allocator/src/lablink_allocator_service/terraform/main.tf
@@ -122,6 +122,7 @@ resource "aws_instance" "lablink_vm" {
       startup_content_b64         = local.startup_content_b64
       startup_on_error            = var.startup_on_error
       api_token                   = var.api_token
+      agent_token                 = var.agent_token
       register_token              = var.register_token
       log_shipper_sh              = file("${path.module}/log_shipper.sh")
     }),

--- a/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
+++ b/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
@@ -181,6 +181,7 @@ if docker run -dit --restart unless-stopped $DOCKER_GPU_ARGS \
     -e SUBJECT_SOFTWARE="${subject_software}" \
     -e STARTUP_ON_ERROR="${startup_on_error}" \
     -e API_TOKEN="${api_token}" \
+    -e AGENT_TOKEN="${agent_token}" \
     -e CLIENT_SECRET="$CLIENT_SECRET" \
     --network host \
     "${image_name}"; then

--- a/packages/allocator/src/lablink_allocator_service/terraform/variables.tf
+++ b/packages/allocator/src/lablink_allocator_service/terraform/variables.tf
@@ -95,6 +95,13 @@ variable "api_token" {
   default     = ""
 }
 
+variable "agent_token" {
+  type        = string
+  description = "Deployment agent-control token the allocator presents to the client agent's session-start endpoint"
+  sensitive   = true
+  default     = ""
+}
+
 variable "register_token" {
   type        = string
   description = "Deployment register-token; authenticates POST /api/v1/clients/register"

--- a/packages/allocator/tests/providers/connectivity/test_allocator_proxied.py
+++ b/packages/allocator/tests/providers/connectivity/test_allocator_proxied.py
@@ -17,7 +17,7 @@ def test_satisfies_protocol_and_name():
 
 
 def test_delegates_to_client_session_unchanged():
-    sentinel = BrowserSessionTarget(upstream="10.0.0.9:6080")
+    sentinel = BrowserSessionTarget(ws_url="proxy/tok", browser_credential=None)
     sid = uuid.uuid4()
     with patch(
         "lablink_allocator_service.providers.connectivity.allocator_proxied."
@@ -30,7 +30,7 @@ def test_delegates_to_client_session_unchanged():
             hostname="vm-1",
             session_id=sid,
             browser_token="tok",
-            api_token="api",
+            agent_token="api",
         )
     assert out is sentinel
     m.assert_called_once_with(
@@ -38,7 +38,7 @@ def test_delegates_to_client_session_unchanged():
         hostname="vm-1",
         session_id=sid,
         browser_token="tok",
-        api_token="api",
+        agent_token="api",
     )
 
 

--- a/packages/allocator/tests/providers/connectivity/test_lan_direct.py
+++ b/packages/allocator/tests/providers/connectivity/test_lan_direct.py
@@ -1,0 +1,47 @@
+import uuid
+
+
+def test_make_join_material_lan_direct():
+    from lablink_allocator_service.providers.connectivity.lan_direct import (
+        LANDirectClientConnectivity,
+    )
+    c = LANDirectClientConnectivity()
+    jm = c.make_join_material(allocator_url="http://a:5000",
+                              client_image="img:1", register_token="tk")
+    assert jm.connectivity == "lan_direct"
+    assert jm.allocator_url == "http://a:5000"
+    assert jm.client_image == "img:1"
+    assert jm.register_token == "tk"
+
+
+def test_prepare_browser_session_lan_direct(monkeypatch):
+    import lablink_allocator_service.client_session as cs
+    from lablink_allocator_service.providers.connectivity.lan_direct import (
+        LANDirectClientConnectivity,
+    )
+    posted = {}
+    monkeypatch.setattr(cs, "_post_rotate",
+                        lambda url, body, *, bearer: posted.update(
+                            url=url, body=body, bearer=bearer))
+    executed = {}
+    class _Cur:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def execute(self, sql, params):
+            executed["sql"] = sql
+            executed["params"] = params
+    class _DB:
+        table_name = "vms"
+        _cursor = _Cur()
+        def get_lan_ip(self, hostname): return "10.0.0.9"
+
+    t = LANDirectClientConnectivity().prepare_browser_session(
+        database=_DB(), hostname="vm-1", session_id=uuid.uuid4(),
+        browser_token="btok", agent_token="agenttok",
+    )
+    assert t.ws_url == "ws://10.0.0.9:6080"
+    assert t.browser_credential and t.browser_credential == posted["body"]["password"]
+    assert posted["url"] == "http://10.0.0.9:7070/api/session/start"
+    assert posted["bearer"] == "agenttok"
+    assert "browser_ws_url" in executed["sql"]
+    assert "browser_credential" in executed["sql"]

--- a/packages/allocator/tests/providers/test_aws_provider.py
+++ b/packages/allocator/tests/providers/test_aws_provider.py
@@ -74,3 +74,11 @@ def test_provision_and_destroy_not_wired_in_pr_b():
         p.provision_hosts(1, {})
     with pytest.raises(ProviderActionNotWired):
         p.destroy_hosts([])
+
+
+def test_aws_provider_tolerant_constructor():
+    from lablink_allocator_service.providers.aws import AWSProvider
+    # extra/None kwargs must not raise (uniform registry call shape)
+    p = AWSProvider(region="us-west-2", terraform_dir="/tmp", client_connectivity=None)
+    assert p.name == "aws"
+    assert p.client_connectivity is not None

--- a/packages/allocator/tests/providers/test_manual_provider.py
+++ b/packages/allocator/tests/providers/test_manual_provider.py
@@ -1,0 +1,51 @@
+import pytest
+
+
+def test_manual_provider_flags_and_connectivity():
+    from lablink_allocator_service.providers.manual import ManualProvider
+    from lablink_allocator_service.providers.connectivity.lan_direct import (
+        LANDirectClientConnectivity,
+    )
+    p = ManualProvider(region=None, terraform_dir=None)
+    assert p.name == "manual"
+    assert p.can_provision_hosts is False
+    assert p.can_destroy_hosts is False
+    assert p.can_recover_hosts is False
+    assert isinstance(p.client_connectivity, LANDirectClientConnectivity)
+
+
+def test_manual_provider_lifecycle_raises():
+    from lablink_allocator_service.providers.manual import ManualProvider
+    p = ManualProvider()
+    for call in (lambda: p.provision_hosts(1, {}),
+                 lambda: p.destroy_hosts([]),
+                 lambda: p.recover_hosts([])):
+        with pytest.raises(NotImplementedError):
+            call()
+
+
+def test_manual_provider_connectivity_injectable():
+    from lablink_allocator_service.providers.manual import ManualProvider
+    sentinel = object()
+    p = ManualProvider(client_connectivity=sentinel)
+    assert p.client_connectivity is sentinel
+
+
+def test_manual_provider_list_hosts_is_lan_agnostic(monkeypatch):
+    from lablink_allocator_service.providers import manual as m
+    from lablink_allocator_service.providers.protocol import ClientHandle
+    seen = {}
+    class _DB:
+        def list_hosts_by_provider(self, provider):
+            seen["p"] = provider
+            return ["vm-1"]
+    monkeypatch.setattr(m, "_db", lambda: _DB(), raising=False)
+    p = m.ManualProvider()
+    result = p.list_hosts()
+    assert len(result) == 1
+    h = result[0]
+    assert isinstance(h, ClientHandle)
+    assert h.id == "vm-1"
+    assert h.hostname == "vm-1"
+    assert h.provider_metadata == {}
+    assert seen["p"] == "manual"

--- a/packages/allocator/tests/providers/test_protocol.py
+++ b/packages/allocator/tests/providers/test_protocol.py
@@ -29,7 +29,7 @@ def test_protocols_are_runtime_checkable():
         name = "allocator_proxied"
 
         def prepare_browser_session(self, **kwargs):
-            return BrowserSessionTarget(upstream="10.0.0.5:6080")
+            return BrowserSessionTarget(ws_url="proxy/tok", browser_credential=None)
 
         def make_join_material(self, **kwargs): ...
 

--- a/packages/allocator/tests/providers/test_registry.py
+++ b/packages/allocator/tests/providers/test_registry.py
@@ -36,7 +36,7 @@ def test_aws_entry_point_is_registered():
 def test_provider_connectivity_round_trips_kwargs():
     p = get_provider("aws", region="us-west-2", terraform_dir="/tf")
     sid = uuid.uuid4()
-    sentinel = BrowserSessionTarget(upstream="10.0.0.5:6080")
+    sentinel = BrowserSessionTarget(ws_url="proxy/tok", browser_credential=None)
     with patch(
         "lablink_allocator_service.providers.connectivity.allocator_proxied."
         "prepare_browser_session",
@@ -44,7 +44,13 @@ def test_provider_connectivity_round_trips_kwargs():
     ) as m:
         out = p.client_connectivity.prepare_browser_session(
             database="DB", hostname="vm-1", session_id=sid,
-            browser_token="t", api_token="a",
+            browser_token="t", agent_token="a",
         )
     assert out is sentinel
     assert m.call_args.kwargs["hostname"] == "vm-1"
+
+
+def test_get_provider_manual_returns_constructed_instance():
+    from lablink_allocator_service.providers.manual import ManualProvider
+    p = get_provider("manual", region=None, terraform_dir=None)
+    assert isinstance(p, ManualProvider)

--- a/packages/allocator/tests/test_cleanliness_guard.py
+++ b/packages/allocator/tests/test_cleanliness_guard.py
@@ -1,0 +1,27 @@
+"""Spec §7 invariant: the allocator core must not branch on connectivity
+or provider *type*. Fails on a type discriminator in the core modules."""
+import re
+from pathlib import Path
+
+CORE = [
+    "src/lablink_allocator_service/routes/desktop.py",
+    "src/lablink_allocator_service/routes/internal_proxy_auth.py",
+    "src/lablink_allocator_service/main.py",
+]
+# type discriminators (NOT data-attribute / capability-flag conditionals)
+BANNED = [
+    re.compile(r'\bconnectivity\s*==\s*["\']'),
+    re.compile(r'\bprovider\s*==\s*["\']'),
+    re.compile(r'isinstance\([^)]*(Provider|Connectivity)\)'),
+]
+
+
+def test_core_has_no_connectivity_or_provider_type_branch():
+    root = Path(__file__).resolve().parents[1]
+    offenders = []
+    for rel in CORE:
+        text = (root / rel).read_text()
+        for pat in BANNED:
+            for m in pat.finditer(text):
+                offenders.append(f"{rel}: {m.group(0)}")
+    assert not offenders, "connectivity/provider type-branch in core: " + "; ".join(offenders)

--- a/packages/allocator/tests/test_client_session.py
+++ b/packages/allocator/tests/test_client_session.py
@@ -54,10 +54,10 @@ def test_happy_path_rotates_and_persists(real_db):
             hostname="host-task10",
             session_id=session_id,
             browser_token="tok-abc",
-            api_token=API_TOKEN,
+            agent_token=API_TOKEN,
         )
 
-    # Agent POST: correct URL, Bearer header sourced from api_token kwarg,
+    # Agent POST: correct URL, Bearer header sourced from agent_token kwarg,
     # body carries only the rotated password (the agent doesn't need
     # session_id or browser_token — those are allocator-side bookkeeping).
     mock_post.assert_called_once()
@@ -81,7 +81,8 @@ def test_happy_path_rotates_and_persists(real_db):
     assert row[1] == "tok-abc"
     assert row[2] == kwargs["json"]["password"]
     assert row[3] == "10.0.0.5:6080"
-    assert target.upstream == "10.0.0.5:6080"
+    assert target.ws_url == "proxy/tok-abc"
+    assert target.browser_credential is None
 
 
 def test_one_retry_then_raises(real_db):
@@ -123,10 +124,52 @@ def test_one_retry_then_raises(real_db):
                 hostname="host-task10-fail",
                 session_id=uuid.uuid4(),
                 browser_token="t",
-                api_token=API_TOKEN,
+                agent_token=API_TOKEN,
             )
 
     assert mock_post.call_count == 2  # initial + one retry
+
+
+def test_prepare_browser_session_persists_render_columns(monkeypatch):
+    import lablink_allocator_service.client_session as cs
+    import uuid
+
+    monkeypatch.setattr(cs, "_lookup_private_ip", lambda h: "10.0.0.5")
+    posted = {}
+    monkeypatch.setattr(cs, "_post_rotate",
+                        lambda url, body, *, bearer: posted.update(
+                            url=url, body=body, bearer=bearer))
+
+    executed = {}
+    class _Cur:
+        def __enter__(self): return self
+        def __exit__(self, *a): return False
+        def execute(self, sql, params):
+            executed["sql"] = sql
+            executed["params"] = params
+    class _DB:
+        table_name = "vms"
+        _cursor = _Cur()
+
+    t = cs.prepare_browser_session(
+        database=_DB(), hostname="vm-1", session_id=uuid.uuid4(),
+        browser_token="btok", agent_token="agenttok",
+    )
+    assert posted["bearer"] == "agenttok"
+    assert posted["body"] == {"password": executed["params"][2]}  # vncpassword param
+    assert t.ws_url == "proxy/btok"
+    assert t.browser_credential is None
+    assert "browser_ws_url" in executed["sql"]
+    assert "browser_credential = NULL" in executed["sql"]
+
+
+def test_browser_session_target_new_shape():
+    from lablink_allocator_service.client_session import BrowserSessionTarget
+    t = BrowserSessionTarget(ws_url="ws://x:6080", browser_credential="pw")
+    assert t.ws_url == "ws://x:6080"
+    assert t.browser_credential == "pw"
+    t2 = BrowserSessionTarget(ws_url="proxy/abc", browser_credential=None)
+    assert t2.browser_credential is None
 
 
 def test_raises_when_instance_id_not_found(real_db):
@@ -157,5 +200,5 @@ def test_raises_when_instance_id_not_found(real_db):
                 hostname="ghost-host",
                 session_id=uuid.uuid4(),
                 browser_token="t",
-                api_token=API_TOKEN,
+                agent_token=API_TOKEN,
             )

--- a/packages/allocator/tests/test_client_session.py
+++ b/packages/allocator/tests/test_client_session.py
@@ -5,9 +5,9 @@ import pytest
 import requests
 
 
-# Per-test API_TOKEN that matches what main.API_TOKEN would generate
+# Per-test AGENT_TOKEN that matches what main.AGENT_TOKEN would generate
 # in production; passed explicitly to prepare_browser_session.
-API_TOKEN = "test-api-token"
+AGENT_TOKEN = "test-agent-token"
 
 
 def test_happy_path_rotates_and_persists(real_db):
@@ -56,7 +56,7 @@ def test_happy_path_rotates_and_persists(real_db):
             hostname="host-task10",
             session_id=session_id,
             browser_token="tok-abc",
-            agent_token=API_TOKEN,
+            agent_token=AGENT_TOKEN,
         )
 
     # Agent POST: correct URL, Bearer header sourced from agent_token kwarg,
@@ -66,7 +66,7 @@ def test_happy_path_rotates_and_persists(real_db):
     url = mock_post.call_args[0][0]
     kwargs = mock_post.call_args[1]
     assert url == "http://10.0.0.5:7070/api/session/start"
-    assert kwargs["headers"]["Authorization"] == f"Bearer {API_TOKEN}"
+    assert kwargs["headers"]["Authorization"] == f"Bearer {AGENT_TOKEN}"
     assert "password" in kwargs["json"]
     assert kwargs["json"].keys() == {"password"}
 
@@ -126,7 +126,7 @@ def test_one_retry_then_raises(real_db):
                 hostname="host-task10-fail",
                 session_id=uuid.uuid4(),
                 browser_token="t",
-                agent_token=API_TOKEN,
+                agent_token=AGENT_TOKEN,
             )
 
     assert mock_post.call_count == 2  # initial + one retry
@@ -202,5 +202,5 @@ def test_raises_when_instance_id_not_found(real_db):
                 hostname="ghost-host",
                 session_id=uuid.uuid4(),
                 browser_token="t",
-                agent_token=API_TOKEN,
+                agent_token=AGENT_TOKEN,
             )

--- a/packages/allocator/tests/test_client_session.py
+++ b/packages/allocator/tests/test_client_session.py
@@ -23,6 +23,8 @@ def test_happy_path_rotates_and_persists(real_db):
             "ADD COLUMN IF NOT EXISTS browsertoken TEXT, "
             "ADD COLUMN IF NOT EXISTS vncpassword TEXT, "
             "ADD COLUMN IF NOT EXISTS upstream TEXT, "
+            "ADD COLUMN IF NOT EXISTS browser_ws_url TEXT, "
+            "ADD COLUMN IF NOT EXISTS browser_credential TEXT, "
             "ADD COLUMN IF NOT EXISTS sessionstartedat TIMESTAMPTZ"
         )
         cur.execute("DELETE FROM vms WHERE hostname = 'host-task10'")

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -1576,3 +1576,39 @@ def test_register_client_none_provider_metadata_serializes_empty_json(
     #                 meta, client_secret_hash, gpu_present, gpu_model)
     params = mock_cursor.execute.call_args[0][1]
     assert params[4] == "{}"
+
+
+def test_get_lan_ip_prefers_provider_metadata(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = ("10.0.0.9", "ws://x:6080")
+    assert db_instance.get_lan_ip("vm-1") == "10.0.0.9"
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "provider_metadata->>'lan_ip'" in sql
+    assert "WHERE hostname = %s" in sql
+
+
+def test_get_lan_ip_falls_back_to_endpoint_url_host(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = (None, "ws://10.0.0.7:6080")
+    assert db_instance.get_lan_ip("vm-1") == "10.0.0.7"
+
+
+def test_get_lan_ip_none_when_absent(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = (None, None)
+    assert db_instance.get_lan_ip("vm-1") is None
+
+
+def test_get_lan_ip_none_when_row_absent(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = None
+    assert db_instance.get_lan_ip("nope") is None
+
+
+def test_list_hosts_by_provider(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchall.return_value = [("vm-1",), ("vm-2",)]
+    assert db_instance.list_hosts_by_provider("manual") == ["vm-1", "vm-2"]
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "WHERE provider = %s" in sql
+    assert mock_cursor.execute.call_args[0][1] == ("manual",)

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -1447,6 +1447,8 @@ def test_release_seat_clears_per_session_columns(real_db):
             "ADD COLUMN IF NOT EXISTS browsertoken TEXT, "
             "ADD COLUMN IF NOT EXISTS vncpassword TEXT, "
             "ADD COLUMN IF NOT EXISTS upstream TEXT, "
+            "ADD COLUMN IF NOT EXISTS browser_ws_url TEXT, "
+            "ADD COLUMN IF NOT EXISTS browser_credential TEXT, "
             "ADD COLUMN IF NOT EXISTS sessionstartedat TIMESTAMPTZ"
         )
         # Clear any leftover row from a prior test
@@ -1454,10 +1456,12 @@ def test_release_seat_clears_per_session_columns(real_db):
         cur.execute(
             "INSERT INTO vms (hostname, status, useremail, sessionid, "
             "                 browsertoken, vncpassword, upstream, "
+            "                 browser_ws_url, browser_credential, "
             "                 sessionstartedat) "
             "VALUES ('host-task2', 'running', 'sam@x.com', "
             "        '11111111-1111-1111-1111-111111111111', "
-            "        'tok-abc', 'pw-xyz', '10.0.0.5:6080', NOW())"
+            "        'tok-abc', 'pw-xyz', '10.0.0.5:6080', "
+            "        'ws://10.0.0.5:6080', 'pw-xyz-cred', NOW())"
         )
 
     real_db.release_seat(hostname='host-task2')
@@ -1465,12 +1469,13 @@ def test_release_seat_clears_per_session_columns(real_db):
     with real_db._cursor as cur:
         cur.execute(
             "SELECT useremail, sessionid, browsertoken, vncpassword, "
-            "       upstream, sessionstartedat "
+            "       upstream, browser_ws_url, browser_credential, "
+            "       sessionstartedat "
             "FROM vms WHERE hostname = 'host-task2'"
         )
         row = cur.fetchone()
 
-    assert row == (None, None, None, None, None, None)
+    assert row == (None, None, None, None, None, None, None, None)
 
 
 def test_set_setting_upserts(db_instance, mock_db_connection):

--- a/packages/allocator/tests/test_desktop_route.py
+++ b/packages/allocator/tests/test_desktop_route.py
@@ -1,5 +1,6 @@
 """Tests for the GET /desktop route."""
 import uuid
+from unittest.mock import MagicMock
 
 import pytest
 
@@ -18,7 +19,9 @@ def _ensure_session_columns(real_db):
             "ADD COLUMN IF NOT EXISTS status TEXT, "
             "ADD COLUMN IF NOT EXISTS useremail TEXT, "
             "ADD COLUMN IF NOT EXISTS sessionid UUID, "
-            "ADD COLUMN IF NOT EXISTS browsertoken TEXT"
+            "ADD COLUMN IF NOT EXISTS browsertoken TEXT, "
+            "ADD COLUMN IF NOT EXISTS browser_ws_url TEXT, "
+            "ADD COLUMN IF NOT EXISTS browser_credential TEXT"
         )
         cur.execute(
             "CREATE TABLE IF NOT EXISTS settings ("
@@ -65,9 +68,10 @@ def test_desktop_redirects_to_kasmvnc_viewer_with_valid_cookie(
         cur.execute("DELETE FROM vms WHERE hostname = 'host-task12'")
         cur.execute(
             "INSERT INTO vms (hostname, status, useremail, "
-            "                 sessionid, browsertoken) "
+            "                 sessionid, browsertoken, "
+            "                 browser_ws_url, browser_credential) "
             "VALUES ('host-task12', 'running', 'sam@x.com', "
-            "        %s, 'tok-abc')",
+            "        %s, 'tok-abc', 'proxy/tok-abc', NULL)",
             (sid,),
         )
     client_with_db.set_cookie("lablink_session", sign(sid, secret=SEED_SECRET))
@@ -100,3 +104,71 @@ def test_desktop_redirects_when_status_not_running(client_with_db, real_db):
     client_with_db.set_cookie("lablink_session", sign(sid, secret=SEED_SECRET))
     resp = client_with_db.get("/desktop", follow_redirects=False)
     assert resp.status_code == 302
+
+
+# ---------------------------------------------------------------------------
+# Mock-based fixture: controls (browser_ws_url, browser_credential) directly
+# without requiring a real Postgres connection.
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def desktop_client_with_row(monkeypatch):
+    """Factory fixture: yields a callable that returns a Flask test client
+    whose /desktop row lookup returns ``(ws_url, cred)`` for a valid running
+    session + signed cookie.  No real Postgres required."""
+
+    def _make(*, ws_url, cred):
+        import lablink_allocator_service.main as main_module
+
+        # Stable session id — sign it with SEED_SECRET.
+        sid = str(uuid.uuid4())
+        signed = sign(sid, secret=SEED_SECRET)
+
+        # Mock cursor: fetchone returns the two new columns.
+        mock_cur = MagicMock()
+        mock_cur.__enter__ = lambda s: s
+        mock_cur.__exit__ = MagicMock(return_value=False)
+        mock_cur.fetchone.return_value = (ws_url, cred)
+
+        # Mock connection: cursor() returns mock_cur.
+        mock_conn = MagicMock()
+        mock_conn.cursor.return_value = mock_cur
+
+        # Mock pool: getconn returns the mock connection, putconn is a no-op.
+        mock_pool = MagicMock()
+        mock_pool.getconn.return_value = mock_conn
+
+        main_module.app.config["DB_POOL"] = mock_pool
+        main_module.app.config["VM_TABLE_NAME"] = "vms"
+
+        # Stub get_or_create_cookie_secret so the route verifies with SEED_SECRET.
+        monkeypatch.setattr(
+            "lablink_allocator_service.routes.desktop.get_or_create_cookie_secret",
+            lambda _: SEED_SECRET,
+            raising=True,
+        )
+
+        flask_client = main_module.app.test_client()
+        flask_client.set_cookie("lablink_session", signed)
+        return flask_client
+
+    return _make
+
+
+def test_desktop_aws_byte_identical(desktop_client_with_row):
+    client = desktop_client_with_row(ws_url="proxy/btok123", cred=None)
+    r = client.get("/desktop")
+    assert r.status_code == 302
+    assert r.headers["Location"] == (
+        "/static/novnc/vnc.html?path=proxy/btok123&autoconnect=1&resize=remote"
+    )
+
+
+def test_desktop_lan_direct_renders_direct_with_credential(desktop_client_with_row):
+    client = desktop_client_with_row(ws_url="ws://10.0.0.9:6080", cred="seshpw")
+    r = client.get("/desktop")
+    assert r.status_code == 200          # rendered page, not a redirect
+    body = r.get_data(as_text=True)
+    assert "10.0.0.9" in body and "6080" in body
+    assert "seshpw" in body              # credential in-page, not in a logged URL
+    assert "?path=proxy/" not in body

--- a/packages/allocator/tests/test_generate_init_sql.py
+++ b/packages/allocator/tests/test_generate_init_sql.py
@@ -59,3 +59,9 @@ def test_phase2_indexes_present():
     assert "_provider_idx" in sql
     assert "_assignable_idx" in sql
     assert "useremail IS NULL AND status = 'running'" in sql
+
+
+def test_d1_render_columns_present():
+    sql = build_init_sql()
+    assert "browser_ws_url     TEXT" in sql
+    assert "browser_credential TEXT" in sql

--- a/packages/allocator/tests/test_manual_e2e.py
+++ b/packages/allocator/tests/test_manual_e2e.py
@@ -1,0 +1,185 @@
+"""D1 hermetic stubbed-agent end-to-end (spec Testing -> Layer 1).
+
+Manual / LAN-direct path, allocator-side only: no real network, no GPU,
+no Postgres.  Drives the three D1 phases against ONE logical hostname so
+the data contract is shown to flow end-to-end:
+
+  1. POST /api/v1/clients/register  -> response carries agent_token and
+     connectivity == "lan_direct" (manual provider selected).
+  2. LANDirectClientConnectivity.prepare_browser_session -> persists
+     browser_ws_url="ws://<lan_ip>:6080" + browser_credential=<pw> via
+     the cursor (agent rotate stubbed; no socket).
+  3. GET /desktop -> 200 in-page render embedding the lan_ip/port and the
+     credential, with NO "?path=proxy/" redirect.
+
+The three phases legitimately use different stubs (Flask client + mock
+db / mock cursor / row-stub) -- we assert the contract, not a shared DB.
+Fixture / patch conventions mirror the sibling modules:
+  - test_registration_api.py  (reg_client: LABLINK_PROVIDER + db stub)
+  - test_lan_direct.py        (_post_rotate monkeypatch + mock cursor)
+  - test_desktop_route.py     (desktop_client_with_row mock pool/cursor)
+"""
+import uuid
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from lablink_allocator_service.providers.manual import ManualProvider
+from lablink_allocator_service.signed_cookie import sign
+
+
+SEED_SECRET = "test-secret"
+HOSTNAME = "vm-e2e"
+LAN_IP = "10.0.0.5"
+EXPECTED_WS_URL = f"ws://{LAN_IP}:6080"
+
+
+@pytest.fixture
+def manual_reg_client(app, monkeypatch):
+    """Flask test client wired to the manual provider.
+
+    Mirrors test_registration_api.py::reg_client but swaps the stub
+    provider's connectivity for LANDirectClientConnectivity so the
+    register view selects the manual / lan_direct path.
+    """
+    from lablink_allocator_service import main
+    from lablink_allocator_service.secret_hash import hash_secret
+
+    app.config["LABLINK_PROVIDER"] = ManualProvider()
+
+    fake_db = MagicMock()
+    fake_db.register_client.return_value = HOSTNAME
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+    monkeypatch.setattr(main, "REGISTER_TOKEN", "tk_test_register", raising=False)
+    fake_db.get_setting.return_value = hash_secret("tk_test_register")
+    return app.test_client(), fake_db
+
+
+def test_manual_lan_direct_e2e(manual_reg_client, monkeypatch):
+    # -------------------------------------------------------------------
+    # Phase 1 -- register: manual provider -> agent_token + lan_direct.
+    # -------------------------------------------------------------------
+    client, _ = manual_reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": HOSTNAME, "machine_identity": "i-e2e"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["agent_token"]  # present + non-empty
+    assert body["connectivity"] == "lan_direct"
+
+    from lablink_allocator_service import main
+
+    agent_token = body["agent_token"]
+    assert agent_token == main.AGENT_TOKEN
+
+    # -------------------------------------------------------------------
+    # Phase 2 -- prepare_browser_session: stub agent rotate (no network),
+    # capture the UPDATE the cursor receives.
+    # -------------------------------------------------------------------
+    import lablink_allocator_service.client_session as cs
+    from lablink_allocator_service.providers.connectivity.lan_direct import (
+        LANDirectClientConnectivity,
+    )
+
+    posted = {}
+    monkeypatch.setattr(
+        cs,
+        "_post_rotate",
+        lambda url, body_, *, bearer: posted.update(
+            url=url, body=body_, bearer=bearer
+        ),
+        raising=True,
+    )
+
+    executed = {}
+
+    class _Cur:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def execute(self, sql, params):
+            executed["sql"] = sql
+            executed["params"] = params
+
+    class _DB:
+        table_name = "vms"
+        _cursor = _Cur()
+
+        def get_lan_ip(self, hostname):
+            assert hostname == HOSTNAME
+            return LAN_IP
+
+    session_id = uuid.uuid4()
+    target = LANDirectClientConnectivity().prepare_browser_session(
+        database=_DB(),
+        hostname=HOSTNAME,
+        session_id=session_id,
+        browser_token="btok-e2e",
+        agent_token=agent_token,
+    )
+
+    # Agent rotate was stubbed -> no socket; bearer is the agent_token
+    # the register response handed back.
+    assert posted["url"] == f"http://{LAN_IP}:7070/api/session/start"
+    assert posted["bearer"] == agent_token
+
+    # Returned target carries the direct ws:// URL + a non-empty
+    # generated credential (secrets.token_urlsafe(24); value not asserted).
+    assert target.ws_url == EXPECTED_WS_URL
+    assert target.browser_credential
+    password = target.browser_credential
+
+    # Same credential flows onto the wire and into the persisted UPDATE.
+    assert posted["body"] == {"password": password}
+    params = executed["params"]
+    assert "browser_ws_url" in executed["sql"]
+    assert "browser_credential" in executed["sql"]
+    assert EXPECTED_WS_URL in params
+    assert password in params
+
+    # -------------------------------------------------------------------
+    # Phase 3 -- /desktop: row stub returns the two persisted columns ->
+    # 200 in-page render with lan_ip/port + credential, NO proxy redirect.
+    # (Mirrors test_desktop_route.py::desktop_client_with_row.)
+    # -------------------------------------------------------------------
+    import lablink_allocator_service.main as main_module
+
+    sid = str(uuid.uuid4())
+    signed = sign(sid, secret=SEED_SECRET)
+
+    mock_cur = MagicMock()
+    mock_cur.__enter__ = lambda s: s
+    mock_cur.__exit__ = MagicMock(return_value=False)
+    mock_cur.fetchone.return_value = (EXPECTED_WS_URL, password)
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cur
+
+    mock_pool = MagicMock()
+    mock_pool.getconn.return_value = mock_conn
+
+    main_module.app.config["DB_POOL"] = mock_pool
+    main_module.app.config["VM_TABLE_NAME"] = "vms"
+
+    monkeypatch.setattr(
+        "lablink_allocator_service.routes.desktop.get_or_create_cookie_secret",
+        lambda _: SEED_SECRET,
+        raising=True,
+    )
+
+    desktop_client = main_module.app.test_client()
+    desktop_client.set_cookie("lablink_session", signed)
+    resp = desktop_client.get("/desktop")
+
+    assert resp.status_code == 200  # rendered page, not a redirect
+    page = resp.get_data(as_text=True)
+    assert LAN_IP in page and "6080" in page
+    assert password in page  # credential in-page (localStorage), not in URL
+    assert "?path=proxy/" not in page

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -178,3 +178,20 @@ def test_register_returns_409_on_integrity_error(reg_client):
         headers={"Authorization": "Bearer tk_test_register"},
     )
     assert r.status_code == 409
+
+
+def test_agent_token_global_exists():
+    from lablink_allocator_service import main
+    assert isinstance(main.AGENT_TOKEN, str) and len(main.AGENT_TOKEN) >= 32
+    assert main.AGENT_TOKEN != main.API_TOKEN
+    assert main.AGENT_TOKEN != main.REGISTER_TOKEN
+
+
+def test_register_response_includes_agent_token(reg_client):
+    client, fake_db = reg_client
+    r = client.post("/api/v1/clients/register",
+                     json={"hostname": "vm-1", "machine_identity": "i-1"},
+                     headers={"Authorization": "Bearer tk_test_register"})
+    assert r.status_code == 200
+    from lablink_allocator_service import main
+    assert r.get_json()["agent_token"] == main.AGENT_TOKEN

--- a/packages/allocator/tests/test_terraform_api.py
+++ b/packages/allocator/tests/test_terraform_api.py
@@ -1015,3 +1015,33 @@ def test_launch_writes_agent_token_to_tfvars_additively(
     # ... and api_token is still written (additive, not replaced).
     assert f'api_token = "{main.API_TOKEN}"' in tfvars
     assert 'api_token = "test-api-token-value"' in tfvars
+
+
+def test_terraform_threads_agent_token_through_user_data():
+    """Static-content guard for the AGENT_TOKEN Terraform wiring.
+
+    Catches typos/renames in the templatefile var name, variables.tf,
+    or user_data.sh's docker-run `-e` line that would slip past both
+    `terraform validate` (HCL only) and the runtime tfvars-write test
+    above (which only pins the .tfvars line). Pins the end-to-end
+    AGENT_TOKEN wiring as additive next to the surviving API_TOKEN.
+    """
+    import re
+    from pathlib import Path
+
+    tf_dir = (
+        Path(__file__).resolve().parents[1]
+        / "src" / "lablink_allocator_service" / "terraform"
+    )
+    variables = (tf_dir / "variables.tf").read_text()
+    main_tf = (tf_dir / "main.tf").read_text()
+    user_data = (tf_dir / "user_data.sh").read_text()
+
+    # variable declared
+    assert 'variable "agent_token"' in variables
+    # passed into the user_data templatefile vars map (HCL aligns the =;
+    # match whitespace-tolerantly so an alignment touch-up does not fail).
+    assert re.search(r"agent_token\s*=\s*var\.agent_token", main_tf)
+    # injected on the client docker run; additive (API_TOKEN still present)
+    assert '-e AGENT_TOKEN="${agent_token}"' in user_data
+    assert '-e API_TOKEN="${api_token}"' in user_data

--- a/packages/allocator/tests/test_terraform_api.py
+++ b/packages/allocator/tests/test_terraform_api.py
@@ -925,6 +925,9 @@ def test_launch_writes_register_token_to_tfvars(
     monkeypatch.setattr(
         "lablink_allocator_service.main.REGISTER_TOKEN", "test-register-token-value", raising=False
     )
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.AGENT_TOKEN", "test-agent-token-value", raising=False
+    )
 
     class R:
         def __init__(self, out="OK"):
@@ -943,3 +946,72 @@ def test_launch_writes_register_token_to_tfvars(
 
     tfvars = (terraform_dir / "terraform.runtime.tfvars").read_text()
     assert 'register_token = "test-register-token-value"' in tfvars
+    assert 'agent_token = "test-agent-token-value"' in tfvars
+
+
+@patch("lablink_allocator_service.main.upload_to_s3")
+@patch("lablink_allocator_service.main.check_support_nvidia", return_value=True)
+@patch("lablink_allocator_service.main.subprocess.run")
+def test_launch_writes_agent_token_to_tfvars_additively(
+    mock_run,
+    mock_check_support_nvidia,
+    mock_upload_to_s3,
+    client,
+    admin_headers,
+    monkeypatch,
+    tmp_path,
+):
+    """Regression: launch() must write agent_token = "<main.AGENT_TOKEN>" into
+    terraform.runtime.tfvars so the client agent receives AGENT_TOKEN env via
+    the bundled user_data — WITHOUT dropping the existing api_token line
+    (additive, not a rename). Guards the D1 shipping-blocker wiring: if the
+    AGENT_TOKEN tfvars thread is ever removed, every /api/session/start 500s.
+    """
+    terraform_dir = tmp_path / "terraform"
+    terraform_dir.mkdir()
+    monkeypatch.setattr("lablink_allocator_service.main.TERRAFORM_DIR", terraform_dir)
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database",
+        MagicMock(get_row_count=MagicMock(return_value=0)),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.allocator_ip", "1.2.3.4", raising=False
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.key_name", "my-key", raising=False
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.ENVIRONMENT", "test", raising=False
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.API_TOKEN", "test-api-token-value", raising=False
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.AGENT_TOKEN", "test-agent-token-value", raising=False
+    )
+
+    class R:
+        def __init__(self, out="OK"):
+            self.stdout, self.stderr, self.returncode = out, "", 0
+
+    timing_json = '{"vm-1": {"start_time": "2025-10-30T12:00:00Z", "end_time": "2025-10-30T12:01:00Z", "seconds": 60.0}}'
+    mock_run.side_effect = [
+        R("OK"),
+        R(CLEAN_PLAN_JSON),
+        R("\x1b[32mapply success\x1b[0m"),
+        R(timing_json),
+    ]
+
+    resp = client.post(POST_ENDPOINT, headers=admin_headers, data={"num_vms": "1"})
+    assert resp.status_code == 200
+
+    from lablink_allocator_service import main
+
+    tfvars = (terraform_dir / "terraform.runtime.tfvars").read_text()
+    # agent_token carries main.AGENT_TOKEN ...
+    assert f'agent_token = "{main.AGENT_TOKEN}"' in tfvars
+    assert 'agent_token = "test-agent-token-value"' in tfvars
+    # ... and api_token is still written (additive, not replaced).
+    assert f'api_token = "{main.API_TOKEN}"' in tfvars
+    assert 'api_token = "test-api-token-value"' in tfvars

--- a/packages/client/src/lablink_client_service/agent/api.py
+++ b/packages/client/src/lablink_client_service/agent/api.py
@@ -7,9 +7,9 @@ handing the seat to a student; the agent rewrites the local
 Basic Auth check, so no signal-based reload is needed (and SIGHUP
 would in fact terminate Xvnc — its reset path is unsupported).
 
-Auth: Bearer = deployment-wide API_TOKEN (same value the allocator
-generates at startup and bakes into the client VM's docker env via
-the Terraform `api_token` variable). Any caller who knows the token
+Auth: Bearer = deployment-wide agent-control token AGENT_TOKEN (same
+value the allocator generates at startup and bakes into the client
+VM's docker env via Terraform). Any caller who knows the token
 can rotate the password; that's adequate because the token is only
 ever set on the client VM by Terraform and only ever sent by the
 allocator. /healthz is unauthenticated for ALB / Docker healthchecks.
@@ -27,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def create_app() -> Flask:
     app = Flask(__name__)
-    expected = os.environ.get("API_TOKEN", "")
+    expected = os.environ.get("AGENT_TOKEN", "")
 
     @app.post("/api/session/start")
     def session_start():
@@ -38,7 +38,7 @@ def create_app() -> Flask:
         # per-seat — timing-channel risk is negligible.
         auth = request.headers.get("Authorization", "")
         if not expected:
-            logger.error("API_TOKEN env var is not set; rejecting all calls")
+            logger.error("AGENT_TOKEN env var is not set; rejecting all calls")
             return jsonify(error="server misconfigured"), 500
         if not auth.startswith("Bearer ") or auth[7:] != expected:
             return jsonify(error="unauthorized"), 401

--- a/packages/client/tests/test_agent_api.py
+++ b/packages/client/tests/test_agent_api.py
@@ -9,9 +9,9 @@ from lablink_client_service.agent.api import create_app
 
 @pytest.fixture
 def client(monkeypatch):
-    """Flask test client with API_TOKEN set and password rotation
+    """Flask test client with AGENT_TOKEN set and password rotation
     patched out so tests don't shell out to `kasmvncpasswd`."""
-    monkeypatch.setenv("API_TOKEN", "test-token-123")
+    monkeypatch.setenv("AGENT_TOKEN", "test-token-123")
     app = create_app()
     app.config["TESTING"] = True
     return app.test_client()
@@ -42,6 +42,23 @@ def test_session_start_rotates_password_on_valid_request(client, authed_headers)
     assert resp.status_code == 200
     assert resp.get_json() == {"ok": True}
     rotate.assert_called_once_with(password="hunter22")
+
+
+def test_agent_validates_agent_token(monkeypatch):
+    """AGENT_TOKEN accepted, wrong token rejected, API_TOKEN not consulted."""
+    monkeypatch.setenv("AGENT_TOKEN", "good-agent")
+    monkeypatch.delenv("API_TOKEN", raising=False)
+    from lablink_client_service.agent.api import create_app
+    app = create_app()
+    app.config["TESTING"] = True
+    c = app.test_client()
+    with patch("lablink_client_service.agent.api.rotate_kasmvnc_password"):
+        ok = c.post("/api/session/start", json={"password": "p"},
+                    headers={"Authorization": "Bearer good-agent"})
+        bad = c.post("/api/session/start", json={"password": "p"},
+                     headers={"Authorization": "Bearer wrong"})
+    assert ok.status_code == 200
+    assert bad.status_code == 401
 
 
 def test_session_start_rejects_missing_auth_header(client):
@@ -84,10 +101,10 @@ def test_session_start_rejects_non_bearer_scheme(client):
     rotate.assert_not_called()
 
 
-def test_session_start_returns_500_when_api_token_unset(monkeypatch):
-    """Misconfigured server (no API_TOKEN env) returns 500 rather than
+def test_session_start_returns_500_when_agent_token_unset(monkeypatch):
+    """Misconfigured server (no AGENT_TOKEN env) returns 500 rather than
     silently accepting empty-Bearer rotations — failing closed."""
-    monkeypatch.delenv("API_TOKEN", raising=False)
+    monkeypatch.delenv("AGENT_TOKEN", raising=False)
     app = create_app()
     app.config["TESTING"] = True
     test_client = app.test_client()


### PR DESCRIPTION
## Summary

One PR of the AWS-decoupling roadmap. Adds a provider-pluggable path so a bring-your-own GPU box (**manual** provider) is reached by the participant's browser **directly over the LAN** (`ws://<lan_ip>:6080`) instead of through the allocator nginx proxy. **Behavior-preserving** for the existing AWS allocator-proxied path.

## Changes

### Added
- `providers/manual.py` — `ManualProvider`: BYO host, never provisions/destroys/recovers, LAN-agnostic, injected connectivity. Registered in registry `_BUILTIN` + the `lablink.providers` entry point.
- `providers/connectivity/lan_direct.py` — `LANDirectClientConnectivity`: resolves the client LAN IP, rotates the per-session KasmVNC password via the **shared** agent-POST helper, persists `ws://<lan_ip>:6080` render data.
- Deployment-wide **`AGENT_TOKEN`** agent-control token: the allocator presents it as the Bearer on the allocator→client-agent `:7070/api/session/start` call; the client agent verifies it. Distinct from `API_TOKEN` (M2M/log-shipper, retired in D4), `REGISTER_TOKEN` (join), and per-client `client_secret`. Threaded `variables.tf` → `main.tf` → `user_data.sh` to the client container.
- Durable `browser_ws_url` / `browser_credential` render columns in the fresh-DB schema.
- Tests: hermetic L1 end-to-end (`test_manual_e2e.py`), core cleanliness guard (`test_cleanliness_guard.py`), unit tests for the new provider/connectivity/db/route paths, and a Terraform-wiring regression test.

### Changed
- `BrowserSessionTarget` reshaped to the opaque `(ws_url, browser_credential)` contract — single canonical dataclass, re-exported by `providers/protocol.py`.
- `/desktop` renders uniformly from the two persisted columns, branching **only on data shape** (`ws_url.startswith("proxy/")`) — no connectivity/provider type-branching in the core (guard-enforced). AWS proxied redirect is **byte-identical**.
- AWS `prepare_browser_session` token kwarg → `agent_token`; persists the render columns.
- `AWSProvider`/`ManualProvider` constructors are tolerant (uniform registry construction).
- Client agent validates `AGENT_TOKEN` instead of `API_TOKEN` (the only client behavior change).

### Fixed
- **Caught & fixed in-PR by the final whole-implementation review:** the bundled Terraform `user_data.sh` did not inject `AGENT_TOKEN` into the client VM — this would have **500'd every AWS `request_vm` in production**. The token is now threaded end-to-end and pinned by a regression test (`test_launch_writes_agent_token_to_tfvars_additively`).

## Technical Details

- **AWS path (`allocator_proxied`, unchanged):** browser → allocator (WS) → allocator nginx reverse-proxies → client `private_ip:6080`.
- **Manual path (`lan_direct`, new):** browser → client `lan_ip:6080` **directly** (no allocator in the WS data path); the allocator only does the control-plane password rotation via the `AGENT_TOKEN`-guarded agent call.
- The core never inspects provider/connectivity type — uniform render from opaque persisted data; the cleanliness invariant has a guard test.

## Testing

- [x] Allocator unit tests — `453 passed, 13 skipped` (`pytest tests --ignore=tests/terraform`)
- [x] Client unit tests — `68 passed`
- [x] `ruff check` clean (allocator + client, src + tests)
- [x] `terraform validate` — success
- [x] Hermetic L1 e2e (register → LAN-direct `prepare_browser_session` → `/desktop`) green
- [ ] **L3 manual GPU-staging smoke — REQUIRED acceptance gate, not CI-automatable.** On real GPU + same-LAN browser: (1) confirm AWS `request_vm` still works end-to-end (regression check for the `AGENT_TOKEN` Terraform fix), (2) manual LAN-direct: register → `connectivity == "lan_direct"`, browser WS goes directly to `ws://<lan_ip>:6080` (no `?path=proxy/`), per-session password rotates, wrong `AGENT_TOKEN` → 401 / correct → 200. (Operator checklist kept local; L2 CPU-docker-harness automation scoped for D2.)

## Reviewer callouts

- **Why a separate `AGENT_TOKEN`** (not reuse `API_TOKEN`): the allocator→agent call needs a plaintext deployment-wide bearer; `client_secret` is per-client + hash-only at rest so can't be presented; keeping it off `API_TOKEN` keeps D4's `API_TOKEN` retirement a clean isolated change and limits blast radius (the agent surface resets live VNC sessions).
- **Manual testing is required before shipping** — the suite stubs the allocator→agent call everywhere, which is exactly why the env-wiring regression above was invisible to green CI.

## Checklist
- [x] Follows project conventions; tests added/updated
- [x] No breaking changes to the AWS path (behavior-preserving, byte-identical desktop redirect, regression-locked)
- [ ] CHANGELOG.md not updated — flag if this repo's process requires it for this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)