### PR TITLE
feat(cli): wizard DNS step gets Guided/Advanced toggle; Cloudflare picks persistent EIP

### DIFF
--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -7,7 +7,7 @@ from pathlib import Path
 from textual import on
 from textual.app import App, ComposeResult
 from textual.binding import Binding
-from textual.containers import Center, Horizontal, VerticalScroll
+from textual.containers import Center, Container, Horizontal, VerticalScroll
 from textual.screen import Screen
 from textual.widgets import (
     Button,
@@ -499,76 +499,239 @@ class DnsScreen(Screen):
                 "Step 4: DNS & SSL", classes="step-title"
             )
 
-            yield Label("Access Method", classes="field-label")
-            with RadioSet(id="dns-mode"):
+            # Mode toggle (Guided default, Advanced opt-in).
+            with RadioSet(id="dns-screen-mode"):
                 yield RadioButton(
-                    "IP Only — simplest setup, access via IP, no SSL",
-                    value=(default_idx == 0),
-                    id="dns-none",
+                    "Guided — common presets",
+                    value=True,
+                    id="screen-mode-guided",
                 )
-                if not is_manual:
-                    yield RadioButton(
-                        "Let's Encrypt — free automatic SSL, requires a "
-                        "domain (https://letsencrypt.org/)",
-                        value=(default_idx == 1),
-                        id="dns-letsencrypt",
-                    )
-                    yield RadioButton(
-                        "CloudFlare — use if your domain is already on "
-                        "CloudFlare (https://www.cloudflare.com/application-services/products/ssl/)",
-                        value=(default_idx == 2),
-                        id="dns-cloudflare",
-                    )
-                    yield RadioButton(
-                        "AWS ACM — AWS-managed SSL with load balancer, "
-                        "requires certificate "
-                        "(https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)",
-                        value=(default_idx == 3),
-                        id="dns-acm",
-                    )
                 yield RadioButton(
-                    "Self-signed — browser warns once; fine for closed-LAN labs",
-                    value=(default_idx == 4),
-                    id="dns-self_signed",
+                    "Advanced — edit every field directly",
+                    value=False,
+                    id="screen-mode-advanced",
                 )
 
-            yield Label(
-                "Domain Name",
-                classes="field-label",
-                id="domain-label",
-            )
-            yield Input(
-                value=cfg.dns.domain or "",
-                placeholder="lablink.example.com",
-                id="domain",
-                disabled=domain_disabled,
-            )
+            with Container(id="dns-guided"):
+                yield Label("Access Method", classes="field-label")
+                with RadioSet(id="dns-mode"):
+                    yield RadioButton(
+                        "IP Only — simplest setup, access via IP, no SSL",
+                        value=(default_idx == 0),
+                        id="dns-none",
+                    )
+                    if not is_manual:
+                        yield RadioButton(
+                            "Let's Encrypt — free automatic SSL, requires a "
+                            "domain (https://letsencrypt.org/)",
+                            value=(default_idx == 1),
+                            id="dns-letsencrypt",
+                        )
+                        yield RadioButton(
+                            "CloudFlare — use if your domain is already on "
+                            "CloudFlare (https://www.cloudflare.com/application-services/products/ssl/)",
+                            value=(default_idx == 2),
+                            id="dns-cloudflare",
+                        )
+                        yield RadioButton(
+                            "AWS ACM — AWS-managed SSL with load balancer, "
+                            "requires certificate "
+                            "(https://docs.aws.amazon.com/acm/latest/userguide/acm-overview.html)",
+                            value=(default_idx == 3),
+                            id="dns-acm",
+                        )
+                    yield RadioButton(
+                        "Self-signed — browser warns once; fine for closed-LAN labs",
+                        value=(default_idx == 4),
+                        id="dns-self_signed",
+                    )
 
-            yield Label(
-                "Email (for SSL certificates)",
-                classes="field-label",
-                id="email-label",
-            )
-            yield Input(
-                value=cfg.ssl.email or "",
-                placeholder="admin@example.com",
-                id="ssl-email",
-                disabled=email_disabled,
-            )
+                yield Label(
+                    "Domain Name",
+                    classes="field-label",
+                    id="domain-label",
+                )
+                yield Input(
+                    value=cfg.dns.domain or "",
+                    placeholder="lablink.example.com",
+                    id="domain",
+                    disabled=domain_disabled,
+                )
 
-            yield Label(
-                "ACM Certificate ARN",
-                classes="field-label",
-                id="acm-label",
-            )
-            yield Input(
-                value=cfg.ssl.certificate_arn or "",
-                placeholder=(
-                    "arn:aws:acm:region:account:certificate/id"
-                ),
-                id="acm-arn",
-                disabled=acm_disabled,
-            )
+                yield Label(
+                    "Email (for SSL certificates)",
+                    classes="field-label",
+                    id="email-label",
+                )
+                yield Input(
+                    value=cfg.ssl.email or "",
+                    placeholder="admin@example.com",
+                    id="ssl-email",
+                    disabled=email_disabled,
+                )
+
+                yield Label(
+                    "ACM Certificate ARN",
+                    classes="field-label",
+                    id="acm-label",
+                )
+                yield Input(
+                    value=cfg.ssl.certificate_arn or "",
+                    placeholder=(
+                        "arn:aws:acm:region:account:certificate/id"
+                    ),
+                    id="acm-arn",
+                    disabled=acm_disabled,
+                )
+
+                tag = (
+                    f"{cfg.deployment_name or '<deployment_name>'}"
+                    f"-eip-"
+                    f"{cfg.environment or '<environment>'}"
+                )
+                yield Label(
+                    "Persistent EIP required for Cloudflare.\n"
+                    "Tag your pre-allocated EIP with:\n"
+                    f"  Name = {tag}\n"
+                    "Example:\n"
+                    "  aws ec2 create-tags --resources eipalloc-XXXXX \\\n"
+                    f"    --tags Key=Name,Value={tag}",
+                    id="eip-help",
+                    classes="step-description",
+                )
+
+            with Container(id="dns-advanced"):
+                yield Label(
+                    "Advanced — direct config edit. "
+                    "Values from current config are pre-filled.",
+                    classes="step-description",
+                )
+
+                yield Label("DNS", classes="field-label")
+
+                yield Label("Enabled", classes="field-label")
+                with RadioSet(id="adv-dns-enabled"):
+                    yield RadioButton(
+                        "Yes",
+                        value=cfg.dns.enabled,
+                        id="adv-dns-enabled-yes",
+                    )
+                    yield RadioButton(
+                        "No",
+                        value=not cfg.dns.enabled,
+                        id="adv-dns-enabled-no",
+                    )
+
+                yield Label(
+                    "Terraform-managed records",
+                    classes="field-label",
+                )
+                with RadioSet(id="adv-dns-tfmanaged"):
+                    yield RadioButton(
+                        "Yes",
+                        value=cfg.dns.terraform_managed,
+                        id="adv-dns-tfmanaged-yes",
+                    )
+                    yield RadioButton(
+                        "No",
+                        value=not cfg.dns.terraform_managed,
+                        id="adv-dns-tfmanaged-no",
+                    )
+
+                yield Label("Domain", classes="field-label")
+                yield Input(
+                    value=cfg.dns.domain or "",
+                    placeholder="lablink.example.com",
+                    id="adv-dns-domain",
+                )
+
+                yield Label(
+                    "Zone ID (optional)", classes="field-label"
+                )
+                yield Input(
+                    value=cfg.dns.zone_id or "",
+                    placeholder="Z0123456789ABCDEFG",
+                    id="adv-dns-zone-id",
+                )
+
+                yield Label("SSL", classes="field-label")
+                yield Label("Provider", classes="field-label")
+                with RadioSet(id="adv-ssl-provider"):
+                    yield RadioButton(
+                        "none",
+                        value=(cfg.ssl.provider == "none"),
+                        id="adv-ssl-none",
+                    )
+                    yield RadioButton(
+                        "letsencrypt",
+                        value=(cfg.ssl.provider == "letsencrypt"),
+                        id="adv-ssl-letsencrypt",
+                    )
+                    yield RadioButton(
+                        "cloudflare",
+                        value=(cfg.ssl.provider == "cloudflare"),
+                        id="adv-ssl-cloudflare",
+                    )
+                    yield RadioButton(
+                        "acm",
+                        value=(cfg.ssl.provider == "acm"),
+                        id="adv-ssl-acm",
+                    )
+                    yield RadioButton(
+                        "self_signed",
+                        value=(cfg.ssl.provider == "self_signed"),
+                        id="adv-ssl-self_signed",
+                    )
+
+                yield Label("Email", classes="field-label")
+                yield Input(
+                    value=cfg.ssl.email or "",
+                    placeholder="admin@example.com",
+                    id="adv-ssl-email",
+                )
+
+                yield Label(
+                    "ACM Certificate ARN", classes="field-label"
+                )
+                yield Input(
+                    value=cfg.ssl.certificate_arn or "",
+                    placeholder=(
+                        "arn:aws:acm:region:account:certificate/id"
+                    ),
+                    id="adv-ssl-acm-arn",
+                )
+
+                yield Label("EIP", classes="field-label")
+                yield Label("Strategy", classes="field-label")
+                with RadioSet(id="adv-eip-strategy"):
+                    yield RadioButton(
+                        "dynamic",
+                        value=(cfg.eip.strategy == "dynamic"),
+                        id="adv-eip-dynamic",
+                    )
+                    yield RadioButton(
+                        "persistent",
+                        value=(cfg.eip.strategy == "persistent"),
+                        id="adv-eip-persistent",
+                    )
+
+                tag = (
+                    f"{cfg.deployment_name or '<deployment_name>'}"
+                    f"-eip-"
+                    f"{cfg.environment or '<environment>'}"
+                )
+                yield Label(
+                    "Persistent EIP requires a pre-allocated EIP tagged:\n"
+                    f"  Name = {tag}",
+                    id="adv-eip-help",
+                    classes="step-description",
+                )
+
+                yield Label(
+                    "",
+                    id="dns-validation-error",
+                    classes="step-description",
+                )
 
         with Center():
             with Horizontal(classes="nav-buttons"):
@@ -594,18 +757,153 @@ class DnsScreen(Screen):
         email_input.disabled = not email_needed
         acm_input.disabled = not acm_needed
 
+        # Toggle EIP-help visibility with the selected provider.
+        self.query_one("#eip-help").display = (provider == "cloudflare")
+
+    @on(RadioSet.Changed, "#dns-screen-mode")
+    def _screen_mode_changed(self, event: RadioSet.Changed) -> None:
+        is_advanced = event.pressed.id == "screen-mode-advanced"
+        if is_advanced:
+            # Save the Guided state to cfg so Advanced sees the latest.
+            self._save_guided()
+            self._refresh_advanced_from_cfg()
+        else:
+            # Going from Advanced back to Guided: save Advanced first.
+            self._save_advanced()
+            self._refresh_guided_from_cfg()
+        self.query_one("#dns-guided").display = not is_advanced
+        self.query_one("#dns-advanced").display = is_advanced
+
+    def _refresh_advanced_from_cfg(self) -> None:
+        cfg = self.app.config
+
+        def _select(radioset_id: str, button_id: str) -> None:
+            # We're called from RadioSet message handlers which run with
+            # `prevent(RadioButton.Changed)` active, so simply setting
+            # button.value won't propagate through RadioSet's single-selection
+            # logic. Mutate values directly and update the RadioSet's
+            # `_pressed_button` so callers see consistent state.
+            radio_set = self.query_one(radioset_id, RadioSet)
+            target: RadioButton | None = None
+            for btn in radio_set.query(RadioButton):
+                if btn.id == button_id:
+                    target = btn
+                else:
+                    if btn.value:
+                        btn.value = False
+            if target is not None:
+                target.value = True
+                radio_set._pressed_button = target
+
+        _select(
+            "#adv-dns-enabled",
+            "adv-dns-enabled-yes"
+            if cfg.dns.enabled
+            else "adv-dns-enabled-no",
+        )
+        _select(
+            "#adv-dns-tfmanaged",
+            "adv-dns-tfmanaged-yes"
+            if cfg.dns.terraform_managed
+            else "adv-dns-tfmanaged-no",
+        )
+        self.query_one("#adv-dns-domain").value = (
+            cfg.dns.domain or ""
+        )
+        self.query_one("#adv-dns-zone-id").value = (
+            cfg.dns.zone_id or ""
+        )
+        _select(
+            "#adv-ssl-provider",
+            {
+                "none": "adv-ssl-none",
+                "letsencrypt": "adv-ssl-letsencrypt",
+                "cloudflare": "adv-ssl-cloudflare",
+                "acm": "adv-ssl-acm",
+                "self_signed": "adv-ssl-self_signed",
+            }.get(cfg.ssl.provider, "adv-ssl-none"),
+        )
+        self.query_one("#adv-ssl-email").value = cfg.ssl.email or ""
+        self.query_one("#adv-ssl-acm-arn").value = (
+            cfg.ssl.certificate_arn or ""
+        )
+        _select(
+            "#adv-eip-strategy",
+            "adv-eip-persistent"
+            if cfg.eip.strategy == "persistent"
+            else "adv-eip-dynamic",
+        )
+        self.query_one("#adv-eip-help").display = (
+            cfg.eip.strategy == "persistent"
+        )
+
+    def _refresh_guided_from_cfg(self) -> None:
+        cfg = self.app.config
+        self.query_one("#domain").value = cfg.dns.domain or ""
+        self.query_one("#ssl-email").value = cfg.ssl.email or ""
+        self.query_one("#acm-arn").value = (
+            cfg.ssl.certificate_arn or ""
+        )
+
+        target_id = {
+            "none": "dns-none",
+            "letsencrypt": "dns-letsencrypt",
+            "cloudflare": "dns-cloudflare",
+            "acm": "dns-acm",
+            "self_signed": "dns-self_signed",
+        }.get(cfg.ssl.provider, "dns-none")
+        if not cfg.dns.enabled and cfg.ssl.provider == "self_signed":
+            target_id = "dns-self_signed"
+        elif not cfg.dns.enabled and cfg.ssl.provider == "none":
+            target_id = "dns-none"
+        # Same caveat as `_refresh_advanced_from_cfg._select`: this runs from
+        # inside a RadioSet message handler with RadioButton.Changed prevented,
+        # so we mutate values directly and reset `_pressed_button`.
+        dns_mode = self.query_one("#dns-mode", RadioSet)
+        target: RadioButton | None = None
+        for btn in dns_mode.query(RadioButton):
+            if btn.id == target_id:
+                target = btn
+            else:
+                if btn.value:
+                    btn.value = False
+        if target is not None:
+            target.value = True
+            dns_mode._pressed_button = target
+        self.query_one("#eip-help").display = (
+            cfg.ssl.provider == "cloudflare"
+        )
+
+    @on(RadioSet.Changed, "#adv-eip-strategy")
+    def _adv_eip_changed(self, event: RadioSet.Changed) -> None:
+        self.query_one("#adv-eip-help").display = (
+            event.pressed.id == "adv-eip-persistent"
+        )
+
+    def on_mount(self) -> None:
+        cfg = self.app.config
+        is_cloudflare = (
+            cfg.dns.enabled
+            and cfg.ssl.provider == "cloudflare"
+        )
+        self.query_one("#eip-help").display = is_cloudflare
+        self.query_one("#dns-guided").display = True
+        self.query_one("#dns-advanced").display = False
+        self.query_one("#adv-eip-help").display = (
+            cfg.eip.strategy == "persistent"
+        )
+        self.query_one("#dns-validation-error").display = False
+
     @on(Button.Pressed, "#back")
     def _back(self) -> None:
         self.app.pop_screen()
 
-    @on(Button.Pressed, "#next")
-    def _next(self) -> None:
+    def _save_guided(self) -> None:
         radio = self.query_one("#dns-mode", RadioSet)
         pressed_button = getattr(radio, "pressed_button", None)
         if pressed_button is not None:
             pressed_id = pressed_button.id
         else:
-            # Fallback for older Textual: find the button with value=True
             pressed_id = "dns-none"
             for btn in radio.query(RadioButton):
                 if btn.value:
@@ -634,7 +932,7 @@ class DnsScreen(Screen):
             cfg.dns.terraform_managed = False
             cfg.dns.domain = domain
             cfg.ssl.provider = "cloudflare"
-            cfg.eip.strategy = "dynamic"
+            cfg.eip.strategy = "persistent"
         elif provider == "acm":
             cfg.dns.enabled = True
             cfg.dns.terraform_managed = True
@@ -646,6 +944,65 @@ class DnsScreen(Screen):
             cfg.dns.enabled = False
             cfg.ssl.provider = "self_signed"
             cfg.eip.strategy = "dynamic"
+
+    def _save_advanced(self) -> None:
+        cfg = self.app.config
+
+        def _selected_id(radioset_id: str) -> str:
+            for btn in self.query_one(radioset_id).query(RadioButton):
+                if btn.value:
+                    return btn.id or ""
+            return ""
+
+        cfg.dns.enabled = (
+            _selected_id("#adv-dns-enabled") == "adv-dns-enabled-yes"
+        )
+        cfg.dns.terraform_managed = (
+            _selected_id("#adv-dns-tfmanaged")
+            == "adv-dns-tfmanaged-yes"
+        )
+        cfg.dns.domain = self.query_one("#adv-dns-domain").value
+        cfg.dns.zone_id = self.query_one("#adv-dns-zone-id").value
+
+        provider_map = {
+            "adv-ssl-none": "none",
+            "adv-ssl-letsencrypt": "letsencrypt",
+            "adv-ssl-cloudflare": "cloudflare",
+            "adv-ssl-acm": "acm",
+            "adv-ssl-self_signed": "self_signed",
+        }
+        cfg.ssl.provider = provider_map.get(
+            _selected_id("#adv-ssl-provider"), "none"
+        )
+        cfg.ssl.email = self.query_one("#adv-ssl-email").value
+        cfg.ssl.certificate_arn = self.query_one(
+            "#adv-ssl-acm-arn"
+        ).value
+
+        cfg.eip.strategy = (
+            "persistent"
+            if _selected_id("#adv-eip-strategy")
+            == "adv-eip-persistent"
+            else "dynamic"
+        )
+
+    @on(Button.Pressed, "#next")
+    def _next(self) -> None:
+        from lablink_cli.config.schema import validate_config
+
+        is_advanced = self.query_one("#dns-advanced").display
+        if is_advanced:
+            self._save_advanced()
+        else:
+            self._save_guided()
+
+        if is_advanced:
+            errors = validate_config(self.app.config)
+            if errors:
+                err_label = self.query_one("#dns-validation-error")
+                err_label.update("\n".join(errors))
+                err_label.display = True
+                return
 
         self.app.push_screen(StartupScreen())
 

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -82,3 +82,343 @@ def test_monitoring_screen_does_not_touch_other_fields():
     assert cfg.monitoring.watch_dir == original_watch_dir
     assert cfg.monitoring.sample_interval_seconds == original_sample
     assert cfg.monitoring.push_interval_seconds == original_push
+
+
+def _build_cfg_and_app(
+    deployment_name: str = "sleap-lablink",
+    environment: str = "prod",
+):
+    """Build a Config + ConfigWizard suitable for DnsScreen tests."""
+    from lablink_cli.config.schema import Config
+    from lablink_cli.tui.wizard import ConfigWizard
+
+    cfg = Config()
+    cfg.deployment_name = deployment_name
+    cfg.environment = environment
+    cfg.provider = "aws"
+    app = ConfigWizard(existing_config=cfg)
+    return cfg, app
+
+
+def _select_radio_by_id(screen, radioset_id: str, button_id: str) -> None:
+    """Set the RadioButton with the given id to value=True within the RadioSet."""
+    from textual.widgets import RadioButton, RadioSet
+
+    radio_set = screen.query_one(radioset_id, RadioSet)
+    for btn in radio_set.query(RadioButton):
+        btn.value = (btn.id == button_id)
+
+
+def test_dns_guided_cloudflare_sets_persistent_eip():
+    """Guided + Cloudflare radio → cfg.eip.strategy == 'persistent'."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> None:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            _select_radio_by_id(screen, "#dns-mode", "dns-cloudflare")
+            # Populate required Cloudflare fields so _next() doesn't bail.
+            screen.query_one("#domain").value = "lablink.sleap.ai"
+            await pilot.pause()
+            screen._next()
+            await pilot.pause()
+
+    asyncio.run(_run())
+    assert cfg.eip.strategy == "persistent"
+
+
+def test_dns_guided_letsencrypt_sets_dynamic_eip():
+    """Guided + Let's Encrypt → cfg.eip.strategy == 'dynamic'."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> None:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            _select_radio_by_id(screen, "#dns-mode", "dns-letsencrypt")
+            screen.query_one("#domain").value = "lablink.example.com"
+            screen.query_one("#ssl-email").value = "admin@example.com"
+            await pilot.pause()
+            screen._next()
+            await pilot.pause()
+
+    asyncio.run(_run())
+    assert cfg.eip.strategy == "dynamic"
+
+
+def test_dns_guided_none_sets_dynamic_eip():
+    """Guided + None (IP only) → cfg.eip.strategy == 'dynamic'."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> None:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            _select_radio_by_id(screen, "#dns-mode", "dns-none")
+            await pilot.pause()
+            screen._next()
+            await pilot.pause()
+
+    asyncio.run(_run())
+    assert cfg.eip.strategy == "dynamic"
+
+
+def test_dns_guided_self_signed_sets_dynamic_eip():
+    """Guided + Self-signed → cfg.eip.strategy == 'dynamic'."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> None:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            _select_radio_by_id(screen, "#dns-mode", "dns-self_signed")
+            await pilot.pause()
+            screen._next()
+            await pilot.pause()
+
+    asyncio.run(_run())
+    assert cfg.eip.strategy == "dynamic"
+
+
+def test_dns_guided_cloudflare_shows_eip_help():
+    """Selecting Cloudflare reveals a help label containing the literal EIP tag."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app(
+        deployment_name="sleap-lablink", environment="prod"
+    )
+
+    async def _run() -> str:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            _select_radio_by_id(screen, "#dns-mode", "dns-cloudflare")
+            await pilot.pause()
+            label = screen.query_one("#eip-help")
+            return str(label.render())
+
+    text = asyncio.run(_run())
+    assert "sleap-lablink-eip-prod" in text
+
+
+def test_dns_screen_has_mode_toggle_default_guided():
+    """DnsScreen mounts with a Guided/Advanced toggle; Guided default."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> tuple[bool, bool]:
+        from textual.widgets import RadioButton, RadioSet
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            radio_set = screen.query_one("#dns-screen-mode", RadioSet)
+            buttons = list(radio_set.query(RadioButton))
+            guided_selected = (
+                buttons[0].id == "screen-mode-guided"
+                and buttons[0].value is True
+            )
+            advanced_hidden = (
+                screen.query_one("#dns-advanced").display is False
+            )
+            return guided_selected, advanced_hidden
+
+    guided, hidden = asyncio.run(_run())
+    assert guided is True
+    assert hidden is True
+
+
+def test_dns_advanced_persistent_eip_writes_through():
+    """Advanced mode: flipping EIP radio to persistent writes cfg.eip.strategy."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> None:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            _select_radio_by_id(
+                screen, "#dns-screen-mode", "screen-mode-advanced"
+            )
+            await pilot.pause()
+            _select_radio_by_id(
+                screen, "#adv-dns-enabled", "adv-dns-enabled-yes"
+            )
+            _select_radio_by_id(
+                screen,
+                "#adv-dns-tfmanaged",
+                "adv-dns-tfmanaged-no",
+            )
+            _select_radio_by_id(
+                screen,
+                "#adv-ssl-provider",
+                "adv-ssl-cloudflare",
+            )
+            _select_radio_by_id(
+                screen,
+                "#adv-eip-strategy",
+                "adv-eip-persistent",
+            )
+            screen.query_one("#adv-dns-domain").value = (
+                "lablink.sleap.ai"
+            )
+            await pilot.pause()
+            screen._next()
+            await pilot.pause()
+
+    asyncio.run(_run())
+    assert cfg.eip.strategy == "persistent"
+    assert cfg.dns.enabled is True
+    assert cfg.dns.terraform_managed is False
+    assert cfg.dns.domain == "lablink.sleap.ai"
+    assert cfg.ssl.provider == "cloudflare"
+
+
+def test_dns_advanced_zone_id_writes_through():
+    """Advanced mode: typed zone_id is saved to cfg.dns.zone_id."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> None:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            _select_radio_by_id(
+                screen, "#dns-screen-mode", "screen-mode-advanced"
+            )
+            await pilot.pause()
+            _select_radio_by_id(
+                screen, "#adv-dns-enabled", "adv-dns-enabled-yes"
+            )
+            _select_radio_by_id(
+                screen,
+                "#adv-dns-tfmanaged",
+                "adv-dns-tfmanaged-yes",
+            )
+            _select_radio_by_id(
+                screen,
+                "#adv-ssl-provider",
+                "adv-ssl-letsencrypt",
+            )
+            screen.query_one("#adv-dns-domain").value = (
+                "lablink.example.com"
+            )
+            screen.query_one("#adv-ssl-email").value = (
+                "admin@example.com"
+            )
+            screen.query_one("#adv-dns-zone-id").value = (
+                "Z0123456789ABCDEFG"
+            )
+            await pilot.pause()
+            screen._next()
+            await pilot.pause()
+
+    asyncio.run(_run())
+    assert cfg.dns.zone_id == "Z0123456789ABCDEFG"
+
+
+def test_dns_toggle_preserves_typed_domain():
+    """Typing a domain in Guided, toggling to Advanced shows the same value."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> str:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            _select_radio_by_id(screen, "#dns-mode", "dns-cloudflare")
+            await pilot.pause()
+            screen.query_one("#domain").value = "lablink.sleap.ai"
+            await pilot.pause()
+            _select_radio_by_id(
+                screen, "#dns-screen-mode", "screen-mode-advanced"
+            )
+            await pilot.pause()
+            return screen.query_one("#adv-dns-domain").value
+
+    domain = asyncio.run(_run())
+    assert domain == "lablink.sleap.ai"
+
+
+def test_dns_advanced_invalid_combo_blocks_next():
+    """Advanced + invalid combo (DNS disabled + letsencrypt) → error shown, no push."""
+    import asyncio
+    from lablink_cli.tui.wizard import DnsScreen
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> tuple[bool, int, str]:
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            stack_before = len(app.screen_stack)
+            _select_radio_by_id(
+                screen, "#dns-screen-mode", "screen-mode-advanced"
+            )
+            await pilot.pause()
+            _select_radio_by_id(
+                screen, "#adv-dns-enabled", "adv-dns-enabled-no"
+            )
+            _select_radio_by_id(
+                screen,
+                "#adv-ssl-provider",
+                "adv-ssl-letsencrypt",
+            )
+            await pilot.pause()
+            screen._next()
+            await pilot.pause()
+            stack_after = len(app.screen_stack)
+            err = str(
+                screen.query_one("#dns-validation-error").render()
+            )
+            visible = screen.query_one(
+                "#dns-validation-error"
+            ).display
+            return visible, stack_after - stack_before, err
+
+    visible, stack_delta, err = asyncio.run(_run())
+    assert visible is True
+    assert stack_delta == 0  # screen did not push StartupScreen
+    assert err  # non-empty error text


### PR DESCRIPTION
## Summary

- `DnsScreen` now offers a top-of-screen Guided/Advanced mode toggle. Guided keeps today's preset-style flow; Advanced is a flat form exposing every `dns.*`/`ssl.*`/`eip.*` field directly.
- The Guided Cloudflare branch now sets `eip.strategy="persistent"` (was silently `dynamic`, which breaks externally-managed Cloudflare A records on each redeploy). The screen displays the literal `{deployment_name}-eip-{environment}` Name tag plus an `aws ec2 create-tags` example so users can tag their pre-allocated EIP correctly.
- Advanced mode adds `dns.zone_id` (no prior wizard path), exposes `dns.terraform_managed`/`dns.enabled` directly, and surfaces `validate_config(cfg)` errors in `#dns-validation-error` instead of pushing forward.

## Changes Made

- `packages/cli/src/lablink_cli/tui/wizard.py`
  - New mode toggle `RadioSet#dns-screen-mode` (Guided default, Advanced opt-in) at the top of `DnsScreen`.
  - Wrapped existing Guided widgets in `Container#dns-guided`; added `Container#dns-advanced` with a flat form for every dns/ssl/eip field.
  - `_screen_mode_changed` saves the visible side via `_save_guided`/`_save_advanced`, refreshes the other side via `_refresh_advanced_from_cfg`/`_refresh_guided_from_cfg`, then flips container `display`.
  - `_save_advanced` validates via `validate_config(cfg)` and surfaces errors inline; Guided's branch table prevents invalid combos by construction, so it skips validation.
  - Cloudflare branch in Guided now defaults `eip.strategy=persistent`. Help block (`#eip-help`) renders the literal tag string computed from `cfg.deployment_name` + `cfg.environment`.

- `packages/cli/tests/test_wizard.py`
  - 9 new `Pilot`-based tests covering: Guided EIP defaults per SSL provider (4), Cloudflare help-block content, mode toggle default state, Advanced writes-through for EIP strategy + zone_id, toggle preserves typed values across modes, Advanced invalid combo blocks Next.

## Testing

- `cd packages/cli && PYTHONPATH=src pytest tests/test_wizard.py -v` → 13/13 pass (3 pre-existing monitoring + 10 DNS).
- Full CLI suite (`pytest -q`): 488/488 pass.
- `ruff check` on both files: clean.
- Manual TUI walkthrough verified by author.

## Design Decisions

- **Two modes on one screen, not two screens.** Toggle is cheap to flip and shared cfg makes value persistence transparent. Other wizard screens have no comparable knob sprawl, so the toggle is local to DNS.
- **No filtering in Advanced.** Email, ACM ARN, zone_id are always editable regardless of SSL provider. If the user chose Advanced, they're trusted to construct a coherent combo; validation catches mistakes before push.
- **Tag instructions are text only.** No `aws ec2 create-tags` execution from the wizard, no boto3 lookup, no schema change. Accepting an `allocation_id` directly would require a cross-repo change in `lablink-template` (Terraform data lookup) and is deferred.
- **Default to Guided each entry.** No persistence of "last-used mode" — keeps the back-button path simple and matches every other screen's re-mount behavior.

## Known technical debt

- `_refresh_advanced_from_cfg` and `_refresh_guided_from_cfg` touch the private Textual attribute `RadioSet._pressed_button` to work around prevent-context behavior of nested `RadioSet.Changed` handlers. Documented inline; will surface as a test failure if Textual renames the attribute.

🤖 Generated with [Claude Code](https://claude.com/claude-code)