### PR TITLE
fix(cli): bump pinned lablink-template to v0.2.2 (Cloudflare Full SSL)

### DIFF
--- a/packages/cli/CHANGELOG.md
+++ b/packages/cli/CHANGELOG.md
@@ -60,6 +60,12 @@ this project uses [Semantic Versioning](https://semver.org/).
 
 ### Fixed
 
+- Bumped the pinned `lablink-template` version to **v0.2.2**, which fixes
+  Cloudflare **Full** SSL mode. The allocator origin now serves HTTPS:443
+  with a self-signed cert (Caddy `tls internal`) instead of HTTP only, so
+  Cloudflare's recommended Full mode can connect (previously it returned
+  Cloudflare Error 521). Updated `TEMPLATE_VERSION` and `TEMPLATE_SHA256`.
+
 - LAN-direct browser auth: switched from HTTP BasicAuth (browser-blocked
   on WebSocket upgrades) to RFB `VncAuth` with a per-session 8-byte
   credential. Includes a `sed` patch on the bundled KasmVNC noVNC to undo

--- a/packages/cli/src/lablink_cli/__init__.py
+++ b/packages/cli/src/lablink_cli/__init__.py
@@ -1,8 +1,8 @@
 """LabLink CLI - Deploy and manage LabLink infrastructure."""
 
 TEMPLATE_REPO = "talmolab/lablink-template"
-TEMPLATE_VERSION = "v0.2.1"
+TEMPLATE_VERSION = "v0.2.2"
 # SHA-256 of the GitHub release tarball for TEMPLATE_VERSION.
 # Update this when bumping TEMPLATE_VERSION.
 # To compute: curl -sL <tarball_url> | sha256sum
-TEMPLATE_SHA256 = "aa9e774df7677f9c6820d0e0279869bde3d3e35f938ff9b5c6da9f1e96c24cbb"
+TEMPLATE_SHA256 = "5f3a03968057410000d9634cc43001fb27785508a0ed78ab2551542670b15ce6"


### PR DESCRIPTION
Bumps the pinned `lablink-template` version so a `lablink` CLI deploy picks up the Cloudflare Full SSL fix.

## What changed

- `TEMPLATE_VERSION`: `v0.2.1` → `v0.2.2`
- `TEMPLATE_SHA256`: updated to the SHA-256 of the v0.2.2 source tarball (`5f3a039680…b15ce6`), verified stable across repeated downloads.
- `CHANGELOG.md`: added a `Fixed` entry under `[Unreleased]`.

## Why

`lablink-template` [v0.2.2](https://github.com/talmolab/lablink-template/releases/tag/v0.2.2) (template PR talmolab/lablink-template#53) makes the `cloudflare` SSL provider serve the origin over **HTTPS:443** with a self-signed cert (Caddy `tls internal`). Cloudflare's recommended **Full** mode connects to the origin over HTTPS and doesn't validate the cert, so this clears the **Error 521** that Full mode otherwise returns against the previous HTTP-only (Flexible) origin.

## Testing

- `pytest tests/test_terraform_source.py tests/test_app.py` → 52 passed (version/SHA assertions are format-based: `startswith("v")`, 64-char hex — no hardcoded value to update).
- SHA recomputed twice from `archive/refs/tags/v0.2.2.tar.gz` — identical both times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)