### PR TITLE
feat(client): anchor session metrics at user-assignment, not VM boot

### DIFF
--- a/packages/client/src/lablink_client_service/agent/api.py
+++ b/packages/client/src/lablink_client_service/agent/api.py
@@ -16,10 +16,12 @@ allocator. /healthz is unauthenticated for ALB / Docker healthchecks.
 """
 import logging
 import os
+from datetime import datetime, timezone
 
 from flask import Flask, request, jsonify
 
 from lablink_client_service.agent.kasmvnc import rotate_kasmvnc_password
+from lablink_client_service.session_anchor import write_anchor
 
 
 logger = logging.getLogger(__name__)
@@ -53,6 +55,18 @@ def create_app() -> Flask:
         except Exception as exc:
             logger.exception("KasmVNC password rotation failed")
             return jsonify(error=f"rotation failed: {exc}"), 500
+
+        # Anchor the monitoring agent's session clock at user-assignment
+        # time. A write failure here is non-fatal: the seat is usable;
+        # only metric timing is affected (clock will stay at last anchor
+        # or at agent boot if none has been written yet).
+        try:
+            write_anchor(datetime.now(timezone.utc))
+        except OSError:
+            logger.exception(
+                "Failed to write session anchor; metrics may be misaligned"
+            )
+
         return jsonify(ok=True), 200
 
     @app.get("/healthz")

--- a/packages/client/src/lablink_client_service/monitoring/__main__.py
+++ b/packages/client/src/lablink_client_service/monitoring/__main__.py
@@ -20,6 +20,7 @@ from lablink_client_service.monitoring.aggregator import (
     new_counters,
 )
 from lablink_client_service.monitoring.pusher import push_summary
+from lablink_client_service.session_anchor import read_anchor
 from lablink_client_service.monitoring.samplers.active_window import (
     sample as _sample_active_window,
 )
@@ -77,6 +78,28 @@ def _resolve_subject_patterns(cfg: dict) -> list[str]:
     return [software] if software else []
 
 
+def _maybe_reanchor(counters: SessionCounters) -> SessionCounters:
+    """Return fresh counters anchored at the on-disk timestamp if the agent
+    has recorded a session-start newer than the current anchor; otherwise
+    return the passed-in counters unchanged.
+
+    Resetting zeros every counter (not just the anchor) so a row's
+    metrics describe one user's session — pre-assignment activity isn't
+    meaningful, and mixed semantics ("anchor = assignment, accumulators =
+    boot") are harder to reason about than a clean reset.
+    """
+    on_disk = read_anchor()
+    if on_disk is None:
+        return counters
+    if on_disk == counters.session_started_at:
+        return counters
+    logger.info(
+        "Session anchor changed (now %s); resetting counters",
+        on_disk.isoformat(),
+    )
+    return new_counters(session_started_at=on_disk)
+
+
 def _tick(cfg: dict, counters: SessionCounters) -> None:
     ts = datetime.now(timezone.utc)
     bucket = _sample_active_window(subject_patterns=_resolve_subject_patterns(cfg))
@@ -132,6 +155,7 @@ def main() -> None:
         push_int,
     )
     while not _stop_event.is_set():
+        _counters = _maybe_reanchor(_counters)
         try:
             _tick(_cfg, _counters)
         except Exception:

--- a/packages/client/src/lablink_client_service/session_anchor.py
+++ b/packages/client/src/lablink_client_service/session_anchor.py
@@ -1,0 +1,59 @@
+"""Inter-process session-start anchor.
+
+The client container runs two long-lived processes started by start.sh: the
+agent (:7070) that receives `POST /api/session/start` from the allocator
+when a user is assigned the seat, and the monitoring agent that pushes
+session counters to the allocator. The monitoring agent's counters
+(`seconds_to_first_sleap_train`, `seconds_in_subject_software`, …) must
+be anchored at user-assignment time, not VM boot, so the metrics describe
+user behavior rather than infrastructure idle time.
+
+The two processes don't share memory, so the agent writes the assignment
+timestamp here and the monitoring loop polls the file each tick. When it
+sees a timestamp it hasn't acted on yet, it resets its counters with the
+new anchor.
+
+File contents: a single ISO-8601 UTC string (microsecond precision).
+Path: $LABLINK_SESSION_ANCHOR_PATH or /tmp/lablink-session-anchor.
+"""
+
+import os
+from datetime import datetime
+
+DEFAULT_ANCHOR_PATH = "/tmp/lablink-session-anchor"
+
+
+def get_anchor_path() -> str:
+    return os.environ.get("LABLINK_SESSION_ANCHOR_PATH", DEFAULT_ANCHOR_PATH)
+
+
+def write_anchor(ts: datetime, path: str | None = None) -> None:
+    """Atomically write the anchor timestamp.
+
+    Write to a sibling temp file then rename so a concurrent reader never
+    sees a half-written line.
+    """
+    target = path or get_anchor_path()
+    tmp = f"{target}.tmp"
+    with open(tmp, "w") as f:
+        f.write(ts.isoformat())
+    os.replace(tmp, target)
+
+
+def read_anchor(path: str | None = None) -> datetime | None:
+    """Return the parsed anchor timestamp, or None if missing/unreadable.
+
+    Any IO or parse error returns None — the caller treats "no anchor" the
+    same as "anchor unchanged", so a transient read failure just defers the
+    reset to the next tick.
+    """
+    target = path or get_anchor_path()
+    try:
+        with open(target) as f:
+            raw = f.read().strip()
+    except OSError:
+        return None
+    try:
+        return datetime.fromisoformat(raw)
+    except ValueError:
+        return None

--- a/packages/client/tests/monitoring/test_session_anchor.py
+++ b/packages/client/tests/monitoring/test_session_anchor.py
@@ -1,0 +1,112 @@
+"""Tests for the cross-process session-anchor mechanism.
+
+Covers the file contract (session_anchor module) and the monitoring
+loop's reset hook (_maybe_reanchor) in isolation from the full main()
+loop — the entry-point tests already exercise that.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from lablink_client_service import session_anchor
+from lablink_client_service.monitoring import __main__ as entry
+from lablink_client_service.monitoring.aggregator import new_counters
+
+
+@pytest.fixture
+def anchor_path(tmp_path, monkeypatch):
+    path = tmp_path / "session-anchor"
+    monkeypatch.setenv("LABLINK_SESSION_ANCHOR_PATH", str(path))
+    return path
+
+
+def test_write_then_read_anchor_round_trip(anchor_path):
+    ts = datetime(2026, 6, 11, 15, 21, 26, 252786, tzinfo=timezone.utc)
+    session_anchor.write_anchor(ts)
+    assert session_anchor.read_anchor() == ts
+
+
+def test_read_anchor_returns_none_when_file_missing(anchor_path):
+    assert not anchor_path.exists()
+    assert session_anchor.read_anchor() is None
+
+
+def test_read_anchor_returns_none_when_file_unparseable(anchor_path):
+    anchor_path.write_text("not a timestamp")
+    assert session_anchor.read_anchor() is None
+
+
+def test_write_anchor_is_atomic_no_temp_left_behind(anchor_path, tmp_path):
+    ts = datetime(2026, 6, 11, 15, 0, 0, tzinfo=timezone.utc)
+    session_anchor.write_anchor(ts)
+    # Only the final file should remain; the .tmp sibling must have been renamed.
+    assert anchor_path.exists()
+    assert not (tmp_path / "session-anchor.tmp").exists()
+
+
+def test_maybe_reanchor_returns_same_counters_when_no_anchor(anchor_path):
+    """No file on disk → no reset; current counters keep advancing."""
+    boot = datetime(2026, 6, 11, 9, 0, 0, tzinfo=timezone.utc)
+    c = new_counters(session_started_at=boot)
+    c.seconds_in_subject_software = 42
+    result = entry._maybe_reanchor(c)
+    assert result is c  # same object, unchanged
+    assert result.seconds_in_subject_software == 42
+
+
+def test_maybe_reanchor_returns_same_counters_when_anchor_unchanged(anchor_path):
+    """File matches the current anchor → no reset, accumulators preserved."""
+    ts = datetime(2026, 6, 11, 15, 21, 26, tzinfo=timezone.utc)
+    session_anchor.write_anchor(ts)
+    c = new_counters(session_started_at=ts)
+    c.seconds_in_subject_software = 100
+    result = entry._maybe_reanchor(c)
+    assert result is c
+    assert result.seconds_in_subject_software == 100
+
+
+def test_maybe_reanchor_resets_when_anchor_is_newer(anchor_path):
+    """Agent wrote a new assignment timestamp → counters reset and re-anchor.
+
+    Full reset: every accumulator field zeroes out so the resulting row
+    describes the new user's session only.
+    """
+    boot_ts = datetime(2026, 6, 11, 9, 0, 0, tzinfo=timezone.utc)
+    assignment_ts = boot_ts + timedelta(hours=6, minutes=21, seconds=26)
+    session_anchor.write_anchor(assignment_ts)
+
+    c = new_counters(session_started_at=boot_ts)
+    c.seconds_in_subject_software = 14396
+    c.seconds_in_terminal = 648
+    c.gpu_active_seconds = 1500
+    c.seconds_to_first_sleap_train = 25138
+
+    result = entry._maybe_reanchor(c)
+
+    assert result is not c
+    assert result.session_started_at == assignment_ts
+    assert result.seconds_in_subject_software == 0
+    assert result.seconds_in_terminal == 0
+    assert result.gpu_active_seconds == 0
+    assert result.seconds_to_first_sleap_train is None
+    assert result.sample_count == 0
+
+
+def test_maybe_reanchor_handles_reclaim_second_assignment(anchor_path):
+    """A second /api/session/start (re-claim) writes a newer anchor;
+    the loop must reset again, dropping the first user's metrics."""
+    first_assignment = datetime(2026, 6, 11, 15, 0, 0, tzinfo=timezone.utc)
+    second_assignment = datetime(2026, 6, 11, 17, 30, 0, tzinfo=timezone.utc)
+
+    session_anchor.write_anchor(first_assignment)
+    boot = datetime(2026, 6, 11, 9, 0, 0, tzinfo=timezone.utc)
+    c = new_counters(session_started_at=boot)
+    c = entry._maybe_reanchor(c)
+    assert c.session_started_at == first_assignment
+    c.seconds_in_subject_software = 2000  # first user accumulated some time
+
+    session_anchor.write_anchor(second_assignment)
+    c = entry._maybe_reanchor(c)
+    assert c.session_started_at == second_assignment
+    assert c.seconds_in_subject_software == 0

--- a/packages/client/tests/test_agent_api.py
+++ b/packages/client/tests/test_agent_api.py
@@ -1,10 +1,20 @@
 """Tests for the client agent's /api/session/start endpoint."""
 
+from datetime import datetime
 from unittest.mock import patch
 
 import pytest
 
 from lablink_client_service.agent.api import create_app
+
+
+@pytest.fixture(autouse=True)
+def anchor_path(tmp_path, monkeypatch):
+    """Redirect the session-anchor file into tmp_path so the agent never
+    writes to /tmp during tests; yield the path so tests can read it back."""
+    path = tmp_path / "session-anchor"
+    monkeypatch.setenv("LABLINK_SESSION_ANCHOR_PATH", str(path))
+    return path
 
 
 @pytest.fixture
@@ -158,3 +168,63 @@ def test_session_start_returns_500_when_rotation_raises(client, authed_headers):
         )
     assert resp.status_code == 500
     rotate.assert_called_once()
+
+
+def test_session_start_writes_anchor_on_success(client, authed_headers, anchor_path):
+    """Happy path also writes the session anchor file so the monitoring
+    agent can reset its session_started_at clock."""
+    assert not anchor_path.exists()
+    with patch("lablink_client_service.agent.api.rotate_kasmvnc_password"):
+        resp = client.post(
+            "/api/session/start",
+            json={"password": "x"},
+            headers=authed_headers,
+        )
+    assert resp.status_code == 200
+    assert anchor_path.exists()
+    # ISO-8601 UTC timestamp parses round-trip and has timezone info.
+    parsed = datetime.fromisoformat(anchor_path.read_text())
+    assert parsed.tzinfo is not None
+
+
+def test_session_start_no_anchor_on_auth_failure(client, anchor_path):
+    """401 paths must not write the anchor — only a real assignment
+    should reset the user-session clock."""
+    with patch("lablink_client_service.agent.api.rotate_kasmvnc_password"):
+        resp = client.post("/api/session/start", json={"password": "x"})
+    assert resp.status_code == 401
+    assert not anchor_path.exists()
+
+
+def test_session_start_no_anchor_on_rotation_failure(
+    client, authed_headers, anchor_path
+):
+    """If rotation fails we return 500 — anchor must not be written, so
+    the monitoring clock keeps its previous value (no false reset)."""
+    with patch(
+        "lablink_client_service.agent.api.rotate_kasmvnc_password",
+        side_effect=RuntimeError("kasmvncpasswd died"),
+    ):
+        resp = client.post(
+            "/api/session/start",
+            json={"password": "x"},
+            headers=authed_headers,
+        )
+    assert resp.status_code == 500
+    assert not anchor_path.exists()
+
+
+def test_session_start_succeeds_even_if_anchor_write_fails(
+    client, authed_headers, monkeypatch
+):
+    """Anchor-write failure must not break seat assignment — log and move
+    on. The seat is usable; only metric alignment degrades."""
+    monkeypatch.setenv("LABLINK_SESSION_ANCHOR_PATH", "/nonexistent-dir/anchor")
+    with patch("lablink_client_service.agent.api.rotate_kasmvnc_password"):
+        resp = client.post(
+            "/api/session/start",
+            json={"password": "x"},
+            headers=authed_headers,
+        )
+    assert resp.status_code == 200
+    assert resp.get_json() == {"ok": True}


### PR DESCRIPTION
## Summary
- The monitoring agent's `session_started_at` was captured at agent boot, so `seconds_to_first_sleap_{train,track,label}` measured time since VM launch rather than time since the user got the seat. Today's session CSV shows everyone clustering at 23 000–27 000 s because the VMs deployed ~6 h before the workshop started — that gap is infrastructure idle time, not user behavior.
- Adds a file-based IPC contract between the agent (`:7070`) and the monitoring process: on successful `POST /api/session/start`, the agent writes the assignment timestamp to `/tmp/lablink-session-anchor`. The monitoring loop reads that file each tick and, when it sees a timestamp newer than its current anchor, replaces `_counters` with a fresh zeroed `SessionCounters` anchored at the new time.
- Full reset (not just re-anchor) so every accumulator field describes one user's session — re-claim of the same VM by a second user is handled automatically.
- Anchor-write failure is non-fatal: the seat assignment still returns 200; only metric alignment degrades.

## What's in the diff
- `session_anchor.py` (new) — atomic temp-rename writer, tolerant reader, env-overridable path (`LABLINK_SESSION_ANCHOR_PATH`)
- `agent/api.py` — writes the anchor after successful KasmVNC password rotation; auth failures, 400s, and rotation failures intentionally do **not** write (no false reset)
- `monitoring/__main__.py` — `_maybe_reanchor()` runs at the top of every loop iteration
- Tests: 4 new in `test_agent_api.py` for anchor-write semantics across all response paths, 8 new in `tests/monitoring/test_session_anchor.py` for the file contract and reset behavior including reclaim

## What this does NOT fix (deferred)
The 90–200 s `train→track` gaps and 0-epoch trainings in today's CSV suggest `sleap-train`/`sleap-track` process detection is firing on brief spawns (init / crash / wrapper script that launches both). A "process must persist ≥ 2 samples to count" filter is a separate change.

## Operational notes
- Existing CSV rows won't change retroactively — they were anchored at agent boot.
- Requires a new client image build → AMI/image refresh. Allocator side needs no changes (it just stores the `session_started_at` from the push payload as-is).

## Test plan
- [x] `PYTHONPATH=src pytest` in `packages/client/` — 133/133 pass
- [x] `ruff check` on all changed files — clean
- [ ] Build a new client image, deploy a test allocator, and verify `sessionmetricsstartedat` in the admin UI matches the user-login time (within seconds) rather than VM boot
- [ ] Trigger a re-claim (release seat → new user takes it) and confirm `seconds_in_*` accumulators reset to 0 in the next push

🤖 Generated with [Claude Code](https://claude.com/claude-code)