### PR TITLE
feat(allocator): async operations worker — core infra (PR 1/3)

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -339,6 +339,13 @@ class PostgresqlDatabase:
         """
         return _PooledCursor(self._pool)
 
+    @property
+    def pool(self):
+        """The underlying connection pool, shared with other classes that
+        need pooled access to the same database (e.g. OperationsDatabase)
+        rather than opening a second one."""
+        return self._pool
+
     def get_all_vms(self) -> list:
         """Get all VMs from the table, excluding logs.
 

--- a/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
+++ b/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
@@ -56,6 +56,27 @@ CREATE TRIGGER scheduled_destructions_updated_at
     FOR EACH ROW
     EXECUTE FUNCTION update_scheduled_destructions_updated_at();
 
+CREATE TABLE IF NOT EXISTS operations (
+    id SERIAL PRIMARY KEY,
+    op_type VARCHAR(16) NOT NULL,
+    status VARCHAR(16) NOT NULL,
+    params TEXT,
+    created_by VARCHAR(255),
+    created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+    started_at TIMESTAMP,
+    finished_at TIMESTAMP,
+    output TEXT,
+    error TEXT
+);
+
+CREATE INDEX idx_operations_created_at ON operations(created_at);
+
+-- At most one queued/running operation at a time. This is the entire
+-- concurrency guard: two near-simultaneous INSERTs under Flask's
+-- threaded=True can't both succeed, so no separate locking code is needed.
+CREATE UNIQUE INDEX IF NOT EXISTS operations_single_flight
+    ON operations ((1)) WHERE status IN ('queued', 'running');
+
 CREATE TABLE IF NOT EXISTS {VM_TABLE} (
     HostName VARCHAR(1024) PRIMARY KEY,
     UserEmail VARCHAR(1024),

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -35,6 +35,8 @@ from lablink_allocator_service.utils.sg_audit import SGAuditFailure
 from lablink_allocator_service.scheduler import ScheduledDestructionService
 from lablink_allocator_service.reboot import AutoRebootService
 from lablink_allocator_service.admin_session_expiry import AdminSessionExpiryService
+from lablink_allocator_service.operations import OperationsWorker
+from lablink_allocator_service.operations_db import OperationsDatabase
 from lablink_allocator_service.client_session import RotationFailed
 from lablink_allocator_service.signed_cookie import (
     sign,
@@ -145,6 +147,14 @@ reboot_service = None
 
 # Admin-session expiry service (initialized in main())
 admin_session_expiry_service = None
+
+# Operations worker for on-demand apply/destroy jobs (initialized in
+# main()). Unlike the other three services, this has no persistent
+# background thread/loop of its own — start() just runs a one-time
+# startup sweep, and each submitted job gets its own short-lived thread.
+# There is deliberately no operations_worker.stop()/atexit registration
+# to match: there is no loop to join.
+operations_worker = None
 
 # Startup timestamp for uptime tracking (set in main())
 _startup_time: float | None = None
@@ -1219,6 +1229,7 @@ def scheduled_destruction_page():
 def main():
     """Main entry point for the allocator service."""
     global scheduler_service, reboot_service, admin_session_expiry_service
+    global operations_worker
     global _startup_time
 
     try:
@@ -1261,6 +1272,15 @@ def main():
         admin_session_expiry_service.start()
         atexit.register(admin_session_expiry_service.stop)
         logger.info("Admin-session expiry service started successfully")
+
+        # Initialize operations worker (on-demand apply/destroy jobs).
+        # No atexit registration: see the module-level comment on
+        # operations_worker — there's no background loop to stop.
+        logger.info("Initializing operations worker...")
+        operations_db = OperationsDatabase(pool=database.pool)
+        operations_worker = OperationsWorker(database=operations_db)
+        operations_worker.start()
+        logger.info("Operations worker started successfully")
 
         # Terraform initialization — gated on the provider's capability flag
         # (mirrors the policy at module top: branch on capability, not type).

--- a/packages/allocator/src/lablink_allocator_service/operations.py
+++ b/packages/allocator/src/lablink_allocator_service/operations.py
@@ -2,8 +2,7 @@
 
 Runs each operation on its own daemon thread, off the Flask request
 thread, so a slow `terraform apply`/`destroy` doesn't hold an HTTP
-connection open long enough to hit Cloudflare's edge timeout. See
-docs/superpowers/specs/2026-07-17-async-terraform-worker-design.md.
+connection open long enough to hit Cloudflare's edge timeout.
 """
 from __future__ import annotations
 
@@ -65,8 +64,8 @@ class OperationsWorker:
         return operation_id
 
     def _run(self, operation_id: int, fn: Callable[[], str]) -> None:
-        self.database.start_operation(operation_id)
         try:
+            self.database.start_operation(operation_id)
             output = fn()
         except Exception as e:
             logger.error(

--- a/packages/allocator/src/lablink_allocator_service/operations.py
+++ b/packages/allocator/src/lablink_allocator_service/operations.py
@@ -1,0 +1,81 @@
+"""Background worker for on-demand Terraform apply/destroy operations.
+
+Runs each operation on its own daemon thread, off the Flask request
+thread, so a slow `terraform apply`/`destroy` doesn't hold an HTTP
+connection open long enough to hit Cloudflare's edge timeout. See
+docs/superpowers/specs/2026-07-17-async-terraform-worker-design.md.
+"""
+from __future__ import annotations
+
+import logging
+from threading import Thread
+from typing import TYPE_CHECKING, Callable, Optional
+
+if TYPE_CHECKING:
+    from lablink_allocator_service.operations_db import OperationsDatabase
+
+logger = logging.getLogger(__name__)
+
+
+class OperationsWorker:
+    """Submits apply/destroy jobs to run on a background thread.
+
+    Args:
+        database: OperationsDatabase instance for operation-status persistence.
+    """
+
+    def __init__(self, database: "OperationsDatabase"):
+        self.database = database
+
+    def start(self) -> None:
+        """Mark any operation left queued/running from a prior process as
+        interrupted. Call once at allocator startup, before any new
+        operation can be submitted, so a crash/restart mid-job is surfaced
+        instead of hanging forever or being silently forgotten."""
+        count = self.database.sweep_interrupted_operations()
+        if count:
+            logger.warning(
+                "Marked %d operation(s) interrupted "
+                "(allocator restarted mid-job)",
+                count,
+            )
+
+    def submit(
+        self,
+        op_type: str,
+        fn: Callable[[], str],
+        params: Optional[str] = None,
+        created_by: Optional[str] = None,
+    ) -> int:
+        """Queue a new operation and run it on a background thread.
+
+        Returns immediately after the operation row is created — does not
+        wait for `fn` to complete.
+
+        Raises:
+            OperationInProgress: propagated from database.create_operation
+                if another operation is already queued/running.
+        """
+        operation_id = self.database.create_operation(
+            op_type=op_type, params=params, created_by=created_by
+        )
+        Thread(
+            target=self._run, args=(operation_id, fn), daemon=True
+        ).start()
+        return operation_id
+
+    def _run(self, operation_id: int, fn: Callable[[], str]) -> None:
+        self.database.start_operation(operation_id)
+        try:
+            output = fn()
+        except Exception as e:
+            logger.error(
+                "Operation #%d failed: %s", operation_id, e, exc_info=True
+            )
+            self.database.finish_operation(
+                operation_id, status="failed", error=str(e)
+            )
+            return
+        self.database.finish_operation(
+            operation_id, status="succeeded", output=output
+        )

--- a/packages/allocator/src/lablink_allocator_service/operations.py
+++ b/packages/allocator/src/lablink_allocator_service/operations.py
@@ -75,6 +75,11 @@ class OperationsWorker:
                 operation_id, status="failed", error=str(e)
             )
             return
+        # Deliberately outside the try: if terraform genuinely succeeded but
+        # this final status write fails, folding it into the except above
+        # would mislabel a successful run as "failed". Leaving the row at
+        # "running" is the more honest outcome — it's picked up as
+        # "interrupted" by the next startup sweep, same as a mid-job crash.
         self.database.finish_operation(
             operation_id, status="succeeded", output=output
         )

--- a/packages/allocator/src/lablink_allocator_service/operations_db.py
+++ b/packages/allocator/src/lablink_allocator_service/operations_db.py
@@ -77,6 +77,11 @@ class OperationsDatabase:
         Raises:
             OperationInProgress: if another operation is already
                 queued/running (operations_single_flight guard).
+            RuntimeError: if the INSERT fails on the single-flight guard
+                but the in-progress operation has since vanished (an
+                unusual race between the failed insert and the
+                get_in_progress_operation lookup, e.g. the colliding
+                operation finished in between).
         """
         query = """
             INSERT INTO operations (op_type, status, params, created_by)

--- a/packages/allocator/src/lablink_allocator_service/operations_db.py
+++ b/packages/allocator/src/lablink_allocator_service/operations_db.py
@@ -1,0 +1,180 @@
+"""Persistence for the operations table (on-demand apply/destroy jobs).
+
+A standalone class rather than more methods on PostgresqlDatabase: the
+operations table has no foreign-key or column coupling to the vms table
+(unlike scheduled_destructions or the AdminReservedAt admin-reservation
+columns, which reach directly into VM rows), so there's no reason for it
+to share PostgresqlDatabase's god-class surface. It shares the same
+connection pool (see PostgresqlDatabase.pool) rather than opening a
+second one, since POOL_MAX_SIZE is already tuned for this allocator's
+total connection budget.
+"""
+from __future__ import annotations
+
+import logging
+from typing import List, Optional
+
+import psycopg2
+
+from lablink_allocator_service.database import _PooledCursor
+
+logger = logging.getLogger(__name__)
+
+# Named-key contract for rows returned by the SELECT * queries below. Every
+# query in this class must emit columns in this order (matches the
+# CREATE TABLE column order in generate_init_sql.py).
+_OPERATION_COLUMNS = (
+    "id",
+    "op_type",
+    "status",
+    "params",
+    "created_by",
+    "created_at",
+    "started_at",
+    "finished_at",
+    "output",
+    "error",
+)
+
+
+class OperationInProgress(Exception):
+    """Raised by create_operation when another operation is already
+    queued/running — the operations_single_flight partial unique index
+    was violated."""
+
+    def __init__(self, job_id: int):
+        self.job_id = job_id
+        super().__init__(
+            f"An operation is already in progress (job #{job_id})"
+        )
+
+
+class OperationsDatabase:
+    """Persistence for the operations table.
+
+    Args:
+        pool: A psycopg2 connection pool, shared with PostgresqlDatabase
+            (see PostgresqlDatabase.pool) rather than owned here.
+    """
+
+    def __init__(self, pool):
+        self._pool = pool
+
+    @property
+    def _cursor(self):
+        """Return a context manager that checks out a pooled connection
+        and yields a cursor. See database._PooledCursor."""
+        return _PooledCursor(self._pool)
+
+    def create_operation(
+        self,
+        op_type: str,
+        params: Optional[str] = None,
+        created_by: Optional[str] = None,
+    ) -> int:
+        """Create a queued operation and return its ID.
+
+        Raises:
+            OperationInProgress: if another operation is already
+                queued/running (operations_single_flight guard).
+        """
+        query = """
+            INSERT INTO operations (op_type, status, params, created_by)
+            VALUES (%s, 'queued', %s, %s)
+            RETURNING id;
+        """
+        with self._cursor as cursor:
+            try:
+                cursor.execute(query, (op_type, params, created_by))
+                operation_id = cursor.fetchone()[0]
+                logger.info(
+                    "Created operation #%d (%s)", operation_id, op_type
+                )
+                return operation_id
+            except psycopg2.IntegrityError as e:
+                existing = self.get_in_progress_operation()
+                if existing is not None:
+                    raise OperationInProgress(job_id=existing["id"]) from e
+                raise RuntimeError(
+                    f"Failed to create operation: {e}"
+                ) from e
+
+    def get_operation(self, operation_id: int) -> Optional[dict]:
+        """Get an operation by ID."""
+        query = "SELECT * FROM operations WHERE id = %s;"
+        with self._cursor as cursor:
+            cursor.execute(query, (operation_id,))
+            row = cursor.fetchone()
+        if row:
+            return dict(zip(_OPERATION_COLUMNS, row))
+        return None
+
+    def list_operations(self, limit: int = 50) -> List[dict]:
+        """List recent operations, newest first."""
+        query = "SELECT * FROM operations ORDER BY created_at DESC LIMIT %s;"
+        with self._cursor as cursor:
+            cursor.execute(query, (limit,))
+            return [
+                dict(zip(_OPERATION_COLUMNS, row))
+                for row in cursor.fetchall()
+            ]
+
+    def get_in_progress_operation(self) -> Optional[dict]:
+        """Return the currently queued/running operation, if any.
+
+        The operations_single_flight partial unique index guarantees at
+        most one row can match; LIMIT 1 is defensive, not load-bearing.
+        """
+        query = (
+            "SELECT * FROM operations "
+            "WHERE status IN ('queued', 'running') "
+            "ORDER BY created_at DESC LIMIT 1;"
+        )
+        with self._cursor as cursor:
+            cursor.execute(query)
+            row = cursor.fetchone()
+        if row:
+            return dict(zip(_OPERATION_COLUMNS, row))
+        return None
+
+    def start_operation(self, operation_id: int) -> None:
+        """Mark an operation running."""
+        query = (
+            "UPDATE operations SET status = 'running', started_at = NOW() "
+            "WHERE id = %s;"
+        )
+        with self._cursor as cursor:
+            cursor.execute(query, (operation_id,))
+
+    def finish_operation(
+        self,
+        operation_id: int,
+        status: str,
+        output: Optional[str] = None,
+        error: Optional[str] = None,
+    ) -> None:
+        """Mark an operation succeeded or failed."""
+        query = """
+            UPDATE operations
+            SET status = %s, output = %s, error = %s, finished_at = NOW()
+            WHERE id = %s;
+        """
+        with self._cursor as cursor:
+            cursor.execute(query, (status, output, error, operation_id))
+
+    def sweep_interrupted_operations(self) -> int:
+        """Mark any queued/running operation as interrupted.
+
+        Called once at allocator startup: a row still queued/running means
+        the allocator process died mid-job last time, so the Terraform
+        subprocess died with it. Returns the number of rows affected.
+        """
+        query = """
+            UPDATE operations
+            SET status = 'interrupted', finished_at = NOW()
+            WHERE status IN ('queued', 'running')
+            RETURNING id;
+        """
+        with self._cursor as cursor:
+            cursor.execute(query)
+            return len(cursor.fetchall())

--- a/packages/allocator/src/lablink_allocator_service/operations_db.py
+++ b/packages/allocator/src/lablink_allocator_service/operations_db.py
@@ -16,8 +16,6 @@ from typing import List, Optional
 
 import psycopg2
 
-from lablink_allocator_service.database import _PooledCursor
-
 logger = logging.getLogger(__name__)
 
 # Named-key contract for rows returned by the SELECT * queries below. Every
@@ -63,7 +61,21 @@ class OperationsDatabase:
     @property
     def _cursor(self):
         """Return a context manager that checks out a pooled connection
-        and yields a cursor. See database._PooledCursor."""
+        and yields a cursor. See database._PooledCursor.
+
+        Imported lazily (not at module level): database.py does a real,
+        unmocked `import psycopg2` at its own top level, and several test
+        files (test_database.py, test_reboot.py) guard against that by
+        patching sys.modules before their own first import of database.py.
+        An eager module-level import here would race those files during
+        pytest collection — whichever import runs first wins, and a real
+        psycopg2 import poisons the cached database module for every test
+        file collected afterward. Deferring the import to first use (well
+        after collection, when those guards have already run) avoids the
+        race entirely.
+        """
+        from lablink_allocator_service.database import _PooledCursor
+
         return _PooledCursor(self._pool)
 
     def create_operation(

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -2089,3 +2089,7 @@ def test_release_expired_admin_sessions_releases_old_and_keeps_recent(real_db):
         cur.execute(
             "DELETE FROM vms WHERE hostname IN ('host-expired', 'host-fresh')"
         )
+
+
+def test_pool_property_returns_underlying_pool(db_instance):
+    assert db_instance.pool is db_instance._pool

--- a/packages/allocator/tests/test_generate_init_sql.py
+++ b/packages/allocator/tests/test_generate_init_sql.py
@@ -110,3 +110,19 @@ def test_assignable_index_excludes_admin_reserved():
     assert "adminreservedat IS NULL" in sql
     # The existing predicate must still be intact alongside the new one.
     assert "useremail IS NULL AND status = 'running'" in sql
+
+
+def test_operations_table_present():
+    sql = build_init_sql()
+    assert "CREATE TABLE IF NOT EXISTS operations" in sql
+    for col in (
+        "op_type", "status", "params", "created_by",
+        "created_at", "started_at", "finished_at", "output", "error",
+    ):
+        assert col in sql, f"missing column {col}"
+
+
+def test_operations_single_flight_index_present():
+    sql = build_init_sql()
+    assert "operations_single_flight" in sql
+    assert "WHERE status IN ('queued', 'running')" in sql

--- a/packages/allocator/tests/test_operations.py
+++ b/packages/allocator/tests/test_operations.py
@@ -1,0 +1,111 @@
+"""Tests for OperationsWorker."""
+from __future__ import annotations
+
+import time
+from unittest.mock import MagicMock
+
+import pytest
+
+from lablink_allocator_service.operations import OperationsWorker
+from lablink_allocator_service.operations_db import OperationInProgress
+
+
+@pytest.fixture
+def mock_database():
+    """Stand-in for OperationsDatabase — OperationsWorker only calls the
+    four methods asserted below, so a plain MagicMock is sufficient."""
+    return MagicMock()
+
+
+@pytest.fixture
+def worker(mock_database):
+    return OperationsWorker(database=mock_database)
+
+
+def _wait_until(predicate, timeout_s=1.0, interval_s=0.01):
+    """Poll predicate() until it's truthy or timeout_s elapses."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if predicate():
+            return True
+        time.sleep(interval_s)
+    return False
+
+
+def test_start_sweeps_interrupted_operations(worker, mock_database):
+    mock_database.sweep_interrupted_operations.return_value = 2
+
+    worker.start()
+
+    mock_database.sweep_interrupted_operations.assert_called_once()
+
+
+def test_submit_creates_queued_operation_and_returns_id(worker, mock_database):
+    mock_database.create_operation.return_value = 17
+    fn = MagicMock(return_value="done")
+
+    job_id = worker.submit(
+        op_type="destroy", fn=fn, params=None, created_by="admin"
+    )
+
+    assert job_id == 17
+    mock_database.create_operation.assert_called_once_with(
+        op_type="destroy", params=None, created_by="admin"
+    )
+
+
+def test_submit_propagates_operation_in_progress(worker, mock_database):
+    mock_database.create_operation.side_effect = OperationInProgress(job_id=5)
+
+    with pytest.raises(OperationInProgress) as exc_info:
+        worker.submit(
+            op_type="apply", fn=MagicMock(), params=None, created_by="admin"
+        )
+
+    assert exc_info.value.job_id == 5
+
+
+def test_submit_runs_fn_on_background_thread_and_marks_succeeded(
+    worker, mock_database
+):
+    mock_database.create_operation.return_value = 1
+    fn = MagicMock(return_value="terraform output")
+
+    worker.submit(op_type="destroy", fn=fn, params=None, created_by="admin")
+
+    assert _wait_until(lambda: mock_database.finish_operation.called)
+    mock_database.start_operation.assert_called_once_with(1)
+    fn.assert_called_once()
+    mock_database.finish_operation.assert_called_once_with(
+        1, status="succeeded", output="terraform output"
+    )
+
+
+def test_submit_marks_failed_when_fn_raises(worker, mock_database):
+    mock_database.create_operation.return_value = 2
+    fn = MagicMock(side_effect=RuntimeError("terraform exploded"))
+
+    worker.submit(op_type="apply", fn=fn, params=None, created_by="admin")
+
+    assert _wait_until(lambda: mock_database.finish_operation.called)
+    mock_database.finish_operation.assert_called_once_with(
+        2, status="failed", error="terraform exploded"
+    )
+
+
+def test_submit_does_not_block_caller_on_slow_fn(worker, mock_database):
+    """The whole point of this worker: submit() returns before fn() finishes."""
+    mock_database.create_operation.return_value = 3
+    started = time.monotonic()
+
+    def slow_fn():
+        time.sleep(0.3)
+        return "done"
+
+    worker.submit(op_type="destroy", fn=slow_fn, params=None, created_by="admin")
+
+    elapsed = time.monotonic() - started
+    assert elapsed < 0.3, (
+        f"submit() blocked for {elapsed:.2f}s waiting on fn() — "
+        f"it must return immediately"
+    )

--- a/packages/allocator/tests/test_operations.py
+++ b/packages/allocator/tests/test_operations.py
@@ -93,6 +93,23 @@ def test_submit_marks_failed_when_fn_raises(worker, mock_database):
     )
 
 
+def test_submit_marks_failed_when_start_operation_raises(worker, mock_database):
+    """If start_operation itself blows up, the row must still be marked
+    failed instead of staying stuck at status='queued' forever (which
+    would make the single-flight guard reject all future submits)."""
+    mock_database.create_operation.return_value = 4
+    mock_database.start_operation.side_effect = RuntimeError("db exploded")
+    fn = MagicMock(return_value="unused")
+
+    worker.submit(op_type="apply", fn=fn, params=None, created_by="admin")
+
+    assert _wait_until(lambda: mock_database.finish_operation.called)
+    fn.assert_not_called()
+    mock_database.finish_operation.assert_called_once_with(
+        4, status="failed", error="db exploded"
+    )
+
+
 def test_submit_does_not_block_caller_on_slow_fn(worker, mock_database):
     """The whole point of this worker: submit() returns before fn() finishes."""
     mock_database.create_operation.return_value = 3

--- a/packages/allocator/tests/test_operations_db.py
+++ b/packages/allocator/tests/test_operations_db.py
@@ -1,0 +1,208 @@
+"""Tests for OperationsDatabase.
+
+psycopg2-binary is a real dependency of this package (see pyproject.toml),
+so unlike test_database.py these tests use the real psycopg2.IntegrityError
+directly rather than mocking the psycopg2 module — OperationsDatabase takes
+a plain pool object and never calls psycopg2.pool.ThreadedConnectionPool
+itself, so there's no real-connection risk to guard against here.
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import psycopg2
+import pytest
+
+from lablink_allocator_service.operations_db import (
+    OperationInProgress,
+    OperationsDatabase,
+)
+
+
+@pytest.fixture
+def mock_pool_and_cursor():
+    """Fixture returning (mock_conn, mock_cursor, mock_pool), wired so
+    mock_pool.getconn() -> mock_conn -> .cursor() -> mock_cursor."""
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_pool = MagicMock()
+    mock_pool.getconn.return_value = mock_conn
+    return mock_conn, mock_cursor, mock_pool
+
+
+@pytest.fixture
+def operations_db(mock_pool_and_cursor):
+    """OperationsDatabase wired to a mocked pool, with a `.cursor` alias
+    for test assertions (mirrors test_database.py's db_instance fixture)."""
+    _, mock_cursor, mock_pool = mock_pool_and_cursor
+    db = OperationsDatabase(pool=mock_pool)
+    db.cursor = mock_cursor
+    return db
+
+
+def test_create_operation_returns_id(operations_db):
+    operations_db.cursor.fetchone.return_value = (7,)
+
+    operation_id = operations_db.create_operation(
+        op_type="destroy", params=None, created_by="admin"
+    )
+
+    assert operation_id == 7
+    args = operations_db.cursor.execute.call_args[0]
+    expected_query = """
+            INSERT INTO operations (op_type, status, params, created_by)
+            VALUES (%s, 'queued', %s, %s)
+            RETURNING id;
+        """
+    assert "".join(args[0].split()) == "".join(expected_query.split())
+    assert args[1] == ("destroy", None, "admin")
+
+
+def test_create_operation_raises_operation_in_progress_with_existing_job_id(
+    operations_db,
+):
+    operations_db.cursor.execute.side_effect = [
+        psycopg2.IntegrityError(
+            'duplicate key value violates unique constraint '
+            '"operations_single_flight"'
+        ),
+        None,  # the SELECT inside get_in_progress_operation
+    ]
+    operations_db.cursor.fetchone.return_value = (
+        5, "destroy", "running", None, "admin",
+        None, None, None, None, None,
+    )
+
+    with pytest.raises(OperationInProgress) as exc_info:
+        operations_db.create_operation(
+            op_type="apply", params=None, created_by="admin"
+        )
+
+    assert exc_info.value.job_id == 5
+
+
+def test_get_operation_returns_dict(operations_db):
+    operations_db.cursor.fetchone.return_value = (
+        3, "apply", "succeeded", '{"num_vms": 2}', "admin",
+        "2026-07-17 10:00:00", "2026-07-17 10:00:01",
+        "2026-07-17 10:02:00", "apply output", None,
+    )
+
+    operation = operations_db.get_operation(3)
+
+    operations_db.cursor.execute.assert_called_with(
+        "SELECT * FROM operations WHERE id = %s;", (3,)
+    )
+    assert operation["id"] == 3
+    assert operation["op_type"] == "apply"
+    assert operation["status"] == "succeeded"
+    assert operation["output"] == "apply output"
+
+
+def test_get_operation_returns_none_when_missing(operations_db):
+    operations_db.cursor.fetchone.return_value = None
+
+    assert operations_db.get_operation(999) is None
+
+
+def test_list_operations_returns_dicts_newest_first(operations_db):
+    operations_db.cursor.fetchall.return_value = [
+        (2, "destroy", "succeeded", None, "admin",
+         "2026-07-17 11:00:00", "2026-07-17 11:00:01",
+         "2026-07-17 11:03:00", "destroy output", None),
+        (1, "apply", "succeeded", '{"num_vms": 1}', "admin",
+         "2026-07-17 10:00:00", "2026-07-17 10:00:01",
+         "2026-07-17 10:02:00", "apply output", None),
+    ]
+
+    operations = operations_db.list_operations(limit=50)
+
+    args = operations_db.cursor.execute.call_args[0]
+    expected_query = (
+        "SELECT * FROM operations ORDER BY created_at DESC LIMIT %s;"
+    )
+    assert "".join(args[0].split()) == "".join(expected_query.split())
+    assert args[1] == (50,)
+    assert [o["id"] for o in operations] == [2, 1]
+
+
+def test_get_in_progress_operation_returns_row(operations_db):
+    operations_db.cursor.fetchone.return_value = (
+        9, "destroy", "running", None, "admin",
+        "2026-07-17 12:00:00", "2026-07-17 12:00:01", None, None, None,
+    )
+
+    operation = operations_db.get_in_progress_operation()
+
+    args = operations_db.cursor.execute.call_args[0]
+    expected_query = (
+        "SELECT * FROM operations "
+        "WHERE status IN ('queued', 'running') "
+        "ORDER BY created_at DESC LIMIT 1;"
+    )
+    assert "".join(args[0].split()) == "".join(expected_query.split())
+    assert operation["id"] == 9
+    assert operation["status"] == "running"
+
+
+def test_get_in_progress_operation_returns_none_when_idle(operations_db):
+    operations_db.cursor.fetchone.return_value = None
+
+    assert operations_db.get_in_progress_operation() is None
+
+
+def test_start_operation_updates_status_and_started_at(operations_db):
+    operations_db.start_operation(4)
+
+    args = operations_db.cursor.execute.call_args[0]
+    expected_query = (
+        "UPDATE operations SET status = 'running', started_at = NOW() "
+        "WHERE id = %s;"
+    )
+    assert "".join(args[0].split()) == "".join(expected_query.split())
+    assert args[1] == (4,)
+
+
+def test_finish_operation_succeeded(operations_db):
+    operations_db.finish_operation(4, status="succeeded", output="terraform output")
+
+    args = operations_db.cursor.execute.call_args[0]
+    expected_query = """
+            UPDATE operations
+            SET status = %s, output = %s, error = %s, finished_at = NOW()
+            WHERE id = %s;
+        """
+    assert "".join(args[0].split()) == "".join(expected_query.split())
+    assert args[1] == ("succeeded", "terraform output", None, 4)
+
+
+def test_finish_operation_failed(operations_db):
+    operations_db.finish_operation(4, status="failed", error="terraform exploded")
+
+    args = operations_db.cursor.execute.call_args[0]
+    assert args[1] == ("failed", None, "terraform exploded", 4)
+
+
+def test_sweep_interrupted_operations_returns_count(operations_db):
+    operations_db.cursor.fetchall.return_value = [(1,), (2,)]
+
+    count = operations_db.sweep_interrupted_operations()
+
+    args = operations_db.cursor.execute.call_args[0]
+    expected_query = """
+            UPDATE operations
+            SET status = 'interrupted', finished_at = NOW()
+            WHERE status IN ('queued', 'running')
+            RETURNING id;
+        """
+    assert "".join(args[0].split()) == "".join(expected_query.split())
+    assert count == 2
+
+
+def test_sweep_interrupted_operations_returns_zero_when_none_in_progress(
+    operations_db,
+):
+    operations_db.cursor.fetchall.return_value = []
+
+    assert operations_db.sweep_interrupted_operations() == 0

--- a/packages/allocator/tests/test_operations_db.py
+++ b/packages/allocator/tests/test_operations_db.py
@@ -82,6 +82,24 @@ def test_create_operation_raises_operation_in_progress_with_existing_job_id(
     assert exc_info.value.job_id == 5
 
 
+def test_create_operation_raises_runtime_error_when_in_progress_operation_vanishes(
+    operations_db,
+):
+    operations_db.cursor.execute.side_effect = [
+        psycopg2.IntegrityError(
+            'duplicate key value violates unique constraint '
+            '"operations_single_flight"'
+        ),
+        None,  # the SELECT inside get_in_progress_operation
+    ]
+    operations_db.cursor.fetchone.return_value = None
+
+    with pytest.raises(RuntimeError):
+        operations_db.create_operation(
+            op_type="apply", params=None, created_by="admin"
+        )
+
+
 def test_get_operation_returns_dict(operations_db):
     operations_db.cursor.fetchone.return_value = (
         3, "apply", "succeeded", '{"num_vms": 2}', "admin",


### PR DESCRIPTION
## Summary

First of a multi-PR roadmap fixing #379 (deleting many VMs via the admin dashboard blocks the Flask request thread on `terraform destroy`, causing Cloudflare gateway timeouts). This PR lays the foundation only — **no route or user-facing behavior changes yet**; `/destroy` and `/api/launch` still run synchronously until PR 2 wires them up.

Design doc: `docs/superpowers/specs/2026-07-17-async-terraform-worker-design.md` (local, not committed — see plan for full rationale)
Plan: `docs/superpowers/plans/2026-07-17-async-terraform-worker-pr1-core-infra.md` (local, not committed)

- **`operations` table** (`generate_init_sql.py`) — tracks one row per apply/destroy job through `queued → running → succeeded|failed|interrupted`, with a Postgres partial unique index (`operations_single_flight`) enforcing "at most one in-flight operation" atomically, no application-level locking needed.
- **`OperationsDatabase`** (new `operations_db.py`) — persistence for that table. Deliberately a standalone class rather than more methods on the already-large `PostgresqlDatabase`: the `operations` table has no FK/column coupling to `vms` (unlike `scheduled_destructions`, which stays put). Shares `PostgresqlDatabase`'s connection pool via a new `.pool` property rather than opening a second one.
- **`OperationsWorker`** (new `operations.py`) — spawns a daemon thread per submitted job (`threading.Thread`, matching the existing `AutoRebootService`/`AdminSessionExpiryService` pattern — no new dependency, no Celery/Redis), and sweeps any job left `queued`/`running` from a prior process into `interrupted` on allocator startup.
- **Startup wiring** (`main.py`) — instantiates and starts the worker alongside the allocator's other background services. No `atexit`/`.stop()`: unlike the other services, there's no persistent loop to stop.

## Notable fix found during verification

Full-suite testing (not part of any individual task's scoped tests) surfaced a real bug: `operations_db.py` did an eager, unmocked `import` of `database.py`, which could win a pytest-collection race against `test_database.py`/`test_reboot.py`'s own psycopg2-mocking guards and poison them into attempting real DB connections. Fixed by deferring that import to first use (see `e3b1b73e`).

## Test plan

- [x] `PYTHONPATH=. pytest` — 633 passed, 19 skipped (allocator package)
- [x] Confirmed stable across 3 repeated full-suite runs (no flake)
- [x] `ruff check src tests` clean
- [x] Every task individually reviewed (spec compliance + code quality) plus a final whole-branch review; all Critical/Important findings resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)