### PR TITLE
PR D4: retire API_TOKEN (unify M2M auth on client_secret)

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -37,23 +37,24 @@ LabLink implements multiple security layers:
 
 ## Authentication & Authorization
 
-### API Bearer Token (Machine-to-Machine)
+### Machine-to-Machine Authentication
 
-All machine-to-machine API endpoints (client VM → allocator) are protected by a shared bearer token. This prevents unauthorized access to endpoints that could otherwise be used for VM hijacking, status spoofing, log injection, or infrastructure enumeration.
+Machine-to-machine endpoints use two distinct bearer tokens depending on direction:
 
-**How it works:**
+**Client → Allocator (per-client `client_secret`):**
 
-1. The allocator auto-generates a random token (`secrets.token_urlsafe(32)`) at startup
-2. When VMs are launched via `/api/launch`, the token is written to `terraform.runtime.tfvars`
-3. Terraform passes the token to client VMs via cloud-init as the `API_TOKEN` environment variable
-4. Client services include `Authorization: Bearer <token>` in all API requests
-5. The allocator validates the token using constant-time comparison (`secrets.compare_digest`)
+1. Each client mints its credential at registration via `POST /api/v1/clients/register` (gated by a deployment-wide `register_token`). The allocator generates a random `client_secret` (`secrets.token_urlsafe(32)`), stores only `argon2(client_secret)` in `vms.client_secret_hash`, and returns the plaintext secret once.
+2. On AWS, `user_data.sh` captures the secret into `CLIENT_SECRET` before any client code runs. On manual BYO deployments, `lablink client register` writes it to `~/.lablink/client.env` (mode 0600).
+3. Every client → allocator request includes `Authorization: Bearer <client_secret>`. The allocator resolves the client by URL path or body field (`hostname`/`vm_id`), looks up the stored hash, and verifies with argon2.
+4. **Protected endpoints (client_secret required):** `/api/update_inuse_status`, `/api/gpu_health`, `/api/heartbeat`, `/api/vm-status`, `/api/vm-logs/<hostname>`, `/api/vm-metrics/<hostname>`, `/api/v1/clients/<id>` (unregister).
 
-**Protected endpoints:** `/vm_startup`, `/api/unassigned_vms_count`, `/api/update_inuse_status`, `/api/gpu_health`, `/api/vm-status`, `/api/vm-logs`, `/api/vm-metrics/<hostname>`
+**Allocator → Agent (deployment-wide `agent_token`):**
 
-**Not protected:** `/api/request_vm` (student-facing, accessed from the web UI)
+The allocator's password-rotation call to each client's agent on port 7070 (`POST /api/session/start`) uses a deployment-wide `agent_token` (`secrets.token_urlsafe(32)`, in-memory only). The agent compares the Bearer header with constant-time comparison and rewrites the per-session KasmVNC password.
 
-**Token lifecycle:** The token is regenerated each time the allocator starts. Since client VMs are always destroyed before the allocator restarts (via `terraform destroy`), token persistence is not needed. New VMs receive the fresh token at launch.
+**Not protected (Basic auth or public):** `/api/request_vm` (student-facing); admin browser views (`/admin/*`, `/api/export-metrics`, `/api/v1/clients` GET) use HTTP Basic auth against the operator's admin credentials.
+
+**Token lifecycle:** `client_secret` is per-client and per-registration — a client that re-registers gets a fresh secret, and unregistering hard-deletes the row including the hash. `agent_token` is regenerated on every allocator restart. Since client containers are torn down before the allocator restarts, token persistence is not required.
 
 ### Change Default Passwords
 

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -137,17 +137,14 @@ key_name = os.getenv("ALLOCATOR_KEY_NAME")
 ENVIRONMENT = os.getenv("ENVIRONMENT", "prod").strip().lower().replace(" ", "-")
 cloud_init_output_log_group = os.getenv("CLOUD_INIT_LOG_GROUP")
 
-# API token for machine-to-machine authentication (auto-generated each startup)
-API_TOKEN = secrets.token_urlsafe(32)
-
-# Deployment register-token (machine registration). Mirrors API_TOKEN
-# semantics: one per allocator process, re-injected via terraform on launch.
+# Deployment register-token (machine registration): one per allocator process,
+# re-injected via terraform on launch.
 REGISTER_TOKEN = secrets.token_urlsafe(32)
 
 # Deployment agent-control token: allocator→client-agent (:7070) control
-# channel. Distinct from API_TOKEN (M2M, → D4) and REGISTER_TOKEN
-# (client→allocator join). Symmetric plaintext (allocator presents, agent
-# verifies); per-process like API_TOKEN/REGISTER_TOKEN.
+# channel. Distinct from REGISTER_TOKEN (client→allocator join). Symmetric
+# plaintext (allocator presents, agent verifies); per-process like
+# REGISTER_TOKEN.
 AGENT_TOKEN = secrets.token_urlsafe(32)
 
 # Initialize the database connection
@@ -225,44 +222,6 @@ def verify_password(username, password):
     if username in users and check_password_hash(users.get(username), password):
         return username
 
-
-def require_api_token(f):
-    """Require a valid API bearer token for machine-to-machine endpoints."""
-
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        auth_header = request.headers.get("Authorization", "")
-        if not auth_header.startswith("Bearer "):
-            return jsonify({"error": "Missing or invalid Authorization header."}), 401
-        token = auth_header[7:]  # Strip "Bearer " prefix
-        if not secrets.compare_digest(token, API_TOKEN):
-            return jsonify({"error": "Invalid API token."}), 401
-        return f(*args, **kwargs)
-
-    return decorated
-
-
-def require_auth(f):
-    """Accept either session auth (admin UI) or API bearer token (VMs)."""
-
-    @wraps(f)
-    def decorated(*args, **kwargs):
-        # Try API token first
-        auth_header = request.headers.get("Authorization", "")
-        if auth_header.startswith("Bearer "):
-            token = auth_header[7:]
-            if secrets.compare_digest(token, API_TOKEN):
-                return f(*args, **kwargs)
-            return jsonify({"error": "Invalid API token."}), 401
-
-        # Fall back to session auth (HTTP Basic)
-        if auth.current_user():
-            return f(*args, **kwargs)
-
-        # No valid auth provided — trigger Basic auth challenge
-        return auth.login_required(f)(*args, **kwargs)
-
-    return decorated
 
 
 def require_client_secret(f):
@@ -551,7 +510,6 @@ def launch():
             f.write(f'cloud_init_output_log_group = "{cloud_init_output_log_group}"\n')
             f.write(f'region = "{cfg.app.region}"\n')
             f.write(f'startup_on_error = "{cfg.startup_script.on_error}"\n')
-            f.write(f'api_token = "{API_TOKEN}"\n')
             f.write(f'agent_token = "{AGENT_TOKEN}"\n')
             f.write(f'register_token = "{REGISTER_TOKEN}"\n')
 
@@ -846,7 +804,7 @@ def update_vm_status():
 
 
 @app.route("/api/vm-status", methods=["GET"])
-@require_auth
+@auth.login_required
 def get_all_vm_status():
     try:
         vm_status = database.get_all_vm_status()
@@ -859,29 +817,27 @@ def get_all_vm_status():
         return jsonify({"error": "Failed to get VM status."}), 500
 
 
-@app.route("/api/vm-logs", methods=["POST"])
-@require_api_token
-def receive_vm_logs():
+@app.route("/api/vm-logs/<hostname>", methods=["POST"])
+@require_client_secret
+def receive_vm_logs(hostname):
     try:
         data = request.get_json()
         log_group = data.get("log_group")
-        log_stream = data.get("log_stream")
         messages = data.get("messages", [])
 
-        if not log_group or not log_stream or not messages:
+        if not log_group or not messages:
             return (
-                jsonify({"error": "Log group, stream, and messages are required."}),
+                jsonify({"error": "Log group and messages are required."}),
                 400,
             )
 
         # Check if the VM exists in the database
-        if not database.vm_exists(log_stream):
-            logger.error(f"VM with log stream {log_stream} does not exist.")
+        if not database.vm_exists(hostname):
+            logger.error(f"VM with hostname {hostname} does not exist.")
             return jsonify({"error": "VM not found."}), 404
 
-        # Process the logs (e.g., save to a file, database, etc.)
         logger.debug(
-            f"Received logs for {log_group}/{log_stream}: {len(messages)} messages"
+            f"Received logs for {log_group}/{hostname}: {len(messages)} messages"
         )
 
         # Strip ANSI escape codes and drop empty lines
@@ -898,7 +854,7 @@ def receive_vm_logs():
         MAX_LOG_SIZE = 1 * 1024 * 1024  # 1MB
         new_logs = "\n".join(messages)
         database.append_logs_by_hostname(
-            hostname=log_stream,
+            hostname=hostname,
             new_logs=new_logs,
             log_type=log_type,
             max_size=MAX_LOG_SIZE,
@@ -911,7 +867,7 @@ def receive_vm_logs():
 
 
 @app.route("/api/vm-logs/<hostname>", methods=["GET"])
-@require_auth
+@auth.login_required
 def get_vm_logs_by_hostname(hostname):
     try:
         if not database.vm_exists(hostname):
@@ -950,7 +906,7 @@ def get_vm_logs(hostname):
 
 
 @app.route("/api/vm-metrics/<hostname>", methods=["POST"])
-@require_api_token
+@require_client_secret
 def receive_vm_metrics(hostname):
     """Receive and store VM Cloud init metrics."""
     try:
@@ -974,7 +930,7 @@ def receive_vm_metrics(hostname):
 
 
 @app.route("/api/export-metrics", methods=["GET"])
-@require_auth
+@auth.login_required
 def export_metrics():
     """Export VM metrics data as JSON."""
     try:

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -17,27 +17,6 @@ from lablink_allocator_service.secret_hash import hash_secret, verify_secret
 bp = Blueprint("registration", __name__)
 
 
-def _require_admin_or_api_token():
-    """Accept Bearer API_TOKEN or admin HTTP Basic.
-
-    Returns None when authorized, or a Flask response to return as-is.
-    Lazy-imports ``main`` to keep this blueprint clear of the
-    module-load cycle, mirroring the other views above.
-    """
-    from lablink_allocator_service import main
-
-    header = request.headers.get("Authorization", "")
-    if header.startswith("Bearer "):
-        token = header[7:]
-        if secrets.compare_digest(token, main.API_TOKEN):
-            return None
-        return jsonify({"error": "Invalid API token."}), 401
-
-    if main.auth.current_user():
-        return None
-    return main.auth.login_required(lambda: None)()
-
-
 @bp.route("/api/v1/clients/register", methods=["POST"])
 def register_client():
     from lablink_allocator_service import main
@@ -98,7 +77,6 @@ def register_client():
         client_id=client_id,
         client_secret=client_secret,
         agent_token=main.AGENT_TOKEN,
-        api_token=main.API_TOKEN,
         register_token=jm.register_token,
         allocator_url=jm.allocator_url,
         connectivity=jm.connectivity,
@@ -153,31 +131,32 @@ def unregister_client(client_id):
 def list_clients():
     """List registered clients for operator status views.
 
-    Auth: Bearer API_TOKEN or admin HTTP Basic — same gate as
-    ``/admin/instances``. Returns only operator-safe columns
-    (no secrets, no log blobs).
+    Auth: admin HTTP Basic — same gate as ``/admin/instances``.
+    Returns only operator-safe columns (no secrets, no log blobs).
     """
+    # Lazy import + manual decorator application: `main.auth` is only
+    # created when main.py imports this blueprint, so we can't decorate
+    # at module load time.
     from lablink_allocator_service import main
 
-    rejection = _require_admin_or_api_token()
-    if rejection is not None:
-        return rejection
+    def _handler():
+        rows = main.database.list_registered_clients()
+        clients = []
+        for row in rows:
+            last_seen = row.get("last_seen_at")
+            if isinstance(last_seen, datetime):
+                last_seen = last_seen.isoformat()
+            clients.append({
+                "hostname": row.get("hostname"),
+                "provider": row.get("provider"),
+                "endpoint_url": row.get("endpoint_url"),
+                "inuse": row.get("inuse"),
+                "status": row.get("status"),
+                "healthy": row.get("healthy"),
+                "gpu_present": row.get("gpu_present"),
+                "gpu_model": row.get("gpu_model"),
+                "last_seen_at": last_seen,
+            })
+        return jsonify(clients=clients), 200
 
-    rows = main.database.list_registered_clients()
-    clients = []
-    for row in rows:
-        last_seen = row.get("last_seen_at")
-        if isinstance(last_seen, datetime):
-            last_seen = last_seen.isoformat()
-        clients.append({
-            "hostname": row.get("hostname"),
-            "provider": row.get("provider"),
-            "endpoint_url": row.get("endpoint_url"),
-            "inuse": row.get("inuse"),
-            "status": row.get("status"),
-            "healthy": row.get("healthy"),
-            "gpu_present": row.get("gpu_present"),
-            "gpu_model": row.get("gpu_model"),
-            "last_seen_at": last_seen,
-        })
-    return jsonify(clients=clients), 200
+    return main.auth.login_required(_handler)()

--- a/packages/allocator/src/lablink_allocator_service/terraform/log_shipper.sh
+++ b/packages/allocator/src/lablink_allocator_service/terraform/log_shipper.sh
@@ -2,7 +2,7 @@
 # log_shipper.sh — Ships log lines to the allocator /api/vm-logs endpoint.
 #
 # Usage:
-#   log_shipper.sh <source> <allocator_url> <vm_name> <log_group> <api_token>
+#   log_shipper.sh <source> <allocator_url> <vm_name> <log_group> <client_secret>
 #
 # <source> is either:
 #   - A file path (e.g., /var/log/cloud-init-output.log) — tailed with tail -F
@@ -13,12 +13,12 @@ SOURCE="$1"
 ALLOCATOR_URL="$2"
 VM_NAME="$3"
 LOG_GROUP="$4"
-API_TOKEN="$5"
+CLIENT_SECRET="$5"
 
 BATCH_SIZE=50
 FLUSH_INTERVAL=15
 MAX_RETRIES=3
-ENDPOINT="$ALLOCATOR_URL/api/vm-logs"
+ENDPOINT="$ALLOCATOR_URL/api/vm-logs/$VM_NAME"
 SELF_LOG="/var/log/log_shipper.log"
 
 # Derive a short label for log messages
@@ -37,7 +37,7 @@ send_batch() {
         HTTP_CODE=$(curl -s -w "%{http_code}" -o /dev/null \
             -X POST "$ENDPOINT" \
             -H "Content-Type: application/json" \
-            -H "Authorization: Bearer $API_TOKEN" \
+            -H "Authorization: Bearer $CLIENT_SECRET" \
             -d "$payload" --max-time 10 2>/dev/null || echo "000")
         if [ "$HTTP_CODE" -ge 200 ] && [ "$HTTP_CODE" -lt 300 ]; then
             return 0
@@ -65,8 +65,8 @@ flush_buffer() {
     done
     JSON_MESSAGES+="]"
 
-    PAYLOAD=$(printf '{"log_group":"%s","log_stream":"%s","messages":%s}' \
-        "$LOG_GROUP" "$VM_NAME" "$JSON_MESSAGES")
+    PAYLOAD=$(printf '{"log_group":"%s","messages":%s}' \
+        "$LOG_GROUP" "$JSON_MESSAGES")
 
     send_batch "$PAYLOAD"
     log "Flushed ${#BUFFER[@]} lines"

--- a/packages/allocator/src/lablink_allocator_service/terraform/main.tf
+++ b/packages/allocator/src/lablink_allocator_service/terraform/main.tf
@@ -121,7 +121,6 @@ resource "aws_instance" "lablink_vm" {
       region                      = var.region
       startup_content_b64         = local.startup_content_b64
       startup_on_error            = var.startup_on_error
-      api_token                   = var.api_token
       agent_token                 = var.agent_token
       register_token              = var.register_token
       log_shipper_sh              = file("${path.module}/log_shipper.sh")

--- a/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
+++ b/packages/allocator/src/lablink_allocator_service/terraform/user_data.sh
@@ -17,7 +17,6 @@ echo "  - Log Group: ${cloud_init_output_log_group}"
 VM_NAME="${resource_prefix}-vm-${count_index}"
 ALLOCATOR_IP="${allocator_ip}"
 ALLOCATOR_URL="${allocator_url}"
-API_TOKEN="${api_token}"
 REGISTER_TOKEN="${register_token}"
 STATUS_ENDPOINT="$ALLOCATOR_URL/api/vm-status"
 LOG_GROUP="${cloud_init_output_log_group}"
@@ -57,7 +56,7 @@ SHIPPER_EOF
 chmod +x /usr/local/bin/log_shipper.sh
 
 echo ">> Starting log shipper for cloud-init log..."
-nohup /usr/local/bin/log_shipper.sh "$CLOUD_INIT_LOG" "$ALLOCATOR_URL" "$VM_NAME" "$LOG_GROUP" "$API_TOKEN" \
+nohup /usr/local/bin/log_shipper.sh "$CLOUD_INIT_LOG" "$ALLOCATOR_URL" "$VM_NAME" "$LOG_GROUP" "$CLIENT_SECRET" \
     >> /var/log/log_shipper.log 2>&1 &
 LOG_SHIPPER_CLOUD_INIT_PID=$!
 echo ">> Log shipper started (PID: $LOG_SHIPPER_CLOUD_INIT_PID)"
@@ -76,7 +75,7 @@ EXISTING_CONTAINER=$(docker ps -a --filter "ancestor=${image_name}" -q 2>/dev/nu
 if [ -n "$EXISTING_CONTAINER" ]; then
     echo ">> Existing container detected: $EXISTING_CONTAINER"
     echo ">> Warm reboot — restarting docker log shipper and skipping provisioning."
-    nohup /usr/local/bin/log_shipper.sh "docker:$EXISTING_CONTAINER" "$ALLOCATOR_URL" "$VM_NAME" "$LOG_GROUP-docker" "$API_TOKEN" \
+    nohup /usr/local/bin/log_shipper.sh "docker:$EXISTING_CONTAINER" "$ALLOCATOR_URL" "$VM_NAME" "$LOG_GROUP-docker" "$CLIENT_SECRET" \
         >> /var/log/log_shipper.log 2>&1 &
     echo ">> Docker log shipper started (PID: $!)"
     exit 0
@@ -180,7 +179,6 @@ if docker run -dit --restart unless-stopped $DOCKER_GPU_ARGS \
     -e VM_NAME="${resource_prefix}-vm-${count_index}" \
     -e SUBJECT_SOFTWARE="${subject_software}" \
     -e STARTUP_ON_ERROR="${startup_on_error}" \
-    -e API_TOKEN="${api_token}" \
     -e AGENT_TOKEN="${agent_token}" \
     -e CLIENT_SECRET="$CLIENT_SECRET" \
     --network host \
@@ -205,7 +203,7 @@ done
 CONTAINER_ID=$(docker ps -q --latest 2>/dev/null || true)
 if [ -n "$CONTAINER_ID" ]; then
     echo ">> Starting log shipper for Docker container (docker logs --follow)..."
-    nohup /usr/local/bin/log_shipper.sh "docker:$CONTAINER_ID" "$ALLOCATOR_URL" "$VM_NAME" "$LOG_GROUP-docker" "$API_TOKEN" \
+    nohup /usr/local/bin/log_shipper.sh "docker:$CONTAINER_ID" "$ALLOCATOR_URL" "$VM_NAME" "$LOG_GROUP-docker" "$CLIENT_SECRET" \
         >> /var/log/log_shipper.log 2>&1 &
     echo ">> Docker log shipper started (PID: $!)"
 else
@@ -228,7 +226,7 @@ for i in {1..5}; do
     HTTP_CODE=$(curl -s -w "%%{http_code}" -o /tmp/metrics_response.txt \
         -X POST "$ALLOCATOR_URL/api/vm-metrics/$VM_NAME" \
         -H "Content-Type: application/json" \
-        -H "Authorization: Bearer $API_TOKEN" \
+        -H "Authorization: Bearer $CLIENT_SECRET" \
         -d "{
             \"cloud_init_start\": $CLOUD_INIT_START_TIME,
             \"cloud_init_end\": $CLOUD_INIT_END,

--- a/packages/allocator/src/lablink_allocator_service/terraform/variables.tf
+++ b/packages/allocator/src/lablink_allocator_service/terraform/variables.tf
@@ -88,13 +88,6 @@ variable "custom_startup_script_path" {
   default     = "/config/custom-startup.sh"
 }
 
-variable "api_token" {
-  type        = string
-  description = "Shared bearer token for authenticating client-to-allocator API requests"
-  sensitive   = true
-  default     = ""
-}
-
 variable "agent_token" {
   type        = string
   description = "Deployment agent-control token the allocator presents to the client agent's session-start endpoint"

--- a/packages/allocator/tests/conftest.py
+++ b/packages/allocator/tests/conftest.py
@@ -88,11 +88,6 @@ def app(monkeypatch, omega_config):
     }
     monkeypatch.setattr(main, "users", test_users, raising=False)
 
-    # Patch the API token to use a fixed test token
-    monkeypatch.setattr(
-        main, "API_TOKEN", "test-api-token-for-testing", raising=False
-    )
-
     # If your code references `main.database`, stub it out:
     if not hasattr(main, "database"):
         monkeypatch.setattr(main, "database", MagicMock(), raising=False)
@@ -123,12 +118,6 @@ def admin_headers(omega_config):
     pw = omega_config.app.admin_password
     token = base64.b64encode(f"{user}:{pw}".encode()).decode()
     return {"Authorization": f"Basic {token}"}
-
-
-@pytest.fixture
-def api_token_headers():
-    """Convenience Bearer token header using the test API token."""
-    return {"Authorization": "Bearer test-api-token-for-testing"}
 
 
 @pytest.fixture

--- a/packages/allocator/tests/test_api_calls.py
+++ b/packages/allocator/tests/test_api_calls.py
@@ -414,7 +414,7 @@ def test_update_vm_status_internal_failure(client, monkeypatch):
     assert resp.get_json() == {"error": "Failed to update VM status."}
 
 
-def test_get_all_vm_status_success(client, api_token_headers, monkeypatch):
+def test_get_all_vm_status_success(client, admin_headers, monkeypatch):
     """Test getting all VM statuses."""
     # Mock the database
     fake_db = MagicMock()
@@ -427,7 +427,7 @@ def test_get_all_vm_status_success(client, api_token_headers, monkeypatch):
     )
 
     # Call the API
-    resp = client.get(VM_STATUS_UPDATE_ENDPOINT, headers=api_token_headers)
+    resp = client.get(VM_STATUS_UPDATE_ENDPOINT, headers=admin_headers)
 
     assert resp.status_code == 200
     assert resp.is_json
@@ -438,7 +438,7 @@ def test_get_all_vm_status_success(client, api_token_headers, monkeypatch):
     fake_db.get_all_vm_status.assert_called_once()
 
 
-def test_get_all_vm_status_empty(client, api_token_headers, monkeypatch):
+def test_get_all_vm_status_empty(client, admin_headers, monkeypatch):
     """Test getting all VM statuses when empty."""
     # Mock the database
     fake_db = MagicMock()
@@ -448,7 +448,7 @@ def test_get_all_vm_status_empty(client, api_token_headers, monkeypatch):
     )
 
     # Call the API
-    resp = client.get(VM_STATUS_UPDATE_ENDPOINT, headers=api_token_headers)
+    resp = client.get(VM_STATUS_UPDATE_ENDPOINT, headers=admin_headers)
 
     assert resp.status_code == 404
     assert resp.is_json
@@ -456,7 +456,7 @@ def test_get_all_vm_status_empty(client, api_token_headers, monkeypatch):
     fake_db.get_all_vm_status.assert_called_once()
 
 
-def test_get_all_vm_status_internal_error(client, api_token_headers, monkeypatch):
+def test_get_all_vm_status_internal_error(client, admin_headers, monkeypatch):
     """Test getting all VM statuses with internal error."""
     # Mock the database
     fake_db = MagicMock()
@@ -466,7 +466,7 @@ def test_get_all_vm_status_internal_error(client, api_token_headers, monkeypatch
     )
 
     # Call the API
-    resp = client.get(VM_STATUS_UPDATE_ENDPOINT, headers=api_token_headers)
+    resp = client.get(VM_STATUS_UPDATE_ENDPOINT, headers=admin_headers)
 
     assert resp.status_code == 500
     assert resp.is_json
@@ -474,11 +474,12 @@ def test_get_all_vm_status_internal_error(client, api_token_headers, monkeypatch
     fake_db.get_all_vm_status.assert_called_once()
 
 
-def test_posting_vm_logs_success(client, api_token_headers, monkeypatch):
+def test_posting_vm_logs_success(client, monkeypatch):
     """Test posting VM logs successfully (cloud-init)."""
     # Mock the database
     fake_db = MagicMock()
     fake_db.vm_exists.return_value = True
+    _stub_client_secret(fake_db)
     monkeypatch.setattr(
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
@@ -486,10 +487,13 @@ def test_posting_vm_logs_success(client, api_token_headers, monkeypatch):
     # Call the API
     data = {
         "log_group": "cloud-init-output-logs",
-        "log_stream": "lablink-vm-test-1",
         "messages": ["Message 1", "Message 2"],
     }
-    resp = client.post(VM_LOGS_ENDPOINT, json=data, headers=api_token_headers)
+    resp = client.post(
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1",
+        json=data,
+        headers=_CLIENT_SECRET_HEADERS,
+    )
 
     assert resp.status_code == 200
     assert resp.is_json
@@ -503,11 +507,12 @@ def test_posting_vm_logs_success(client, api_token_headers, monkeypatch):
     )
 
 
-def test_posting_docker_logs_success(client, api_token_headers, monkeypatch):
+def test_posting_docker_logs_success(client, monkeypatch):
     """Test posting VM logs successfully (docker)."""
     # Mock the database
     fake_db = MagicMock()
     fake_db.vm_exists.return_value = True
+    _stub_client_secret(fake_db)
     monkeypatch.setattr(
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
@@ -515,10 +520,13 @@ def test_posting_docker_logs_success(client, api_token_headers, monkeypatch):
     # Call the API with log_group ending in -docker
     data = {
         "log_group": "cloud-init-output-logs-docker",
-        "log_stream": "lablink-vm-test-1",
         "messages": ["Docker msg 1"],
     }
-    resp = client.post(VM_LOGS_ENDPOINT, json=data, headers=api_token_headers)
+    resp = client.post(
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1",
+        json=data,
+        headers=_CLIENT_SECRET_HEADERS,
+    )
 
     assert resp.status_code == 200
     assert resp.is_json
@@ -531,53 +539,60 @@ def test_posting_docker_logs_success(client, api_token_headers, monkeypatch):
     )
 
 
-def test_posting_vm_logs_missing_data(client, api_token_headers, monkeypatch):
+def test_posting_vm_logs_missing_data(client, monkeypatch):
     """Test posting VM logs with missing data."""
     # Mock the database
     fake_db = MagicMock()
+    _stub_client_secret(fake_db)
     monkeypatch.setattr(
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
 
     # Call the API with missing data
-    resp = client.post(VM_LOGS_ENDPOINT, json={}, headers=api_token_headers)
+    resp = client.post(
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1",
+        json={},
+        headers=_CLIENT_SECRET_HEADERS,
+    )
 
     assert resp.status_code == 400
     assert resp.is_json
-    assert resp.get_json() == {"error": "Log group, stream, and messages are required."}
+    assert resp.get_json() == {"error": "Log group and messages are required."}
     fake_db.vm_exists.assert_not_called()
     fake_db.append_logs_by_hostname.assert_not_called()
 
 
-def test_posting_vm_logs_vm_not_exists(client, api_token_headers, monkeypatch):
-    """Test posting VM logs when VM does not exist."""
-    # Mock the database
+def test_posting_vm_logs_rejects_unregistered_hostname(client, monkeypatch):
+    """Posting logs for a hostname with no registered client_secret returns 401
+    (no identity leak — the handler is never reached)."""
+    # Mock the database — unknown hostname: get_client_secret_hash returns None
     fake_db = MagicMock()
-    fake_db.vm_exists.return_value = False
+    fake_db.get_client_secret_hash.return_value = None
     monkeypatch.setattr(
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
 
-    # Call the API
+    # Call the API with a hostname that has no registered secret
     data = {
         "log_group": "cloud-init-output-logs",
-        "log_stream": "lablink-vm-test-1",
         "messages": ["Message 1", "Message 2"],
     }
-    resp = client.post(VM_LOGS_ENDPOINT, json=data, headers=api_token_headers)
+    resp = client.post(
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-missing",
+        json=data,
+        headers=_CLIENT_SECRET_HEADERS,
+    )
 
-    assert resp.status_code == 404
-    assert resp.is_json
-    assert resp.get_json() == {"error": "VM not found."}
-    fake_db.vm_exists.assert_called_once_with("lablink-vm-test-1")
+    assert resp.status_code == 401
     fake_db.append_logs_by_hostname.assert_not_called()
 
 
-def test_posting_vm_logs_internal_error(client, api_token_headers, monkeypatch):
+def test_posting_vm_logs_internal_error(client, monkeypatch):
     """Test posting VM logs with internal error."""
     # Mock the database
     fake_db = MagicMock()
     fake_db.vm_exists.side_effect = Exception("Internal error")
+    _stub_client_secret(fake_db)
     monkeypatch.setattr(
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
@@ -585,10 +600,13 @@ def test_posting_vm_logs_internal_error(client, api_token_headers, monkeypatch):
     # Call the API
     data = {
         "log_group": "cloud-init-output-logs",
-        "log_stream": "lablink-vm-test-1",
         "messages": ["Message 1", "Message 2"],
     }
-    resp = client.post(VM_LOGS_ENDPOINT, json=data, headers=api_token_headers)
+    resp = client.post(
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1",
+        json=data,
+        headers=_CLIENT_SECRET_HEADERS,
+    )
 
     assert resp.status_code == 500
     assert resp.is_json
@@ -597,7 +615,7 @@ def test_posting_vm_logs_internal_error(client, api_token_headers, monkeypatch):
     fake_db.append_logs_by_hostname.assert_not_called()
 
 
-def test_get_vm_logs_by_hostname_success(client, api_token_headers, monkeypatch):
+def test_get_vm_logs_by_hostname_success(client, admin_headers, monkeypatch):
     """Test getting VM logs by hostname successfully."""
     # Mock the database
     fake_db = MagicMock()
@@ -613,7 +631,7 @@ def test_get_vm_logs_by_hostname_success(client, api_token_headers, monkeypatch)
 
     # Call the API
     resp = client.get(
-        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1", headers=api_token_headers
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1", headers=admin_headers
     )
 
     assert resp.status_code == 200
@@ -626,7 +644,7 @@ def test_get_vm_logs_by_hostname_success(client, api_token_headers, monkeypatch)
     fake_db.get_vm_logs.assert_called_once_with(hostname="lablink-vm-test-1")
 
 
-def test_vm_logs_by_hostname_not_found(client, api_token_headers, monkeypatch):
+def test_vm_logs_by_hostname_not_found(client, admin_headers, monkeypatch):
     """Test getting VM logs by hostname when not found."""
     # Mock the database
     fake_db = MagicMock()
@@ -637,7 +655,7 @@ def test_vm_logs_by_hostname_not_found(client, api_token_headers, monkeypatch):
 
     # Call the API
     resp = client.get(
-        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1", headers=api_token_headers
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1", headers=admin_headers
     )
 
     assert resp.status_code == 404
@@ -647,7 +665,7 @@ def test_vm_logs_by_hostname_not_found(client, api_token_headers, monkeypatch):
 
 
 def test_vm_logs_by_hostname_installing_cloud_watch(
-    client, api_token_headers, monkeypatch
+    client, admin_headers, monkeypatch
 ):
     """Test getting VM logs by hostname when VM is initializing."""
     # Mock the database
@@ -661,7 +679,7 @@ def test_vm_logs_by_hostname_installing_cloud_watch(
 
     # Call the API
     resp = client.get(
-        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1", headers=api_token_headers
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1", headers=admin_headers
     )
 
     assert resp.status_code == 503
@@ -669,7 +687,7 @@ def test_vm_logs_by_hostname_installing_cloud_watch(
     assert resp.get_json() == {"error": "VM is initializing."}
 
 
-def test_vm_logs_by_hostname_internal_error(client, api_token_headers, monkeypatch):
+def test_vm_logs_by_hostname_internal_error(client, admin_headers, monkeypatch):
     """Test getting VM logs by hostname with internal error."""
     # Mock the database
     fake_db = MagicMock()
@@ -680,7 +698,7 @@ def test_vm_logs_by_hostname_internal_error(client, api_token_headers, monkeypat
 
     # Call the API
     resp = client.get(
-        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1", headers=api_token_headers
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1", headers=admin_headers
     )
 
     assert resp.status_code == 500
@@ -689,11 +707,12 @@ def test_vm_logs_by_hostname_internal_error(client, api_token_headers, monkeypat
     fake_db.get_vm_logs.assert_not_called()
 
 
-def test_receive_vm_metrics_success(client, api_token_headers, monkeypatch):
+def test_receive_vm_metrics_success(client, monkeypatch):
     """Test the /api/vm-metrics/<hostname> endpoint with valid data."""
     # Mock the database
     fake_db = MagicMock()
     fake_db.vm_exists.return_value = True
+    _stub_client_secret(fake_db)
 
     # Patch globals
     monkeypatch.setattr(
@@ -708,7 +727,7 @@ def test_receive_vm_metrics_success(client, api_token_headers, monkeypatch):
         "cloud_init_duration_seconds": 120,
     }
     resp = client.post(
-        f"{METRICS_ENDPOINT}/{hostname}", json=metrics_data, headers=api_token_headers
+        f"{METRICS_ENDPOINT}/{hostname}", json=metrics_data, headers=_CLIENT_SECRET_HEADERS
     )
 
     # Assert the response
@@ -721,11 +740,12 @@ def test_receive_vm_metrics_success(client, api_token_headers, monkeypatch):
     )
 
 
-def test_receive_vm_metrics_vm_not_found(client, api_token_headers, monkeypatch):
+def test_receive_vm_metrics_vm_not_found(client, monkeypatch):
     """Test the /api/vm-metrics/<hostname> endpoint when the VM is not found."""
     # Mock the database
     fake_db = MagicMock()
     fake_db.vm_exists.return_value = False
+    _stub_client_secret(fake_db)
 
     # Patch globals
     monkeypatch.setattr(
@@ -736,7 +756,7 @@ def test_receive_vm_metrics_vm_not_found(client, api_token_headers, monkeypatch)
     hostname = "non-existent-vm"
     metrics_data = {"cloud_init_duration_seconds": 120}
     resp = client.post(
-        f"{METRICS_ENDPOINT}/{hostname}", json=metrics_data, headers=api_token_headers
+        f"{METRICS_ENDPOINT}/{hostname}", json=metrics_data, headers=_CLIENT_SECRET_HEADERS
     )
 
     # Assert the response
@@ -746,12 +766,13 @@ def test_receive_vm_metrics_vm_not_found(client, api_token_headers, monkeypatch)
     fake_db.update_vm_metrics_atomic.assert_not_called()
 
 
-def test_receive_vm_metrics_internal_error(client, api_token_headers, monkeypatch):
+def test_receive_vm_metrics_internal_error(client, monkeypatch):
     """Test the /api/vm-metrics/<hostname> endpoint with an internal error."""
     # Mock the database
     fake_db = MagicMock()
     fake_db.vm_exists.return_value = True
     fake_db.update_vm_metrics_atomic.side_effect = Exception("Database error")
+    _stub_client_secret(fake_db)
 
     # Patch globals
     monkeypatch.setattr(
@@ -762,7 +783,7 @@ def test_receive_vm_metrics_internal_error(client, api_token_headers, monkeypatc
     hostname = "test-vm-01"
     metrics_data = {"cloud_init_duration_seconds": 120}
     resp = client.post(
-        f"{METRICS_ENDPOINT}/{hostname}", json=metrics_data, headers=api_token_headers
+        f"{METRICS_ENDPOINT}/{hostname}", json=metrics_data, headers=_CLIENT_SECRET_HEADERS
     )
 
     # Assert the response
@@ -774,13 +795,14 @@ def test_receive_vm_metrics_internal_error(client, api_token_headers, monkeypatc
     )
 
 
-def test_receive_vm_metrics_concurrent(client, api_token_headers, monkeypatch):
+def test_receive_vm_metrics_concurrent(client, monkeypatch):
     """Test that concurrent metrics requests are handled correctly."""
     import concurrent.futures
 
     # Mock the database
     fake_db = MagicMock()
     fake_db.vm_exists.return_value = True
+    _stub_client_secret(fake_db)
 
     # Patch globals
     monkeypatch.setattr(
@@ -798,7 +820,7 @@ def test_receive_vm_metrics_concurrent(client, api_token_headers, monkeypatch):
         return client.post(
             f"{METRICS_ENDPOINT}/{hostname}",
             json=metrics_data,
-            headers=api_token_headers,
+            headers=_CLIENT_SECRET_HEADERS,
         )
 
     # Send all requests concurrently
@@ -1492,84 +1514,21 @@ def test_create_scheduled_destruction_duplicate_name(
 # ──────────────────────────────────────────────────────────────────────
 
 
-# Endpoints that require ONLY API token auth (machine-to-machine)
-TOKEN_PROTECTED_ENDPOINTS = [
-    ("POST", VM_LOGS_ENDPOINT, {"log_group": "g", "log_stream": "s", "messages": ["m"]}),
-    ("POST", f"{METRICS_ENDPOINT}/vm-1", {"cloud_init_duration_seconds": 120}),
-]
-
 # Endpoints that require a per-client secret (require_client_secret decorator)
 CLIENT_SECRET_PROTECTED_ENDPOINTS = [
     ("POST", UPDATE_INUSE_STATUS_ENDPOINT, {"hostname": "vm-1", "status": True}),
     ("POST", UPDATE_GPU_HEALTH_ENDPOINT, {"hostname": "vm-1", "gpu_status": "Healthy"}),
     ("POST", HEARTBEAT_ENDPOINT, {"vm_id": "vm-1"}),
     ("POST", VM_STATUS_UPDATE_ENDPOINT, {"hostname": "vm-1", "status": "running"}),
+    ("POST", f"{METRICS_ENDPOINT}/vm-1", {"cloud_init_duration_seconds": 120}),
+    ("POST", f"{VM_LOGS_ENDPOINT}/vm-1", {"log_group": "g", "messages": ["m"]}),
 ]
 
-# Endpoints that accept either session auth or API token (admin UI + VMs)
-DUAL_AUTH_ENDPOINTS = [
+# Endpoints that require admin Basic auth (auth.login_required)
+ADMIN_AUTH_ENDPOINTS = [
     ("GET", VM_STATUS_UPDATE_ENDPOINT, None),
     ("GET", f"{VM_LOGS_ENDPOINT}/vm-1", None),
 ]
-
-
-@pytest.mark.parametrize("method,endpoint,json_data", TOKEN_PROTECTED_ENDPOINTS)
-def test_token_protected_endpoints_reject_no_token(
-    client, monkeypatch, method, endpoint, json_data
-):
-    """All token-protected endpoints return 401 without a bearer token."""
-    fake_db = MagicMock()
-    monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
-    )
-
-    if method == "GET":
-        resp = client.get(endpoint)
-    else:
-        resp = client.post(endpoint, json=json_data)
-
-    assert resp.status_code == 401
-    assert resp.get_json()["error"] == "Missing or invalid Authorization header."
-
-
-@pytest.mark.parametrize("method,endpoint,json_data", TOKEN_PROTECTED_ENDPOINTS)
-def test_token_protected_endpoints_reject_wrong_token(
-    client, monkeypatch, method, endpoint, json_data
-):
-    """All token-protected endpoints return 401 with an invalid bearer token."""
-    fake_db = MagicMock()
-    monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
-    )
-
-    bad_headers = {"Authorization": "Bearer wrong-token-value"}
-    if method == "GET":
-        resp = client.get(endpoint, headers=bad_headers)
-    else:
-        resp = client.post(endpoint, json=json_data, headers=bad_headers)
-
-    assert resp.status_code == 401
-    assert resp.get_json()["error"] == "Invalid API token."
-
-
-@pytest.mark.parametrize("method,endpoint,json_data", TOKEN_PROTECTED_ENDPOINTS)
-def test_token_protected_endpoints_reject_non_bearer_auth(
-    client, monkeypatch, method, endpoint, json_data
-):
-    """All token-protected endpoints reject non-Bearer auth schemes."""
-    fake_db = MagicMock()
-    monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
-    )
-
-    bad_headers = {"Authorization": "Basic dXNlcjpwYXNz"}
-    if method == "GET":
-        resp = client.get(endpoint, headers=bad_headers)
-    else:
-        resp = client.post(endpoint, json=json_data, headers=bad_headers)
-
-    assert resp.status_code == 401
-    assert resp.get_json()["error"] == "Missing or invalid Authorization header."
 
 
 @pytest.mark.parametrize("method,endpoint,json_data", CLIENT_SECRET_PROTECTED_ENDPOINTS)
@@ -1632,11 +1591,11 @@ def test_client_secret_endpoints_reject_non_bearer_auth(
     assert resp.get_json()["error"] == "Missing or invalid Authorization header."
 
 
-@pytest.mark.parametrize("method,endpoint,json_data", DUAL_AUTH_ENDPOINTS)
-def test_dual_auth_endpoints_reject_no_auth(
+@pytest.mark.parametrize("method,endpoint,json_data", ADMIN_AUTH_ENDPOINTS)
+def test_admin_auth_endpoints_reject_no_auth(
     client, monkeypatch, method, endpoint, json_data
 ):
-    """Dual-auth endpoints return 401 without any authentication."""
+    """Admin endpoints return 401 without any authentication."""
     fake_db = MagicMock()
     monkeypatch.setattr(
         "lablink_allocator_service.main.database", fake_db, raising=False
@@ -1650,31 +1609,33 @@ def test_dual_auth_endpoints_reject_no_auth(
     assert resp.status_code == 401
 
 
-@pytest.mark.parametrize("method,endpoint,json_data", DUAL_AUTH_ENDPOINTS)
-def test_dual_auth_endpoints_reject_wrong_token(
+@pytest.mark.parametrize("method,endpoint,json_data", ADMIN_AUTH_ENDPOINTS)
+def test_admin_auth_endpoints_reject_wrong_credentials(
     client, monkeypatch, method, endpoint, json_data
 ):
-    """Dual-auth endpoints return 401 with an invalid bearer token."""
+    """Admin endpoints return 401 with wrong Basic auth credentials."""
+    import base64
+
     fake_db = MagicMock()
     monkeypatch.setattr(
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
 
-    bad_headers = {"Authorization": "Bearer wrong-token-value"}
+    bad_creds = base64.b64encode(b"wrong:credentials").decode()
+    bad_headers = {"Authorization": f"Basic {bad_creds}"}
     if method == "GET":
         resp = client.get(endpoint, headers=bad_headers)
     else:
         resp = client.post(endpoint, json=json_data, headers=bad_headers)
 
     assert resp.status_code == 401
-    assert resp.get_json()["error"] == "Invalid API token."
 
 
-@pytest.mark.parametrize("method,endpoint,json_data", DUAL_AUTH_ENDPOINTS)
-def test_dual_auth_endpoints_accept_api_token(
-    client, api_token_headers, monkeypatch, method, endpoint, json_data
+@pytest.mark.parametrize("method,endpoint,json_data", ADMIN_AUTH_ENDPOINTS)
+def test_admin_auth_endpoints_accept_basic_auth(
+    client, admin_headers, monkeypatch, method, endpoint, json_data
 ):
-    """Dual-auth endpoints accept a valid API bearer token."""
+    """Admin endpoints accept valid admin Basic auth credentials."""
     fake_db = MagicMock()
     fake_db.get_unassigned_vms.return_value = []
     fake_db.get_all_vm_status.return_value = {"vm-1": "running"}
@@ -1689,9 +1650,9 @@ def test_dual_auth_endpoints_accept_api_token(
     )
 
     if method == "GET":
-        resp = client.get(endpoint, headers=api_token_headers)
+        resp = client.get(endpoint, headers=admin_headers)
     else:
-        resp = client.post(endpoint, json=json_data, headers=api_token_headers)
+        resp = client.post(endpoint, json=json_data, headers=admin_headers)
 
     assert resp.status_code == 200
 
@@ -1879,10 +1840,11 @@ def test_vm_status_bumps_last_seen(client, monkeypatch):
     fake_db.touch_last_seen.assert_called_once_with(hostname="vm-1")
 
 
-def test_vm_metrics_bumps_last_seen(client, api_token_headers, monkeypatch):
+def test_vm_metrics_bumps_last_seen(client, monkeypatch):
     """POST /api/vm-metrics/<hostname> refreshes last_seen_at."""
     fake_db = MagicMock()
     fake_db.vm_exists.return_value = True
+    _stub_client_secret(fake_db)
     monkeypatch.setattr(
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
@@ -1890,7 +1852,7 @@ def test_vm_metrics_bumps_last_seen(client, api_token_headers, monkeypatch):
     resp = client.post(
         f"{METRICS_ENDPOINT}/vm-1",
         json={"container_start": 0, "container_end": 1},
-        headers=api_token_headers,
+        headers=_CLIENT_SECRET_HEADERS,
     )
 
     assert resp.status_code == 200

--- a/packages/allocator/tests/test_no_api_token_refs.py
+++ b/packages/allocator/tests/test_no_api_token_refs.py
@@ -5,6 +5,8 @@ API_TOKEN. The CHANGELOG entry announcing the removal is excluded.
 import subprocess
 from pathlib import Path
 
+import pytest
+
 
 REPO_ROOT = Path(__file__).resolve().parents[3]
 PACKAGES = REPO_ROOT / "packages"
@@ -12,6 +14,11 @@ PACKAGES = REPO_ROOT / "packages"
 
 def test_no_api_token_references_in_source():
     """grep -rn API_TOKEN under packages/ in source files — must return zero hits."""
+    if not PACKAGES.is_dir():
+        # Test ships inside the allocator docker image / installed wheel where the
+        # monorepo layout doesn't exist. The guard's purpose is to catch a
+        # regression at PR-review time on a full checkout; skip elsewhere.
+        pytest.skip(f"packages/ not found at {PACKAGES} (not running from repo tree)")
     result = subprocess.run(
         [
             "grep",
@@ -48,7 +55,7 @@ def test_no_api_token_references_in_changelog_except_retirement_context():
     """The CLI CHANGELOG may mention API_TOKEN only in retired/removed context."""
     changelog = REPO_ROOT / "packages" / "cli" / "CHANGELOG.md"
     if not changelog.exists():
-        return  # CHANGELOG optional
+        pytest.skip(f"CHANGELOG not found at {changelog} (not running from repo tree)")
     content = changelog.read_text()
     suspicious_lines = [
         line

--- a/packages/allocator/tests/test_no_api_token_refs.py
+++ b/packages/allocator/tests/test_no_api_token_refs.py
@@ -1,0 +1,65 @@
+"""Guard test: after PR D4, no source file under packages/ should reference
+API_TOKEN. The CHANGELOG entry announcing the removal is excluded.
+"""
+
+import subprocess
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PACKAGES = REPO_ROOT / "packages"
+
+
+def test_no_api_token_references_in_source():
+    """grep -rn API_TOKEN under packages/ in source files — must return zero hits."""
+    result = subprocess.run(
+        [
+            "grep",
+            "-rn",
+            "--include=*.py",
+            "--include=*.sh",
+            "--include=*.tf",
+            "API_TOKEN",
+            str(PACKAGES),
+        ],
+        capture_output=True,
+        text=True,
+    )
+    # grep exit 1 = no matches (success)
+    # grep exit 0 = matches found (failure)
+    if result.returncode == 0:
+        # Filter out lines from test files (they're allowed to use the string)
+        lines = [
+            line
+            for line in result.stdout.splitlines()
+            if "/tests/" not in line
+        ]
+        if lines:
+            raise AssertionError(
+                "Unexpected API_TOKEN references in source after PR D4:\n"
+                + "\n".join(lines)
+            )
+    elif result.returncode != 1:
+        # grep error (other than no-match) — report it
+        raise AssertionError(f"grep failed: {result.stderr}")
+
+
+def test_no_api_token_references_in_changelog_except_retirement_context():
+    """The CLI CHANGELOG may mention API_TOKEN only in retired/removed context."""
+    changelog = REPO_ROOT / "packages" / "cli" / "CHANGELOG.md"
+    if not changelog.exists():
+        return  # CHANGELOG optional
+    content = changelog.read_text()
+    suspicious_lines = [
+        line
+        for line in content.splitlines()
+        if "API_TOKEN" in line
+        and not any(
+            phrase in line.lower()
+            for phrase in ("retired", "removed", "drop", "no longer")
+        )
+    ]
+    assert not suspicious_lines, (
+        f"Unexpected API_TOKEN CHANGELOG mentions (outside retirement context): "
+        f"{suspicious_lines}"
+    )

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -183,7 +183,6 @@ def test_register_returns_409_on_integrity_error(reg_client):
 def test_agent_token_global_exists():
     from lablink_allocator_service import main
     assert isinstance(main.AGENT_TOKEN, str) and len(main.AGENT_TOKEN) >= 32
-    assert main.AGENT_TOKEN != main.API_TOKEN
     assert main.AGENT_TOKEN != main.REGISTER_TOKEN
 
 
@@ -197,17 +196,18 @@ def test_register_response_includes_agent_token(reg_client):
     assert r.get_json()["agent_token"] == main.AGENT_TOKEN
 
 
-def test_register_response_includes_api_token(reg_client):
-    """BYO clients need API_TOKEN so start.sh can POST /api/vm-metrics
-    (which is @require_api_token-gated, not per-client). Without this,
-    container-startup timing never lands for manual clients."""
+def test_register_response_omits_api_token(reg_client):
+    """API_TOKEN is retired — registration response no longer includes it.
+    Clients must use per-client client_secret for all authenticated endpoints."""
     client, fake_db = reg_client
     r = client.post("/api/v1/clients/register",
                      json={"hostname": "vm-1", "machine_identity": "i-1"},
                      headers={"Authorization": "Bearer tk_test_register"})
     assert r.status_code == 200
-    from lablink_allocator_service import main
-    assert r.get_json()["api_token"] == main.API_TOKEN
+    body = r.get_json()
+    assert "api_token" not in body
+    assert body.get("client_secret") is not None
+    assert body.get("agent_token") is not None
 
 
 def test_register_response_honors_x_forwarded_proto(reg_client, monkeypatch):
@@ -340,14 +340,6 @@ def test_list_clients_rejects_bad_bearer(reg_client):
     assert r.status_code == 401
 
 
-def test_list_clients_accepts_api_token(reg_client, api_token_headers):
-    client, fake_db = reg_client
-    fake_db.list_registered_clients.return_value = []
-    r = client.get("/api/v1/clients", headers=api_token_headers)
-    assert r.status_code == 200
-    assert r.get_json() == {"clients": []}
-
-
 def test_list_clients_accepts_admin_basic(reg_client, admin_headers):
     client, fake_db = reg_client
     fake_db.list_registered_clients.return_value = []
@@ -356,7 +348,7 @@ def test_list_clients_accepts_admin_basic(reg_client, admin_headers):
     assert r.get_json() == {"clients": []}
 
 
-def test_list_clients_returns_safe_fields(reg_client, api_token_headers):
+def test_list_clients_returns_safe_fields(reg_client, admin_headers):
     from datetime import datetime
 
     client, fake_db = reg_client
@@ -384,7 +376,7 @@ def test_list_clients_returns_safe_fields(reg_client, api_token_headers):
             "last_seen_at": None,
         },
     ]
-    r = client.get("/api/v1/clients", headers=api_token_headers)
+    r = client.get("/api/v1/clients", headers=admin_headers)
     assert r.status_code == 200
     body = r.get_json()
     assert len(body["clients"]) == 2

--- a/packages/allocator/tests/test_terraform_api.py
+++ b/packages/allocator/tests/test_terraform_api.py
@@ -963,8 +963,7 @@ def test_launch_writes_agent_token_to_tfvars_additively(
 ):
     """Regression: launch() must write agent_token = "<main.AGENT_TOKEN>" into
     terraform.runtime.tfvars so the client agent receives AGENT_TOKEN env via
-    the bundled user_data — WITHOUT dropping the existing api_token line
-    (additive, not a rename). Guards the D1 shipping-blocker wiring: if the
+    the bundled user_data. Guards the D1 shipping-blocker wiring: if the
     AGENT_TOKEN tfvars thread is ever removed, every /api/session/start 500s.
     """
     terraform_dir = tmp_path / "terraform"
@@ -983,9 +982,6 @@ def test_launch_writes_agent_token_to_tfvars_additively(
     )
     monkeypatch.setattr(
         "lablink_allocator_service.main.ENVIRONMENT", "test", raising=False
-    )
-    monkeypatch.setattr(
-        "lablink_allocator_service.main.API_TOKEN", "test-api-token-value", raising=False
     )
     monkeypatch.setattr(
         "lablink_allocator_service.main.AGENT_TOKEN", "test-agent-token-value", raising=False
@@ -1012,9 +1008,8 @@ def test_launch_writes_agent_token_to_tfvars_additively(
     # agent_token carries main.AGENT_TOKEN ...
     assert f'agent_token = "{main.AGENT_TOKEN}"' in tfvars
     assert 'agent_token = "test-agent-token-value"' in tfvars
-    # ... and api_token is still written (additive, not replaced).
-    assert f'api_token = "{main.API_TOKEN}"' in tfvars
-    assert 'api_token = "test-api-token-value"' in tfvars
+    # api_token is retired (PR D4) — must NOT appear in tfvars.
+    assert "api_token" not in tfvars
 
 
 def test_terraform_threads_agent_token_through_user_data():
@@ -1023,8 +1018,8 @@ def test_terraform_threads_agent_token_through_user_data():
     Catches typos/renames in the templatefile var name, variables.tf,
     or user_data.sh's docker-run `-e` line that would slip past both
     `terraform validate` (HCL only) and the runtime tfvars-write test
-    above (which only pins the .tfvars line). Pins the end-to-end
-    AGENT_TOKEN wiring as additive next to the surviving API_TOKEN.
+    above (which only pins the .tfvars line). After PR D4, api_token is
+    retired from the terraform template — only agent_token remains.
     """
     import re
     from pathlib import Path
@@ -1042,6 +1037,7 @@ def test_terraform_threads_agent_token_through_user_data():
     # passed into the user_data templatefile vars map (HCL aligns the =;
     # match whitespace-tolerantly so an alignment touch-up does not fail).
     assert re.search(r"agent_token\s*=\s*var\.agent_token", main_tf)
-    # injected on the client docker run; additive (API_TOKEN still present)
+    # injected on the client docker run
     assert '-e AGENT_TOKEN="${agent_token}"' in user_data
-    assert '-e API_TOKEN="${api_token}"' in user_data
+    # After PR D4, api_token is retired from the bundled terraform template.
+    assert '-e API_TOKEN="${api_token}"' not in user_data

--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -21,6 +21,15 @@ this project uses [Semantic Versioning](https://semver.org/).
 
 ### Changed
 
+- **Breaking — `API_TOKEN` retired.** Machine-to-machine auth from client to
+  allocator (status, heartbeat, metrics, log-shipping) now uses per-client
+  `client_secret` exclusively; the deployment-wide `API_TOKEN` is no longer
+  generated, written to `client.env`, or returned by
+  `POST /api/v1/clients/register`. The `/api/vm-logs` endpoint moved to
+  `/api/vm-logs/<hostname>` for symmetric identity resolution with
+  `/api/vm-metrics/<hostname>`. No backwards-compatibility path: a D4
+  allocator paired with a pre-D4 client is unsupported.
+
 - **Breaking:** the following top-level commands have moved under the new
   `client` subgroup. Existing scripts must be updated:
 

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -149,7 +149,6 @@ def _write_env_file(
         f"VM_NAME={resp['client_id']}",
         f"CLIENT_SECRET={resp['client_secret']}",
         f"AGENT_TOKEN={resp['agent_token']}",
-        f"API_TOKEN={resp.get('api_token', '')}",
         f"REGISTER_TOKEN={resp['register_token']}",
         f"ALLOCATOR_URL={resolved_url}",
         f"ALLOCATOR_HOST={allocator_host}",

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -19,7 +19,6 @@ def successful_response():
         "client_id": 42,
         "client_secret": "s",
         "agent_token": "a",
-        "api_token": "apitok",
         "register_token": "r",
         "allocator_url": "https://lablink.example.com",
         "connectivity": "lan_direct",
@@ -87,7 +86,7 @@ class TestSuccessFlow:
         assert "VM_NAME=42" in content
         assert "CLIENT_SECRET=s" in content
         assert "AGENT_TOKEN=a" in content
-        assert "API_TOKEN=apitok" in content
+        assert "API_TOKEN" not in content
         assert "REGISTER_TOKEN=r" in content
         assert "ALLOCATOR_URL=https://lablink.example.com" in content
         assert "ALLOCATOR_HOST=lablink.example.com" in content

--- a/packages/cli/tests/test_registration_client.py
+++ b/packages/cli/tests/test_registration_client.py
@@ -44,7 +44,6 @@ class TestRegister:
             "client_id": 42,
             "client_secret": "s",
             "agent_token": "a",
-            "api_token": "apitok",
             "register_token": "r",
             "allocator_url": "https://lablink.example.com",
             "connectivity": "lan_direct",

--- a/packages/cli/tests/test_unregister.py
+++ b/packages/cli/tests/test_unregister.py
@@ -13,7 +13,6 @@ _ENV_BODY = (
     "VM_NAME=vm-1\n"
     "CLIENT_SECRET=sek\n"
     "AGENT_TOKEN=agent\n"
-    "API_TOKEN=api\n"
     "REGISTER_TOKEN=reg\n"
     "ALLOCATOR_URL=http://allocator.example.com\n"
     "ALLOCATOR_HOST=allocator.example.com\n"

--- a/packages/client/src/lablink_client_service/check_gpu.py
+++ b/packages/client/src/lablink_client_service/check_gpu.py
@@ -21,20 +21,20 @@ MAX_REPORT_RETRIES = 5
 REPORT_RETRY_DELAY = 10  # seconds
 
 
-def check_gpu_health(allocator_url: str, interval: int = 20, api_token: str = ""):
+def check_gpu_health(allocator_url: str, interval: int = 20, client_secret: str = ""):
     """Check the health of the GPU.
 
     Args:
         allocator_url (str): The base URL of the allocator service.
         interval (int, optional): The interval in seconds to check the GPU health.
-        api_token (str, optional): Bearer token for API authentication.
+        client_secret (str, optional): Per-client secret for Bearer auth.
     """
     logger.info("Starting GPU health monitoring")
     last_status = None
     base_url = sanitize_url(allocator_url)
 
     headers = {"Content-Type": "application/json"}
-    headers.update(get_auth_headers(api_token))
+    headers.update(get_auth_headers(client_secret))
 
     while True:
         curr_status = None
@@ -128,8 +128,8 @@ def main(cfg: Config) -> None:
         module_name="check_gpu",
     )
     # Check GPU health
-    base_url, api_token, _ = get_client_env(cfg)
-    check_gpu_health(allocator_url=base_url, api_token=api_token)
+    base_url, client_secret, _ = get_client_env(cfg)
+    check_gpu_health(allocator_url=base_url, client_secret=client_secret)
 
 
 if __name__ == "__main__":

--- a/packages/client/src/lablink_client_service/heartbeat.py
+++ b/packages/client/src/lablink_client_service/heartbeat.py
@@ -91,7 +91,7 @@ def send_heartbeat(
 
 def run_heartbeat_loop(
     allocator_url: str,
-    api_token: str = "",
+    client_secret: str = "",
     interval: int = HEARTBEAT_INTERVAL_SECONDS,
     stop_event: threading.Event | None = None,
 ) -> None:
@@ -105,7 +105,7 @@ def run_heartbeat_loop(
     logger.info("Starting heartbeat loop")
     base_url = sanitize_url(allocator_url)
     headers = {"Content-Type": "application/json"}
-    headers.update(get_auth_headers(api_token))
+    headers.update(get_auth_headers(client_secret))
 
     vm_id = os.getenv("VM_NAME")
     boot_id = read_boot_id()
@@ -126,8 +126,8 @@ def run_heartbeat_loop(
 def main(cfg: Config) -> None:
     global logger
     logger = CloudAndConsoleLogger(module_name="heartbeat")
-    base_url, api_token, _ = get_client_env(cfg)
-    run_heartbeat_loop(allocator_url=base_url, api_token=api_token)
+    base_url, client_secret, _ = get_client_env(cfg)
+    run_heartbeat_loop(allocator_url=base_url, client_secret=client_secret)
 
 
 if __name__ == "__main__":

--- a/packages/client/src/lablink_client_service/http_utils.py
+++ b/packages/client/src/lablink_client_service/http_utils.py
@@ -19,12 +19,9 @@ def sanitize_url(url: str) -> str:
     return url
 
 
-def get_auth_headers(token: str = "") -> dict:
-    """Build HTTP headers with optional Bearer token auth."""
-    headers = {}
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
+def get_auth_headers(token: str) -> dict:
+    """Build Bearer-auth headers for the given client_secret token."""
+    return {"Authorization": f"Bearer {token}"}
 
 
 def get_client_env(cfg) -> tuple:

--- a/packages/client/src/lablink_client_service/http_utils.py
+++ b/packages/client/src/lablink_client_service/http_utils.py
@@ -19,11 +19,11 @@ def sanitize_url(url: str) -> str:
     return url
 
 
-def get_auth_headers(api_token: str = "") -> dict:
+def get_auth_headers(token: str = "") -> dict:
     """Build HTTP headers with optional Bearer token auth."""
     headers = {}
-    if api_token:
-        headers["Authorization"] = f"Bearer {api_token}"
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
     return headers
 
 
@@ -31,7 +31,10 @@ def get_client_env(cfg) -> tuple:
     """Read common client environment variables with config fallback.
 
     Returns:
-        (base_url, api_token, vm_name) tuple.
+        (base_url, client_secret, vm_name) tuple.
+
+    Raises:
+        RuntimeError: If CLIENT_SECRET is not set.
     """
     allocator_url = os.getenv("ALLOCATOR_URL")
     if allocator_url:
@@ -39,7 +42,14 @@ def get_client_env(cfg) -> tuple:
     else:
         base_url = f"http://{cfg.allocator.host}:{cfg.allocator.port}"
 
-    api_token = os.getenv("CLIENT_SECRET") or os.getenv("API_TOKEN", "")
+    client_secret = os.environ.get("CLIENT_SECRET")
+    if not client_secret:
+        raise RuntimeError(
+            "CLIENT_SECRET environment variable is required. "
+            "Each client must be registered via /api/v1/clients/register "
+            "(handled automatically by user_data.sh on AWS and "
+            "`lablink register` on manual deployments)."
+        )
     vm_name = os.getenv("VM_NAME")
 
-    return base_url, api_token, vm_name
+    return base_url, client_secret, vm_name

--- a/packages/client/src/lablink_client_service/update_inuse_status.py
+++ b/packages/client/src/lablink_client_service/update_inuse_status.py
@@ -76,11 +76,11 @@ def listen_for_process(
         time.sleep(interval + jitter)
 
 
-def call_api(process_name, url, api_token=""):
+def call_api(process_name, url, client_secret=""):
     hostname = os.getenv("VM_NAME")
     status = is_process_running(process_name=process_name)
 
-    headers = get_auth_headers(api_token)
+    headers = get_auth_headers(client_secret)
 
     retry_count = 0
 
@@ -116,9 +116,9 @@ def call_api(process_name, url, api_token=""):
         )
 
 
-def api_callback(process_name: str, url: str, api_token: str = ""):
+def api_callback(process_name: str, url: str, client_secret: str = ""):
     """Callback to call the API when process state changes."""
-    call_api(process_name, url, api_token=api_token)
+    call_api(process_name, url, client_secret=client_secret)
 
 
 @hydra.main(version_base=None, config_path="conf", config_name="config")
@@ -128,14 +128,14 @@ def main(cfg: Config) -> None:
     logger = CloudAndConsoleLogger(module_name="update_inuse_status")
     logger.info("Starting in-use status monitoring service")
 
-    base_url, api_token, _ = get_client_env(cfg)
+    base_url, client_secret, _ = get_client_env(cfg)
     url = f"{base_url}/api/update_inuse_status"
 
     # Start listening for the process
     listen_for_process(
         process_name=cfg.client.software,
         interval=20,
-        callback_func=lambda: api_callback(cfg.client.software, url, api_token),
+        callback_func=lambda: api_callback(cfg.client.software, url, client_secret),
     )
 
 

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -20,7 +20,7 @@ send_status() {
   local status="$1"
   echo ">> Reporting status='$status' to allocator..."
   curl -sS -X POST "$ALLOCATOR_URL/api/vm-status" \
-    -H "Authorization: Bearer ${CLIENT_SECRET:-$API_TOKEN}" \
+    -H "Authorization: Bearer $CLIENT_SECRET" \
     -H "Content-Type: application/json" \
     -d "{\"hostname\":\"$VM_NAME\",\"status\":\"$status\"}" \
     --max-time 5 \
@@ -258,7 +258,7 @@ CONTAINER_DURATION=$((CONTAINER_END_TIME - CONTAINER_START_TIME))
 # Send container startup completion to allocator
 curl -X POST "$ALLOCATOR_URL/api/vm-metrics/$VM_NAME" \
   -H "Content-Type: application/json" \
-  -H "Authorization: Bearer $API_TOKEN" \
+  -H "Authorization: Bearer $CLIENT_SECRET" \
   -d "{
     \"container_start\": $CONTAINER_START_TIME,
     \"container_end\": $CONTAINER_END_TIME,

--- a/packages/client/tests/test_agent_api.py
+++ b/packages/client/tests/test_agent_api.py
@@ -45,9 +45,8 @@ def test_session_start_rotates_password_on_valid_request(client, authed_headers)
 
 
 def test_agent_validates_agent_token(monkeypatch):
-    """AGENT_TOKEN accepted, wrong token rejected, API_TOKEN not consulted."""
+    """AGENT_TOKEN accepted, wrong token rejected."""
     monkeypatch.setenv("AGENT_TOKEN", "good-agent")
-    monkeypatch.delenv("API_TOKEN", raising=False)
     from lablink_client_service.agent.api import create_app
     app = create_app()
     app.config["TESTING"] = True

--- a/packages/client/tests/test_check_gpu.py
+++ b/packages/client/tests/test_check_gpu.py
@@ -330,10 +330,11 @@ def test_check_gpu_main_with_env_var(
 ):
     """Test main function with ALLOCATOR_URL environment variable."""
     monkeypatch.setenv("ALLOCATOR_URL", "https://test.com")
+    monkeypatch.setenv("CLIENT_SECRET", "test-secret")
     monkeypatch.delenv("API_TOKEN", raising=False)
     main(cfg)
     mock_check_gpu_health.assert_called_once_with(
-        allocator_url="https://test.com", api_token=""
+        allocator_url="https://test.com", api_token="test-secret"
     )
 
 
@@ -344,9 +345,10 @@ def test_check_gpu_main_without_env_var(
 ):
     """Test main function without ALLOCATOR_URL environment variable."""
     monkeypatch.delenv("ALLOCATOR_URL", raising=False)
+    monkeypatch.setenv("CLIENT_SECRET", "test-secret")
     monkeypatch.delenv("API_TOKEN", raising=False)
     main(cfg)
     mock_check_gpu_health.assert_called_once_with(
-        allocator_url="http://localhost:80", api_token=""
+        allocator_url="http://localhost:80", api_token="test-secret"
     )
 

--- a/packages/client/tests/test_check_gpu.py
+++ b/packages/client/tests/test_check_gpu.py
@@ -30,13 +30,13 @@ def test_check_gpu_health_machine_with_no_gpu(mock_run, mock_post, mock_environm
     ]
     mock_post.return_value = MagicMock(status_code=200)
 
-    check_gpu_health("http://localhost:5000")
+    check_gpu_health("http://localhost:5000", client_secret="tok")
 
     assert mock_post.call_count == 1
     mock_post.assert_called_with(
         "http://localhost:5000/api/gpu_health",
         json={"hostname": "vm-1", "gpu_status": "N/A"},
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json", "Authorization": "Bearer tok"},
         timeout=(10, 20),
     )
 
@@ -64,13 +64,13 @@ def test_check_gpu_health_machine_with_gpu(
     mock_post.return_value = MagicMock(status_code=200)
 
     with pytest.raises(StopIteration):
-        check_gpu_health("http://localhost:5000")
+        check_gpu_health("http://localhost:5000", client_secret="tok")
 
     assert mock_post.call_count == 1
     mock_post.assert_called_with(
         "http://localhost:5000/api/gpu_health",
         json={"hostname": "vm-1", "gpu_status": "Healthy"},
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json", "Authorization": "Bearer tok"},
         timeout=(10, 20),
     )
 
@@ -108,13 +108,15 @@ def test_check_gpu_health_machine_with_gpu_multiple(
     mock_post.return_value = MagicMock(status_code=200)
 
     with pytest.raises(StopIteration):
-        check_gpu_health(allocator_url="http://localhost:5000", interval=10)
+        check_gpu_health(
+            allocator_url="http://localhost:5000", interval=10, client_secret="tok"
+        )
 
     assert mock_post.call_count == 1
     mock_post.assert_called_with(
         "http://localhost:5000/api/gpu_health",
         json={"hostname": "vm-1", "gpu_status": "Healthy"},
-        headers={"Content-Type": "application/json"},
+        headers={"Content-Type": "application/json", "Authorization": "Bearer tok"},
         timeout=(10, 20),
     )
 
@@ -331,10 +333,9 @@ def test_check_gpu_main_with_env_var(
     """Test main function with ALLOCATOR_URL environment variable."""
     monkeypatch.setenv("ALLOCATOR_URL", "https://test.com")
     monkeypatch.setenv("CLIENT_SECRET", "test-secret")
-    monkeypatch.delenv("API_TOKEN", raising=False)
     main(cfg)
     mock_check_gpu_health.assert_called_once_with(
-        allocator_url="https://test.com", api_token="test-secret"
+        allocator_url="https://test.com", client_secret="test-secret"
     )
 
 
@@ -346,9 +347,8 @@ def test_check_gpu_main_without_env_var(
     """Test main function without ALLOCATOR_URL environment variable."""
     monkeypatch.delenv("ALLOCATOR_URL", raising=False)
     monkeypatch.setenv("CLIENT_SECRET", "test-secret")
-    monkeypatch.delenv("API_TOKEN", raising=False)
     main(cfg)
     mock_check_gpu_health.assert_called_once_with(
-        allocator_url="http://localhost:80", api_token="test-secret"
+        allocator_url="http://localhost:80", client_secret="test-secret"
     )
 

--- a/packages/client/tests/test_heartbeat.py
+++ b/packages/client/tests/test_heartbeat.py
@@ -129,7 +129,7 @@ def test_run_heartbeat_loop_reads_boot_id_once_and_respects_stop_event(
     ):
         heartbeat.run_heartbeat_loop(
             allocator_url="http://alloc",
-            api_token="tok",
+            client_secret="tok",
             interval=0,
             stop_event=stop,
         )

--- a/packages/client/tests/test_http_utils.py
+++ b/packages/client/tests/test_http_utils.py
@@ -3,6 +3,8 @@
 import importlib
 from unittest.mock import MagicMock
 
+import pytest
+
 from lablink_client_service.http_utils import (
     get_auth_headers,
     get_client_env,
@@ -45,7 +47,7 @@ class TestGetAuthHeaders:
 class TestGetClientEnv:
     def test_from_env_vars(self, monkeypatch):
         monkeypatch.setenv("ALLOCATOR_URL", "https://.example.com/")
-        monkeypatch.setenv("API_TOKEN", "tok123")
+        monkeypatch.setenv("CLIENT_SECRET", "tok123")
         monkeypatch.setenv("VM_NAME", "vm-1")
 
         cfg = MagicMock()
@@ -55,9 +57,9 @@ class TestGetClientEnv:
         assert api_token == "tok123"
         assert vm_name == "vm-1"
 
-    def test_fallback_to_config(self, monkeypatch):
+    def test_fallback_to_config_url(self, monkeypatch):
         monkeypatch.delenv("ALLOCATOR_URL", raising=False)
-        monkeypatch.delenv("API_TOKEN", raising=False)
+        monkeypatch.setenv("CLIENT_SECRET", "tok123")
         monkeypatch.delenv("VM_NAME", raising=False)
 
         cfg = MagicMock()
@@ -67,11 +69,11 @@ class TestGetClientEnv:
         base_url, api_token, vm_name = get_client_env(cfg)
 
         assert base_url == "http://localhost:5000"
-        assert api_token == ""
+        assert api_token == "tok123"
         assert vm_name is None
 
 
-def test_get_client_env_prefers_client_secret(monkeypatch):
+def test_get_client_env_uses_client_secret(monkeypatch):
     from lablink_client_service import http_utils
     importlib.reload(http_utils)
 
@@ -81,7 +83,6 @@ def test_get_client_env_prefers_client_secret(monkeypatch):
             port = 5000
 
     monkeypatch.setenv("ALLOCATOR_URL", "http://a:5000")
-    monkeypatch.setenv("API_TOKEN", "old-api-token")
     monkeypatch.setenv("CLIENT_SECRET", "new-client-secret")
     monkeypatch.setenv("VM_NAME", "vm-1")
 
@@ -90,19 +91,15 @@ def test_get_client_env_prefers_client_secret(monkeypatch):
     assert vm == "vm-1"
 
 
-def test_get_client_env_falls_back_to_api_token(monkeypatch):
-    from lablink_client_service import http_utils
-    importlib.reload(http_utils)
-
-    class _Cfg:
-        class allocator:
-            host = "h"
-            port = 5000
-
-    monkeypatch.setenv("ALLOCATOR_URL", "http://a:5000")
-    monkeypatch.setenv("API_TOKEN", "old-api-token")
+def test_get_client_env_raises_when_client_secret_missing(monkeypatch):
+    """After PR D4, CLIENT_SECRET is mandatory — no API_TOKEN fallback."""
     monkeypatch.delenv("CLIENT_SECRET", raising=False)
-    monkeypatch.setenv("VM_NAME", "vm-1")
+    monkeypatch.delenv("API_TOKEN", raising=False)
+    from lablink_client_service.http_utils import get_client_env
 
-    _, token, _ = http_utils.get_client_env(_Cfg)
-    assert token == "old-api-token"
+    cfg = MagicMock()
+    cfg.allocator.host = "localhost"
+    cfg.allocator.port = 5000
+
+    with pytest.raises(RuntimeError, match="CLIENT_SECRET"):
+        get_client_env(cfg)

--- a/packages/client/tests/test_http_utils.py
+++ b/packages/client/tests/test_http_utils.py
@@ -37,12 +37,6 @@ class TestGetAuthHeaders:
         headers = get_auth_headers("my-token")
         assert headers == {"Authorization": "Bearer my-token"}
 
-    def test_empty_token(self):
-        assert get_auth_headers("") == {}
-
-    def test_no_token(self):
-        assert get_auth_headers() == {}
-
 
 class TestGetClientEnv:
     def test_from_env_vars(self, monkeypatch):
@@ -51,10 +45,10 @@ class TestGetClientEnv:
         monkeypatch.setenv("VM_NAME", "vm-1")
 
         cfg = MagicMock()
-        base_url, api_token, vm_name = get_client_env(cfg)
+        base_url, client_secret, vm_name = get_client_env(cfg)
 
         assert base_url == "https://example.com"
-        assert api_token == "tok123"
+        assert client_secret == "tok123"
         assert vm_name == "vm-1"
 
     def test_fallback_to_config_url(self, monkeypatch):
@@ -66,10 +60,10 @@ class TestGetClientEnv:
         cfg.allocator.host = "localhost"
         cfg.allocator.port = 5000
 
-        base_url, api_token, vm_name = get_client_env(cfg)
+        base_url, client_secret, vm_name = get_client_env(cfg)
 
         assert base_url == "http://localhost:5000"
-        assert api_token == "tok123"
+        assert client_secret == "tok123"
         assert vm_name is None
 
 
@@ -92,9 +86,8 @@ def test_get_client_env_uses_client_secret(monkeypatch):
 
 
 def test_get_client_env_raises_when_client_secret_missing(monkeypatch):
-    """After PR D4, CLIENT_SECRET is mandatory — no API_TOKEN fallback."""
+    """After PR D4, CLIENT_SECRET is mandatory — no fallback."""
     monkeypatch.delenv("CLIENT_SECRET", raising=False)
-    monkeypatch.delenv("API_TOKEN", raising=False)
     from lablink_client_service.http_utils import get_client_env
 
     cfg = MagicMock()

--- a/packages/client/tests/test_update_inuse.py
+++ b/packages/client/tests/test_update_inuse.py
@@ -129,7 +129,7 @@ def test_api_callback(mock_call_api):
     """Test that the API callback calls the call_api function."""
     api_callback("myproc", "http://fake.url")
     mock_call_api.assert_called_once_with(
-        "myproc", "http://fake.url", api_token=""
+        "myproc", "http://fake.url", client_secret=""
     )
 
 
@@ -139,7 +139,6 @@ def test_update_inuse_status_main(mock_logger, mock_listen, monkeypatch):
     """Test the main function of the update_inuse_status module."""
     monkeypatch.setenv("ALLOCATOR_URL", "https://test.com")
     monkeypatch.setenv("CLIENT_SECRET", "test-secret")
-    monkeypatch.delenv("API_TOKEN", raising=False)
     cfg = OmegaConf.create(
         {
             "client": {"software": "sleap"},

--- a/packages/client/tests/test_update_inuse.py
+++ b/packages/client/tests/test_update_inuse.py
@@ -138,6 +138,7 @@ def test_api_callback(mock_call_api):
 def test_update_inuse_status_main(mock_logger, mock_listen, monkeypatch):
     """Test the main function of the update_inuse_status module."""
     monkeypatch.setenv("ALLOCATOR_URL", "https://test.com")
+    monkeypatch.setenv("CLIENT_SECRET", "test-secret")
     monkeypatch.delenv("API_TOKEN", raising=False)
     cfg = OmegaConf.create(
         {
@@ -158,6 +159,6 @@ def test_update_inuse_status_main(mock_logger, mock_listen, monkeypatch):
         ) as mock_api_callback:
         callback()
         mock_api_callback.assert_called_once_with(
-            "sleap", "https://test.com/api/update_inuse_status", ""
+            "sleap", "https://test.com/api/update_inuse_status", "test-secret"
         )
 


### PR DESCRIPTION
Closes the long-running migration to retire the deployment-wide `API_TOKEN` shared secret. After D4, machine-to-machine auth in LabLink uses exactly two secrets:

| Direction | Secret | Where it lives |
|---|---|---|
| **Client → Allocator** (status, heartbeat, metrics, logs, log-shipping) | per-client `client_secret` (argon2-hashed at rest) | client side: `client.env` → `CLIENT_SECRET=…`; allocator side: `vms.client_secret_hash` |
| **Allocator → Agent** (`POST :7070/api/session/start`) | deployment-wide `agent_token` | client side: `client.env` → `AGENT_TOKEN=…`; allocator side: in-memory global |

No backwards-compat path: a D4 allocator paired with a pre-D4 client is unsupported.

## Summary

- `/api/vm-metrics/<hostname>` and `/api/vm-logs` swap from `@require_api_token` to `@require_client_secret`. `/api/vm-logs` reshapes to `/api/vm-logs/<hostname>` so identity lives in the URL — symmetric with vm-metrics; the `log_stream` body field is gone (identity now in URL).
- `API_TOKEN` is removed end-to-end: the allocator global, the `require_api_token` decorator, the `require_auth` (API_TOKEN-or-Basic) shim, the registration response field, the bundled-terraform variable and `templatefile()` passthrough, the `user_data.sh` env wiring, the `log_shipper.sh` argument, the client-side fallback in `start.sh` / `http_utils.py`, and the CLI register command's `client.env` writer.
- The four admin-facing endpoints that used `@require_auth` (`/api/vm-status` GET, `/api/vm-logs/<hostname>` GET, `/api/export-metrics`, `/api/v1/clients`) collapse to `@auth.login_required` (Basic auth only). `_require_admin_or_api_token` in `routes/registration.py` is also gone.
- `http_utils.get_client_env` now raises `RuntimeError` if `CLIENT_SECRET` is absent — no silent fallback. Containers fail fast at startup instead of silently sending unauthenticated requests.
- New `packages/allocator/tests/test_no_api_token_refs.py` greps `packages/` for `API_TOKEN` (excluding `/tests/` and CHANGELOG retirement-context lines) and fails the suite if any source reference reappears. Prevents regression.

## Roadmap context

D4 is the 8th PR in the manual-BYO roadmap tracked by #355. A, B, C, D1, D2, D3 are merged; D5 (admin password hash, register-token lifecycle, SR-F1 import guard, dashboard per-seat controls) is the last remaining piece.

## Scope correction (vs. the original design)

The original spec scoped a companion PR in `talmolab/lablink-template` to drop an `api_token` Terraform variable + bump `TEMPLATE_VERSION`. Verified during implementation: the template repo (which provisions the *allocator host*) has zero `api_token` references — the Flask service generated `API_TOKEN` internally at runtime. So this PR is entirely contained in the monorepo; no template-repo PR or version bump needed.

## Files touched

- Allocator service: `main.py`, `routes/registration.py`
- Allocator bundled client-VM terraform: `variables.tf`, `main.tf`, `user_data.sh`, `log_shipper.sh`
- Allocator tests: `conftest.py`, `test_api_calls.py`, `test_registration_api.py`, `test_terraform_api.py`, new `test_no_api_token_refs.py`
- Client: `start.sh`, `http_utils.py`, plus 3 client tests
- CLI: `commands/register.py`, `CHANGELOG.md`, plus 3 CLI tests

21 files modified, 1 new test file. +277 / -333.

## Follow-up cleanup (commits `6ab8289d`, `6dc0ebb9`)

After the initial commit, an external pass surfaced stale `api_token` naming and dead-code paths that survived the initial cleanup. Plus a CI fix.

**`6ab8289d` — fix: skip API_TOKEN guard test when not running from repo tree.** The new `test_no_api_token_refs.py` resolved `REPO_ROOT` via `parents[3]`, which works locally but fails in the docker-image-test step where the test ships inside the image and `packages/` doesn't exist on that filesystem. Added `pytest.skip(...)` when the expected paths aren't found, so the guard runs at PR-review time on a full checkout and skips cleanly in docker-installed contexts.

**`6dc0ebb9` — follow-up: rename stale `api_token`, prune dead empty-token paths.**

- Renamed the parameter `api_token` → `client_secret` in `check_gpu.check_gpu_health`, `heartbeat.run_heartbeat_loop`, and `update_inuse_status.{call_api, api_callback, main}` (plus matching test kwargs). The functions were receiving `CLIENT_SECRET` from `get_client_env` but the local variable name still said `api_token` — misleading on read.
- Collapsed `get_auth_headers`: dropped the `token: str = ""` default and the `if token:` guard. After D4, `get_client_env` raises on missing `CLIENT_SECRET`, so the function is never called with a falsy value in production. Function is now a one-line dict literal.
- Deleted the two `TestGetAuthHeaders` empty-token cases (`test_empty_token`, `test_no_token`) — the cases they pinned are now unreachable.
- Updated three pre-existing `check_gpu` tests that called `check_gpu_health("http://localhost:5000")` without a token — they now pass `client_secret="tok"` and assert the expected `Authorization: Bearer tok` header.
- Dropped 5 stale `monkeypatch.delenv("API_TOKEN", raising=False)` calls — no source reads the env var anymore.
- Rewrote `docs/security.md` "API Bearer Token (Machine-to-Machine)" section to describe the post-D4 two-token model (per-client `client_secret` + deployment-wide `agent_token`) instead of the retired shared API_TOKEN. Updated the protected-endpoints list to the new URLs.

Client test count went from 71 → 69 (the two `get_auth_headers` empty-case tests). `grep -rn 'API_TOKEN\|api_token' packages/{allocator,client,cli}/src/ docs/security.md` returns zero hits.

## Test plan

Automated (already green locally):

- [x] `cd packages/allocator && PYTHONPATH=. pytest --ignore=tests/terraform` — 475 passed, 14 pre-existing skipped
- [x] `cd packages/client && PYTHONPATH=. pytest` — 69 passed (2 dead empty-token tests removed in `6dc0ebb9`)
- [x] `cd packages/cli && PYTHONPATH=src pytest` — 399 passed
- [x] `ruff check packages/{allocator,client,cli}/{src,tests}` — clean
- [x] `grep -rn API_TOKEN packages/{allocator,client,cli}/src/` — zero hits
- [x] `tests/test_no_api_token_refs.py` regression-tested: injecting `API_TOKEN = "test"` into a source file triggers the guard

Manual smoke (pre-merge):

- [x] **AWS path:** `lablink deploy` (AWS provider) → launch one client VM → confirm the row receives `cloud_init_*` metrics from `user_data.sh:228`, `container_start*` from `start.sh:261`, and both `cloud_init_logs` and `docker_logs` from the log shipper. No 401s in the shipper retry log.
- [x] **Manual path:** `configure → deploy → register` → confirm the BYO row receives `container_start*` metrics. (No log shipping on the manual path today — pre-existing scope.)
- [x] **Warm-reboot edge case:** deferred to follow-up #359. Cold-path AWS + Manual smokes cover the steady-state surface; warm-reboot is a recovery flow worth confirming separately (the failure mode would be loud auth breaks rather than silent corruption).
- [x] **Hostname casing:** confirm the URL hostname segment used by `log_shipper.sh` (`$VM_NAME`) matches exactly what registration recorded — any prefix or case mismatch will produce 401s.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

