### PR TITLE
cli: ship manual BYO docker container logs to allocator

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -902,7 +902,13 @@ def get_vm_logs(hostname):
     if not database.vm_exists(hostname=hostname):
         logger.error(f"VM with hostname {hostname} not found.")
         return jsonify({"error": "VM not found."}), 404
-    return render_template("instance-logs.html", hostname=hostname)
+    # Non-AWS providers (manual/BYO) have no cloud-init concept; the
+    # template hides that section when provider != "aws".
+    return render_template(
+        "instance-logs.html",
+        hostname=hostname,
+        provider=cfg.provider,
+    )
 
 
 @app.route("/api/vm-metrics/<hostname>", methods=["POST"])

--- a/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
@@ -236,7 +236,9 @@
             </div>
 
             <!-- Log type tabs -->
+            {% set has_cloud_init = (provider or 'aws') == 'aws' %}
             <ul class="nav nav-tabs mb-0" id="logTabs" role="tablist">
+                {% if has_cloud_init %}
                 <li class="nav-item" role="presentation">
                     <button class="nav-link active" id="cloudInitTab" data-bs-toggle="tab"
                             data-bs-target="#cloudInitPane" type="button" role="tab"
@@ -244,15 +246,17 @@
                         Cloud Init <span class="badge bg-secondary ms-1" id="cloudInitLineCount">0</span>
                     </button>
                 </li>
+                {% endif %}
                 <li class="nav-item" role="presentation">
-                    <button class="nav-link" id="dockerTab" data-bs-toggle="tab"
+                    <button class="nav-link {% if not has_cloud_init %}active{% endif %}" id="dockerTab" data-bs-toggle="tab"
                             data-bs-target="#dockerPane" type="button" role="tab"
-                            aria-controls="dockerPane" aria-selected="false">
+                            aria-controls="dockerPane" aria-selected="{% if has_cloud_init %}false{% else %}true{% endif %}">
                         Docker <span class="badge bg-secondary ms-1" id="dockerLineCount">0</span>
                     </button>
                 </li>
             </ul>
             <div class="tab-content">
+                {% if has_cloud_init %}
                 <div class="tab-pane fade show active" id="cloudInitPane" role="tabpanel" aria-labelledby="cloudInitTab">
                     <div class="log-container" id="cloudInitLogBox" style="border-top-left-radius: 0; border-top-right-radius: 0;">
                         <div style="text-align: center; color: #888; padding: 2rem;">
@@ -260,7 +264,8 @@
                         </div>
                     </div>
                 </div>
-                <div class="tab-pane fade" id="dockerPane" role="tabpanel" aria-labelledby="dockerTab">
+                {% endif %}
+                <div class="tab-pane fade {% if not has_cloud_init %}show active{% endif %}" id="dockerPane" role="tabpanel" aria-labelledby="dockerTab">
                     <div class="log-container" id="dockerLogBox" style="border-top-left-radius: 0; border-top-right-radius: 0;">
                         <div style="text-align: center; color: #888; padding: 2rem;">
                             Loading logs...
@@ -281,6 +286,7 @@
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script>
         const hostname = "{{ hostname }}";
+        const hasCloudInit = {{ 'true' if has_cloud_init else 'false' }};
         let autoRefreshInterval = null;
         let isAutoRefreshing = false;
 
@@ -290,10 +296,14 @@
             updateTimestamp();
         });
 
+        function setBoxText(id, text) {
+            // Tolerate the cloud-init pane being absent (non-AWS providers).
+            const el = document.getElementById(id);
+            if (el) el.textContent = text;
+        }
+
         async function refreshLogs() {
             try {
-                const cloudInitLogBox = document.getElementById("cloudInitLogBox");
-                const dockerLogBox = document.getElementById("dockerLogBox");
                 const shouldFollowTail = document.getElementById("followTail").checked;
 
                 const res = await fetch(`/api/vm-logs/${hostname}`, { credentials : 'include' });
@@ -302,8 +312,8 @@
                     const cloudInitLogs = data.cloud_init_logs || "No logs available.";
                     const dockerLogs = data.docker_logs || "No logs available.";
 
-                    cloudInitLogBox.textContent = cloudInitLogs;
-                    dockerLogBox.textContent = dockerLogs;
+                    setBoxText("cloudInitLogBox", cloudInitLogs);
+                    setBoxText("dockerLogBox", dockerLogs);
 
                     // Update stats
                     updateLogStats(cloudInitLogs, dockerLogs);
@@ -317,17 +327,17 @@
                         }
                     }
                 } else if (res.status === 503) {
-                    cloudInitLogBox.textContent = "The VM is currently initializing. Please wait.";
-                    dockerLogBox.textContent = "The VM is currently initializing. Please wait.";
+                    setBoxText("cloudInitLogBox", "The VM is currently initializing. Please wait.");
+                    setBoxText("dockerLogBox", "The VM is currently initializing. Please wait.");
                 } else {
-                    cloudInitLogBox.textContent = "Error loading logs. Please try again.";
-                    dockerLogBox.textContent = "Error loading logs. Please try again.";
+                    setBoxText("cloudInitLogBox", "Error loading logs. Please try again.");
+                    setBoxText("dockerLogBox", "Error loading logs. Please try again.");
                 }
             } catch (err) {
                 console.error("Error fetching logs:", err);
                 const msg = "Network error. Please check your connection.";
-                document.getElementById("cloudInitLogBox").textContent = msg;
-                document.getElementById("dockerLogBox").textContent = msg;
+                setBoxText("cloudInitLogBox", msg);
+                setBoxText("dockerLogBox", msg);
             }
         }
 
@@ -353,9 +363,14 @@
         }
 
         function downloadLogs() {
-            const cloudInit = document.getElementById("cloudInitLogBox").textContent;
             const docker = document.getElementById("dockerLogBox").textContent;
-            const logs = "=== Cloud Init Logs ===\n" + cloudInit + "\n\n=== Docker Logs ===\n" + docker;
+            let logs;
+            if (hasCloudInit) {
+                const cloudInit = document.getElementById("cloudInitLogBox").textContent;
+                logs = "=== Cloud Init Logs ===\n" + cloudInit + "\n\n=== Docker Logs ===\n" + docker;
+            } else {
+                logs = "=== Docker Logs ===\n" + docker;
+            }
             const blob = new Blob([logs], { type: 'text/plain' });
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
@@ -368,12 +383,15 @@
         }
 
         function updateLogStats(cloudInitLogs, dockerLogs) {
-            const cloudInitLines = cloudInitLogs ? cloudInitLogs.split('\n').length : 0;
+            const cloudInitLines = (hasCloudInit && cloudInitLogs) ? cloudInitLogs.split('\n').length : 0;
             const dockerLines = dockerLogs ? dockerLogs.split('\n').length : 0;
             const totalLines = cloudInitLines + dockerLines;
 
             document.getElementById("lineCount").textContent = totalLines.toLocaleString();
-            document.getElementById("cloudInitLineCount").textContent = cloudInitLines.toLocaleString();
+            const cloudInitBadge = document.getElementById("cloudInitLineCount");
+            if (cloudInitBadge) {
+                cloudInitBadge.textContent = cloudInitLines.toLocaleString();
+            }
             document.getElementById("dockerLineCount").textContent = dockerLines.toLocaleString();
         }
 

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
     "rich>=13.0",
     "pyyaml>=6.0",
     "boto3>=1.35",
+    "psutil>=5.9",
 ]
 
 [project.optional-dependencies]

--- a/packages/cli/src/lablink_cli/commands/logs.py
+++ b/packages/cli/src/lablink_cli/commands/logs.py
@@ -255,31 +255,141 @@ def fetch_allocator_logs(
 
 
 # ------------------------------------------------------------------
-# Manual-provider logs
+# Log fetching — manual-provider allocator (local docker container)
+# ------------------------------------------------------------------
+_MANUAL_ALLOCATOR_TAIL = 2000
+
+
+def fetch_manual_allocator_logs() -> dict:
+    """Snapshot the local lablink-allocator container's logs.
+
+    Mirrors :func:`fetch_allocator_logs` / :func:`fetch_client_logs`
+    contract (cloud_init_logs, docker_logs, error keys) so the TUI can
+    treat manual + AWS uniformly.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "docker", "logs",
+                "--tail", str(_MANUAL_ALLOCATOR_TAIL),
+                "lablink-allocator",
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError) as e:
+        return {
+            "cloud_init_logs": None,
+            "docker_logs": None,
+            "error": f"docker logs failed: {e}",
+        }
+
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        if "No such container" in stderr:
+            err = (
+                "lablink-allocator container is not running. "
+                "Run `lablink deploy` to start it."
+            )
+        else:
+            err = stderr or f"docker logs exited {result.returncode}"
+        return {
+            "cloud_init_logs": None,
+            "docker_logs": None,
+            "error": err,
+        }
+
+    # docker writes the container's own stdout to its stdout, stderr to its
+    # stderr — merge them so the TUI shows everything chronologically.
+    combined = (result.stdout or "") + (result.stderr or "")
+    return {
+        "cloud_init_logs": None,
+        "docker_logs": combined.strip() or None,
+        "error": None,
+    }
+
+
+# ------------------------------------------------------------------
+# Manual-provider TUI launcher
 # ------------------------------------------------------------------
 def _run_logs_manual(cfg: Config) -> None:
-    """Tail `docker logs` of the local allocator container.
+    """Discover BYO clients via /api/v1/clients and launch the TUI.
 
-    Per-VM client logs are not centralized for the manual provider;
-    operators run `docker logs lablink-client` on each BYO box.
+    The TUI shows the local allocator container plus every registered
+    BYO client. Client logs come from /api/vm-logs/<hostname> (populated
+    by the manual-client log shipper). The allocator entry is fetched
+    via local ``docker logs lablink-allocator`` instead of SSH.
     """
-    console.print(
-        "[bold]Tailing allocator logs (Ctrl+C to stop)[/bold]\n"
-        "[dim]Per-VM client logs are not centralized for the manual "
-        "provider — run `docker logs lablink-client` on each BYO box.[/dim]\n"
+    from lablink_cli.commands.deploy_compose import DEFAULT_HTTP_PORT
+    from lablink_cli.commands.status import (
+        _fetch_registered_clients,
+        _resolve_manual_admin_credentials,
     )
-    with subprocess.Popen(
-        ["docker", "logs", "-f", "lablink-allocator"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    ) as proc:
-        try:
-            if proc.stdout is not None:
-                for line in proc.stdout:
-                    print(line, end="")
-        except KeyboardInterrupt:
-            proc.terminate()
+
+    workdir = Path.home() / ".lablink" / "compose" / (
+        cfg.deployment_name or "lablink"
+    )
+
+    creds = _resolve_manual_admin_credentials(cfg, workdir)
+    if not creds:
+        console.print(
+            "[red]Could not resolve allocator admin credentials.[/red]\n"
+            f"Run `lablink deploy` first (expected workdir: {workdir})."
+        )
+        raise SystemExit(1)
+    admin_user, admin_pw = creds
+
+    allocator_url = f"http://localhost:{DEFAULT_HTTP_PORT}"
+
+    console.print(
+        "[dim]Fetching registered BYO clients from the allocator...[/dim]"
+    )
+    clients, err = _fetch_registered_clients(
+        allocator_url, admin_user, admin_pw
+    )
+    if clients is None:
+        console.print(
+            f"[red]Failed to list clients:[/red] {err}\n"
+            "Is the allocator running? Try `lablink status`."
+        )
+        raise SystemExit(1)
+
+    # Synthetic VM list: allocator first, then clients. Shapes match the
+    # AWS-mode dicts (name, type, vm_type, public_ip, state) so LogsApp +
+    # VMListItem work uniformly. The allocator is implicitly "running"
+    # here — _fetch_registered_clients just succeeded against it.
+    vms: list[dict] = [
+        {
+            "name": "lablink-allocator",
+            "type": "compose",
+            "vm_type": "allocator",
+            "public_ip": "localhost",
+            "state": "running",
+        }
+    ]
+    for c in clients:
+        hostname = c.get("hostname") or "-"
+        vms.append({
+            "name": hostname,
+            "type": "byo",
+            "vm_type": "client",
+            "public_ip": c.get("lan_ip") or "—",
+            "state": c.get("status") or "unknown",
+        })
+
+    from lablink_cli.tui.logs_viewer import LogsApp
+
+    app = LogsApp(
+        cfg=cfg,
+        vms=vms,
+        allocator_url=allocator_url,
+        admin_user=admin_user,
+        admin_pw=admin_pw,
+        deploy_dir=workdir,
+        manual=True,
+    )
+    app.run()
 
 
 # ------------------------------------------------------------------

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -2,15 +2,20 @@
 
 from __future__ import annotations
 
+import os
 import shutil
 import subprocess
+import sys
 from datetime import datetime, timezone
 from pathlib import Path
 from urllib.parse import urlparse
 
+import psutil
+
 from rich.console import Console
 
 from lablink_cli import byo_detect
+from lablink_cli.log_shipper import inspect_container as inspect_container_for_register
 from lablink_cli.api import (
     AllocatorAuthError,
     AllocatorConflictError,
@@ -20,6 +25,7 @@ from lablink_cli.api import (
 )
 
 DEFAULT_ENV_FILE = Path.home() / ".lablink" / "client.env"
+PID_FILE = Path.home() / ".lablink" / "log_shipper.pid"
 
 
 def run_register(
@@ -44,14 +50,10 @@ def run_register(
     console = Console()
     env_file = env_file or DEFAULT_ENV_FILE
 
-    # Step 1: idempotency
+    # Step 1: idempotency / resume
     if env_file.exists() and not force:
-        console.print(
-            f"[red]Already registered — {env_file} exists.[/red]\n"
-            "Re-register with --force to mint a new client_secret "
-            "(existing client container will be orphaned)."
-        )
-        raise SystemExit(1)
+        _resume(env_file, console)
+        return
 
     # Step 2: auto-detect (user overrides win)
     resolved_hostname = hostname or byo_detect.detect_hostname()
@@ -134,6 +136,71 @@ def run_register(
         f"[green]Registered as client #{response['client_id']}[/green]"
     )
     _exec_docker(cmd, console)
+    _start_log_shipper(env_file, console)
+
+
+def _resume(env_file: Path, console: Console) -> None:
+    """Re-run mode for an already-registered host.
+
+    Does NOT mint a new client_secret. Restarts the container if stopped,
+    revives the shipper if dead, otherwise prints a no-op message.
+
+    Note: container image is NOT re-pulled — that's `--force` territory.
+    """
+    status = inspect_container_for_register("lablink-client")
+    container_action: str | None = None
+
+    if status == "missing":
+        console.print(
+            "[yellow]Already registered, but lablink-client container is "
+            "missing.[/yellow] Re-run with [bold]--force[/bold] to recreate "
+            "it (this mints a new client_secret)."
+        )
+        raise SystemExit(1)
+    if status == "daemon_error":
+        console.print(
+            "[red]Docker daemon is unreachable.[/red] Start Docker and re-run."
+        )
+        raise SystemExit(1)
+    if status in ("exited", "restarting"):
+        try:
+            subprocess.run(
+                ["docker", "start", "lablink-client"],
+                check=True,
+                capture_output=True,
+            )
+            container_action = "restarted"
+        except subprocess.CalledProcessError as e:
+            console.print(
+                f"[red]docker start lablink-client failed:[/red] "
+                f"{e.stderr.decode().strip() if e.stderr else e}"
+            )
+            raise SystemExit(1) from e
+
+    shipper_action: str | None = None
+    if _shipper_alive():
+        if container_action is None:
+            console.print(
+                "[green]Already registered. Container and log shipper "
+                "are running.[/green]"
+            )
+            return
+    else:
+        _start_log_shipper(env_file, console)
+        shipper_action = "restarted"
+
+    if container_action and shipper_action:
+        console.print(
+            "[green]Restarted container and log shipper.[/green] "
+            "To pull a newer client image, re-run with --force."
+        )
+    elif container_action:
+        console.print(
+            "[green]Restarted container.[/green] "
+            "To pull a newer client image, re-run with --force."
+        )
+    elif shipper_action:
+        console.print("[green]Restarted log shipper.[/green]")
 
 
 def _write_env_file(
@@ -298,3 +365,65 @@ def _exec_docker(cmd: list[str], console: Console) -> None:
         "[green]Container running as lablink-client.[/green] "
         "View logs with: docker logs -f lablink-client"
     )
+
+
+def _start_log_shipper(env_file: Path, console: Console) -> None:
+    """Spawn the log shipper as a detached background process.
+
+    The shipper survives this `register` invocation and runs until either
+    the user does ``docker stop lablink-client`` (shipper's docker-logs
+    subprocess exits and inspect reports missing) or the host reboots.
+    """
+    log_dir = Path.home() / ".lablink"
+    log_dir.mkdir(parents=True, exist_ok=True)
+    shipper_log = log_dir / "log_shipper.log"
+    # Append-mode handle for the detached child's stdout+stderr. The
+    # shipper itself writes structured lines to this file via self_log();
+    # the open handle here is just a safety net for any stray print.
+    log_fd = open(shipper_log, "a", buffering=1)
+
+    cmd = [sys.executable, "-m", "lablink_cli.log_shipper", str(env_file)]
+
+    popen_kwargs: dict = {
+        "stdin": subprocess.DEVNULL,
+        "stdout": log_fd,
+        "stderr": log_fd,
+        "close_fds": True,
+    }
+    if os.name == "nt":
+        # Windows: detach so the child survives the parent's exit.
+        popen_kwargs["creationflags"] = (
+            subprocess.DETACHED_PROCESS
+            | subprocess.CREATE_NEW_PROCESS_GROUP
+        )
+    else:
+        # POSIX: new session detaches from the controlling TTY and parent
+        # process group, matching nohup semantics.
+        popen_kwargs["start_new_session"] = True
+
+    proc = subprocess.Popen(cmd, **popen_kwargs)
+    console.print(
+        f"[green]Log shipping started (PID {proc.pid}).[/green] "
+        f"Logs: {shipper_log}"
+    )
+
+
+def _shipper_alive() -> bool:
+    """True iff a live log-shipper process matching our PID file exists.
+
+    Two-stage check: PID present in PID file AND that PID belongs to a
+    process whose cmdline mentions ``lablink_cli.log_shipper``. The
+    cmdline guard prevents false positives from PID reuse after reboot.
+    """
+    if not PID_FILE.exists():
+        return False
+    try:
+        pid = int(PID_FILE.read_text().strip())
+    except (OSError, ValueError):
+        return False
+    try:
+        proc = psutil.Process(pid)
+        cmdline = proc.cmdline()
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        return False
+    return any("lablink_cli.log_shipper" in arg for arg in cmdline)

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -367,6 +367,48 @@ def _exec_docker(cmd: list[str], console: Console) -> None:
     )
 
 
+def _stop_existing_shipper(console: Console) -> None:
+    """Terminate any running shipper recorded in the PID file.
+
+    Called before spawning a new shipper so ``--force`` re-register doesn't
+    leave the old shipper briefly tailing the replaced container and
+    POSTing duplicates against the same hostname. The cmdline guard
+    matches ``_shipper_alive`` so an unrelated PID-reused process is left
+    alone.
+    """
+    if not PID_FILE.exists():
+        return
+    try:
+        pid = int(PID_FILE.read_text().strip())
+    except (OSError, ValueError):
+        PID_FILE.unlink(missing_ok=True)
+        return
+    try:
+        proc = psutil.Process(pid)
+        cmdline = proc.cmdline()
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        PID_FILE.unlink(missing_ok=True)
+        return
+    if not any("lablink_cli.log_shipper" in arg for arg in cmdline):
+        PID_FILE.unlink(missing_ok=True)
+        return
+
+    console.print(f"[dim]Stopping existing log shipper (PID {pid})...[/dim]")
+    try:
+        proc.terminate()
+        proc.wait(timeout=5)
+    except psutil.TimeoutExpired:
+        try:
+            proc.kill()
+        except psutil.NoSuchProcess:
+            pass
+    except (psutil.NoSuchProcess, psutil.AccessDenied):
+        pass
+    # The shipper's SIGTERM handler removes the PID file; if we escalated
+    # to SIGKILL the handler never ran, so clean up here.
+    PID_FILE.unlink(missing_ok=True)
+
+
 def _start_log_shipper(env_file: Path, console: Console) -> None:
     """Spawn the log shipper as a detached background process.
 
@@ -374,6 +416,8 @@ def _start_log_shipper(env_file: Path, console: Console) -> None:
     the user does ``docker stop lablink-client`` (shipper's docker-logs
     subprocess exits and inspect reports missing) or the host reboots.
     """
+    _stop_existing_shipper(console)
+
     log_dir = Path.home() / ".lablink"
     log_dir.mkdir(parents=True, exist_ok=True)
     shipper_log = log_dir / "log_shipper.log"

--- a/packages/cli/src/lablink_cli/log_shipper.py
+++ b/packages/cli/src/lablink_cli/log_shipper.py
@@ -1,0 +1,421 @@
+"""Ships docker container logs from a BYO client to the allocator.
+
+Invoked as: ``python -m lablink_cli.log_shipper <env_file>``
+by ``lablink register``. Reads CLIENT_SECRET / ALLOCATOR_URL / VM_NAME from
+the env file written by register, batches ``docker logs --follow`` output,
+and POSTs to ``/api/vm-logs/<hostname>``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import signal
+import subprocess
+import sys
+import time
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Callable, Literal
+from urllib.error import HTTPError, URLError
+from urllib.request import Request
+from urllib.request import urlopen as _stdlib_urlopen
+
+
+def load_env(env_file: Path) -> dict[str, str]:
+    """Parse the BYO client.env file (KEY=VALUE per line, # comments)."""
+    text = Path(env_file).read_text()
+    env: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        if "=" not in line:
+            continue
+        key, _, value = line.partition("=")
+        env[key.strip()] = value
+    return env
+
+
+def read_last_shipped_ts(state_file: Path) -> str | None:
+    """Return the timestamp of the last successfully shipped line, or None.
+
+    Treats missing or corrupt state as None (first-attach behavior).
+    """
+    try:
+        data = json.loads(Path(state_file).read_text())
+    except (FileNotFoundError, json.JSONDecodeError):
+        return None
+    ts = data.get("last_shipped_ts")
+    return ts if isinstance(ts, str) else None
+
+
+def write_last_shipped_ts(state_file: Path, ts: str) -> None:
+    """Persist last_shipped_ts atomically (write-and-rename)."""
+    path = Path(state_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    tmp = path.with_suffix(path.suffix + ".tmp")
+    tmp.write_text(json.dumps({"last_shipped_ts": ts}))
+    tmp.replace(path)
+
+
+MAX_RETRIES = 3
+RETRY_BACKOFF_S = (1, 2, 4)  # sleep before retry attempt 1, 2, 3
+LOG_GROUP = "docker"
+
+PostResult = Literal["ok", "drop", "fatal"]
+
+
+def post_batch(
+    *,
+    allocator_url: str,
+    vm_name: str,
+    client_secret: str,
+    messages: list[str],
+    log_group: str = LOG_GROUP,
+    urlopen: Callable = _stdlib_urlopen,
+    sleep: Callable[[float], None] = time.sleep,
+) -> PostResult:
+    """POST a batch of log lines to /api/vm-logs/<vm_name>.
+
+    Returns ``"ok"`` on 2xx, ``"fatal"`` on 4xx (no retry — shipper should
+    exit), and ``"drop"`` after MAX_RETRIES of 5xx or network failures.
+    """
+    url = f"{allocator_url.rstrip('/')}/api/vm-logs/{vm_name}"
+    body = json.dumps({"log_group": log_group, "messages": messages}).encode()
+    headers = {
+        "Content-Type": "application/json",
+        "Authorization": f"Bearer {client_secret}",
+    }
+
+    for attempt in range(MAX_RETRIES):
+        if attempt > 0:
+            sleep(RETRY_BACKOFF_S[attempt - 1])
+        try:
+            req = Request(url, data=body, headers=headers, method="POST")
+            with urlopen(req, timeout=10) as resp:
+                if 200 <= resp.status < 300:
+                    return "ok"
+                continue
+        except HTTPError as e:
+            if 400 <= e.code < 500:
+                return "fatal"  # bad secret / unknown hostname — exit
+            continue
+        except URLError:
+            continue
+    return "drop"
+
+
+BATCH_SIZE = 50
+FLUSH_INTERVAL_S = 15
+
+
+def should_flush(*, buffer_len: int, elapsed_s: float) -> bool:
+    """Return True if the buffer should be flushed now."""
+    if buffer_len == 0:
+        return False
+    return buffer_len >= BATCH_SIZE or elapsed_s >= FLUSH_INTERVAL_S
+
+
+ContainerStatus = Literal[
+    "running", "restarting", "exited", "missing", "daemon_error"
+]
+
+
+def inspect_container(name: str) -> ContainerStatus:
+    """Map ``docker inspect`` output to a coarse status.
+
+    - "running"     → container is up
+    - "restarting"  → docker is bringing it back (e.g. --restart unless-stopped)
+    - "exited"      → container is stopped (could be transient or permanent)
+    - "missing"     → no container with that name exists
+    - "daemon_error"→ docker daemon is unreachable
+    """
+    try:
+        result = subprocess.run(
+            ["docker", "inspect", name, "--format", "{{.State.Status}}"],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+    except (subprocess.TimeoutExpired, OSError):
+        return "daemon_error"
+
+    if result.returncode == 0:
+        status = result.stdout.strip()
+        if status in ("running", "restarting", "exited"):
+            return status  # type: ignore[return-value]
+        # Other statuses (created, paused, dead) — treat like exited.
+        return "exited"
+
+    stderr = (result.stderr or "").lower()
+    if "no such" in stderr or "no such object" in stderr:
+        return "missing"
+    return "daemon_error"
+
+
+CONTAINER_NAME = "lablink-client"
+
+# Strip RFC3339Nano fractional seconds (e.g.
+# 2026-05-28T14:23:01.123456789Z → 2026-05-28T14:23:01Z) so admin views
+# aren't cluttered with nanosecond noise. Matches log_shipper.sh:101.
+_TS_RE = re.compile(
+    r"^(\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2})(?:\.\d+)?Z (.*)$"
+)
+
+
+def parse_docker_line(line: str) -> tuple[str | None, str]:
+    """Split a ``docker logs --timestamps`` line into ``(ts, message)``.
+
+    Returns ``(None, line)`` if no timestamp prefix is present.
+    """
+    m = _TS_RE.match(line)
+    if not m:
+        return None, line
+    return f"{m.group(1)}Z", m.group(2)
+
+
+def open_docker_logs(
+    name: str, *, since: str | None
+) -> subprocess.Popen:
+    """Spawn ``docker logs --follow --timestamps [--since <ts>] <name>``."""
+    cmd = ["docker", "logs", "--follow", "--timestamps"]
+    if since:
+        cmd += ["--since", since]
+    cmd.append(name)
+    return subprocess.Popen(
+        cmd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+        bufsize=1,  # line-buffered
+    )
+
+
+LOG_SHIPPER_DIR = Path.home() / ".lablink"
+PID_FILE = LOG_SHIPPER_DIR / "log_shipper.pid"
+STATE_FILE = LOG_SHIPPER_DIR / "log_shipper.state"
+SELF_LOG_FILE = LOG_SHIPPER_DIR / "log_shipper.log"
+FIRST_ATTACH_LOOKBACK_S = 60
+CONTAINER_RESTART_WAIT_S = 5
+INSPECT_RETRY_INTERVAL_S = 30
+INSPECT_MAX_RETRIES = 5
+
+SELF_LOG_MAX_BYTES = 1_000_000
+
+
+def self_log(log_file: Path, message: str) -> None:
+    """Append a timestamped line to the shipper's own diagnostic log.
+
+    Rotates to <log>.1 (single rotation) when the file exceeds 1MB. This
+    is the shipper's only error channel; it runs detached so stdout/stderr
+    are discarded.
+    """
+    path = Path(log_file)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists() and path.stat().st_size >= SELF_LOG_MAX_BYTES:
+        rotated = path.with_suffix(path.suffix + ".1")
+        path.replace(rotated)
+    ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    with path.open("a") as f:
+        f.write(f"{ts} {message}\n")
+
+
+def _initial_since() -> str:
+    """RFC3339 timestamp ~1 minute ago, for first-ever shipper attach."""
+    ts = datetime.now(timezone.utc) - timedelta(
+        seconds=FIRST_ATTACH_LOOKBACK_S
+    )
+    return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _read_lines_from_popen(proc):
+    """Wrap a Popen's stdout for line-by-line iteration."""
+    if proc.stdout is None:
+        return
+    for line in proc.stdout:
+        yield line.rstrip("\n")
+
+
+def run_shipper(
+    env_file: Path,
+    *,
+    _line_iter: Callable | None = None,
+    _sleep: Callable[[float], None] = time.sleep,
+) -> None:
+    """Main shipper loop. Returns when shipping should stop."""
+    env = load_env(env_file)
+    allocator_url = env["ALLOCATOR_URL"]
+    vm_name = env["VM_NAME"]
+    client_secret = env["CLIENT_SECRET"]
+
+    self_log(SELF_LOG_FILE, f"shipper starting for vm_name={vm_name}")
+
+    since = read_last_shipped_ts(STATE_FILE) or _initial_since()
+    self_log(SELF_LOG_FILE, f"attaching to docker logs --since {since}")
+
+    # ---- Attach loop: re-runs if container restarts ----
+    inspect_failures = 0
+    while True:
+        if _line_iter is not None:
+            line_source = _line_iter()
+            proc = None
+        else:
+            proc = open_docker_logs(CONTAINER_NAME, since=since)
+            line_source = _read_lines_from_popen(proc)
+
+        buffer: list[str] = []
+        buffer_first_ts: float | None = None
+        last_ts_in_batch: str | None = None
+
+        # ---- Inner read loop ----
+        try:
+            for line in line_source:
+                ts, msg = parse_docker_line(line)
+                # Buffer the original tagged line, preserving the timestamp
+                # prefix so admin views show it (matches log_shipper.sh's
+                # docker --timestamps + sed pipeline).
+                if ts is not None:
+                    buffer.append(f"{ts} {msg}")
+                    last_ts_in_batch = ts
+                else:
+                    buffer.append(msg)
+                if buffer_first_ts is None:
+                    buffer_first_ts = time.monotonic()
+
+                elapsed = (
+                    time.monotonic() - buffer_first_ts
+                    if buffer_first_ts is not None
+                    else 0
+                )
+                if should_flush(
+                    buffer_len=len(buffer), elapsed_s=elapsed
+                ):
+                    result = post_batch(
+                        allocator_url=allocator_url,
+                        vm_name=vm_name,
+                        client_secret=client_secret,
+                        messages=buffer,
+                    )
+                    if result == "ok" and last_ts_in_batch:
+                        write_last_shipped_ts(
+                            STATE_FILE, last_ts_in_batch
+                        )
+                    elif result == "fatal":
+                        self_log(
+                            SELF_LOG_FILE,
+                            "POST returned fatal (4xx); exiting",
+                        )
+                        return
+                    elif result == "drop":
+                        self_log(
+                            SELF_LOG_FILE,
+                            f"dropped batch of {len(buffer)} after retries",
+                        )
+                    buffer = []
+                    buffer_first_ts = None
+                    last_ts_in_batch = None
+        finally:
+            if proc is not None:
+                try:
+                    proc.terminate()
+                    proc.wait(timeout=5)
+                except Exception:
+                    pass
+
+        # Flush any tail buffer before deciding whether to reconnect.
+        if buffer:
+            result = post_batch(
+                allocator_url=allocator_url,
+                vm_name=vm_name,
+                client_secret=client_secret,
+                messages=buffer,
+            )
+            if result == "ok" and last_ts_in_batch:
+                write_last_shipped_ts(STATE_FILE, last_ts_in_batch)
+            elif result == "fatal":
+                self_log(
+                    SELF_LOG_FILE,
+                    "POST returned fatal during tail flush; exiting",
+                )
+                return
+
+        # docker logs --follow exited. Inspect to decide what to do.
+        status = inspect_container(CONTAINER_NAME)
+        self_log(
+            SELF_LOG_FILE, f"docker logs ended; container status={status}"
+        )
+        if status == "missing":
+            self_log(SELF_LOG_FILE, "container missing; exiting")
+            return
+        if status == "daemon_error":
+            inspect_failures += 1
+            if inspect_failures >= INSPECT_MAX_RETRIES:
+                self_log(
+                    SELF_LOG_FILE,
+                    "daemon unreachable after max retries; exiting",
+                )
+                return
+            _sleep(INSPECT_RETRY_INTERVAL_S)
+            continue
+        inspect_failures = 0
+        if status == "exited" or status == "restarting":
+            _sleep(CONTAINER_RESTART_WAIT_S)
+        # status == "running" → reconnect immediately
+        # update since for the reconnect so we don't re-ship
+        new_since = read_last_shipped_ts(STATE_FILE)
+        if new_since:
+            since = new_since
+        # If _line_iter is set (test), exit the outer loop after one pass to
+        # keep tests deterministic.
+        if _line_iter is not None:
+            return
+
+
+def _handle_shutdown(signum, _frame) -> None:
+    """SIGTERM/SIGINT handler: unlink PID file and exit cleanly."""
+    try:
+        PID_FILE.unlink(missing_ok=True)
+    except OSError:
+        pass
+    self_log(SELF_LOG_FILE, f"received signal {signum}; exiting")
+    sys.exit(0)
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point for ``python -m lablink_cli.log_shipper <env_file>``."""
+    args = argv if argv is not None else sys.argv[1:]
+    if len(args) != 1:
+        print(
+            "usage: python -m lablink_cli.log_shipper <env_file>",
+            file=sys.stderr,
+        )
+        return 2
+
+    env_file = Path(args[0])
+
+    LOG_SHIPPER_DIR.mkdir(parents=True, exist_ok=True)
+    PID_FILE.write_text(str(os.getpid()))
+
+    # Best-effort signal handlers. Windows lacks SIGTERM in the standard
+    # sense; signal.signal(SIGTERM, ...) works on POSIX but is a no-op or
+    # raises on Windows for some signals — guard with try/except.
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            signal.signal(sig, _handle_shutdown)
+        except (ValueError, AttributeError):
+            pass
+
+    try:
+        run_shipper(env_file)
+    finally:
+        try:
+            PID_FILE.unlink(missing_ok=True)
+        except OSError:
+            pass
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/packages/cli/src/lablink_cli/log_shipper.py
+++ b/packages/cli/src/lablink_cli/log_shipper.py
@@ -62,7 +62,11 @@ def write_last_shipped_ts(state_file: Path, ts: str) -> None:
 
 MAX_RETRIES = 3
 RETRY_BACKOFF_S = (1, 2, 4)  # sleep before retry attempt 1, 2, 3
-LOG_GROUP = "docker"
+# The allocator routes logs to the docker_logs column when log_group ends
+# with "-docker"; cloud_init otherwise (main.py:851). Manual/BYO clients
+# only ship docker container output, so use a name that satisfies the
+# suffix check.
+LOG_GROUP = "manual-docker"
 
 PostResult = Literal["ok", "drop", "fatal"]
 

--- a/packages/cli/src/lablink_cli/log_shipper.py
+++ b/packages/cli/src/lablink_cli/log_shipper.py
@@ -201,6 +201,12 @@ FIRST_ATTACH_LOOKBACK_S = 60
 CONTAINER_RESTART_WAIT_S = 5
 INSPECT_RETRY_INTERVAL_S = 30
 INSPECT_MAX_RETRIES = 5
+# After this many consecutive "exited" inspections, give up — the container
+# has stopped and docker is not restarting it, which means the user invoked
+# `docker stop`. With `--restart unless-stopped`, a crashed container goes to
+# "restarting" within ms, so consecutive "exited" reliably indicates user
+# intent rather than a transient state.
+MAX_EXITED_CONSECUTIVE = 3
 
 SELF_LOG_MAX_BYTES = 1_000_000
 
@@ -257,6 +263,7 @@ def run_shipper(
 
     # ---- Attach loop: re-runs if container restarts ----
     inspect_failures = 0
+    exited_consecutive = 0
     while True:
         if _line_iter is not None:
             line_source = _line_iter()
@@ -360,9 +367,25 @@ def run_shipper(
             _sleep(INSPECT_RETRY_INTERVAL_S)
             continue
         inspect_failures = 0
-        if status == "exited" or status == "restarting":
+        if status == "exited":
+            exited_consecutive += 1
+            if exited_consecutive >= MAX_EXITED_CONSECUTIVE:
+                self_log(
+                    SELF_LOG_FILE,
+                    f"container stayed exited for {exited_consecutive} "
+                    "consecutive checks; treating as user-initiated stop; "
+                    "exiting",
+                )
+                return
             _sleep(CONTAINER_RESTART_WAIT_S)
-        # status == "running" → reconnect immediately
+        elif status == "restarting":
+            # docker is bringing it back — don't count toward the give-up
+            # threshold, just wait and reconnect.
+            exited_consecutive = 0
+            _sleep(CONTAINER_RESTART_WAIT_S)
+        else:
+            # status == "running" → reconnect immediately
+            exited_consecutive = 0
         # update since for the reconnect so we don't re-ship
         new_since = read_last_shipped_ts(STATE_FILE)
         if new_since:

--- a/packages/cli/src/lablink_cli/tui/logs_viewer.py
+++ b/packages/cli/src/lablink_cli/tui/logs_viewer.py
@@ -116,6 +116,7 @@ class LogsApp(App):
         admin_user: str,
         admin_pw: str,
         deploy_dir: Path,
+        manual: bool = False,
     ) -> None:
         super().__init__()
         self._cfg = cfg
@@ -124,6 +125,7 @@ class LogsApp(App):
         self._admin_user = admin_user
         self._admin_pw = admin_pw
         self._deploy_dir = deploy_dir
+        self._manual = manual
         self._selected_vm: dict | None = None
         self._current_tab = "cloud_init"
         self._cached_logs: dict | None = None
@@ -280,14 +282,23 @@ class LogsApp(App):
                     ssl_provider=self._cfg.ssl.provider,
                 )
         else:
-            from lablink_cli.commands.logs import fetch_allocator_logs
+            # Manual provider's allocator is a local docker container, not
+            # an EC2 instance — bypass SSH and read `docker logs` directly.
+            if self._manual:
+                from lablink_cli.commands.logs import (
+                    fetch_manual_allocator_logs,
+                )
 
-            logs = fetch_allocator_logs(
-                instance_id=vm["instance_id"],
-                public_ip=vm.get("public_ip", "—"),
-                region=self._cfg.app.region,
-                deploy_dir=self._deploy_dir,
-            )
+                logs = fetch_manual_allocator_logs()
+            else:
+                from lablink_cli.commands.logs import fetch_allocator_logs
+
+                logs = fetch_allocator_logs(
+                    instance_id=vm["instance_id"],
+                    public_ip=vm.get("public_ip", "—"),
+                    region=self._cfg.app.region,
+                    deploy_dir=self._deploy_dir,
+                )
 
         # Guard: discard results if user selected a different VM while fetching
         if self._selected_vm is not vm:

--- a/packages/cli/src/lablink_cli/tui/logs_viewer.py
+++ b/packages/cli/src/lablink_cli/tui/logs_viewer.py
@@ -127,7 +127,9 @@ class LogsApp(App):
         self._deploy_dir = deploy_dir
         self._manual = manual
         self._selected_vm: dict | None = None
-        self._current_tab = "cloud_init"
+        # Manual provider has no cloud-init concept (BYO hosts boot
+        # themselves); default to docker and skip the cloud-init tab UI.
+        self._current_tab = "docker" if manual else "cloud_init"
         self._cached_logs: dict | None = None
 
     def compose(self) -> ComposeResult:
@@ -145,18 +147,27 @@ class LogsApp(App):
             with Vertical(id="log-panel"):
                 yield Label("Select a VM to view logs", id="vm-info")
                 with Horizontal(id="tab-bar"):
-                    yield Static(
-                        "[bold]Cloud-Init[/bold]",
-                        id="tab-cloud-init",
-                        classes="tab tab-active",
-                        markup=True,
-                    )
-                    yield Static(
-                        "Docker",
-                        id="tab-docker",
-                        classes="tab tab-inactive",
-                        markup=True,
-                    )
+                    if not self._manual:
+                        yield Static(
+                            "[bold]Cloud-Init[/bold]",
+                            id="tab-cloud-init",
+                            classes="tab tab-active",
+                            markup=True,
+                        )
+                        yield Static(
+                            "Docker",
+                            id="tab-docker",
+                            classes="tab tab-inactive",
+                            markup=True,
+                        )
+                    else:
+                        # Manual provider: only docker logs exist.
+                        yield Static(
+                            "[bold]Docker[/bold]",
+                            id="tab-docker",
+                            classes="tab tab-active",
+                            markup=True,
+                        )
                 yield RichLog(
                     id="log-output",
                     auto_scroll=True,
@@ -202,6 +213,9 @@ class LogsApp(App):
 
     def _update_tab_styles(self) -> None:
         """Update tab visual state."""
+        if self._manual:
+            # Manual mode renders only the docker tab; nothing to swap.
+            return
         cloud_init_tab = self.query_one("#tab-cloud-init", Static)
         docker_tab = self.query_one("#tab-docker", Static)
         if self._current_tab == "cloud_init":
@@ -321,6 +335,9 @@ class LogsApp(App):
 
     def action_show_cloud_init(self) -> None:
         """Switch to cloud-init log tab."""
+        if self._manual:
+            # No cloud-init for manual provider; binding is a no-op.
+            return
         self._current_tab = "cloud_init"
         self._update_tab_styles()
         self._display_logs()

--- a/packages/cli/tests/test_log_shipper.py
+++ b/packages/cli/tests/test_log_shipper.py
@@ -114,7 +114,7 @@ class TestPostBatch:
         assert req.get_header("Content-type") == "application/json"
         body = json.loads(req.data.decode())
         assert body == {
-            "log_group": "docker",
+            "log_group": "manual-docker",
             "messages": ["[start] booting", "[agent] ready"],
         }
 

--- a/packages/cli/tests/test_log_shipper.py
+++ b/packages/cli/tests/test_log_shipper.py
@@ -1,0 +1,547 @@
+"""Tests for lablink_cli.log_shipper."""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+
+class TestLoadEnv:
+    def test_parses_key_value_lines(self, tmp_path):
+        from lablink_cli.log_shipper import load_env
+
+        env_file = tmp_path / "client.env"
+        env_file.write_text(
+            "# Comment line\n"
+            "CLIENT_ID=42\n"
+            "VM_NAME=42\n"
+            "CLIENT_SECRET=s3cr3t\n"
+            "ALLOCATOR_URL=https://lablink.example.com\n"
+            "\n"
+        )
+
+        env = load_env(env_file)
+
+        assert env["CLIENT_ID"] == "42"
+        assert env["VM_NAME"] == "42"
+        assert env["CLIENT_SECRET"] == "s3cr3t"
+        assert env["ALLOCATOR_URL"] == "https://lablink.example.com"
+        assert "# Comment line" not in env
+
+    def test_missing_file_raises(self, tmp_path):
+        from lablink_cli.log_shipper import load_env
+
+        with pytest.raises(FileNotFoundError):
+            load_env(tmp_path / "nope.env")
+
+    def test_value_with_equals_sign_preserved(self, tmp_path):
+        from lablink_cli.log_shipper import load_env
+
+        env_file = tmp_path / "client.env"
+        env_file.write_text("WEIRD=a=b=c\n")
+
+        assert load_env(env_file)["WEIRD"] == "a=b=c"
+
+
+class TestStateFile:
+    def test_read_missing_returns_none(self, tmp_path):
+        from lablink_cli.log_shipper import read_last_shipped_ts
+
+        assert read_last_shipped_ts(tmp_path / "missing.state") is None
+
+    def test_round_trip(self, tmp_path):
+        from lablink_cli.log_shipper import (
+            read_last_shipped_ts,
+            write_last_shipped_ts,
+        )
+
+        state = tmp_path / "log_shipper.state"
+        write_last_shipped_ts(state, "2026-05-28T14:23:01Z")
+
+        assert read_last_shipped_ts(state) == "2026-05-28T14:23:01Z"
+
+    def test_corrupt_state_returns_none(self, tmp_path):
+        from lablink_cli.log_shipper import read_last_shipped_ts
+
+        state = tmp_path / "bad.state"
+        state.write_text("{not json")
+
+        assert read_last_shipped_ts(state) is None
+
+    def test_state_dir_created(self, tmp_path):
+        from lablink_cli.log_shipper import write_last_shipped_ts
+
+        nested = tmp_path / "subdir" / "log_shipper.state"
+        write_last_shipped_ts(nested, "2026-05-28T14:23:01Z")
+
+        assert nested.exists()
+
+
+class TestPostBatch:
+    def _args(self, **overrides):
+        base = dict(
+            allocator_url="https://lablink.example.com",
+            vm_name="42",
+            client_secret="s3cr3t",
+            messages=["[start] booting", "[agent] ready"],
+        )
+        base.update(overrides)
+        return base
+
+    def test_success_returns_ok(self):
+        from unittest.mock import MagicMock
+        from lablink_cli.log_shipper import post_batch
+
+        resp = MagicMock()
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = False
+        resp.status = 200
+        resp.read.return_value = b'{"ok": true}'
+        urlopen = MagicMock(return_value=resp)
+        sleep = MagicMock()
+
+        result = post_batch(**self._args(), urlopen=urlopen, sleep=sleep)
+
+        assert result == "ok"
+        assert urlopen.call_count == 1
+        sleep.assert_not_called()
+        # verify request shape
+        req = urlopen.call_args.args[0]
+        assert req.full_url == "https://lablink.example.com/api/vm-logs/42"
+        assert req.get_method() == "POST"
+        assert req.get_header("Authorization") == "Bearer s3cr3t"
+        assert req.get_header("Content-type") == "application/json"
+        body = json.loads(req.data.decode())
+        assert body == {
+            "log_group": "docker",
+            "messages": ["[start] booting", "[agent] ready"],
+        }
+
+    def test_retries_on_5xx_then_succeeds(self):
+        from io import BytesIO
+        from unittest.mock import MagicMock
+        from urllib.error import HTTPError
+        from lablink_cli.log_shipper import post_batch
+
+        ok_resp = MagicMock()
+        ok_resp.__enter__.return_value = ok_resp
+        ok_resp.__exit__.return_value = False
+        ok_resp.status = 200
+
+        urlopen = MagicMock(
+            side_effect=[
+                HTTPError("u", 503, "boom", {}, BytesIO(b"")),
+                HTTPError("u", 503, "boom", {}, BytesIO(b"")),
+                ok_resp,
+            ]
+        )
+        sleep = MagicMock()
+
+        result = post_batch(**self._args(), urlopen=urlopen, sleep=sleep)
+
+        assert result == "ok"
+        assert urlopen.call_count == 3
+        # backoffs: 1s before retry 1, 2s before retry 2
+        sleep.assert_any_call(1)
+        sleep.assert_any_call(2)
+
+    def test_drops_on_3_consecutive_5xx(self):
+        from io import BytesIO
+        from unittest.mock import MagicMock
+        from urllib.error import HTTPError
+        from lablink_cli.log_shipper import post_batch
+
+        urlopen = MagicMock(
+            side_effect=HTTPError("u", 503, "boom", {}, BytesIO(b""))
+        )
+        sleep = MagicMock()
+
+        result = post_batch(**self._args(), urlopen=urlopen, sleep=sleep)
+
+        assert result == "drop"
+        assert urlopen.call_count == 3  # initial + 2 retries
+
+    def test_drops_on_network_errors(self):
+        from unittest.mock import MagicMock
+        from urllib.error import URLError
+        from lablink_cli.log_shipper import post_batch
+
+        urlopen = MagicMock(side_effect=URLError("connection refused"))
+        sleep = MagicMock()
+
+        result = post_batch(**self._args(), urlopen=urlopen, sleep=sleep)
+
+        assert result == "drop"
+        assert urlopen.call_count == 3
+
+    def test_fatal_on_401(self):
+        from io import BytesIO
+        from unittest.mock import MagicMock
+        from urllib.error import HTTPError
+        from lablink_cli.log_shipper import post_batch
+
+        urlopen = MagicMock(
+            side_effect=HTTPError("u", 401, "unauthorized", {}, BytesIO(b""))
+        )
+        sleep = MagicMock()
+
+        result = post_batch(**self._args(), urlopen=urlopen, sleep=sleep)
+
+        assert result == "fatal"
+        assert urlopen.call_count == 1  # no retry on 4xx
+        sleep.assert_not_called()
+
+    def test_fatal_on_404(self):
+        from io import BytesIO
+        from unittest.mock import MagicMock
+        from urllib.error import HTTPError
+        from lablink_cli.log_shipper import post_batch
+
+        urlopen = MagicMock(
+            side_effect=HTTPError("u", 404, "not found", {}, BytesIO(b""))
+        )
+        sleep = MagicMock()
+
+        result = post_batch(**self._args(), urlopen=urlopen, sleep=sleep)
+
+        assert result == "fatal"
+        assert urlopen.call_count == 1
+
+
+class TestShouldFlush:
+    def test_empty_buffer_never_flushes(self):
+        from lablink_cli.log_shipper import should_flush
+
+        assert should_flush(buffer_len=0, elapsed_s=999) is False
+
+    def test_flushes_at_batch_size(self):
+        from lablink_cli.log_shipper import should_flush
+
+        assert should_flush(buffer_len=50, elapsed_s=0) is True
+        assert should_flush(buffer_len=49, elapsed_s=0) is False
+
+    def test_flushes_at_time_threshold(self):
+        from lablink_cli.log_shipper import should_flush
+
+        assert should_flush(buffer_len=1, elapsed_s=15) is True
+        assert should_flush(buffer_len=1, elapsed_s=14.9) is False
+
+
+class TestInspectContainer:
+    def test_running(self):
+        from unittest.mock import MagicMock, patch
+        from lablink_cli.log_shipper import inspect_container
+
+        with patch("lablink_cli.log_shipper.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="running\n", stderr=""
+            )
+            assert inspect_container("lablink-client") == "running"
+
+    def test_exited(self):
+        from unittest.mock import MagicMock, patch
+        from lablink_cli.log_shipper import inspect_container
+
+        with patch("lablink_cli.log_shipper.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="exited\n", stderr=""
+            )
+            assert inspect_container("lablink-client") == "exited"
+
+    def test_restarting(self):
+        from unittest.mock import MagicMock, patch
+        from lablink_cli.log_shipper import inspect_container
+
+        with patch("lablink_cli.log_shipper.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=0, stdout="restarting\n", stderr=""
+            )
+            assert inspect_container("lablink-client") == "restarting"
+
+    def test_missing_returns_missing(self):
+        from unittest.mock import MagicMock, patch
+        from lablink_cli.log_shipper import inspect_container
+
+        with patch("lablink_cli.log_shipper.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="Error: No such object: lablink-client\n",
+            )
+            assert inspect_container("lablink-client") == "missing"
+
+    def test_daemon_error(self):
+        from unittest.mock import MagicMock, patch
+        from lablink_cli.log_shipper import inspect_container
+
+        with patch("lablink_cli.log_shipper.subprocess.run") as mock_run:
+            mock_run.return_value = MagicMock(
+                returncode=1,
+                stdout="",
+                stderr="Cannot connect to the Docker daemon\n",
+            )
+            assert inspect_container("lablink-client") == "daemon_error"
+
+
+class TestParseDockerLine:
+    def test_strips_nanoseconds(self):
+        from lablink_cli.log_shipper import parse_docker_line
+
+        ts, msg = parse_docker_line(
+            "2026-05-28T14:23:01.123456789Z [agent] hello world"
+        )
+        assert ts == "2026-05-28T14:23:01Z"
+        assert msg == "[agent] hello world"
+
+    def test_whole_seconds_passthrough(self):
+        from lablink_cli.log_shipper import parse_docker_line
+
+        ts, msg = parse_docker_line("2026-05-28T14:23:01Z [start] boot")
+        assert ts == "2026-05-28T14:23:01Z"
+        assert msg == "[start] boot"
+
+    def test_no_timestamp_returns_none_ts(self):
+        from lablink_cli.log_shipper import parse_docker_line
+
+        ts, msg = parse_docker_line("no timestamp here")
+        assert ts is None
+        assert msg == "no timestamp here"
+
+
+class TestOpenDockerLogs:
+    def test_builds_command_with_since(self):
+        from unittest.mock import MagicMock, patch
+        from lablink_cli.log_shipper import open_docker_logs
+
+        with patch("lablink_cli.log_shipper.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock()
+            open_docker_logs("lablink-client", since="2026-05-28T14:00:00Z")
+
+        cmd = mock_popen.call_args.args[0]
+        assert cmd[:3] == ["docker", "logs", "--follow"]
+        assert "--timestamps" in cmd
+        assert "--since" in cmd
+        assert "2026-05-28T14:00:00Z" in cmd
+        assert "lablink-client" in cmd
+
+    def test_omits_since_when_none(self):
+        from unittest.mock import MagicMock, patch
+        from lablink_cli.log_shipper import open_docker_logs
+
+        with patch("lablink_cli.log_shipper.subprocess.Popen") as mock_popen:
+            mock_popen.return_value = MagicMock()
+            open_docker_logs("lablink-client", since=None)
+
+        cmd = mock_popen.call_args.args[0]
+        assert "--since" not in cmd
+
+
+class TestSelfLog:
+    def test_appends_line(self, tmp_path):
+        from lablink_cli.log_shipper import self_log
+
+        log = tmp_path / "log_shipper.log"
+        self_log(log, "first")
+        self_log(log, "second")
+
+        content = log.read_text()
+        assert "first" in content
+        assert "second" in content
+        # one line per call
+        assert content.count("\n") == 2
+
+    def test_rotates_at_size_cap(self, tmp_path):
+        from lablink_cli.log_shipper import self_log
+
+        log = tmp_path / "log_shipper.log"
+        # Pre-fill above cap
+        log.write_text("x" * 1_100_000)
+
+        self_log(log, "new line")
+
+        rotated = tmp_path / "log_shipper.log.1"
+        assert rotated.exists()
+        assert log.read_text().rstrip().endswith("new line")
+        # the rotated file holds the old content
+        assert len(rotated.read_text()) >= 1_000_000
+
+
+class TestRunShipper:
+    def _env(self, tmp_path):
+        env_file = tmp_path / "client.env"
+        env_file.write_text(
+            "CLIENT_ID=42\n"
+            "VM_NAME=42\n"
+            "CLIENT_SECRET=s3cr3t\n"
+            "ALLOCATOR_URL=https://lablink.example.com\n"
+        )
+        return env_file
+
+    def test_flushes_full_batch_then_exits_on_missing_container(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+        from lablink_cli.log_shipper import run_shipper
+
+        env_file = self._env(tmp_path)
+
+        # 50 lines → triggers batch flush
+        lines = [
+            f"2026-05-28T14:23:{i:02d}Z [start] line-{i}" for i in range(50)
+        ]
+        post_calls = []
+
+        def fake_post_batch(**kw):
+            post_calls.append(kw)
+            return "ok"
+
+        def fake_iter():
+            yield from lines
+
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.post_batch", fake_post_batch
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.inspect_container",
+            MagicMock(return_value="missing"),
+        )
+        # state_dir override so tests don't touch ~/.lablink
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.STATE_FILE",
+            tmp_path / "log_shipper.state",
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.SELF_LOG_FILE",
+            tmp_path / "log_shipper.log",
+        )
+
+        run_shipper(env_file, _line_iter=fake_iter, _sleep=lambda s: None)
+
+        assert len(post_calls) == 1
+        assert len(post_calls[0]["messages"]) == 50
+        # state updated with the timestamp of the last line in the batch
+        state = (tmp_path / "log_shipper.state").read_text()
+        assert "2026-05-28T14:23:49Z" in state
+
+    def test_exits_on_fatal_post(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+        from lablink_cli.log_shipper import run_shipper
+
+        env_file = self._env(tmp_path)
+
+        def fake_iter():
+            for i in range(50):
+                yield f"2026-05-28T14:23:{i:02d}Z [agent] x"
+
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.post_batch",
+            lambda **kw: "fatal",
+        )
+        inspect = MagicMock(return_value="running")
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.inspect_container", inspect
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.STATE_FILE",
+            tmp_path / "log_shipper.state",
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.SELF_LOG_FILE",
+            tmp_path / "log_shipper.log",
+        )
+
+        run_shipper(env_file, _line_iter=fake_iter, _sleep=lambda s: None)
+
+        log = (tmp_path / "log_shipper.log").read_text()
+        assert "fatal" in log.lower() or "exiting" in log.lower()
+
+    def test_resumes_from_last_shipped_ts(
+        self, tmp_path, monkeypatch
+    ):
+        """When a state file exists, the docker logs --since arg matches it."""
+        from unittest.mock import MagicMock
+        from lablink_cli.log_shipper import run_shipper
+
+        env_file = self._env(tmp_path)
+        state_file = tmp_path / "log_shipper.state"
+        state_file.write_text('{"last_shipped_ts": "2026-05-28T14:00:00Z"}')
+
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.STATE_FILE", state_file
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.SELF_LOG_FILE",
+            tmp_path / "log_shipper.log",
+        )
+        captured_since: list[str | None] = []
+
+        def fake_open_logs(name, *, since):
+            captured_since.append(since)
+            # Yield no lines, end immediately
+            mock = MagicMock()
+            mock.stdout = iter([])
+            mock.terminate = MagicMock()
+            mock.wait = MagicMock()
+            return mock
+
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.open_docker_logs", fake_open_logs
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.inspect_container",
+            MagicMock(return_value="missing"),
+        )
+
+        run_shipper(env_file, _sleep=lambda s: None)
+
+        assert captured_since == ["2026-05-28T14:00:00Z"]
+
+
+class TestMainEntry:
+    def test_writes_pid_file_on_start(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+        from lablink_cli import log_shipper
+
+        env_file = tmp_path / "client.env"
+        env_file.write_text(
+            "CLIENT_ID=1\nVM_NAME=1\nCLIENT_SECRET=s\n"
+            "ALLOCATOR_URL=https://x\n"
+        )
+        pid_file = tmp_path / "log_shipper.pid"
+        monkeypatch.setattr(log_shipper, "PID_FILE", pid_file)
+        monkeypatch.setattr(
+            log_shipper, "STATE_FILE", tmp_path / "log_shipper.state"
+        )
+        monkeypatch.setattr(
+            log_shipper, "SELF_LOG_FILE", tmp_path / "log_shipper.log"
+        )
+        monkeypatch.setattr(
+            log_shipper, "run_shipper", MagicMock()
+        )
+
+        log_shipper.main([str(env_file)])
+
+        # main() should have written the PID and then removed it on exit.
+        assert log_shipper.run_shipper.call_count == 1
+        # PID file cleaned up after run_shipper returns
+        assert not pid_file.exists()
+
+    def test_signal_handler_unlinks_pid_file(
+        self, tmp_path, monkeypatch
+    ):
+        import signal
+        from lablink_cli import log_shipper
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("12345")
+        monkeypatch.setattr(log_shipper, "PID_FILE", pid_file)
+        monkeypatch.setattr(
+            log_shipper, "SELF_LOG_FILE", tmp_path / "log_shipper.log"
+        )
+
+        with pytest.raises(SystemExit) as exc:
+            log_shipper._handle_shutdown(signal.SIGTERM, None)
+
+        assert exc.value.code == 0
+        assert not pid_file.exists()

--- a/packages/cli/tests/test_log_shipper.py
+++ b/packages/cli/tests/test_log_shipper.py
@@ -497,6 +497,93 @@ class TestRunShipper:
 
         assert captured_since == ["2026-05-28T14:00:00Z"]
 
+    def test_exits_after_consecutive_exited_inspections(
+        self, tmp_path, monkeypatch
+    ):
+        """`docker stop` leaves the container in 'exited' state; shipper must
+        exit rather than busy-looping. With --restart unless-stopped, a
+        crashed container reaches 'restarting' within ms, so consecutive
+        'exited' reliably means the user invoked stop."""
+        from unittest.mock import MagicMock
+        from lablink_cli.log_shipper import run_shipper, MAX_EXITED_CONSECUTIVE
+
+        env_file = self._env(tmp_path)
+
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.STATE_FILE",
+            tmp_path / "log_shipper.state",
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.SELF_LOG_FILE",
+            tmp_path / "log_shipper.log",
+        )
+
+        # Each docker-logs attach yields no lines (container is stopped).
+        def fake_open_logs(name, *, since):
+            mock = MagicMock()
+            mock.stdout = iter([])
+            return mock
+
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.open_docker_logs", fake_open_logs
+        )
+        inspect = MagicMock(return_value="exited")
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.inspect_container", inspect
+        )
+
+        run_shipper(env_file, _sleep=lambda s: None)
+
+        # Should give up after MAX_EXITED_CONSECUTIVE inspections — not loop
+        # forever. Pre-fix this test would hang indefinitely.
+        assert inspect.call_count == MAX_EXITED_CONSECUTIVE
+
+    def test_restarting_resets_exited_counter(
+        self, tmp_path, monkeypatch
+    ):
+        """If docker restarts the container (crash + --restart unless-stopped),
+        the 'restarting' status should reset the exited counter so the shipper
+        doesn't accumulate exits across reconnects and prematurely give up."""
+        from unittest.mock import MagicMock
+        from lablink_cli.log_shipper import run_shipper, MAX_EXITED_CONSECUTIVE
+
+        env_file = self._env(tmp_path)
+
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.STATE_FILE",
+            tmp_path / "log_shipper.state",
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.SELF_LOG_FILE",
+            tmp_path / "log_shipper.log",
+        )
+
+        def fake_open_logs(name, *, since):
+            mock = MagicMock()
+            mock.stdout = iter([])
+            return mock
+
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.open_docker_logs", fake_open_logs
+        )
+        # Alternate: exited, restarting, exited, restarting, ..., then a run
+        # of exited that should trigger the give-up. The intervening
+        # "restarting" results should keep resetting the counter.
+        sequence = (
+            ["exited", "restarting"] * (MAX_EXITED_CONSECUTIVE + 2)
+            + ["exited"] * MAX_EXITED_CONSECUTIVE
+        )
+        inspect = MagicMock(side_effect=sequence)
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.inspect_container", inspect
+        )
+
+        run_shipper(env_file, _sleep=lambda s: None)
+
+        # Total inspections = alternating prefix + N trailing exited.
+        expected = 2 * (MAX_EXITED_CONSECUTIVE + 2) + MAX_EXITED_CONSECUTIVE
+        assert inspect.call_count == expected
+
 
 class TestMainEntry:
     def test_writes_pid_file_on_start(self, tmp_path, monkeypatch):

--- a/packages/cli/tests/test_logs.py
+++ b/packages/cli/tests/test_logs.py
@@ -117,42 +117,213 @@ class TestSshViaPrivateKey:
 
 
 # ------------------------------------------------------------------
-# Manual-provider logs
+# fetch_manual_allocator_logs — local docker container
 # ------------------------------------------------------------------
-class TestManualLogs:
-    @patch("lablink_cli.commands.logs.subprocess.Popen")
-    def test_manual_tails_docker_logs(self, mock_popen, mock_cfg):
-        from lablink_cli.commands.logs import run_logs
+class TestFetchManualAllocatorLogs:
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    def test_success_returns_docker_logs(self, mock_run):
+        from lablink_cli.commands.logs import fetch_manual_allocator_logs
 
-        mock_cfg.provider = "manual"
-        mock_cfg.deployment_name = "testlab"
-        proc = MagicMock()
-        proc.stdout = iter([])
-        mock_popen.return_value.__enter__.return_value = proc
+        mock_run.return_value = MagicMock(
+            returncode=0, stdout="line 1\nline 2\n", stderr=""
+        )
 
-        run_logs(mock_cfg)
+        result = fetch_manual_allocator_logs()
 
-        assert mock_popen.called
-        cmd = mock_popen.call_args[0][0]
-        assert "docker" in cmd[0]
-        assert "logs" in cmd
-        assert "-f" in cmd
+        assert result["error"] is None
+        assert result["cloud_init_logs"] is None
+        assert result["docker_logs"] == "line 1\nline 2"
+        # Calls `docker logs --tail N lablink-allocator`.
+        cmd = mock_run.call_args.args[0]
+        assert cmd[:2] == ["docker", "logs"]
+        assert "--tail" in cmd
         assert "lablink-allocator" in cmd
 
-    @patch("lablink_cli.commands.logs.subprocess.Popen")
-    def test_manual_does_not_use_ssh_or_deploy_dir(
-        self, mock_popen, mock_cfg,
-    ):
-        """Manual provider must not touch Terraform deploy dir or SSH."""
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    def test_no_such_container_returns_friendly_error(self, mock_run):
+        from lablink_cli.commands.logs import fetch_manual_allocator_logs
+
+        mock_run.return_value = MagicMock(
+            returncode=1,
+            stdout="",
+            stderr="Error: No such container: lablink-allocator\n",
+        )
+
+        result = fetch_manual_allocator_logs()
+
+        assert result["docker_logs"] is None
+        assert "lablink-allocator container is not running" in result["error"]
+
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    def test_other_nonzero_returns_stderr(self, mock_run):
+        from lablink_cli.commands.logs import fetch_manual_allocator_logs
+
+        mock_run.return_value = MagicMock(
+            returncode=2, stdout="", stderr="permission denied\n"
+        )
+
+        result = fetch_manual_allocator_logs()
+
+        assert result["docker_logs"] is None
+        assert "permission denied" in result["error"]
+
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    def test_docker_missing_returns_error(self, mock_run):
+        from lablink_cli.commands.logs import fetch_manual_allocator_logs
+
+        mock_run.side_effect = FileNotFoundError("docker")
+
+        result = fetch_manual_allocator_logs()
+
+        assert result["docker_logs"] is None
+        assert "docker logs failed" in result["error"]
+
+    @patch("lablink_cli.commands.logs.subprocess.run")
+    def test_merges_stdout_and_stderr(self, mock_run):
+        """Container can write to both stdout and stderr; the TUI shows one
+        chronological view."""
+        from lablink_cli.commands.logs import fetch_manual_allocator_logs
+
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout="[info] up\n",
+            stderr="[warn] slow query\n",
+        )
+
+        result = fetch_manual_allocator_logs()
+
+        assert "up" in result["docker_logs"]
+        assert "slow query" in result["docker_logs"]
+
+
+# ------------------------------------------------------------------
+# Manual-provider TUI launcher (_run_logs_manual)
+# ------------------------------------------------------------------
+class TestRunLogsManualTui:
+    def _patch_common(self):
+        """Patches shared by every test in this class."""
+        return [
+            patch("lablink_cli.commands.status._resolve_manual_admin_credentials"),
+            patch("lablink_cli.commands.status._fetch_registered_clients"),
+            patch("lablink_cli.tui.logs_viewer.LogsApp"),
+        ]
+
+    def test_launches_tui_with_allocator_and_clients(self, mock_cfg):
         from lablink_cli.commands.logs import run_logs
 
         mock_cfg.provider = "manual"
         mock_cfg.deployment_name = "testlab"
-        proc = MagicMock()
-        proc.stdout = iter([])
-        mock_popen.return_value.__enter__.return_value = proc
 
         with patch(
+            "lablink_cli.commands.status._resolve_manual_admin_credentials",
+            return_value=("admin", "pw"),
+        ), patch(
+            "lablink_cli.commands.status._fetch_registered_clients",
+            return_value=([
+                {"hostname": "byo-01", "lan_ip": "192.168.1.10"},
+                {"hostname": "byo-02", "lan_ip": "192.168.1.11"},
+            ], ""),
+        ), patch(
+            "lablink_cli.tui.logs_viewer.LogsApp"
+        ) as mock_app_cls:
+            mock_app_cls.return_value = MagicMock()
+
+            run_logs(mock_cfg)
+
+        # LogsApp invoked with manual=True and a VM list containing
+        # allocator + both clients.
+        kwargs = mock_app_cls.call_args.kwargs
+        assert kwargs["manual"] is True
+        names = [vm["name"] for vm in kwargs["vms"]]
+        assert names[0] == "lablink-allocator"
+        assert "byo-01" in names
+        assert "byo-02" in names
+        # Allocator gets vm_type="allocator"; clients get vm_type="client".
+        types = {vm["name"]: vm["vm_type"] for vm in kwargs["vms"]}
+        assert types["lablink-allocator"] == "allocator"
+        assert types["byo-01"] == "client"
+        # Every VM dict must carry the keys VMListItem reads: vm_type, name,
+        # state. Missing state crashes the TUI at compose time.
+        required_keys = {"vm_type", "name", "state", "type", "public_ip"}
+        for vm in kwargs["vms"]:
+            assert required_keys.issubset(vm.keys()), (
+                f"VM dict missing keys: {required_keys - vm.keys()}"
+            )
+
+    def test_no_clients_still_shows_allocator(self, mock_cfg):
+        from lablink_cli.commands.logs import run_logs
+
+        mock_cfg.provider = "manual"
+        mock_cfg.deployment_name = "testlab"
+
+        with patch(
+            "lablink_cli.commands.status._resolve_manual_admin_credentials",
+            return_value=("admin", "pw"),
+        ), patch(
+            "lablink_cli.commands.status._fetch_registered_clients",
+            return_value=([], ""),
+        ), patch(
+            "lablink_cli.tui.logs_viewer.LogsApp"
+        ) as mock_app_cls:
+            mock_app_cls.return_value = MagicMock()
+
+            run_logs(mock_cfg)
+
+        vms = mock_app_cls.call_args.kwargs["vms"]
+        assert len(vms) == 1
+        assert vms[0]["name"] == "lablink-allocator"
+
+    def test_missing_creds_exits_with_helpful_message(self, mock_cfg):
+        import pytest
+        from lablink_cli.commands.logs import run_logs
+
+        mock_cfg.provider = "manual"
+        mock_cfg.deployment_name = "testlab"
+
+        with patch(
+            "lablink_cli.commands.status._resolve_manual_admin_credentials",
+            return_value=None,
+        ):
+            with pytest.raises(SystemExit) as exc:
+                run_logs(mock_cfg)
+
+        assert exc.value.code == 1
+
+    def test_fetch_clients_failure_exits(self, mock_cfg):
+        import pytest
+        from lablink_cli.commands.logs import run_logs
+
+        mock_cfg.provider = "manual"
+        mock_cfg.deployment_name = "testlab"
+
+        with patch(
+            "lablink_cli.commands.status._resolve_manual_admin_credentials",
+            return_value=("admin", "pw"),
+        ), patch(
+            "lablink_cli.commands.status._fetch_registered_clients",
+            return_value=(None, "connection refused"),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                run_logs(mock_cfg)
+
+        assert exc.value.code == 1
+
+    def test_does_not_touch_aws_paths(self, mock_cfg):
+        """Manual provider must not call list_all_vms, get_deploy_dir, etc."""
+        from lablink_cli.commands.logs import run_logs
+
+        mock_cfg.provider = "manual"
+        mock_cfg.deployment_name = "testlab"
+
+        with patch(
+            "lablink_cli.commands.status._resolve_manual_admin_credentials",
+            return_value=("admin", "pw"),
+        ), patch(
+            "lablink_cli.commands.status._fetch_registered_clients",
+            return_value=([], ""),
+        ), patch(
+            "lablink_cli.tui.logs_viewer.LogsApp"
+        ), patch(
             "lablink_cli.commands.logs.get_deploy_dir"
         ) as mock_deploy_dir, patch(
             "lablink_cli.commands.logs.list_all_vms"
@@ -161,24 +332,3 @@ class TestManualLogs:
 
         mock_deploy_dir.assert_not_called()
         mock_list_vms.assert_not_called()
-
-    @patch("lablink_cli.commands.logs.subprocess.Popen")
-    def test_manual_handles_keyboard_interrupt(self, mock_popen, mock_cfg):
-        """KeyboardInterrupt during tail should terminate the subprocess."""
-        from lablink_cli.commands.logs import run_logs
-
-        mock_cfg.provider = "manual"
-        mock_cfg.deployment_name = "testlab"
-
-        proc = MagicMock()
-
-        def _raise_kbi():
-            raise KeyboardInterrupt()
-            yield  # pragma: no cover
-
-        proc.stdout = _raise_kbi()
-        mock_popen.return_value.__enter__.return_value = proc
-
-        # Should not propagate KeyboardInterrupt.
-        run_logs(mock_cfg)
-        proc.terminate.assert_called_once()

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -642,10 +642,18 @@ class TestErrorMapping:
 class TestStartLogShipper:
     @patch("lablink_cli.commands.register.subprocess.Popen")
     def test_spawns_detached_python_module(
-        self, mock_popen, tmp_path
+        self, mock_popen, tmp_path, monkeypatch
     ):
         from lablink_cli.commands.register import _start_log_shipper
         from rich.console import Console
+
+        # Point PID_FILE at tmp_path so _stop_existing_shipper doesn't
+        # touch the real ~/.lablink/log_shipper.pid (would otherwise risk
+        # terminating a live shipper on the developer's machine).
+        monkeypatch.setattr(
+            "lablink_cli.commands.register.PID_FILE",
+            tmp_path / "log_shipper.pid",
+        )
 
         env_file = tmp_path / "client.env"
         env_file.write_text("CLIENT_ID=1\n")
@@ -667,6 +675,159 @@ class TestStartLogShipper:
         )
         # stdin closed; stdout/stderr to log file
         assert kwargs.get("stdin") is not None  # DEVNULL
+
+    @patch("lablink_cli.commands.register._stop_existing_shipper")
+    @patch("lablink_cli.commands.register.subprocess.Popen")
+    def test_terminates_existing_shipper_before_spawn(
+        self, mock_popen, mock_stop, tmp_path
+    ):
+        """Guarantees there is no overlap between old and new shippers
+        (which would POST duplicates under --force re-register)."""
+        from lablink_cli.commands.register import _start_log_shipper
+        from rich.console import Console
+
+        env_file = tmp_path / "client.env"
+        env_file.write_text("CLIENT_ID=1\n")
+        mock_popen.return_value = MagicMock(pid=99999)
+
+        _start_log_shipper(env_file, Console())
+
+        # _stop_existing_shipper must be called before Popen.
+        assert mock_stop.called
+        # Ordering check: Popen happens after the stop.
+        stop_call_order = mock_stop.mock_calls[0]
+        popen_call_order = mock_popen.mock_calls[0]
+        # Both fire once; just confirm both are present (call ordering
+        # within a single sync function is guaranteed by source order).
+        assert stop_call_order is not None
+        assert popen_call_order is not None
+
+
+class TestStopExistingShipper:
+    """Covers `_stop_existing_shipper` — the kill-old-shipper step that
+    prevents double-shipper duplicate POSTs during --force re-register."""
+
+    def _fake_psutil(self, monkeypatch, process_factory):
+        """Install a fake psutil module whose `Process()` returns whatever
+        process_factory() yields. Exceptions are re-exported as classes so
+        ``except psutil.NoSuchProcess`` works in the SUT."""
+        from unittest.mock import MagicMock
+        from lablink_cli.commands import register
+
+        fake = MagicMock()
+        fake.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+        fake.AccessDenied = type("AccessDenied", (Exception,), {})
+        fake.TimeoutExpired = type("TimeoutExpired", (Exception,), {})
+        fake.Process.side_effect = process_factory
+        monkeypatch.setattr(register, "psutil", fake)
+        return fake
+
+    def test_no_pid_file_is_noop(self, tmp_path, monkeypatch):
+        from lablink_cli.commands import register
+        from rich.console import Console
+
+        pid_file = tmp_path / "log_shipper.pid"
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        # Should not raise; should not touch psutil at all.
+        register._stop_existing_shipper(Console())
+
+    def test_terminates_matching_shipper(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+        from lablink_cli.commands import register
+        from rich.console import Console
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("12345")
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        fake_proc = MagicMock()
+        fake_proc.cmdline.return_value = [
+            "/usr/bin/python", "-m",
+            "lablink_cli.log_shipper", "/x/client.env",
+        ]
+        self._fake_psutil(monkeypatch, lambda _pid: fake_proc)
+
+        register._stop_existing_shipper(Console())
+
+        fake_proc.terminate.assert_called_once()
+        fake_proc.wait.assert_called_once()
+        # PID file cleared so a stale entry never confuses the next run.
+        assert not pid_file.exists()
+
+    def test_escalates_to_kill_on_timeout(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+        from lablink_cli.commands import register
+        from rich.console import Console
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("12345")
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        fake_proc = MagicMock()
+        fake_proc.cmdline.return_value = [
+            "python", "-m", "lablink_cli.log_shipper", "/x"
+        ]
+        fake = self._fake_psutil(monkeypatch, lambda _pid: fake_proc)
+        # SIGTERM didn't take — wait() raises TimeoutExpired.
+        fake_proc.wait.side_effect = fake.TimeoutExpired()
+
+        register._stop_existing_shipper(Console())
+
+        fake_proc.terminate.assert_called_once()
+        fake_proc.kill.assert_called_once()
+        # PID file still cleaned up after SIGKILL (handler never ran).
+        assert not pid_file.exists()
+
+    def test_does_not_kill_unrelated_pid(self, tmp_path, monkeypatch):
+        """PID file points at a real but unrelated process (e.g. PID reuse
+        after reboot). Cmdline guard must protect it."""
+        from unittest.mock import MagicMock
+        from lablink_cli.commands import register
+        from rich.console import Console
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("12345")
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        fake_proc = MagicMock()
+        fake_proc.cmdline.return_value = ["/usr/bin/vim", "notes.txt"]
+        self._fake_psutil(monkeypatch, lambda _pid: fake_proc)
+
+        register._stop_existing_shipper(Console())
+
+        fake_proc.terminate.assert_not_called()
+        fake_proc.kill.assert_not_called()
+        # Stale PID file dropped so we don't keep skipping forever.
+        assert not pid_file.exists()
+
+    def test_stale_pid_removes_file_silently(self, tmp_path, monkeypatch):
+        """PID file references a PID that no longer exists."""
+        from lablink_cli.commands import register
+        from rich.console import Console
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("99999")
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        fake = self._fake_psutil(monkeypatch, None)
+        fake.Process.side_effect = fake.NoSuchProcess()
+
+        register._stop_existing_shipper(Console())
+
+        assert not pid_file.exists()
+
+    def test_corrupt_pid_file_removed(self, tmp_path, monkeypatch):
+        from lablink_cli.commands import register
+        from rich.console import Console
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("not-a-number")
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        register._stop_existing_shipper(Console())
+
+        assert not pid_file.exists()
 
 
 class TestShipperAlive:

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -43,25 +43,126 @@ def _kwargs(env_file, **overrides):
     return base
 
 
-class TestIdempotencyGuard:
-    def test_aborts_if_env_file_exists_without_force(
-        self, tmp_env_file
+class TestResumePath:
+    @patch("lablink_cli.commands.register._start_log_shipper")
+    @patch("lablink_cli.commands.register.inspect_container_for_register")
+    @patch("lablink_cli.commands.register._shipper_alive")
+    @patch("lablink_cli.commands.register.subprocess.run")
+    def test_everything_running_is_noop(
+        self, mock_run, mock_alive, mock_inspect, mock_spawn, tmp_env_file
     ):
         from lablink_cli.commands.register import run_register
-        tmp_env_file.write_text("CLIENT_ID=99\n")
-        with pytest.raises(SystemExit) as exc:
-            run_register(**_kwargs(tmp_env_file))
-        assert exc.value.code != 0
+        tmp_env_file.write_text("CLIENT_ID=42\nCLIENT_SECRET=s\n")
+        mock_inspect.return_value = "running"
+        mock_alive.return_value = True
+
+        run_register(**_kwargs(tmp_env_file))
+
+        # Should NOT start a new container, NOT spawn a new shipper.
+        mock_spawn.assert_not_called()
+        # And should NOT do a fresh `docker run`.
+        run_cmds = [
+            c for call in mock_run.call_args_list
+            for c in [call.args[0]]
+            if "run" in c and "--env-file" in c
+        ]
+        assert run_cmds == []
+
+    @patch("lablink_cli.commands.register._start_log_shipper")
+    @patch("lablink_cli.commands.register.inspect_container_for_register")
+    @patch("lablink_cli.commands.register._shipper_alive")
+    @patch("lablink_cli.commands.register.subprocess.run")
+    def test_dead_shipper_revived_no_re_register(
+        self, mock_run, mock_alive, mock_inspect, mock_spawn, tmp_env_file
+    ):
+        from lablink_cli.commands.register import run_register
+        tmp_env_file.write_text("CLIENT_ID=42\nCLIENT_SECRET=s\n")
+        mock_inspect.return_value = "running"
+        mock_alive.return_value = False
+
+        run_register(**_kwargs(tmp_env_file))
+
+        mock_spawn.assert_called_once()
+        # The secret didn't change — env file content untouched.
+        assert "CLIENT_SECRET=s" in tmp_env_file.read_text()
+
+    @patch("lablink_cli.commands.register._start_log_shipper")
+    @patch("lablink_cli.commands.register.inspect_container_for_register")
+    @patch("lablink_cli.commands.register._shipper_alive")
+    @patch("lablink_cli.commands.register.subprocess.run")
+    def test_exited_container_restarted(
+        self, mock_run, mock_alive, mock_inspect, mock_spawn, tmp_env_file
+    ):
+        from lablink_cli.commands.register import run_register
+        tmp_env_file.write_text("CLIENT_ID=42\nCLIENT_SECRET=s\n")
+        mock_inspect.return_value = "exited"
+        mock_alive.return_value = False
+        mock_run.return_value = MagicMock(returncode=0)
+
+        run_register(**_kwargs(tmp_env_file))
+
+        # docker start lablink-client invoked
+        start_cmds = [
+            c for call in mock_run.call_args_list
+            for c in [call.args[0]]
+            if c[:3] == ["docker", "start", "lablink-client"]
+        ]
+        assert start_cmds, (
+            f"expected `docker start lablink-client` in {mock_run.call_args_list}"
+        )
+        mock_spawn.assert_called_once()
+
+    def test_force_still_re_registers(
+        self, tmp_env_file, successful_response,
+    ):
+        """--force must still mint a new secret (NOT enter resume path)."""
+        from unittest.mock import patch
+        from lablink_cli.commands.register import run_register
+        tmp_env_file.write_text("CLIENT_ID=42\nCLIENT_SECRET=old\n")
+
+        with patch(
+            "lablink_cli.commands.register.RegistrationClient"
+        ) as mock_client_cls, patch(
+            "lablink_cli.commands.register.byo_detect"
+        ) as mock_detect, patch(
+            "lablink_cli.commands.register.shutil.which",
+            return_value="/usr/bin/docker",
+        ), patch(
+            "lablink_cli.commands.register.subprocess.run"
+        ) as mock_run, patch(
+            "lablink_cli.commands.register.subprocess.Popen"
+        ):
+            mock_detect.detect_hostname.return_value = "byo-01"
+            mock_detect.detect_lan_ip.return_value = "192.168.1.42"
+            mock_detect.resolve_machine_identity.return_value = "mid"
+            mock_detect.detect_gpu.return_value = (False, None)
+            client = MagicMock()
+            client.register.return_value = successful_response
+            mock_client_cls.return_value = client
+            mock_run.return_value = MagicMock(returncode=0, stdout="cgroupfs\n")
+
+            run_register(**_kwargs(tmp_env_file, force=True))
+
+            # A real `docker run` happened (not just `docker start`).
+            run_cmds = [
+                c for call in mock_run.call_args_list
+                for c in [call.args[0]]
+                if "run" in c and "--env-file" in c
+            ]
+            assert run_cmds, "expected `docker run` to be invoked under --force"
+            # Env file was overwritten with the new secret.
+            assert "CLIENT_SECRET=s" in tmp_env_file.read_text()
 
 
 class TestSuccessFlow:
+    @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
     @patch("lablink_cli.commands.register.RegistrationClient")
     @patch("lablink_cli.commands.register.byo_detect")
     def test_full_success_writes_env_file_and_execs_docker(
         self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
-        tmp_env_file, successful_response,
+        mock_popen, tmp_env_file, successful_response,
     ):
         from lablink_cli.commands.register import run_register
         mock_detect.detect_hostname.return_value = "byo-01"
@@ -122,13 +223,20 @@ class TestSuccessFlow:
         assert cmd[pull_idx + 1] == "always"
         assert "ghcr.io/talmolab/lablink-client:0.4.0" in cmd
 
+        # Log shipper spawned exactly once with the env file
+        assert mock_popen.call_count == 1
+        shipper_cmd = mock_popen.call_args.args[0]
+        assert "lablink_cli.log_shipper" in shipper_cmd
+        assert str(tmp_env_file) in shipper_cmd
+
+    @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
     @patch("lablink_cli.commands.register.RegistrationClient")
     @patch("lablink_cli.commands.register.byo_detect")
     def test_user_overrides_beat_detection(
         self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
-        tmp_env_file, successful_response,
+        mock_popen, tmp_env_file, successful_response,
     ):
         from lablink_cli.commands.register import run_register
         mock_detect.detect_hostname.return_value = "auto-host"
@@ -176,13 +284,14 @@ class TestSuccessFlow:
         with pytest.raises(SystemExit):
             run_register(**_kwargs(tmp_env_file))
 
+    @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
     @patch("lablink_cli.commands.register.RegistrationClient")
     @patch("lablink_cli.commands.register.byo_detect")
     def test_gpu_present_override_keeps_detected_model(
         self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
-        tmp_env_file, successful_response,
+        mock_popen, tmp_env_file, successful_response,
     ):
         """User passes --gpu-present (no --gpu-model); detection still provides
         the model. Fixes a previous gap where this combination dropped the model."""
@@ -210,13 +319,14 @@ class TestSuccessFlow:
             gpu_model="NVIDIA A100",  # detection-supplied fallback
         )
 
+    @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
     @patch("lablink_cli.commands.register.RegistrationClient")
     @patch("lablink_cli.commands.register.byo_detect")
     def test_gpu_model_override_wins_over_detection(
         self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
-        tmp_env_file, successful_response,
+        mock_popen, tmp_env_file, successful_response,
     ):
         from lablink_cli.commands.register import run_register
         mock_detect.detect_hostname.return_value = "h"
@@ -243,13 +353,14 @@ class TestSuccessFlow:
             gpu_model="USER_PROVIDED",
         )
 
+    @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
     @patch("lablink_cli.commands.register.RegistrationClient")
     @patch("lablink_cli.commands.register.byo_detect")
     def test_publishes_agent_and_kasmvnc_ports_not_network_host(
         self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
-        tmp_env_file, successful_response,
+        mock_popen, tmp_env_file, successful_response,
     ):
         """The allocator reaches the BYO client over the LAN at
         ``<lan_ip>:7070`` (agent) and proxies KasmVNC over ``:6080``.
@@ -350,13 +461,14 @@ class TestGpuRuntimePreflight:
             f"got {all_cmds}"
         )
 
+    @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
     @patch("lablink_cli.commands.register.RegistrationClient")
     @patch("lablink_cli.commands.register.byo_detect")
     def test_skips_cgroup_check_when_gpu_absent(
         self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
-        tmp_env_file, successful_response,
+        mock_popen, tmp_env_file, successful_response,
     ):
         """CPU-only BYO clients don't need GPU runtime — never query
         docker info, never block on cgroup driver. Even if the host is
@@ -439,13 +551,14 @@ class TestDockerMissing:
 
 
 class TestForceFlag:
+    @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
     @patch("lablink_cli.commands.register.RegistrationClient")
     @patch("lablink_cli.commands.register.byo_detect")
     def test_force_overwrites_env_file(
         self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
-        tmp_env_file, successful_response,
+        mock_popen, tmp_env_file, successful_response,
     ):
         from lablink_cli.commands.register import run_register
         tmp_env_file.write_text("CLIENT_ID=99\n")  # stale
@@ -464,13 +577,14 @@ class TestForceFlag:
         assert "CLIENT_ID=42" in tmp_env_file.read_text()
         assert "CLIENT_ID=99" not in tmp_env_file.read_text()
 
+    @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
     @patch("lablink_cli.commands.register.RegistrationClient")
     @patch("lablink_cli.commands.register.byo_detect")
     def test_force_removes_existing_container_before_run(
         self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
-        tmp_env_file, successful_response,
+        mock_popen, tmp_env_file, successful_response,
     ):
         """With --force, the orchestrator must `docker rm -f` the old container
         before `docker run`, otherwise the new run hits a name collision."""
@@ -523,3 +637,111 @@ class TestErrorMapping:
         assert exc.value.code != 0
         # env file NOT created on failed register
         assert not tmp_env_file.exists()
+
+
+class TestStartLogShipper:
+    @patch("lablink_cli.commands.register.subprocess.Popen")
+    def test_spawns_detached_python_module(
+        self, mock_popen, tmp_path
+    ):
+        from lablink_cli.commands.register import _start_log_shipper
+        from rich.console import Console
+
+        env_file = tmp_path / "client.env"
+        env_file.write_text("CLIENT_ID=1\n")
+        mock_popen.return_value = MagicMock(pid=99999)
+
+        _start_log_shipper(env_file, Console())
+
+        assert mock_popen.call_count == 1
+        cmd = mock_popen.call_args.args[0]
+        # invoked as: python -m lablink_cli.log_shipper <env_file>
+        assert cmd[0].endswith("python") or "python" in cmd[0]
+        assert "-m" in cmd
+        assert "lablink_cli.log_shipper" in cmd
+        assert str(env_file) in cmd
+        # detached: start_new_session on POSIX OR Windows creationflags
+        kwargs = mock_popen.call_args.kwargs
+        assert kwargs.get("start_new_session") is True or (
+            kwargs.get("creationflags", 0) != 0
+        )
+        # stdin closed; stdout/stderr to log file
+        assert kwargs.get("stdin") is not None  # DEVNULL
+
+
+class TestShipperAlive:
+    def test_no_pid_file_returns_false(self, tmp_path, monkeypatch):
+        from lablink_cli.commands import register
+
+        pid_file = tmp_path / "log_shipper.pid"
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        assert register._shipper_alive() is False
+
+    def test_pid_with_matching_cmdline_returns_true(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+        from lablink_cli.commands import register
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("12345")
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        fake_proc = MagicMock()
+        fake_proc.cmdline.return_value = [
+            "/usr/bin/python", "-m",
+            "lablink_cli.log_shipper", "/home/u/.lablink/client.env",
+        ]
+        fake_psutil = MagicMock()
+        fake_psutil.Process.return_value = fake_proc
+        fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+        fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+        monkeypatch.setattr(register, "psutil", fake_psutil)
+
+        assert register._shipper_alive() is True
+
+    def test_pid_with_wrong_cmdline_returns_false(
+        self, tmp_path, monkeypatch
+    ):
+        from unittest.mock import MagicMock
+        from lablink_cli.commands import register
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("12345")
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        fake_proc = MagicMock()
+        fake_proc.cmdline.return_value = ["/usr/bin/vim"]
+        fake_psutil = MagicMock()
+        fake_psutil.Process.return_value = fake_proc
+        fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+        fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+        monkeypatch.setattr(register, "psutil", fake_psutil)
+
+        assert register._shipper_alive() is False
+
+    def test_dead_pid_returns_false(self, tmp_path, monkeypatch):
+        from unittest.mock import MagicMock
+        from lablink_cli.commands import register
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("12345")
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        fake_psutil = MagicMock()
+        fake_psutil.NoSuchProcess = type("NoSuchProcess", (Exception,), {})
+        fake_psutil.AccessDenied = type("AccessDenied", (Exception,), {})
+        fake_psutil.Process.side_effect = fake_psutil.NoSuchProcess()
+        monkeypatch.setattr(register, "psutil", fake_psutil)
+
+        assert register._shipper_alive() is False
+
+    def test_corrupt_pid_file_returns_false(self, tmp_path, monkeypatch):
+        from lablink_cli.commands import register
+
+        pid_file = tmp_path / "log_shipper.pid"
+        pid_file.write_text("not-a-number")
+        monkeypatch.setattr(register, "PID_FILE", pid_file)
+
+        assert register._shipper_alive() is False

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -683,6 +683,7 @@ class TestStartLogShipper:
     ):
         """Guarantees there is no overlap between old and new shippers
         (which would POST duplicates under --force re-register)."""
+        from unittest.mock import Mock
         from lablink_cli.commands.register import _start_log_shipper
         from rich.console import Console
 
@@ -690,17 +691,19 @@ class TestStartLogShipper:
         env_file.write_text("CLIENT_ID=1\n")
         mock_popen.return_value = MagicMock(pid=99999)
 
+        # Attach both mocks to a parent so we get a single ordered call
+        # log. Asserting the call names appear in source order catches a
+        # future refactor that moves Popen above _stop_existing_shipper.
+        parent = Mock()
+        parent.attach_mock(mock_stop, "stop")
+        parent.attach_mock(mock_popen, "popen")
+
         _start_log_shipper(env_file, Console())
 
-        # _stop_existing_shipper must be called before Popen.
-        assert mock_stop.called
-        # Ordering check: Popen happens after the stop.
-        stop_call_order = mock_stop.mock_calls[0]
-        popen_call_order = mock_popen.mock_calls[0]
-        # Both fire once; just confirm both are present (call ordering
-        # within a single sync function is guaranteed by source order).
-        assert stop_call_order is not None
-        assert popen_call_order is not None
+        call_names = [c[0] for c in parent.mock_calls]
+        assert call_names == ["stop", "popen"], (
+            f"expected stop -> popen, got {call_names}"
+        )
 
 
 class TestStopExistingShipper:


### PR DESCRIPTION
## Summary
- Adds a Python log shipper to `lablink_cli` that batches `docker logs --follow lablink-client` output and POSTs to the existing `/api/vm-logs/<hostname>` endpoint, closing the gap left after PR D2 where manual BYO clients registered but never shipped logs back.
- `lablink register` now auto-spawns the shipper on success and becomes idempotent on re-run (resume after reboot without minting a new `client_secret`).
- `lablink logs` now works for the manual provider: the TUI lists the local allocator container plus every registered BYO client, fetching allocator logs via local `docker logs` and client logs via `/api/vm-logs/<hostname>`.
- Allocator's instance-logs page and the CLI TUI both hide the cloud-init tab when the provider isn't AWS (manual/BYO hosts have no cloud-init).
- No allocator-side schema or contract changes — the endpoint, auth (`Bearer client_secret`), and `docker_logs` storage column are reused exactly as managed/Terraform VMs use them.

## Changes Made

**New module** `packages/cli/src/lablink_cli/log_shipper.py`:
- `load_env` parses `~/.lablink/client.env`.
- `read_last_shipped_ts` / `write_last_shipped_ts` track progress in `~/.lablink/log_shipper.state` so reconnects use `docker logs --since` and avoid both gaps and duplicates.
- `post_batch` POSTs to `/api/vm-logs/<vm_name>` with three outcomes — `ok` (2xx), `drop` (3× retry of 5xx/network failure), `fatal` (4xx → exit). Uses stdlib `urllib` to match the existing `api.py` pattern.
- `LOG_GROUP = "manual-docker"` — the allocator routes a request to the `docker_logs` column only when `log_group` ends with `-docker` (otherwise it falls through to `cloud_init`); the suffix is required for manual BYO output to land in the right column.
- `should_flush` triggers at 50 lines or 15 s, mirroring the managed VM's `log_shipper.sh`.
- `inspect_container` wraps `docker inspect` into a coarse status (`running` / `restarting` / `exited` / `missing` / `daemon_error`).
- `open_docker_logs` + `parse_docker_line` spawn `docker logs --follow --timestamps` and strip RFC3339Nano fractional seconds to whole seconds (matches `log_shipper.sh:101`).
- `self_log` writes diagnostics to `~/.lablink/log_shipper.log` with 1 MB rotation.
- `run_shipper` is the main loop: load env → resume from state → attach → batch → POST → handle container restart/exit. A consecutive-`exited` counter (3 inspections / ~15 s) exits cleanly on `docker stop` instead of busy-looping; `restarting`/`running` reset the counter, so a crash that docker is recovering from still keeps the shipper alive.
- `__main__` entry writes PID, installs SIGTERM/SIGINT handlers (Windows-safe), cleans up on exit.

**`packages/cli/src/lablink_cli/commands/register.py`**:
- `_start_log_shipper(env_file, console)` spawns the shipper detached — `start_new_session=True` on POSIX, `DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` on Windows.
- `_shipper_alive()` checks PID file with a `psutil` cmdline guard (PID-only check would false-positive after PID reuse on reboot).
- `_resume(env_file, console)` handles re-runs without `--force`: inspects container, restarts if `exited`/`restarting`, revives shipper if dead. Errors clearly if container is `missing` (needs `--force` to recreate). Image is NOT re-pulled — that's `--force` territory.
- `run_register` calls `_start_log_shipper` after `_exec_docker` succeeds, and routes re-runs through `_resume` instead of the old hard-exit.

**`packages/cli/src/lablink_cli/commands/logs.py`** — `lablink logs` now supports the manual provider end-to-end:
- New `fetch_manual_allocator_logs()` snapshots the local `lablink-allocator` container via `docker logs --tail 2000`. Returns the same `{cloud_init_logs, docker_logs, error}` shape as `fetch_allocator_logs` / `fetch_client_logs` so the TUI treats AWS and manual uniformly. Friendly error when the container isn't running.
- `_run_logs_manual` rewritten: instead of just streaming the local allocator's `docker logs -f`, it resolves admin credentials from the compose workdir, lists registered BYO clients via `/api/v1/clients`, synthesizes a VM list (allocator + clients) shaped like the AWS-mode dicts, and launches the existing `LogsApp` with `manual=True`.

**`packages/cli/src/lablink_cli/tui/logs_viewer.py`**:
- New `manual: bool` flag on `LogsApp`. When set, the cloud-init tab isn't rendered, the default tab is `docker`, the `action_show_cloud_init` keybinding is a no-op, and `_update_tab_styles` short-circuits.
- Allocator fetch path branches: manual mode calls `fetch_manual_allocator_logs()` (local docker logs) instead of `fetch_allocator_logs()` (SSH into an EC2 instance).

**`packages/allocator/src/lablink_allocator_service/main.py` + `templates/instance-logs.html`**:
- `get_vm_logs` passes `provider=cfg.provider` to the template; the page hides the Cloud-Init tab/pane (and adjusts the download/stats JS) when `provider != "aws"`. Same allocator UI, just doesn't promise log streams that don't exist for BYO.

**`packages/cli/pyproject.toml`**: adds `psutil>=5.9` for cross-platform process liveness checks.

## Testing

- 84+ new tests across `test_log_shipper.py` (including regression coverage for the busy-loop fix: bare `exited` must give up; alternating `exited`/`restarting` must keep going) and `test_register.py` (`TestStartLogShipper` / `TestShipperAlive` / `TestResumePath`).
- `test_logs.py` expanded with manual-provider coverage for `fetch_manual_allocator_logs` and the rewritten `_run_logs_manual` path.
- Full CLI suite: **441 passed, 0 failed** (`PYTHONPATH=packages/cli/src pytest packages/cli/tests/`).
- Lint clean: `ruff check packages/cli/src packages/cli/tests`.
- Removed the old `TestIdempotencyGuard.test_aborts_if_env_file_exists_without_force` test — its behavior is intentionally replaced by `TestResumePath`.

Manual smoke (recipe documented in the spec):
1. `lablink register …` → shipper auto-starts, admin panel's `docker_logs` populates (now routed correctly via `manual-docker` log_group).
2. `kill $(cat ~/.lablink/log_shipper.pid) && lablink register` (no args) → shipper revives, no duplicate lines (state file's `last_shipped_ts` prevents re-shipping).
3. `docker stop lablink-client` → shipper exits cleanly within ~15 s (3 consecutive `exited` inspections), PID file removed — no more 5 s polling loop.
4. `lablink register --force …` → fresh registration, new `client_secret`, new shipper.
5. `lablink logs` against a manual deployment → TUI lists the local allocator + every registered BYO client; allocator logs come from local `docker logs`, client logs from `/api/vm-logs/<hostname>`; no cloud-init tab is shown.
6. Allocator admin panel → BYO client's logs page shows only the Docker tab; AWS-managed VMs still show both.

## Design Decisions

- **Python shipper inside the CLI** rather than reusing the bash `log_shipper.sh` on the host (Windows-hostile — requires bash + curl) or refactoring the client image (touches the managed VM flow that already works).
- **No new CLI subcommands.** Stop is `docker stop lablink-client`; status is `docker ps` + `~/.lablink/log_shipper.log`; restart-after-reboot is `lablink register` with no args. Keeps the user surface to one command.
- **No reboot persistence** (no systemd/launchd/Task Scheduler install). Adds ~3× the code with platform-specific failure modes; deferred behind `lablink register` being idempotent.
- **Re-use existing log_group routing**, don't add a new column. The allocator's existing `endswith("-docker")` rule decides cloud_init vs docker_logs — picking `manual-docker` slots manual BYO output into the right column without any allocator change.
- **Consecutive-exited counter, not a single-shot exit**, so a transient crash that `--restart unless-stopped` is recovering from doesn't kill the shipper.
- **Reuse `LogsApp` with a `manual` flag** instead of forking a second TUI. The synthetic allocator+clients VM list matches the AWS-mode dict shape so `LogsApp` / `VMListItem` stay generic; cloud-init UI is conditionally skipped only at render time.
- **Allocator untouched on the data path.** `/api/vm-logs/<hostname>` already had everything needed (auth, `log_group`, 1 MB cap). The only allocator-side change is a cosmetic template tweak to hide the Cloud-Init tab when the provider isn't AWS.

## Related Issues
None — gap was identified during conversation after #361 merged.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
