### PR TITLE
fix(cli): wizard Advanced form was clipped — EIP strategy radio unreachable

### DIFF
--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -1394,6 +1394,12 @@ class ConfigWizard(App):
     Screen {
         align: center middle;
     }
+    VerticalScroll {
+        height: 1fr;
+    }
+    #dns-guided, #dns-advanced {
+        height: auto;
+    }
     .step-title {
         text-style: bold;
         color: $accent;

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -101,12 +101,22 @@ def _build_cfg_and_app(
 
 
 def _select_radio_by_id(screen, radioset_id: str, button_id: str) -> None:
-    """Set the RadioButton with the given id to value=True within the RadioSet."""
+    """Set the RadioButton with the given id to value=True within the RadioSet.
+
+    Only flips the target to True; RadioSet's own RadioButton.Changed handler
+    unsets the previously-pressed sibling inside a prevent block. Setting the
+    sibling to False here would race that handler — its "click off" guard
+    re-asserts value=True when it sees Changed(value=False), so depending on
+    cross-widget message-queue order both buttons can end up True and
+    `_save_advanced` (which returns the first True button) reads the wrong one.
+    """
     from textual.widgets import RadioButton, RadioSet
 
     radio_set = screen.query_one(radioset_id, RadioSet)
     for btn in radio_set.query(RadioButton):
-        btn.value = (btn.id == button_id)
+        if btn.id == button_id:
+            btn.value = True
+            return
 
 
 def test_dns_guided_cloudflare_sets_persistent_eip():

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -422,3 +422,56 @@ def test_dns_advanced_invalid_combo_blocks_next():
     assert visible is True
     assert stack_delta == 0  # screen did not push StartupScreen
     assert err  # non-empty error text
+
+
+def test_dns_advanced_eip_radio_is_scrollable_into_view():
+    """Regression: under #dns-advanced the form is longer than the viewport.
+    A previous CSS configuration left the inner VerticalScroll viewport
+    sized to 1 row and the dns-advanced Container clamped to ~10 rows,
+    so widgets near the bottom of Advanced (the EIP strategy radio
+    being the rearmost) were unreachable — they rendered at y≈55 with
+    no scroll headroom. This asserts the layout permits a real user to
+    scroll the EIP radio into view at a normal terminal size."""
+    import asyncio
+    from textual.widgets import RadioSet
+
+    cfg, app = _build_cfg_and_app()
+
+    async def _run() -> tuple[int, int]:
+        async with app.run_test(size=(100, 30)) as pilot:
+            await pilot.pause()
+            from lablink_cli.tui.wizard import DnsScreen
+
+            screen = DnsScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+
+            # Real keyboard activation; pilot.click is unreliable on
+            # RadioButtons in this Textual version (see issue tracker
+            # / monitoring screen tests for the same workaround).
+            mode = screen.query_one("#dns-screen-mode", RadioSet)
+            mode.focus()
+            await pilot.pause()
+            await pilot.press("down", "enter")
+            for _ in range(5):
+                await pilot.pause()
+
+            vs = next(iter(screen.query("VerticalScroll")))
+            eip = screen.query_one("#adv-eip-strategy", RadioSet)
+            vs.scroll_to_widget(eip, animate=False, top=True)
+            for _ in range(5):
+                await pilot.pause()
+            return vs.max_scroll_y, eip.region.y
+
+    max_scroll_y, eip_y = asyncio.run(_run())
+    # If max_scroll_y == 0 the container collapsed and the user has no
+    # way to reach the bottom of Advanced. Should be substantial.
+    assert max_scroll_y > 0, (
+        f"dns-advanced collapsed: VerticalScroll.max_scroll_y={max_scroll_y}; "
+        "the EIP strategy radio (and any field below it) is unreachable."
+    )
+    # After scrolling, EIP should land inside the viewport (0..screen.height).
+    assert 1 <= eip_y < 30, (
+        f"After scroll_to_widget, EIP radio at y={eip_y} is outside the "
+        "30-row test viewport — scroll isn't bringing it into view."
+    )


### PR DESCRIPTION
## Summary

In `lablink configure`, after switching the DNS & SSL screen to **Advanced** mode, the EIP strategy radio (and the validation-error label below it) rendered offscreen with no way to scroll to them. Pre-existing test `test_dns_advanced_persistent_eip_writes_through` set radio values via `btn.value = True` directly, so it happened to pass locally (bypassing real rendering) and masked the bug.

## Root cause

In `ConfigWizard.CSS`:
```css
Screen { align: center middle; }
```
… vertically-centered the screen's inner `VerticalScroll`, sizing it to its content rather than the available viewport. Combined with default `Container` sizing, this collapsed:
- `VerticalScroll` viewport → ~1 row
- `#dns-advanced` Container → ~10 rows

Any field positioned past row 10 of the Advanced form (the EIP strategy radio renders at virtual y ≈ 55) was unreachable — `max_scroll_y` reported `0`, so the user had no scroll headroom either.

Guided mode wasn't affected because its content fits within the clamped 10-row window.

## Fix

Two CSS rules in `packages/cli/src/lablink_cli/tui/wizard.py`:
```css
VerticalScroll { height: 1fr; }
#dns-guided, #dns-advanced { height: auto; }
```

- `1fr` lets the scroll viewport claim the available vertical space inside the screen.
- `height: auto` on the inner mode-toggle containers tells them to size to their content instead of inheriting the clamped default.

After the fix, with a 100×30 test viewport: `VerticalScroll` reports `height=23, max_scroll_y=25`, and `scroll_to_widget(eip_radio)` lands the radio at `y=22` (inside the viewport).

## Tests

New: `test_dns_advanced_eip_radio_is_scrollable_into_view`.
- Pushes `DnsScreen`, toggles to Advanced via real keyboard input (pilot.click on RadioButton is unreliable in this Textual version — same workaround used elsewhere in this file).
- Asserts `VerticalScroll.max_scroll_y > 0` (i.e. user can actually scroll).
- Asserts `scroll_to_widget(eip)` lands the radio within the viewport.

Verified the test fails on `main` with the exact diagnostic:
> `dns-advanced collapsed: VerticalScroll.max_scroll_y=0; the EIP strategy radio (and any field below it) is unreachable.`

## Verification

- `pytest packages/cli/tests/test_wizard.py` → 14 passed (was 13 + 1 new).
- `ruff check packages/cli/src/lablink_cli/tui/wizard.py` → clean.

## Test plan

- [x] Reviewer: run `lablink configure`, advance to DNS & SSL, flip to **Advanced**, and confirm you can scroll to the EIP strategy radio.
- [x] Reviewer: confirm Guided mode rendering hasn't regressed (it shouldn't — Guided's content fits the viewport regardless).

🤖 Generated with [Claude Code](https://claude.com/claude-code)