### PR TITLE
chore(cli): bump lablink-template to v0.2.1

### DIFF
--- a/packages/cli/src/lablink_cli/__init__.py
+++ b/packages/cli/src/lablink_cli/__init__.py
@@ -1,8 +1,8 @@
 """LabLink CLI - Deploy and manage LabLink infrastructure."""
 
 TEMPLATE_REPO = "talmolab/lablink-template"
-TEMPLATE_VERSION = "v0.2.0"
+TEMPLATE_VERSION = "v0.2.1"
 # SHA-256 of the GitHub release tarball for TEMPLATE_VERSION.
 # Update this when bumping TEMPLATE_VERSION.
 # To compute: curl -sL <tarball_url> | sha256sum
-TEMPLATE_SHA256 = "93c2694915e588e3c804612639666a73354fcdaa53607734c2d26f07d08eca58"
+TEMPLATE_SHA256 = "aa9e774df7677f9c6820d0e0279869bde3d3e35f938ff9b5c6da9f1e96c24cbb"


### PR DESCRIPTION
## Summary
- Pin CLI to [lablink-template v0.2.1](https://github.com/talmolab/lablink-template/releases/tag/v0.2.1).
- Update `TEMPLATE_SHA256` for the new release tarball.

## What's in v0.2.1
Two PRs merged in the template repo since v0.2.0:
- [lablink-template#51](https://github.com/talmolab/lablink-template/pull/51) — docs: audit READMEs against current Terraform surface
- [lablink-template#52](https://github.com/talmolab/lablink-template/pull/52) — fix: set ALB `idle_timeout` to 3600s for KasmVNC WebSocket connections

The ALB idle_timeout fix is the substantive change here: KasmVNC WebSockets were being dropped by the ALB's default 60s idle timeout, breaking long-lived browser sessions.

## Verification
- `TEMPLATE_SHA256` recomputed from `https://github.com/talmolab/lablink-template/archive/refs/tags/v0.2.1.tar.gz` (matches the value committed).
- `ruff check packages/cli/src packages/cli/tests` — clean.
- `PYTHONPATH=src pytest` in `packages/cli` — 468 passed.

## Risk
Low. Only the version pin + checksum change. The template tarball is fetched on demand by `lablink deploy`; no runtime behavior changes in the CLI itself.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)