### PR TITLE
ship startup script to manual/BYO clients via register response

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -6,6 +6,7 @@ routes/desktop.py using current_app instead of importing main.
 """
 from __future__ import annotations
 
+import base64
 from datetime import datetime
 import psycopg2
 import secrets
@@ -73,6 +74,25 @@ def register_client():
         hostname_hint=hostname,
     )
 
+    # Ship the custom startup script to the client. BYO clients (manual
+    # provider) have no other channel to receive it — the AWS path bakes
+    # it into user_data, but `lablink client register` is the only
+    # handshake the BYO box gets. Convention: the CLI stages the file at
+    # /config/custom-startup.sh in both the AWS deploy dir and the manual
+    # compose dir, so the path is the same regardless of provider.
+    startup_b64 = ""
+    if main.cfg.startup_script.enabled:
+        script_path = "/config/custom-startup.sh"
+        try:
+            with open(script_path, "rb") as f:
+                content = f.read()
+            if content:
+                startup_b64 = base64.b64encode(content).decode("ascii")
+        except FileNotFoundError:
+            current_app.logger.warning(
+                "startup_script.enabled=true but %s not found", script_path
+            )
+
     return jsonify(
         client_id=client_id,
         client_secret=client_secret,
@@ -81,6 +101,8 @@ def register_client():
         allocator_url=jm.allocator_url,
         connectivity=jm.connectivity,
         client_image=jm.client_image,
+        startup_script_b64=startup_b64,
+        startup_on_error=main.cfg.startup_script.on_error,
     ), 200
 
 

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -210,6 +210,123 @@ def test_register_response_omits_api_token(reg_client):
     assert body.get("agent_token") is not None
 
 
+def test_register_response_omits_startup_script_when_disabled(reg_client):
+    """startup_script.enabled=false (default) → empty payload + the
+    config's on_error knob. BYO CLI uses the empty b64 as the signal
+    to skip the mount, so the field must be present and empty rather
+    than missing."""
+    client, fake_db = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": "vm-1", "machine_identity": "i-1"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["startup_script_b64"] == ""
+    assert body["startup_on_error"] == "continue"
+
+
+def test_register_response_includes_startup_script_when_enabled(
+    reg_client, monkeypatch
+):
+    """startup_script.enabled=true + non-empty file at the conventional
+    path → base64-encoded content is shipped in the response so the
+    BYO CLI can write+mount it without filesystem access to the
+    operator's host. Round-trip the bytes to catch encoder regressions."""
+    import base64
+    from unittest.mock import mock_open, patch
+
+    from lablink_allocator_service import main
+    monkeypatch.setattr(
+        main.cfg.startup_script, "enabled", True, raising=False
+    )
+    monkeypatch.setattr(
+        main.cfg.startup_script, "on_error", "fail", raising=False
+    )
+
+    fake_content = b"#!/bin/bash\necho hi from custom startup\n"
+    client, fake_db = reg_client
+    with patch(
+        "lablink_allocator_service.routes.registration.open",
+        mock_open(read_data=fake_content),
+        create=True,
+    ):
+        r = client.post(
+            "/api/v1/clients/register",
+            json={"hostname": "vm-1", "machine_identity": "i-1"},
+            headers={"Authorization": "Bearer tk_test_register"},
+        )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["startup_script_b64"] == base64.b64encode(fake_content).decode()
+    assert body["startup_on_error"] == "fail"
+    # Round-trip back to bytes to guard against double-encoding regressions.
+    assert base64.b64decode(body["startup_script_b64"]) == fake_content
+
+
+def test_register_response_empty_when_enabled_but_file_missing(
+    reg_client, monkeypatch
+):
+    """enabled=true but /config/custom-startup.sh absent (operator
+    misconfiguration) → empty payload + warning logged. The CLI handles
+    the empty payload by skipping the mount; the warning is the operator
+    signal that something is wrong."""
+    from lablink_allocator_service import main
+    monkeypatch.setattr(
+        main.cfg.startup_script, "enabled", True, raising=False
+    )
+
+    from unittest.mock import patch
+
+    def _raise_fnf(*args, **kwargs):
+        raise FileNotFoundError("/config/custom-startup.sh")
+
+    client, fake_db = reg_client
+    with patch(
+        "lablink_allocator_service.routes.registration.open",
+        _raise_fnf,
+        create=True,
+    ):
+        r = client.post(
+            "/api/v1/clients/register",
+            json={"hostname": "vm-1", "machine_identity": "i-1"},
+            headers={"Authorization": "Bearer tk_test_register"},
+        )
+    assert r.status_code == 200
+    assert r.get_json()["startup_script_b64"] == ""
+
+
+def test_register_response_empty_when_enabled_but_file_empty(
+    reg_client, monkeypatch
+):
+    """enabled=true but the file is zero bytes — happens in the manual
+    flow when the wizard's "Disabled" path is selected (deploy_compose
+    still touches the file so the bind mount resolves). Must NOT ship
+    `base64("")` (which would still trigger the CLI to materialize an
+    empty script and mount it); ship `""` so the CLI skips the mount."""
+    from unittest.mock import mock_open, patch
+
+    from lablink_allocator_service import main
+    monkeypatch.setattr(
+        main.cfg.startup_script, "enabled", True, raising=False
+    )
+
+    client, fake_db = reg_client
+    with patch(
+        "lablink_allocator_service.routes.registration.open",
+        mock_open(read_data=b""),
+        create=True,
+    ):
+        r = client.post(
+            "/api/v1/clients/register",
+            json={"hostname": "vm-1", "machine_identity": "i-1"},
+            headers={"Authorization": "Bearer tk_test_register"},
+        )
+    assert r.status_code == 200
+    assert r.get_json()["startup_script_b64"] == ""
+
+
 def test_register_response_honors_x_forwarded_proto(reg_client, monkeypatch):
     """nginx terminates TLS and proxies plain HTTP to Flask. With HTTPS
     enabled, the ProxyFix gate opens and request.host_url reflects the

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -83,6 +83,32 @@ def render_compose_dir(cfg: Config, target: Path) -> None:
     #    CONFIG_DIR default).
     save_config(cfg, target / "config.yaml")
 
+    # 4. Stage the custom startup script. Mirrors deploy.py:99-117 for
+    #    the AWS path: ~/.lablink/custom-startup.sh wins (CLI override),
+    #    else cfg.startup_script.path on the operator's filesystem. The
+    #    file is always materialized (empty when disabled or absent) so
+    #    the docker-compose bind mount resolves on every deploy; the
+    #    allocator's registration handler only forwards it to clients
+    #    when cfg.startup_script.enabled is true AND the file is non-
+    #    empty.
+    startup_target = target / "custom-startup.sh"
+    if cfg.startup_script.enabled and cfg.startup_script.path:
+        user_script = Path.home() / ".lablink" / "custom-startup.sh"
+        if user_script.exists():
+            src_startup = user_script
+        else:
+            src_startup = Path(cfg.startup_script.path)
+        if src_startup.exists():
+            shutil.copy2(src_startup, startup_target)
+        else:
+            console.print(
+                f"[yellow]startup_script.enabled=true but {src_startup} "
+                "not found — continuing without it.[/yellow]"
+            )
+            startup_target.touch()
+    else:
+        startup_target.touch()
+
 
 def _allocator_image(cfg: Config) -> str:
     """Construct the full allocator image string from base + image_tag.

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import base64
 import os
 import shutil
 import subprocess
@@ -25,6 +26,11 @@ from lablink_cli.api import (
 )
 
 DEFAULT_ENV_FILE = Path.home() / ".lablink" / "client.env"
+# Distinct from the operator-side override at ~/.lablink/custom-startup.sh
+# (read by deploy.py:101-103) so that running operator + BYO client on the
+# same box doesn't have the client-received copy clobber the operator's
+# local override.
+DEFAULT_STARTUP_SCRIPT = Path.home() / ".lablink" / "client-custom-startup.sh"
 PID_FILE = Path.home() / ".lablink" / "log_shipper.pid"
 
 
@@ -131,7 +137,10 @@ def run_register(
         _verify_gpu_runtime(console)
 
     # Step 7 + 8: docker run (always)
-    cmd = _build_docker_run(env_file, response, resolved_gpu_present)
+    startup_script_path = _write_startup_script(response)
+    cmd = _build_docker_run(
+        env_file, response, resolved_gpu_present, startup_script_path
+    )
     console.print(
         f"[green]Registered as client #{response['client_id']}[/green]"
     )
@@ -226,8 +235,31 @@ def _write_env_file(
     env_file.chmod(0o600)
 
 
+def _write_startup_script(resp: dict) -> Path | None:
+    """Materialize the allocator-provided startup script to disk.
+
+    Returns the host path to bind-mount into the client container, or
+    None when the allocator returned no script (disabled, file missing,
+    or empty). Mode 0755 so root-in-container can exec it via ``bash``.
+    Stale files from prior registrations are removed when the current
+    response carries no payload, so a script disabled on the allocator
+    side is not silently kept alive locally.
+    """
+    b64 = resp.get("startup_script_b64") or ""
+    if not b64:
+        DEFAULT_STARTUP_SCRIPT.unlink(missing_ok=True)
+        return None
+    DEFAULT_STARTUP_SCRIPT.parent.mkdir(parents=True, exist_ok=True)
+    DEFAULT_STARTUP_SCRIPT.write_bytes(base64.b64decode(b64))
+    DEFAULT_STARTUP_SCRIPT.chmod(0o755)
+    return DEFAULT_STARTUP_SCRIPT
+
+
 def _build_docker_run(
-    env_file: Path, resp: dict, gpu_present: bool
+    env_file: Path,
+    resp: dict,
+    gpu_present: bool,
+    startup_script: Path | None,
 ) -> list[str]:
     cmd = [
         "docker", "run", "-d",
@@ -243,6 +275,21 @@ def _build_docker_run(
     ]
     if gpu_present:
         cmd += ["--gpus", "all"]
+    # Mount path mirrors the AWS terraform/user_data mount so the client
+    # start.sh finds the script at /docker_scripts/custom-startup.sh
+    # regardless of provider. Skipped when the allocator returned no
+    # script — docker would refuse the run otherwise (bind src must
+    # exist), and start.sh already no-ops when the file is absent.
+    if startup_script is not None:
+        cmd += [
+            "--mount",
+            (
+                f"type=bind,src={startup_script},"
+                "dst=/docker_scripts/custom-startup.sh,ro"
+            ),
+            "-e",
+            f"STARTUP_ON_ERROR={resp.get('startup_on_error', 'continue')}",
+        ]
     # Publish 7070 (agent's /api/session/start) and 6080 (KasmVNC) on
     # the LAN IP so the allocator can reach them. `--network host` would
     # also do this on Linux, but on Docker Desktop (Windows/macOS) it

--- a/packages/cli/src/lablink_cli/templates/docker-compose.yml
+++ b/packages/cli/src/lablink_cli/templates/docker-compose.yml
@@ -26,6 +26,13 @@ services:
     container_name: lablink-allocator
     volumes:
       - ./config.yaml:/config/config.yaml:ro
+      # The CLI's render_compose_dir always materializes custom-startup.sh
+      # in this directory (empty when disabled), so this bind mount
+      # always resolves. The allocator reads it at register time and
+      # ships its base64 content to BYO clients via the register
+      # response — matching the AWS path where Terraform/user_data
+      # delivers the same file to the client container.
+      - ./custom-startup.sh:/config/custom-startup.sh:ro
       - allocator_pgdata:/var/lib/postgresql
     ports:
       # The container's nginx listens on :5000 (see lablink-nginx.conf in

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -647,11 +647,7 @@ class DnsScreen(Screen):
             cfg.ssl.provider = "self_signed"
             cfg.eip.strategy = "dynamic"
 
-        is_manual = getattr(cfg, "provider", "aws") == "manual"
-        if is_manual:
-            self.app.push_screen(ReviewScreen())
-        else:
-            self.app.push_screen(StartupScreen())
+        self.app.push_screen(StartupScreen())
 
 
 # ---------------------------------------------------------------------------

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -142,6 +142,137 @@ class TestRenderComposeDir:
         )
 
 
+class TestStartupScriptStaging:
+    """`render_compose_dir` is responsible for putting custom-startup.sh
+    into the compose workdir so the docker-compose bind mount (added in
+    the template) resolves and the allocator container can read the
+    script at /config/custom-startup.sh. The file MUST exist on every
+    deploy — disabled or not — because docker-compose refuses a missing
+    bind-mount source. The allocator gates content delivery on a
+    separate non-empty check, not on file existence.
+    """
+
+    @pytest.fixture(autouse=True)
+    def isolate_home(self, tmp_path, monkeypatch):
+        """Redirect ``Path.home()`` away from the developer's real
+        ``~/.lablink/custom-startup.sh`` for every test in this class —
+        otherwise tests that exercise non-override branches accidentally
+        pick up the developer's real override file and assert against
+        its content. The dedicated override test plants its own file
+        inside ``fake_home`` to exercise that branch deliberately.
+        """
+        from lablink_cli.commands import deploy_compose
+
+        fake_home = tmp_path / "fake-home"
+        fake_home.mkdir()
+        monkeypatch.setattr(
+            deploy_compose.Path, "home", lambda: fake_home
+        )
+
+    def test_creates_empty_file_when_disabled(self, tmp_path):
+        """Default config (startup_script.enabled=false) → file is
+        present but empty so the compose bind mount resolves; the
+        allocator reads it and ships ``startup_script_b64=""`` to BYO
+        clients."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg()
+        # Sanity: default-disabled — guard against a schema flip
+        # making this test silently exercise the wrong branch.
+        assert cfg.startup_script.enabled is False
+
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        script = target / "custom-startup.sh"
+        assert script.exists(), (
+            "custom-startup.sh must always be materialized so the "
+            "docker-compose bind mount resolves"
+        )
+        assert script.read_bytes() == b""
+
+    def test_copies_script_from_config_path(self, tmp_path):
+        """enabled=true + path on the operator's filesystem → contents
+        copied verbatim into the compose dir."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        # Source script lives on the operator's machine; the path in
+        # the config points to it directly.
+        src = tmp_path / "operator-script.sh"
+        body = "#!/bin/bash\necho operator script\n"
+        src.write_text(body)
+
+        cfg = _manual_cfg()
+        cfg.startup_script.enabled = True
+        cfg.startup_script.path = str(src)
+
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        assert (target / "custom-startup.sh").read_text() == body
+
+    def test_user_override_at_home_wins(self, tmp_path):
+        """If ``~/.lablink/custom-startup.sh`` exists, it overrides
+        ``cfg.startup_script.path`` (mirrors deploy.py:101-103 for the
+        AWS path so operators have one mental model regardless of
+        provider). The autouse ``isolate_home`` fixture has already
+        redirected ``Path.home()`` to a fresh tmp dir; this test plants
+        the override there.
+        """
+        from lablink_cli.commands import deploy_compose
+
+        fake_home = deploy_compose.Path.home()
+        (fake_home / ".lablink").mkdir(parents=True)
+        override_body = "#!/bin/bash\necho FROM OVERRIDE\n"
+        (fake_home / ".lablink" / "custom-startup.sh").write_text(override_body)
+
+        # cfg.startup_script.path points at a real but DIFFERENT script;
+        # the override must still win.
+        cfg_src = tmp_path / "from-config.sh"
+        cfg_src.write_text("#!/bin/bash\necho FROM CONFIG\n")
+
+        cfg = _manual_cfg()
+        cfg.startup_script.enabled = True
+        cfg.startup_script.path = str(cfg_src)
+
+        target = tmp_path / "compose"
+        deploy_compose.render_compose_dir(cfg, target)
+
+        assert (target / "custom-startup.sh").read_text() == override_body
+
+    def test_falls_back_to_empty_when_configured_path_missing(self, tmp_path):
+        """enabled=true but the path doesn't exist on disk → warn and
+        materialize an empty file so the deploy doesn't crash. Operator
+        sees the yellow warning; the allocator's register handler will
+        also log + return empty b64."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg()
+        cfg.startup_script.enabled = True
+        cfg.startup_script.path = str(tmp_path / "does-not-exist.sh")
+
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        script = target / "custom-startup.sh"
+        assert script.exists()
+        assert script.read_bytes() == b""
+
+    def test_compose_template_mounts_startup_script(self, tmp_path):
+        """The rendered compose YAML must declare the bind mount —
+        otherwise the staged file at ./custom-startup.sh would not
+        reach the allocator container at /config/custom-startup.sh and
+        the registration handler would silently always ship empty b64."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg()
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        compose_yaml = (target / "docker-compose.yml").read_text()
+        assert "./custom-startup.sh:/config/custom-startup.sh" in compose_yaml
+
+
 def _read_env_var(env_file: Path, key: str) -> str:
     for line in env_file.read_text().splitlines():
         if line.startswith(f"{key}="):

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -13,6 +13,22 @@ def tmp_env_file(tmp_path):
     return tmp_path / "client.env"
 
 
+@pytest.fixture(autouse=True)
+def isolate_startup_script_path(tmp_path, monkeypatch):
+    """Redirect DEFAULT_STARTUP_SCRIPT into tmp_path for every test.
+
+    `_write_startup_script` writes/unlinks at this path on every
+    `run_register` call (including when the allocator returns an empty
+    payload — it unlinks then). Without this fixture, tests that
+    exercise the success path would touch the developer's real
+    ``~/.lablink/client-custom-startup.sh``.
+    """
+    monkeypatch.setattr(
+        "lablink_cli.commands.register.DEFAULT_STARTUP_SCRIPT",
+        tmp_path / "client-custom-startup.sh",
+    )
+
+
 @pytest.fixture
 def successful_response():
     return {
@@ -23,6 +39,12 @@ def successful_response():
         "allocator_url": "https://lablink.example.com",
         "connectivity": "lan_direct",
         "client_image": "ghcr.io/talmolab/lablink-client:0.4.0",
+        # New fields shipped by routes/registration.py. Defaults are
+        # the "disabled" payload (empty b64 → no mount, no env var),
+        # which matches the existing tests' assumption that docker run
+        # carries no --mount and no STARTUP_ON_ERROR.
+        "startup_script_b64": "",
+        "startup_on_error": "continue",
     }
 
 
@@ -900,6 +922,189 @@ class TestShipperAlive:
         monkeypatch.setattr(register, "psutil", fake_psutil)
 
         assert register._shipper_alive() is False
+
+
+class TestWriteStartupScript:
+    """Covers `_write_startup_script` — decodes the allocator-shipped
+    startup script to a host file the docker run can bind-mount.
+    """
+
+    def test_writes_decoded_bytes_when_payload_present(self, tmp_path, monkeypatch):
+        import base64
+        from lablink_cli.commands import register
+
+        target = tmp_path / "client-custom-startup.sh"
+        monkeypatch.setattr(register, "DEFAULT_STARTUP_SCRIPT", target)
+
+        payload = b"#!/bin/bash\necho hi\n"
+        resp = {"startup_script_b64": base64.b64encode(payload).decode()}
+        result = register._write_startup_script(resp)
+
+        assert result == target
+        assert target.read_bytes() == payload
+
+    def test_sets_executable_mode(self, tmp_path, monkeypatch):
+        """0755 so root-in-container can ``bash`` the file (start.sh also
+        chmod +x's it, but the source mode shouldn't be 0600 either —
+        keeps `ls -l` and direct host-side debugging meaningful)."""
+        import base64
+        import stat
+        from lablink_cli.commands import register
+
+        target = tmp_path / "client-custom-startup.sh"
+        monkeypatch.setattr(register, "DEFAULT_STARTUP_SCRIPT", target)
+
+        resp = {"startup_script_b64": base64.b64encode(b"#!/bin/bash\n").decode()}
+        register._write_startup_script(resp)
+
+        mode = stat.S_IMODE(target.stat().st_mode)
+        assert mode == 0o755
+
+    def test_returns_none_and_removes_stale_when_payload_empty(
+        self, tmp_path, monkeypatch
+    ):
+        """Re-register after the operator disables the script: a previous
+        registration left the file at DEFAULT_STARTUP_SCRIPT — must be
+        unlinked so we don't silently keep mounting old content. Without
+        this cleanup, a `--force` rerun would still bind-mount the prior
+        script even though the new register response says "no script"."""
+        from lablink_cli.commands import register
+
+        target = tmp_path / "client-custom-startup.sh"
+        target.write_text("stale content from a prior register")
+        monkeypatch.setattr(register, "DEFAULT_STARTUP_SCRIPT", target)
+
+        result = register._write_startup_script({"startup_script_b64": ""})
+
+        assert result is None
+        assert not target.exists()
+
+    def test_returns_none_when_field_absent(self, tmp_path, monkeypatch):
+        """Belt-and-suspenders: the allocator always emits the field, but
+        if a downstream proxy/transformer drops it, the CLI must treat
+        "missing key" the same as "empty payload" rather than KeyError."""
+        from lablink_cli.commands import register
+
+        target = tmp_path / "client-custom-startup.sh"
+        monkeypatch.setattr(register, "DEFAULT_STARTUP_SCRIPT", target)
+
+        # Response with NO startup_script_b64 key at all.
+        assert register._write_startup_script({}) is None
+        assert not target.exists()
+
+
+class TestDockerRunMountsStartupScript:
+    """End-to-end shape check via run_register: an enabled startup script
+    on the allocator side must produce a docker-run that bind-mounts it
+    at /docker_scripts/custom-startup.sh and forwards STARTUP_ON_ERROR.
+    This is the actual delivery path the bug fix is closing.
+    """
+
+    @patch("lablink_cli.commands.register.subprocess.Popen")
+    @patch("lablink_cli.commands.register.subprocess.run")
+    @patch("lablink_cli.commands.register.shutil.which")
+    @patch("lablink_cli.commands.register.RegistrationClient")
+    @patch("lablink_cli.commands.register.byo_detect")
+    def test_run_register_mounts_script_when_allocator_ships_one(
+        self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
+        mock_popen, tmp_env_file, successful_response,
+    ):
+        import base64
+
+        from lablink_cli.commands.register import run_register
+
+        # Allocator-side response carrying a script and "fail" semantics.
+        payload = b"#!/bin/bash\necho hi from startup\n"
+        successful_response["startup_script_b64"] = base64.b64encode(payload).decode()
+        successful_response["startup_on_error"] = "fail"
+
+        mock_detect.detect_hostname.return_value = "byo-01"
+        mock_detect.detect_lan_ip.return_value = "192.168.1.42"
+        mock_detect.resolve_machine_identity.return_value = "mid"
+        mock_detect.detect_gpu.return_value = (False, None)
+        mock_client = MagicMock()
+        mock_client.register.return_value = successful_response
+        mock_client_cls.return_value = mock_client
+        mock_which.return_value = "/usr/bin/docker"
+        mock_subproc_run.return_value = MagicMock(returncode=0, stdout="cgroupfs\n")
+
+        run_register(**_kwargs(tmp_env_file))
+
+        all_cmds = [call.args[0] for call in mock_subproc_run.call_args_list]
+        run_cmds = [c for c in all_cmds if "run" in c and "--env-file" in c]
+        assert run_cmds, f"Expected `docker run` call; got {all_cmds}"
+        cmd = run_cmds[0]
+
+        # The mount target inside the container MUST be the same path
+        # start.sh:64 reads from — AWS already mounts /docker_scripts/
+        # via Terraform/user_data; the BYO path mirrors it so start.sh
+        # has a single, provider-independent contract.
+        mount_args = [
+            cmd[i + 1] for i, v in enumerate(cmd)
+            if v == "--mount" and i + 1 < len(cmd)
+        ]
+        assert mount_args, f"expected --mount in docker run, got {cmd}"
+        assert any(
+            "dst=/docker_scripts/custom-startup.sh" in m for m in mount_args
+        ), f"mount target wrong; mounts={mount_args}"
+
+        # STARTUP_ON_ERROR must be forwarded — start.sh:73 gates fail-vs-
+        # continue on this env var. Picked up from the allocator's
+        # cfg.startup_script.on_error via the register response so the
+        # operator's "fail" choice actually reaches the client.
+        env_args = [
+            cmd[i + 1] for i, v in enumerate(cmd)
+            if v == "-e" and i + 1 < len(cmd)
+        ]
+        assert "STARTUP_ON_ERROR=fail" in env_args, (
+            f"STARTUP_ON_ERROR not forwarded; -e args={env_args}"
+        )
+
+    @patch("lablink_cli.commands.register.subprocess.Popen")
+    @patch("lablink_cli.commands.register.subprocess.run")
+    @patch("lablink_cli.commands.register.shutil.which")
+    @patch("lablink_cli.commands.register.RegistrationClient")
+    @patch("lablink_cli.commands.register.byo_detect")
+    def test_run_register_skips_mount_when_no_script(
+        self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
+        mock_popen, tmp_env_file, successful_response,
+    ):
+        """Allocator returned empty payload (script disabled) → no
+        --mount, no -e STARTUP_ON_ERROR. Docker would refuse the run
+        with a missing bind-mount source, so the skip must be on the
+        client side, not just "rely on docker to reject"."""
+        from lablink_cli.commands.register import run_register
+
+        # Fixture default is already empty — make it explicit for clarity.
+        successful_response["startup_script_b64"] = ""
+
+        mock_detect.detect_hostname.return_value = "byo-01"
+        mock_detect.detect_lan_ip.return_value = "192.168.1.42"
+        mock_detect.resolve_machine_identity.return_value = "mid"
+        mock_detect.detect_gpu.return_value = (False, None)
+        mock_client = MagicMock()
+        mock_client.register.return_value = successful_response
+        mock_client_cls.return_value = mock_client
+        mock_which.return_value = "/usr/bin/docker"
+        mock_subproc_run.return_value = MagicMock(returncode=0, stdout="cgroupfs\n")
+
+        run_register(**_kwargs(tmp_env_file))
+
+        all_cmds = [call.args[0] for call in mock_subproc_run.call_args_list]
+        run_cmds = [c for c in all_cmds if "run" in c and "--env-file" in c]
+        assert run_cmds, f"Expected `docker run` call; got {all_cmds}"
+        cmd = run_cmds[0]
+
+        assert "--mount" not in cmd, (
+            f"--mount must not appear when allocator ships no script; got {cmd}"
+        )
+        env_args = [
+            cmd[i + 1] for i, v in enumerate(cmd)
+            if v == "-e" and i + 1 < len(cmd)
+        ]
+        assert not any("STARTUP_ON_ERROR" in a for a in env_args), (
+            f"STARTUP_ON_ERROR must not be forwarded when no script; got {env_args}"
+        )
 
     def test_corrupt_pid_file_returns_false(self, tmp_path, monkeypatch):
         from lablink_cli.commands import register


### PR DESCRIPTION
## Summary

- Closes the gap where the operator-defined startup script never reached BYO/manual client containers (AWS path delivered it via Terraform/user_data; manual path had no transport).
- Allocator now reads `/config/custom-startup.sh` at registration time and ships base64 + `on_error` knob in the `/api/v1/clients/register` response; BYO CLI materializes it and bind-mounts to `/docker_scripts/custom-startup.sh` — the same path `start.sh:64` already reads from on the AWS path.
- Operator-side `render_compose_dir` always stages `custom-startup.sh` (real content when enabled+present, empty otherwise) so the docker-compose bind mount resolves on every deploy. Compose template carries the new mount.
- Wizard's manual-mode `StartupScreen` skip (added in #357 when manual mode couldn't use the script) is removed — operators now get the same startup-script step as AWS.

## What changed

- `packages/allocator/src/lablink_allocator_service/routes/registration.py` — register response gains `startup_script_b64` + `startup_on_error`; empty payload on disabled/missing/empty file.
- `packages/cli/src/lablink_cli/commands/register.py` — new `_write_startup_script` (decodes to `~/.lablink/client-custom-startup.sh`, 0755, cleans up stale on empty payload); `_build_docker_run` gains a `startup_script` param that adds `--mount` + `-e STARTUP_ON_ERROR` when present.
- `packages/cli/src/lablink_cli/commands/deploy_compose.py` — `render_compose_dir` stages `custom-startup.sh` in the compose dir (override at `~/.lablink/custom-startup.sh` wins, mirroring AWS `deploy.py:101-103`).
- `packages/cli/src/lablink_cli/templates/docker-compose.yml` — bind-mounts the staged script into the allocator at `/config/custom-startup.sh`.
- `packages/cli/src/lablink_cli/tui/wizard.py` — drops the manual-provider skip so the StartupScreen runs for both providers.

## Test plan

- [x] `pytest tests/test_registration_api.py` — 31 passed (4 new tests: disabled, enabled+content with b64 round-trip, enabled+missing, enabled+empty)
- [x] `pytest tests/test_register.py` — 37 passed (new `TestWriteStartupScript` + `TestDockerRunMountsStartupScript`; existing tests continue to pass via the new `successful_response` defaults and the autouse `isolate_startup_script_path` fixture)
- [x] `pytest tests/test_deploy_compose.py` — 31 passed (new `TestStartupScriptStaging`: disabled→empty file, configured path copied, home override wins, missing path→empty, template carries mount line)
- [x] Manual smoke on a laptop: `lablink configure` (manual provider) → StartupScreen shows → save → `lablink deploy` → `docker exec lablink-allocator cat /config/custom-startup.sh` → `lablink client register …` → `docker logs lablink-client | grep '\[start\] Running custom startup'`
- [x] Negative manual smoke: disable script via wizard → redeploy → re-register → confirm `start.sh:79` logs `No custom startup script found. Skipping.` and `~/.lablink/client-custom-startup.sh` is removed

## Notes

- AWS path is unchanged. AWS VMs do not call `/api/v1/clients/register`, so the new response fields are inert for that flow.
- Client-side script lives at `~/.lablink/client-custom-startup.sh` — deliberately distinct from the operator-side override at `~/.lablink/custom-startup.sh` (read by `deploy.py:101`) so running operator + BYO client on the same machine doesn't have the client-received copy clobber the operator's local override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)