### PR TITLE
fix(cli): send product User-Agent so Cloudflare-proxied allocators don't 403

### DIFF
--- a/packages/cli/src/lablink_cli/api.py
+++ b/packages/cli/src/lablink_cli/api.py
@@ -9,6 +9,18 @@ from typing import NoReturn
 from urllib.error import HTTPError, URLError
 from urllib.request import Request, urlopen
 
+try:
+    from importlib.metadata import version as _pkg_version
+
+    _CLI_VERSION = _pkg_version("lablink-cli")
+except Exception:  # pragma: no cover - package metadata unavailable
+    _CLI_VERSION = "0.0.0"
+
+# Product User-Agent for all CLI HTTP requests. urllib's default
+# "Python-urllib/x.y" is blocked with HTTP 403 by Cloudflare-proxied
+# allocators, so every Request must identify itself with this instead.
+USER_AGENT = f"lablink-cli/{_CLI_VERSION}"
+
 
 class AllocatorError(Exception):
     """Base exception for allocator API errors."""
@@ -59,6 +71,7 @@ class AllocatorAPI:
         """Send an HTTP request to the allocator."""
         url = f"{self.base_url}{path}"
         req = Request(url, data=data, method=method)
+        req.add_header("User-Agent", USER_AGENT)
         req.add_header("Authorization", self._auth_header)
         req.add_header("Accept", "application/json")
 
@@ -165,6 +178,7 @@ class RegistrationClient:
         url = f"{self.base_url}{path}"
         data = json.dumps(body).encode()
         req = Request(url, data=data, method="POST")
+        req.add_header("User-Agent", USER_AGENT)
         req.add_header("Authorization", self._auth_header)
         req.add_header("Content-Type", "application/json")
         req.add_header("Accept", "application/json")

--- a/packages/cli/src/lablink_cli/commands/export_metrics.py
+++ b/packages/cli/src/lablink_cli/commands/export_metrics.py
@@ -23,6 +23,7 @@ from urllib.request import Request, urlopen
 
 from rich.console import Console
 
+from lablink_cli.api import USER_AGENT
 from lablink_cli.commands.utils import (
     get_allocator_url,
     resolve_admin_credentials,
@@ -67,6 +68,7 @@ def _export_client_metrics(
     ).decode()
 
     req = Request(url, method="GET")
+    req.add_header("User-Agent", USER_AGENT)
     req.add_header("Authorization", f"Basic {credentials}")
     req.add_header("Accept", "application/json")
 

--- a/packages/cli/src/lablink_cli/commands/launch.py
+++ b/packages/cli/src/lablink_cli/commands/launch.py
@@ -15,6 +15,7 @@ from rich.console import Console
 
 from lablink_allocator_service.conf.structured_config import Config
 
+from lablink_cli.api import USER_AGENT
 from lablink_cli.commands.utils import (
     get_allocator_url,
     resolve_admin_credentials,
@@ -81,6 +82,7 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
     ).decode()
 
     req = Request(url, data=data, method="POST")
+    req.add_header("User-Agent", USER_AGENT)
     req.add_header("Authorization", f"Basic {credentials}")
     req.add_header("Content-Type", "application/x-www-form-urlencoded")
     req.add_header("Accept", "application/json")

--- a/packages/cli/src/lablink_cli/commands/logs.py
+++ b/packages/cli/src/lablink_cli/commands/logs.py
@@ -16,6 +16,7 @@ from rich.console import Console
 
 from lablink_allocator_service.conf.structured_config import Config
 
+from lablink_cli.api import USER_AGENT
 from lablink_cli.commands.utils import (
     get_allocator_url,
     get_deploy_dir,
@@ -44,6 +45,7 @@ def fetch_client_logs(
     ).decode()
 
     req = Request(url, method="GET")
+    req.add_header("User-Agent", USER_AGENT)
     req.add_header("Authorization", f"Basic {credentials}")
     req.add_header("Accept", "application/json")
 

--- a/packages/cli/src/lablink_cli/commands/stats.py
+++ b/packages/cli/src/lablink_cli/commands/stats.py
@@ -17,6 +17,7 @@ from urllib.request import Request, urlopen
 from rich.console import Console
 from rich.table import Table
 
+from lablink_cli.api import USER_AGENT
 from lablink_cli.commands.utils import (
     get_allocator_url,
     resolve_admin_credentials,
@@ -39,6 +40,7 @@ def _fetch(cfg) -> dict:
     req = Request(
         f"{allocator_url}/api/session-metrics/summary", method="GET"
     )
+    req.add_header("User-Agent", USER_AGENT)
     req.add_header("Authorization", f"Basic {credentials}")
     req.add_header("Accept", "application/json")
 

--- a/packages/cli/src/lablink_cli/commands/status.py
+++ b/packages/cli/src/lablink_cli/commands/status.py
@@ -20,6 +20,7 @@ from rich.table import Table
 
 from lablink_allocator_service.conf.structured_config import Config
 
+from lablink_cli.api import USER_AGENT
 from lablink_cli.commands.utils import (
     get_client_vms,
     get_deploy_dir as _get_deploy_dir,
@@ -79,6 +80,7 @@ def check_http(url: str) -> dict:
     result = {"check": "HTTP Health", "status": "fail"}
     try:
         req = Request(url, method="GET")
+        req.add_header("User-Agent", USER_AGENT)
         resp = urlopen(req, timeout=10)  # noqa: S310
         code = resp.getcode()
         if code and code < 400:
@@ -114,6 +116,7 @@ def check_health_endpoint(base_url: str) -> dict:
     }
     try:
         req = Request(url, method="GET")
+        req.add_header("User-Agent", USER_AGENT)
         resp = urlopen(req, timeout=10)  # noqa: S310
         body = json.loads(resp.read().decode())
         if body.get("status") == "healthy":

--- a/packages/cli/src/lablink_cli/commands/unregister.py
+++ b/packages/cli/src/lablink_cli/commands/unregister.py
@@ -13,6 +13,8 @@ from urllib.request import Request, urlopen
 import typer
 from rich.console import Console
 
+from lablink_cli.api import USER_AGENT
+
 DEFAULT_ENV_FILE = Path.home() / ".lablink" / "client.env"
 
 
@@ -124,6 +126,7 @@ def _notify_deregister(
     """
     url = f"{allocator_url.rstrip('/')}/api/v1/clients/{client_id}"
     req = Request(url, method="DELETE")
+    req.add_header("User-Agent", USER_AGENT)
     req.add_header("Authorization", f"Bearer {client_secret}")
     req.add_header("Accept", "application/json")
 

--- a/packages/cli/tests/test_status.py
+++ b/packages/cli/tests/test_status.py
@@ -134,6 +134,40 @@ class TestCheckHealthEndpoint:
 
 
 # ------------------------------------------------------------------
+# User-Agent header
+#
+# Cloudflare-proxied allocators return HTTP 403 to the default
+# "Python-urllib/x.y" User-Agent. Health-check requests must send a
+# product User-Agent so they reach the origin instead of being blocked
+# at the Cloudflare edge.
+# ------------------------------------------------------------------
+class TestUserAgent:
+    @patch("lablink_cli.commands.status.urlopen")
+    def test_check_http_sends_product_user_agent(self, mock_urlopen):
+        mock_resp = MagicMock()
+        mock_resp.getcode.return_value = 200
+        mock_urlopen.return_value = mock_resp
+
+        check_http("http://example.com")
+
+        req = mock_urlopen.call_args.args[0]
+        assert req.get_header("User-agent", "").startswith("lablink-cli/")
+
+    @patch("lablink_cli.commands.status.urlopen")
+    def test_check_health_endpoint_sends_product_user_agent(self, mock_urlopen):
+        import json
+
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps({"status": "healthy"}).encode()
+        mock_urlopen.return_value = mock_resp
+
+        check_health_endpoint("http://1.2.3.4:5000")
+
+        req = mock_urlopen.call_args.args[0]
+        assert req.get_header("User-agent", "").startswith("lablink-cli/")
+
+
+# ------------------------------------------------------------------
 # estimate_costs
 # ------------------------------------------------------------------
 class TestEstimateCosts:


### PR DESCRIPTION
## Problem

The CLI health check reports a false-negative failure against Cloudflare-proxied allocators:

```
Allocator Health   FAIL   https://lablink.sleap.ai/api/health → HTTP 403
```

The allocator is actually healthy — `curl` returns `200` (origin is Caddy behind Cloudflare). The 403 is injected by **Cloudflare's edge**, which blocks requests carrying urllib's default `User-Agent: Python-urllib/x.y`. Every CLI request was built with `Request(url, ...)` and never set a User-Agent, so `lablink status`/`doctor` showed a failure even when nothing was wrong — and `logs`/`stats`/`launch`/`destroy`/`register` would 403 the same way on a Cloudflare-fronted deployment.

(The `DNS Resolution: WARN` and `SSL issuer: Google Trust Services` in the same report are the Cloudflare proxy showing through — expected, not separate bugs.)

## Fix

- Add a shared `USER_AGENT = "lablink-cli/<version>"` constant in `api.py`, derived from package metadata with a safe fallback.
- Set `User-Agent: lablink-cli/...` on **every** CLI urllib request: health checks (`status.py`), the allocator API + registration client (`api.py`), and `launch` / `logs` / `stats` / `export-metrics` / `unregister`.

## Verification

| Check | Result |
|---|---|
| New TDD tests (`test_status.py::TestUserAgent`) | RED → GREEN |
| Full CLI suite | **490 passed** |
| `ruff check src tests` | clean |
| Live: new `lablink-cli/0.1.0` UA → `/api/health` | **200** |
| Live: old `Python-urllib/3.11` UA → `/api/health` | **403** (reproduces the bug) |

## Notes

- The `DNS Resolution: WARN` under a Cloudflare-proxied (orange-cloud) record is left as-is — it's informational, not a failure. Making `check_dns` Cloudflare-aware is a separate change.
- No allocator/Terraform changes; this only affects the CLI's outbound requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)