### PR TITLE
chore(allocator): rename admin button to "Delete VMs"

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/templates/admin.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/admin.html
@@ -102,7 +102,7 @@
         {% endif %}
         {% if can_destroy_hosts %}
         <button onclick="location.href='/admin/instances/delete'">
-          Extract or Delete VM Data
+          Delete VMs
         </button>
         <button onclick="location.href='/admin/scheduled-destruction'">
           Schedule Destructions

--- a/packages/allocator/tests/test_admin_template_gating.py
+++ b/packages/allocator/tests/test_admin_template_gating.py
@@ -26,7 +26,7 @@ def test_aws_provider_shows_provision_destroy_hides_byo(
     r = client.get("/admin", headers=admin_headers)
     body = r.get_data(as_text=True)
     assert "Create New VM Instance" in body
-    assert "Extract or Delete VM Data" in body
+    assert "Delete VMs" in body
     assert "Schedule Destructions" in body
     assert "BYO Client Onboarding" not in body
     # View Current Instances is provider-agnostic; should always render.


### PR DESCRIPTION
## Summary

Renames the admin landing button from **"Extract or Delete VM Data"** to **"Delete VMs"**. The SCP-based data-extraction feature was removed in an earlier PR; the old label promised functionality that no longer exists. The destination page is already titled "Delete All LabLink Instances", so the new button label matches what it actually does.

## Changes

- `templates/admin.html` — button label update
- `tests/test_admin_template_gating.py` — both assertions updated to match

## Test plan

- [x] `pytest --ignore=tests/terraform` — 509 passed, 14 skipped
- [x] `ruff check src tests` — clean
- [x] Manual: open `/admin`, confirm the button reads "Delete VMs" and still routes to `/admin/instances/delete`

## Merge note for #366

The Tier 1 monitoring PR (#366) extends this same test file with two new tests but still asserts the old label in the pre-existing tests. Whichever lands second will need a trivial rebase (one-line conflict in two assertions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)