### PR TITLE
fix(allocator): make VM assignment atomic to stop double-booking under load

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -539,35 +539,59 @@ class PostgresqlDatabase:
             )
             raise
 
-    def assign_vm(self, email) -> None:
-        """Assign a VM to a user.
+    def assign_vm(self, email) -> str:
+        """Atomically claim an available VM for a user and return its hostname.
+
+        The claim is a single statement: the inner SELECT picks one
+        unassigned, running, non-Unhealthy row and locks it with
+        ``FOR UPDATE SKIP LOCKED``, so concurrent callers each lock a
+        *different* row instead of racing on the same one. ``RETURNING``
+        hands back the hostname that was actually claimed, so the caller
+        never has to re-look it up by email (which is itself racy).
+
+        Skips rows marked Unhealthy so a VM whose agent went dark (rotation
+        failed, etc.) isn't handed to the next student to wedge in turn —
+        the reboot service picks it back up.
 
         Args:
             email (str): The email of the user.
+
+        Returns:
+            str: The hostname of the claimed VM.
+
+        Raises:
+            ValueError: If no VM is available to assign.
         """
-        hostname = self.get_first_available_vm()
-
-        if not hostname:
-            logger.warning("No available VMs to assign")
-            raise ValueError("No available VMs to assign.")
-
         query = f"""
         UPDATE {self.table_name}
         SET useremail = %s,
             inuse = FALSE
-        WHERE hostname = %s;
+        WHERE hostname = (
+            SELECT hostname FROM {self.table_name}
+            WHERE useremail IS NULL
+            AND status = 'running'
+            AND (healthy IS NULL OR healthy <> 'Unhealthy')
+            ORDER BY hostname
+            FOR UPDATE SKIP LOCKED
+            LIMIT 1
+        )
+        RETURNING hostname;
         """
         with self._cursor as cursor:
             try:
-                cursor.execute(query, (email, hostname))
-                logger.info(
-                    f"Assigned VM '{hostname}' to user '{email}'"
-                )
+                cursor.execute(query, (email,))
+                row = cursor.fetchone()
             except Exception as e:
-                logger.error(
-                    f"Failed to assign VM '{hostname}': {e}"
-                )
+                logger.error(f"Failed to assign VM to '{email}': {e}")
                 raise
+
+        if row is None:
+            logger.warning("No available VMs to assign")
+            raise ValueError("No available VMs to assign.")
+
+        hostname = row[0]
+        logger.info(f"Assigned VM '{hostname}' to user '{email}'")
+        return hostname
 
     def release_seat(self, *, hostname: str) -> None:
         """Clear useremail and every per-session column on a VM row,
@@ -586,28 +610,6 @@ class PostgresqlDatabase:
         )
         with self._cursor as cursor:
             cursor.execute(query, (hostname,))
-
-    def get_first_available_vm(self) -> str:
-        """Get the first available VM that is not assigned.
-
-        Skips rows marked Unhealthy so that a VM whose agent went dark
-        (rotation failed, etc.) isn't handed to the next student to
-        wedge in turn — it'll be picked back up by the reboot service.
-
-        Returns:
-            str: The hostname of the first available VM.
-        """
-        query = (
-            f"SELECT hostname FROM {self.table_name} "
-            f"WHERE useremail IS NULL "
-            f"AND status = 'running' "
-            f"AND (healthy IS NULL OR healthy <> 'Unhealthy') "
-            f"LIMIT 1"
-        )
-        with self._cursor as cursor:
-            cursor.execute(query)
-            row = cursor.fetchone()
-        return row[0] if row else None
 
     def update_vm_in_use(self, hostname: str, in_use: bool) -> None:
         """Update the in-use status of a VM.

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -343,22 +343,16 @@ def submit_vm_details():
         if existing is not None and existing["status"] == "running":
             hostname = existing["hostname"]
         else:
-            # Fresh assignment. assign_vm raises ValueError if no VM is
-            # available; we treat that as 503 (no seats).
+            # Fresh assignment. assign_vm atomically claims a seat and
+            # returns its hostname, or raises ValueError if the pool is
+            # empty; we treat that as 503 (no seats). Because the claim is
+            # atomic (FOR UPDATE SKIP LOCKED), there's no separate lookup
+            # to race against.
             try:
-                database.assign_vm(email=email)
+                hostname = database.assign_vm(email=email)
             except ValueError:
                 logger.warning("Pool empty when '%s' asked for a seat", email)
                 return render_template("no_seats.html"), 503
-            re_lookup = database.get_assigned_vm_for_email(email=email)
-            if re_lookup is None:
-                # Shouldn't happen: assign_vm succeeded but lookup missed.
-                logger.error(
-                    "Assigned VM not visible to follow-up lookup for '%s'",
-                    email,
-                )
-                return render_template("no_seats.html"), 503
-            hostname = re_lookup["hostname"]
 
         # Mint per-session identifiers and rotate the VNC password on the
         # assigned client. RotationFailed → mark unhealthy and ask the

--- a/packages/allocator/tests/test_api_calls.py
+++ b/packages/allocator/tests/test_api_calls.py
@@ -246,6 +246,49 @@ def test_request_vm_success(client, monkeypatch):
     assert "SameSite=Strict" in set_cookie
 
 
+def test_request_vm_fresh_assignment_uses_returned_hostname(client, monkeypatch):
+    """Fresh assignment (no existing seat) uses the hostname assign_vm
+    returns directly — there is no second lookup-by-email, which is the
+    racy step the old handler relied on."""
+    fake_db = MagicMock()
+    # No existing seat -> take the fresh-assignment branch.
+    fake_db.get_assigned_vm_for_email.return_value = None
+    fake_db.assign_vm.return_value = "host-fresh"
+    fake_conn = MagicMock()
+    fake_db._pool.getconn.return_value = fake_conn
+
+    captured = {}
+
+    def _prepare(**kw):
+        captured.update(kw)
+
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=True
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.providers.connectivity.allocator_proxied.prepare_browser_session",
+        _prepare,
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.get_or_create_cookie_secret",
+        lambda conn: "test-secret",
+    )
+
+    resp = client.post(
+        "/api/request_vm",
+        data={"email": "fresh@example.com"},
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 303
+    assert resp.headers["Location"].endswith("/desktop")
+    # The hostname handed to session-prep is exactly what assign_vm returned.
+    assert captured["hostname"] == "host-fresh"
+    fake_db.assign_vm.assert_called_once_with(email="fresh@example.com")
+    # Only the initial idempotency check ran — no second re-lookup by email.
+    fake_db.get_assigned_vm_for_email.assert_called_once()
+
+
 def test_request_vm_missing(client, monkeypatch):
     """POST /api/request_vm with missing email -> index.html with error."""
     fake_db = MagicMock()

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -163,45 +163,26 @@ def test_vm_exists_returns_none(db_instance):
 
 
 def test_assign_vm(db_instance):
-    """Test assigning an available VM to a user."""
+    """assign_vm atomically claims a VM and returns its hostname."""
     email = "new-user@example.com"
     hostname = "available-vm"
+    db_instance.cursor.fetchone.return_value = (hostname,)
 
-    db_instance.get_first_available_vm = MagicMock(return_value=hostname)
-    db_instance.assign_vm(email)
+    result = db_instance.assign_vm(email)
 
-    # Using ANY to avoid matching the exact whitespace in the multi-line query string
-    db_instance.cursor.execute.assert_called_with(
-        ANY, (email, hostname)
-    )
+    assert result == hostname
+    # Single atomic claim, parameterized by email only (no separate SELECT).
+    db_instance.cursor.execute.assert_called_with(ANY, (email,))
+    sql = db_instance.cursor.execute.call_args[0][0]
+    assert "FOR UPDATE SKIP LOCKED" in sql
+    assert "RETURNING hostname" in sql
 
 
 def test_assign_vm_no_available(db_instance):
-    """Test assigning a VM when no VMs are available."""
-    db_instance.get_first_available_vm = MagicMock(return_value=None)
+    """assign_vm raises ValueError when the atomic claim returns no row."""
+    db_instance.cursor.fetchone.return_value = None
     with pytest.raises(ValueError, match="No available VMs to assign."):
         db_instance.assign_vm("user@example.com")
-
-
-def test_get_first_available_vm(db_instance):
-    """Test getting the first available VM.
-
-    The query skips rows marked Unhealthy so that a wedged VM
-    (rotation failed, agent unreachable) isn't handed to the next
-    student until the reboot service rescues it."""
-    hostname = "free-vm-01"
-    db_instance.cursor.fetchone.return_value = (hostname,)
-
-    result = db_instance.get_first_available_vm()
-
-    expected_query = (
-        "SELECT hostname FROM vms WHERE useremail IS NULL "
-        "AND status = 'running' "
-        "AND (healthy IS NULL OR healthy <> 'Unhealthy') "
-        "LIMIT 1"
-    )
-    db_instance.cursor.execute.assert_called_with(expected_query)
-    assert result == hostname
 
 
 def test_update_vm_in_use(db_instance):
@@ -625,8 +606,6 @@ def test_get_unassigned_vms_error(db_instance, caplog):
 
 def test_assign_vm_db_error(db_instance, caplog):
     """Test error handling in assign_vm."""
-    hostname = "available-vm"
-    db_instance.get_first_available_vm = MagicMock(return_value=hostname)
     db_instance.cursor.execute.side_effect = Exception("DB error")
     with pytest.raises(Exception, match="DB error"):
         db_instance.assign_vm("user@example.com")
@@ -1371,6 +1350,143 @@ def test_release_seat_clears_per_session_columns(real_db):
         row = cur.fetchone()
 
     assert row == (None, None, None, None, None, None, None, None)
+
+
+def _seed_race_table(real_db, hostnames):
+    """Create the columns assign_vm needs and seed the given running VMs."""
+    with real_db._cursor as cur:
+        cur.execute(
+            "ALTER TABLE vms "
+            "ADD COLUMN IF NOT EXISTS status TEXT, "
+            "ADD COLUMN IF NOT EXISTS useremail TEXT, "
+            "ADD COLUMN IF NOT EXISTS healthy TEXT, "
+            "ADD COLUMN IF NOT EXISTS inuse BOOLEAN"
+        )
+        # Clean slate: the seeded VMs must be the ONLY claimable rows, so a
+        # leftover available row from another real_db test can't be claimed
+        # and skew the distinct-VM count.
+        cur.execute("DELETE FROM vms")
+        for h in hostnames:
+            cur.execute(
+                "INSERT INTO vms (hostname, status, useremail, healthy) "
+                "VALUES (%s, 'running', NULL, NULL)",
+                (h,),
+            )
+
+
+def _assigned_rows(real_db):
+    with real_db._cursor as cur:
+        cur.execute(
+            "SELECT hostname, useremail FROM vms "
+            "WHERE hostname LIKE 'race-vm-%' AND useremail IS NOT NULL"
+        )
+        return cur.fetchall()
+
+
+def test_assign_vm_concurrent_no_double_assignment(real_db):
+    """N participants clicking 'join' at the same instant must each get a
+    DISTINCT VM.
+
+    The old design (SELECT ... LIMIT 1 with no ORDER BY / row lock, then a
+    separate UPDATE) let concurrent requests claim the same row, so students
+    collided onto one VM while the rest of the pool sat unused. assign_vm
+    must claim atomically (FOR UPDATE SKIP LOCKED ... RETURNING)."""
+    import threading
+
+    n = 6
+    _seed_race_table(real_db, [f"race-vm-{i:02d}" for i in range(n)])
+
+    barrier = threading.Barrier(n)
+    assigned: list = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def claim(idx):
+        try:
+            barrier.wait(timeout=5)
+            hostname = real_db.assign_vm(email=f"student{idx}@example.com")
+            with lock:
+                assigned.append(hostname)
+        except BaseException as e:  # noqa: BLE001
+            with lock:
+                errors.append(e)
+
+    threads = [threading.Thread(target=claim, args=(i,)) for i in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    try:
+        assert not errors, f"Unexpected errors: {errors}"
+
+        # Ground truth from the DB: how many VMs were actually claimed.
+        rows = _assigned_rows(real_db)
+        distinct_vms = {r[0] for r in rows}
+        distinct_emails = {r[1] for r in rows}
+        assert len(distinct_vms) == n, (
+            f"Double-assignment race: {n} concurrent requests claimed only "
+            f"{len(distinct_vms)} VM(s) (expected {n} distinct): {sorted(distinct_vms)}"
+        )
+        assert len(distinct_emails) == n
+
+        # Each caller must learn its own distinct hostname via the return value.
+        assert len(assigned) == n
+        assert set(assigned) == distinct_vms
+    finally:
+        with real_db._cursor as cur:
+            cur.execute("DELETE FROM vms WHERE hostname LIKE 'race-vm-%'")
+
+
+def test_assign_vm_concurrent_oversubscribed(real_db):
+    """When more participants request than there are seats, each free VM is
+    claimed exactly once and the surplus requests raise ValueError — never a
+    double-assignment."""
+    import threading
+
+    n_vms = 3
+    n_req = 6
+    _seed_race_table(real_db, [f"race-vm-{i:02d}" for i in range(n_vms)])
+
+    barrier = threading.Barrier(n_req)
+    assigned: list = []
+    no_seat = []
+    other_errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def claim(idx):
+        try:
+            barrier.wait(timeout=5)
+            hostname = real_db.assign_vm(email=f"student{idx}@example.com")
+            with lock:
+                assigned.append(hostname)
+        except ValueError:
+            with lock:
+                no_seat.append(idx)
+        except BaseException as e:  # noqa: BLE001
+            with lock:
+                other_errors.append(e)
+
+    threads = [threading.Thread(target=claim, args=(i,)) for i in range(n_req)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=10)
+
+    try:
+        assert not other_errors, f"Unexpected errors: {other_errors}"
+        rows = _assigned_rows(real_db)
+        distinct_vms = {r[0] for r in rows}
+        assert len(distinct_vms) == n_vms, (
+            f"Expected exactly {n_vms} VMs claimed, got {len(distinct_vms)}: "
+            f"{sorted(distinct_vms)}"
+        )
+        assert len(assigned) == n_vms
+        assert set(assigned) == distinct_vms
+        assert len(no_seat) == n_req - n_vms
+    finally:
+        with real_db._cursor as cur:
+            cur.execute("DELETE FROM vms WHERE hostname LIKE 'race-vm-%'")
 
 
 def test_set_setting_upserts(db_instance, mock_db_connection):


### PR DESCRIPTION
## Summary

Fixes a concurrency bug in VM assignment that breaks the core tutorial use case (a roomful of participants clicking **Join** at the same instant). Under a concurrent burst, the allocator double-booked participants onto a handful of VMs while the rest of the pool sat idle, and rejected most participants with `503` — *despite having free capacity*.

## How it was found

A staged scalability test against a live 22-VM deployment (`lablink.sleap.ai`) firing truly-simultaneous `POST /api/request_vm` calls:

| Burst | Requests | `303` (got a session) | `503` (rejected) | **Distinct VMs actually allocated** |
|---|---|---|---|---|
| 5 | 5 | 4 | 1 | **2** |
| 20 | 20 | 7 | 13 | **6** |

Of 25 simultaneous join attempts against 22 VMs, only **8** got their own VM, **3** were double-booked, **14** were rejected — while 14 VMs sat idle.

## Root cause

`assign_vm` did a non-atomic **check-then-act**:
1. `get_first_available_vm()` — `SELECT hostname … LIMIT 1` with **no `ORDER BY`, no `FOR UPDATE`, no `SKIP LOCKED`**. Concurrent requests gravitate to the same physical "first" row.
2. A *separate* `UPDATE … WHERE hostname=%s`. Last writer wins; earlier `useremail` silently overwritten.
3. `main.py` then **re-looked-up the VM by email**; the collision loser's row was overwritten, so the lookup missed → spurious `503 no_seats.html` (the dominant 503 source).

## Fix

Claim a VM in a **single atomic statement** so concurrent callers each lock a *different* row:

```sql
UPDATE vms SET useremail = %s, inuse = FALSE
WHERE hostname = (
    SELECT hostname FROM vms
    WHERE useremail IS NULL AND status = 'running'
      AND (healthy IS NULL OR healthy <> 'Unhealthy')
    ORDER BY hostname FOR UPDATE SKIP LOCKED LIMIT 1
)
RETURNING hostname;
```

- `assign_vm` now returns the claimed hostname (or raises `ValueError` when the pool is empty).
- Removed the racy `get_first_available_vm` helper.
- Removed the re-lookup-by-email branch in `submit_vm_details` — the atomic claim hands back the hostname directly, so there's nothing left to race against.

Correct under the existing autocommit/`READ COMMITTED` model: the row lock is held for the duration of the single statement, and `SKIP LOCKED` makes concurrent statements pick different rows.

## Tests

- **New** `real_db` regression tests (`test_database.py`): `test_assign_vm_concurrent_no_double_assignment` and `test_assign_vm_concurrent_oversubscribed` — barrier-synced threads assert each request gets a **distinct** VM (and oversubscribed requests raise `ValueError`, never double-assign). These **fail on the old code** (`6 concurrent requests claimed only 1 VM`) and pass with the fix; stable across repeated runs.
- **New** route test (`test_api_calls.py`): `test_request_vm_fresh_assignment_uses_returned_hostname` — asserts the handler uses `assign_vm`'s return value and does **not** issue a second lookup-by-email.
- Updated the mock-based `assign_vm` tests; removed the `get_first_available_vm` test.

The concurrency tests require a real Postgres (CI provides one; locally they `pytest.skip` if unreachable).

## Testing

- `ruff check src tests` → clean.
- Full allocator suite (minus `tests/terraform`) → `560 passed`. The one unrelated failure (`test_aws_entry_point_is_registered`) is pre-existing/environmental (fails identically on clean `main` — entry points aren't registered in the dev env).

## Relationship to #370

**Orthogonal.** #370 raises the DB connection-pool ceiling to fix `connection pool exhausted` 500s under steady-state polling. This PR fixes the *assignment race* under a join burst. #370 does not touch the assignment path; if anything, more pool headroom lets more requests reach the racy code, so this fix is needed regardless.

## Out of scope (separate follow-ups)

Capacity margin (≥25 VMs for 20 participants), production WSGI/gunicorn, and read-path latency under load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)