### PR TITLE
feat(allocator): wire POST /destroy to OperationsWorker (PR 2/3)

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -36,7 +36,10 @@ from lablink_allocator_service.scheduler import ScheduledDestructionService
 from lablink_allocator_service.reboot import AutoRebootService
 from lablink_allocator_service.admin_session_expiry import AdminSessionExpiryService
 from lablink_allocator_service.operations import OperationsWorker
-from lablink_allocator_service.operations_db import OperationsDatabase
+from lablink_allocator_service.operations_db import (
+    OperationInProgress,
+    OperationsDatabase,
+)
 from lablink_allocator_service.client_session import RotationFailed
 from lablink_allocator_service.signed_cookie import (
     sign,
@@ -155,6 +158,12 @@ admin_session_expiry_service = None
 # There is deliberately no operations_worker.stop()/atexit registration
 # to match: there is no loop to join.
 operations_worker = None
+
+# Operations-table query layer (initialized in main()), promoted to a
+# module global alongside operations_worker so routes can read job status
+# directly (list/get/in-progress) without going through the worker, which
+# only exposes submit()/start().
+operations_db = None
 
 # Startup timestamp for uptime tracking (set in main())
 _startup_time: float | None = None
@@ -1226,10 +1235,27 @@ def scheduled_destruction_page():
     return render_template("scheduled-destruction.html")
 
 
+@app.route("/api/operations", methods=["GET"])
+@auth.login_required
+def list_operations():
+    if request.args.get("status") == "in_progress":
+        return jsonify(operations_db.get_in_progress_operation())
+    return jsonify(operations_db.list_operations(limit=50))
+
+
+@app.route("/api/operations/<int:operation_id>", methods=["GET"])
+@auth.login_required
+def get_operation(operation_id):
+    operation = operations_db.get_operation(operation_id)
+    if operation is None:
+        return jsonify({"error": "Operation not found"}), 404
+    return jsonify(operation)
+
+
 def main():
     """Main entry point for the allocator service."""
     global scheduler_service, reboot_service, admin_session_expiry_service
-    global operations_worker
+    global operations_worker, operations_db
     global _startup_time
 
     try:

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -663,42 +663,53 @@ def destroy():
             return jsonify({"status": "error", "error": error_msg}), 405
         return render_template("delete-dashboard.html", error=error_msg), 405
 
-    # Seal any open session-metrics rows before tearing down VMs, so the
-    # final sessions get a duration even though the client agents are about
-    # to be killed. Best-effort: never block destroy on a seal failure.
-    try:
-        sealed = database.bulk_seal_session_metrics()
-        logger.info("Sealed %d session-metrics rows before destroy", sealed)
-    except Exception as e:
-        # Sealing is best-effort; do not block the destroy.
-        logger.warning("Could not bulk-seal session metrics: %s", e)
+    def _run_destroy() -> str:
+        """Runs on OperationsWorker's background thread, not the request
+        thread."""
+        # Seal any open session-metrics rows before tearing down VMs, so the
+        # final sessions get a duration even though the client agents are
+        # about to be killed. Best-effort: never block destroy on a seal
+        # failure.
+        try:
+            sealed = database.bulk_seal_session_metrics()
+            logger.info("Sealed %d session-metrics rows before destroy", sealed)
+        except Exception as e:
+            logger.warning("Could not bulk-seal session metrics: %s", e)
 
-    # destroy_hosts ignores the handles arg (terraform destroy operates on
-    # the whole workspace); skip the list_hosts() call.
-    try:
-        result = provider.destroy_hosts([])
-    except FileNotFoundError as e:
-        # No terraform.runtime.tfvars → no client VMs were ever launched.
-        msg = str(e)
-        logger.info(msg)
-        if _wants_json():
-            return jsonify({"status": "error", "error": msg}), 404
-        return render_template("delete-dashboard.html", error=msg), 404
-    except subprocess.CalledProcessError as e:
-        logger.error(f"Error during Terraform destroy: {e}")
-        error_output = ANSI_ESCAPE.sub("", e.stderr or e.stdout or "")
-        if _wants_json():
-            return jsonify({"status": "error", "error": error_output}), 500
-        return render_template("delete-dashboard.html", error=error_output)
+        # destroy_hosts ignores the handles arg (terraform destroy operates
+        # on the whole workspace); skip the list_hosts() call.
+        try:
+            result = provider.destroy_hosts([])
+        except FileNotFoundError as e:
+            # No terraform.runtime.tfvars → no client VMs were ever launched.
+            raise RuntimeError(str(e)) from e
+        except subprocess.CalledProcessError as e:
+            error_output = ANSI_ESCAPE.sub("", e.stderr or e.stdout or "")
+            raise RuntimeError(error_output) from e
 
-    # Clear the database after successful destroy.
-    logger.debug("Clearing the database...")
-    database.clear_database()
-    logger.debug("Database cleared successfully.")
+        logger.debug("Clearing the database...")
+        database.clear_database()
+        logger.debug("Database cleared successfully.")
+        return result.stdout
+
+    try:
+        job_id = operations_worker.submit(
+            op_type="destroy",
+            fn=_run_destroy,
+            params=None,
+            created_by=auth.current_user(),
+        )
+    except OperationInProgress as exc:
+        error_msg = f"An operation is already in progress (job #{exc.job_id})"
+        if _wants_json():
+            return jsonify({
+                "status": "error", "error": error_msg, "job_id": exc.job_id,
+            }), 409
+        return render_template("delete-dashboard.html", error=error_msg), 409
 
     if _wants_json():
-        return jsonify({"status": "success", "output": result.stdout})
-    return render_template("delete-dashboard.html", output=result.stdout)
+        return jsonify({"job_id": job_id, "status": "queued"}), 202
+    return redirect(f"/admin/instances?job={job_id}")
 
 
 @app.route("/api/unassigned_vms_count", methods=["GET"])

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -3,6 +3,7 @@ import logging
 import secrets
 import subprocess
 import time
+import json
 from pathlib import Path
 from datetime import datetime
 import re
@@ -602,49 +603,54 @@ def launch():
         "deployment_name": getattr(cfg, "deployment_name", "lablink"),
     }
 
+    def _run_launch() -> str:
+        """Runs on OperationsWorker's background thread, not the request
+        thread. Reformats known failure types into RuntimeError with the
+        same user-facing text the old synchronous route used, so that
+        text ends up in the operation's `error` column."""
+        try:
+            result = provider.provision_hosts(count=total_vms, spec=spec)
+        except SGAuditFailure as exc:
+            raise RuntimeError(
+                f"Security-group audit refused the plan: {exc}"
+            ) from exc
+        except subprocess.CalledProcessError as e:
+            clean_err = ANSI_ESCAPE.sub("", (e.stderr or "")).strip()
+            raise RuntimeError(f"Terraform failed: {clean_err}") from e
+
+        for hostname, times in result.timings.items():
+            start_time = datetime.fromisoformat(
+                times["start_time"].replace("Z", "+00:00")
+            )
+            end_time = datetime.fromisoformat(
+                times["end_time"].replace("Z", "+00:00")
+            )
+            database.update_terraform_timing(
+                hostname=hostname,
+                per_instance_seconds=float(times["seconds"]),
+                per_instance_start_time=start_time,
+                per_instance_end_time=end_time,
+            )
+        return result.apply_stdout
+
     try:
-        result = provider.provision_hosts(count=total_vms, spec=spec)
-    except SGAuditFailure as exc:
-        logger.error("SG audit refused the plan: %s", exc)
-        error_msg = f"Security-group audit refused the plan: {exc}"
+        job_id = operations_worker.submit(
+            op_type="apply",
+            fn=_run_launch,
+            params=json.dumps({"num_vms": num_vms}),
+            created_by=auth.current_user(),
+        )
+    except OperationInProgress as exc:
+        error_msg = f"An operation is already in progress (job #{exc.job_id})"
         if _wants_json():
-            return jsonify({"status": "error", "error": error_msg}), 400
-        return render_template("dashboard.html", error=error_msg), 400
-    except subprocess.CalledProcessError as e:
-        logger.error("Terraform failed: %s", e.stderr)
-        clean_err = ANSI_ESCAPE.sub("", (e.stderr or "")).strip()
-        error_msg = f"Terraform failed: {clean_err}"
-        if _wants_json():
-            return jsonify({"status": "error", "error": error_msg}), 500
-        return render_template("dashboard.html", error=error_msg)
-    except Exception as e:
-        logger.error("Unexpected error during launch: %s", e)
-        if _wants_json():
-            return jsonify({"status": "error", "error": str(e)}), 500
-        return render_template("dashboard.html", error=str(e))
+            return jsonify({
+                "status": "error", "error": error_msg, "job_id": exc.job_id,
+            }), 409
+        return render_template("dashboard.html", error=error_msg), 409
 
-    # Update DB with timings (route-owned; provider returned them)
-    for hostname, times in result.timings.items():
-        start_time = datetime.fromisoformat(
-            times["start_time"].replace("Z", "+00:00")
-        )
-        end_time = datetime.fromisoformat(
-            times["end_time"].replace("Z", "+00:00")
-        )
-        database.update_terraform_timing(
-            hostname=hostname,
-            per_instance_seconds=float(times["seconds"]),
-            per_instance_start_time=start_time,
-            per_instance_end_time=end_time,
-        )
-
-    # Success response — match the pre-refactor shape EXACTLY
     if _wants_json():
-        return jsonify({
-            "status": "success",
-            "output": result.apply_stdout,
-        })
-    return render_template("dashboard.html", output=result.apply_stdout)
+        return jsonify({"job_id": job_id, "status": "queued"}), 202
+    return redirect(f"/admin/instances?job={job_id}")
 
 
 @app.route("/destroy", methods=["POST"])

--- a/packages/allocator/src/lablink_allocator_service/scheduler.py
+++ b/packages/allocator/src/lablink_allocator_service/scheduler.py
@@ -80,6 +80,24 @@ def execute_scheduled_destruction_job(
             status="executing",
         )
 
+        from lablink_allocator_service.operations_db import OperationsDatabase
+
+        operations_db = OperationsDatabase(pool=database.pool)
+        if operations_db.get_in_progress_operation() is not None:
+            logger.info(
+                "Scheduled destruction %s skipped — an on-demand operation "
+                "is in progress",
+                schedule_id,
+            )
+            database.update_scheduled_destruction_status(
+                schedule_id=schedule_id,
+                status="failed",
+                execution_result=(
+                    "Skipped: an on-demand operation was in progress"
+                ),
+            )
+            return
+
         if not provider.can_destroy_hosts:
             logger.info(
                 "Scheduled destruction skipped — provider %s does not support destroy.",

--- a/packages/allocator/src/lablink_allocator_service/templates/create-instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/create-instances.html
@@ -1,15 +1,29 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="UTF-8">
+  <meta charset="UTF-8" />
   <title>VM Allocator Dashboard</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
   <link
     href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css"
-    rel="stylesheet">
+    rel="stylesheet"
+  />
+  <style>
+    body {
+      background-color: #f0f2f5;
+    }
+    .spinner-border {
+      width: 1.25rem;
+      height: 1.25rem;
+    }
+  </style>
 </head>
-<body>
-  <div class="container mt-5">
-    <h1 class="mb-4">VM Allocator Dashboard</h1>
+<body class="d-flex justify-content-center align-items-center min-vh-100">
+  <div class="card shadow-lg p-4 w-100" style="max-width: 500px;">
+    <h2 class="mb-3 text-center">Launch New LabLink Instances</h2>
+    <p class="text-center text-muted">
+      Create new client VM instances via Terraform.
+    </p>
 
     <form method="POST" action="/api/launch" onsubmit="return handleSubmit();">
       <div class="mb-3">
@@ -18,19 +32,21 @@
         <div id="vm-validation-message" class="form-text mt-1">
         </div>
       </div>
-      <button id="launch-btn" type="submit" class="btn btn-primary" disabled>Launch VMs</button>
-      <div id="loading-message" class="mt-2 text-muted" style="display: none;">
+      <div class="d-grid mb-3">
+        <button id="launch-btn" type="submit" class="btn btn-primary" disabled>Launch VMs</button>
+      </div>
+      <div id="loading-message" class="text-muted text-center mb-3 d-none">
+        <div class="spinner-border spinner-border-sm me-2" role="status"></div>
         Launching VMs... please wait.
       </div>
     </form>
 
-    <div class="mt-3">
+    <div class="text-center">
       <a href="/admin" class="btn btn-secondary">&larr; Back to Admin Dashboard</a>
     </div>
   </div>
-  <script>
-    let availableInstanceTypes = [];
 
+  <script>
     function validateForm() {
       const numVMs = document.getElementById("num_vms").value.trim();
       const launchBtn = document.getElementById("launch-btn");
@@ -49,11 +65,11 @@
       const button = document.getElementById("launch-btn");
       const message = document.getElementById("loading-message");
       button.disabled = true;
-      button.style.cursor = "not-allowed";
       button.innerText = "Launching...";
-      message.style.display = "block";
+      message.classList.remove("d-none");
       return true;
     }
   </script>
+  <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
 </body>
 </html>

--- a/packages/allocator/src/lablink_allocator_service/templates/create-instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/create-instances.html
@@ -23,6 +23,10 @@
         Launching VMs... please wait.
       </div>
     </form>
+
+    <div class="mt-3">
+      <a href="/admin" class="btn btn-secondary">&larr; Back to Admin Dashboard</a>
+    </div>
   </div>
   <script>
     let availableInstanceTypes = [];

--- a/packages/allocator/src/lablink_allocator_service/templates/create-instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/create-instances.html
@@ -16,10 +16,21 @@
       width: 1.25rem;
       height: 1.25rem;
     }
+    .back-link {
+      display: inline-block;
+      margin-bottom: 20px;
+      color: #007bff;
+      text-decoration: none;
+    }
+    .back-link:hover {
+      text-decoration: underline;
+    }
   </style>
 </head>
 <body class="d-flex justify-content-center align-items-center min-vh-100">
   <div class="card shadow-lg p-4 w-100" style="max-width: 500px;">
+    <a href="/admin" class="back-link">&larr; Back to Admin Dashboard</a>
+
     <h2 class="mb-3 text-center">Launch New LabLink Instances</h2>
     <p class="text-center text-muted">
       Create new client VM instances via Terraform.
@@ -40,10 +51,6 @@
         Launching VMs... please wait.
       </div>
     </form>
-
-    <div class="text-center">
-      <a href="/admin" class="btn btn-secondary">&larr; Back to Admin Dashboard</a>
-    </div>
   </div>
 
   <script>

--- a/packages/allocator/src/lablink_allocator_service/templates/delete-instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/delete-instances.html
@@ -16,10 +16,21 @@
       width: 1.25rem;
       height: 1.25rem;
     }
+    .back-link {
+      display: inline-block;
+      margin-bottom: 20px;
+      color: #007bff;
+      text-decoration: none;
+    }
+    .back-link:hover {
+      text-decoration: underline;
+    }
   </style>
 </head>
 <body class="d-flex justify-content-center align-items-center min-vh-100">
   <div class="card shadow-lg p-4 w-100" style="max-width: 500px;">
+    <a href="/admin" class="back-link">&larr; Back to Admin Dashboard</a>
+
     <h2 class="mb-3 text-center">Delete All LabLink Instances</h2>
     <p class="text-danger text-center fw-semibold">
       This action will remove <strong>all VMs</strong> created via Terraform.
@@ -37,10 +48,6 @@
         Destroying VMs... please wait.
       </div>
     </form>
-
-    <div class="text-center">
-      <a href="/admin" class="btn btn-secondary">&larr; Back to Admin Dashboard</a>
-    </div>
   </div>
 
   <script>

--- a/packages/allocator/src/lablink_allocator_service/templates/delete-instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/delete-instances.html
@@ -38,6 +38,9 @@
       </div>
     </form>
 
+    <div class="text-center">
+      <a href="/admin" class="btn btn-secondary">&larr; Back to Admin Dashboard</a>
+    </div>
   </div>
 
   <script>

--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -212,6 +212,12 @@
     <script>
       const initialJobId = "{{ request.args.get('job', '') }}";
 
+      function escapeHtml(str) {
+        const div = document.createElement("div");
+        div.textContent = str;
+        return div.innerHTML;
+      }
+
       function renderOperationBanner(op) {
         const banner = document.getElementById("operation-banner");
         if (!op) {
@@ -231,14 +237,14 @@
           banner.innerHTML =
             `${label} job #${op.id}: succeeded` +
             (op.output
-              ? `<details><summary>Show output</summary><pre>${op.output}</pre></details>`
+              ? `<details><summary>Show output</summary><pre>${escapeHtml(op.output)}</pre></details>`
               : "");
         } else if (op.status === "failed") {
           banner.className = "state-failed";
           banner.innerHTML =
             `${label} job #${op.id}: failed` +
             (op.error
-              ? `<details><summary>Show error</summary><pre>${op.error}</pre></details>`
+              ? `<details><summary>Show error</summary><pre>${escapeHtml(op.error)}</pre></details>`
               : "");
         } else if (op.status === "interrupted") {
           banner.className = "state-interrupted";

--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -79,6 +79,43 @@
         color: #555;
         font-size: 13px;
       }
+
+      #operation-banner {
+        display: none;
+        padding: 12px 16px;
+        margin-bottom: 16px;
+        border-radius: 6px;
+        font-size: 14px;
+      }
+
+      #operation-banner.state-active {
+        display: block;
+        background: #e7f1ff;
+        color: #004085;
+      }
+
+      #operation-banner.state-succeeded {
+        display: block;
+        background: #e2f6e9;
+        color: #14532d;
+      }
+
+      #operation-banner.state-failed,
+      #operation-banner.state-interrupted {
+        display: block;
+        background: #ffe0e0;
+        color: #900;
+      }
+
+      #operation-banner details {
+        margin-top: 8px;
+      }
+
+      #operation-banner pre {
+        white-space: pre-wrap;
+        max-height: 300px;
+        overflow-y: auto;
+      }
     </style>
   </head>
   <body>
@@ -100,6 +137,8 @@
       {% endif %}
     </div>
     {% endif %}
+
+    <div id="operation-banner"></div>
 
     <table>
       <thead>
@@ -169,5 +208,79 @@
         {% endfor %}
       </tbody>
     </table>
+
+    <script>
+      const initialJobId = "{{ request.args.get('job', '') }}";
+
+      function renderOperationBanner(op) {
+        const banner = document.getElementById("operation-banner");
+        if (!op) {
+          banner.className = "";
+          banner.innerHTML = "";
+          return;
+        }
+
+        const label = op.op_type === "apply" ? "Launch" : "Destroy";
+
+        if (op.status === "queued" || op.status === "running") {
+          banner.className = "state-active";
+          banner.innerHTML =
+            `${label} job #${op.id}: ${op.status}…`;
+        } else if (op.status === "succeeded") {
+          banner.className = "state-succeeded";
+          banner.innerHTML =
+            `${label} job #${op.id}: succeeded` +
+            (op.output
+              ? `<details><summary>Show output</summary><pre>${op.output}</pre></details>`
+              : "");
+        } else if (op.status === "failed") {
+          banner.className = "state-failed";
+          banner.innerHTML =
+            `${label} job #${op.id}: failed` +
+            (op.error
+              ? `<details><summary>Show error</summary><pre>${op.error}</pre></details>`
+              : "");
+        } else if (op.status === "interrupted") {
+          banner.className = "state-interrupted";
+          banner.innerHTML =
+            `${label} job #${op.id}: interrupted — the allocator ` +
+            `restarted mid-job. Check Terraform state manually.`;
+        }
+      }
+
+      function pollOperation(jobId) {
+        let intervalId = null;
+
+        function tick() {
+          fetch(`/api/operations/${jobId}`)
+            .then((res) => (res.ok ? res.json() : null))
+            .then((op) => {
+              renderOperationBanner(op);
+              if (op && op.status !== "queued" && op.status !== "running") {
+                if (intervalId) clearInterval(intervalId);
+              }
+            })
+            .catch((err) => console.error("Error polling operation:", err));
+        }
+
+        tick();
+        intervalId = setInterval(tick, 3000);
+      }
+
+      document.addEventListener("DOMContentLoaded", function () {
+        if (initialJobId) {
+          pollOperation(initialJobId);
+          return;
+        }
+        fetch("/api/operations?status=in_progress")
+          .then((res) => (res.ok ? res.json() : null))
+          .then((op) => {
+            if (op) pollOperation(op.id);
+          })
+          .catch((err) =>
+            console.error("Error checking in-progress operation:", err)
+          );
+      });
+    </script>
   </body>
 </html>

--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -179,7 +179,8 @@
               View Logs
             </a>
           </td>
-          <td class="actions-cell">
+          <td>
+            <div class="actions-cell">
             {% if vm.useremail and vm.status == 'running' and vm.sessionid %}
             <a href="/admin/instances/{{ vm.hostname }}/peek" class="btn-sm" target="_blank">
               Peek (view-only)
@@ -203,6 +204,7 @@
             {% else %}
             <span class="admin-session-label">—</span>
             {% endif %}
+            </div>
           </td>
         </tr>
         {% endfor %}

--- a/packages/allocator/tests/test_destroy_route_baseline.py
+++ b/packages/allocator/tests/test_destroy_route_baseline.py
@@ -1,109 +1,57 @@
-"""Pre-refactor regression baseline for /destroy.
+"""Regression baseline for /destroy.
 
-After Tasks 7-8, /destroy calls provider.destroy_hosts(...) which performs:
-- FileNotFoundError if no terraform.runtime.tfvars exists (→ 404)
+Since the async rewrite (PR 2 of the async-terraform-worker roadmap), the
+route no longer runs terraform synchronously — it submits a job to
+OperationsWorker and returns immediately. These tests assert:
 - current_instance_security_group + NotOnEC2Error catch (in provider)
 - terraform destroy -auto-approve -var-file=terraform.runtime.tfvars
-  [-var=allocator_sg_id=<sg>]
+  [-var=allocator_sg_id=<sg>] — via the captured closure, not the route directly
 - ANSI-strip of output (in provider, DestroyResult.stdout is already clean)
-- database.clear_database() after success (still in route)
+- database.clear_database() after success, inside the closure
 
-Post-Task-8 note: all AWS-specific calls (current_instance_security_group,
-subprocess.run for terraform destroy) now execute inside AWSProvider.destroy_hosts —
-patch them in the providers.aws namespace, not the main namespace.
-list_hosts() calls get_instance_ids / get_instance_names (terraform output),
-which must also be patched to avoid real terraform invocations.
+All AWS-specific calls (current_instance_security_group, subprocess.run for
+terraform destroy) execute inside AWSProvider.destroy_hosts — patch them in
+the providers.aws namespace, not the main namespace. list_hosts() calls
+get_instance_ids / get_instance_names (terraform output), which must also
+be patched to avoid real terraform invocations.
 """
 from __future__ import annotations
 
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
 
-# ---------------------------------------------------------------------------
-# Shared setup
-# ---------------------------------------------------------------------------
-
 @pytest.fixture
 def destroy_setup(app, monkeypatch, tmp_path):
-    """Standard monkeypatches for /destroy baseline tests.
-
-    Depends on `app` so these monkeypatches run after the `app` fixture
-    sets up the Flask test context — preventing the `app` fixture's direct
-    `main.database = MagicMock()` assignment from overwriting our fake_db.
-
-    Post-Task-8: also replaces LABLINK_PROVIDER in app.config with a fresh
-    AWSProvider pointing at tmp_path, so destroy_hosts checks for the
-    runtime tfvars in tmp_path and calls terraform in the tmp directory.
-
-    Writes terraform.runtime.tfvars to tmp_path so the route does not
-    early-return 404 (that path is tested separately in
-    test_destroy_returns_404_when_no_runtime_tfvars).
-    """
+    """Standard monkeypatches for /destroy baseline tests. See PR 1's
+    version of this fixture for the rationale of each monkeypatch."""
     from lablink_allocator_service import main
     from lablink_allocator_service.providers.aws import AWSProvider
 
     monkeypatch.setattr(main, "TERRAFORM_DIR", tmp_path)
     (tmp_path / "terraform.runtime.tfvars").write_text("# baseline-test stub\n")
 
-    # Wire a fresh AWSProvider pointing at tmp_path so destroy_hosts
-    # checks for tfvars and runs terraform relative to tmp_path.
     provider = AWSProvider(region="us-west-2", terraform_dir=str(tmp_path))
     monkeypatch.setitem(main.app.config, "LABLINK_PROVIDER", provider)
 
     fake_db = MagicMock()
     fake_db.clear_database = MagicMock()
+    fake_db.bulk_seal_session_metrics = MagicMock(return_value=0)
     monkeypatch.setattr(main, "database", fake_db, raising=False)
 
     return {"tmp_path": tmp_path, "database": fake_db}
 
 
-# ---------------------------------------------------------------------------
-# Baseline tests
-# ---------------------------------------------------------------------------
-
-@patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
-@patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
-@patch("lablink_allocator_service.providers.aws.current_instance_security_group",
-       return_value="sg-allocator-test")
-@patch("lablink_allocator_service.providers.aws.subprocess.run")
-def test_destroy_runs_terraform_destroy(
-    mock_run, mock_sg, mock_ids, mock_names,
-    destroy_setup, client, admin_headers,
-):
-    """Baseline: terraform destroy is called with the required flags."""
-    mock_run.return_value = MagicMock(
-        stdout="Destroy complete (mocked)", stderr="", returncode=0
-    )
-
+def _capture_closure(client, admin_headers, mock_worker):
+    """POST /destroy and return the `fn` closure captured from the mocked
+    operations_worker.submit call, so the test can invoke it directly."""
     r = client.post("/destroy", headers=admin_headers)
-
-    assert r.status_code == 200, (
-        f"Expected 200, got {r.status_code}: {r.get_data(as_text=True)[:500]}"
+    assert r.status_code == 302, (
+        f"Expected redirect, got {r.status_code}: {r.get_data(as_text=True)[:300]}"
     )
-
-    calls = mock_run.call_args_list
-    cmds = [
-        list(c.args[0])
-        for c in calls
-        if c.args and isinstance(c.args[0], (list, tuple))
-    ]
-    destroy_cmds = [
-        c for c in cmds
-        if c and c[0] == "terraform" and "destroy" in c
-    ]
-    assert destroy_cmds, f"terraform destroy not called; cmds: {cmds}"
-
-    cmd = destroy_cmds[0]
-    assert "-auto-approve" in cmd, f"-auto-approve missing: {cmd}"
-    assert "-var-file=terraform.runtime.tfvars" in cmd, (
-        f"-var-file=terraform.runtime.tfvars missing: {cmd}"
-    )
-    assert any("allocator_sg_id" in arg for arg in cmd), (
-        f"allocator_sg_id var missing from destroy cmd: {cmd}"
-    )
+    mock_worker.submit.assert_called_once()
+    return mock_worker.submit.call_args.kwargs["fn"]
 
 
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
@@ -111,45 +59,41 @@ def test_destroy_runs_terraform_destroy(
 @patch("lablink_allocator_service.providers.aws.current_instance_security_group",
        return_value="sg-allocator-test")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
-def test_destroy_clears_database_on_success(
+def test_destroy_submits_job_and_returns_202(
     mock_run, mock_sg, mock_ids, mock_names,
     destroy_setup, client, admin_headers,
 ):
-    """Baseline: database.clear_database() is called after successful destroy."""
+    """`main.operations_worker` is patched here (like every other test below)
+    because the module-level global is `None` until the real allocator's
+    `main()` initializes it at process startup; tests never call `main()`,
+    so the route would otherwise hit `AttributeError` on `None.submit`.
+    """
     mock_run.return_value = MagicMock(
         stdout="Destroy complete (mocked)", stderr="", returncode=0
     )
 
-    client.post("/destroy", headers=admin_headers)
-
-    destroy_setup["database"].clear_database.assert_called_once()
-
-
-def test_destroy_returns_404_when_no_runtime_tfvars(
-    monkeypatch, tmp_path, client, admin_headers,
-):
-    """Baseline: /destroy returns 404 when no terraform.runtime.tfvars exists."""
-    from lablink_allocator_service import main
-    from lablink_allocator_service.providers.aws import AWSProvider
-
-    monkeypatch.setattr(main, "TERRAFORM_DIR", tmp_path)
-    # Intentionally do NOT create tfvars so the provider raises FileNotFoundError
-    # which the route maps to 404.
-    provider = AWSProvider(region="us-west-2", terraform_dir=str(tmp_path))
-    monkeypatch.setitem(main.app.config, "LABLINK_PROVIDER", provider)
-
-    with patch("lablink_allocator_service.providers.aws.get_instance_ids",
-               return_value=[]), \
-         patch("lablink_allocator_service.providers.aws.get_instance_names",
-               return_value=[]):
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 42
         r = client.post(
             "/destroy",
             headers={**admin_headers, "Accept": "application/json"},
         )
-    assert r.status_code == 404, (
-        f"Expected 404 when no tfvars, got {r.status_code}: "
-        f"{r.get_data(as_text=True)[:300]}"
+
+    assert r.status_code == 202, (
+        f"Expected 202, got {r.status_code}: {r.get_data(as_text=True)[:500]}"
     )
+    body = r.get_json()
+    assert body["status"] == "queued"
+    assert isinstance(body["job_id"], int)
+
+
+def test_destroy_redirects_browser_client_with_job_id(client, admin_headers):
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 9
+        r = client.post("/destroy", headers=admin_headers, follow_redirects=False)
+
+    assert r.status_code == 302
+    assert r.headers["Location"] == "/admin/instances?job=9"
 
 
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
@@ -157,44 +101,123 @@ def test_destroy_returns_404_when_no_runtime_tfvars(
 @patch("lablink_allocator_service.providers.aws.current_instance_security_group",
        return_value="sg-allocator-test")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
-def test_destroy_strips_ansi_from_output(
+def test_destroy_closure_runs_terraform_destroy_and_clears_db(
     mock_run, mock_sg, mock_ids, mock_names,
     destroy_setup, client, admin_headers,
 ):
-    """Baseline: ANSI escape codes are stripped from terraform destroy output."""
-    mock_run.return_value = MagicMock(
-        stdout="\x1b[32mresources destroyed\x1b[0m", stderr="", returncode=0
-    )
-
-    r = client.post("/destroy", headers=admin_headers)
-    assert r.status_code == 200
-    body = r.get_data(as_text=True)
-    assert "resources destroyed" in body
-    assert "\x1b[" not in body, "ANSI escape codes were NOT stripped from response"
-
-
-@patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
-@patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
-@patch("lablink_allocator_service.providers.aws.current_instance_security_group",
-       return_value="sg-allocator-test")
-@patch("lablink_allocator_service.providers.aws.subprocess.run")
-def test_destroy_json_response_on_success(
-    mock_run, mock_sg, mock_ids, mock_names,
-    destroy_setup, client, admin_headers,
-):
-    """Baseline: JSON-accepting client gets status=success + output on destroy."""
+    """Capture the closure and invoke it directly — this is what actually
+    runs on the background thread."""
     mock_run.return_value = MagicMock(
         stdout="Destroy complete (mocked)", stderr="", returncode=0
     )
 
-    r = client.post(
-        "/destroy",
-        headers={**admin_headers, "Accept": "application/json"},
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        fn = _capture_closure(client, admin_headers, mock_worker)
+        output = fn()
+
+    assert "Destroy complete" in output
+
+    calls = mock_run.call_args_list
+    cmds = [
+        list(c.args[0]) for c in calls
+        if c.args and isinstance(c.args[0], (list, tuple))
+    ]
+    destroy_cmds = [c for c in cmds if c and c[0] == "terraform" and "destroy" in c]
+    assert destroy_cmds, f"terraform destroy not called; cmds: {cmds}"
+    cmd = destroy_cmds[0]
+    assert "-auto-approve" in cmd
+    assert "-var-file=terraform.runtime.tfvars" in cmd
+    assert any("allocator_sg_id" in arg for arg in cmd)
+
+    destroy_setup["database"].clear_database.assert_called_once()
+
+
+@patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
+@patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
+@patch("lablink_allocator_service.providers.aws.current_instance_security_group",
+       return_value="sg-allocator-test")
+@patch("lablink_allocator_service.providers.aws.subprocess.run")
+def test_destroy_closure_strips_ansi_from_output(
+    mock_run, mock_sg, mock_ids, mock_names,
+    destroy_setup, client, admin_headers,
+):
+    mock_run.return_value = MagicMock(
+        stdout="\x1b[32mresources destroyed\x1b[0m", stderr="", returncode=0
     )
-    assert r.status_code == 200
-    body = json.loads(r.get_data(as_text=True))
-    assert body["status"] == "success"
-    assert "Destroy complete" in body["output"]
+
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        fn = _capture_closure(client, admin_headers, mock_worker)
+        output = fn()
+
+    assert "resources destroyed" in output
+    assert "\x1b[" not in output
+
+
+def test_destroy_closure_fails_when_no_runtime_tfvars(
+    monkeypatch, tmp_path, client, admin_headers,
+):
+    """No terraform.runtime.tfvars -> the closure raises RuntimeError (marks
+    the operation failed) instead of the route returning 404 synchronously."""
+    from lablink_allocator_service import main
+    from lablink_allocator_service.providers.aws import AWSProvider
+
+    monkeypatch.setattr(main, "TERRAFORM_DIR", tmp_path)
+    provider = AWSProvider(region="us-west-2", terraform_dir=str(tmp_path))
+    monkeypatch.setitem(main.app.config, "LABLINK_PROVIDER", provider)
+    fake_db = MagicMock()
+    fake_db.bulk_seal_session_metrics = MagicMock(return_value=0)
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    with patch("lablink_allocator_service.providers.aws.get_instance_ids",
+               return_value=[]), \
+         patch("lablink_allocator_service.providers.aws.get_instance_names",
+               return_value=[]), \
+         patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        fn = _capture_closure(client, admin_headers, mock_worker)
+
+        with pytest.raises(RuntimeError, match="tfvars does not exist"):
+            fn()
+
+
+@patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
+@patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
+@patch("lablink_allocator_service.providers.aws.current_instance_security_group",
+       return_value="sg-allocator-test")
+def test_destroy_closure_wraps_terraform_failure(
+    mock_sg, mock_ids, mock_names, destroy_setup, client, admin_headers,
+):
+    import subprocess
+
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.run",
+        side_effect=subprocess.CalledProcessError(
+            1, ["terraform", "destroy"], stderr="\x1b[31mError: boom\x1b[0m",
+        ),
+    ), patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        fn = _capture_closure(client, admin_headers, mock_worker)
+
+        with pytest.raises(RuntimeError, match="Error: boom"):
+            fn()
+
+
+def test_destroy_returns_409_when_operation_in_progress(client, admin_headers):
+    from lablink_allocator_service.operations_db import OperationInProgress
+
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.side_effect = OperationInProgress(job_id=4)
+        r = client.post(
+            "/destroy",
+            headers={**admin_headers, "Accept": "application/json"},
+        )
+
+    assert r.status_code == 409
+    body = r.get_json()
+    assert body["job_id"] == 4
+    assert "already in progress" in body["error"]
 
 
 def test_destroy_returns_405_when_provider_cannot_destroy(
@@ -203,7 +226,6 @@ def test_destroy_returns_405_when_provider_cannot_destroy(
     """After Task 8, the route returns 405 when the provider can't destroy."""
     from lablink_allocator_service import main
 
-    # Force can_destroy_hosts=False via a fake provider in app.config
     fake_provider = type("FakeProvider", (), {
         "can_provision_hosts": False,
         "can_destroy_hosts": False,

--- a/packages/allocator/tests/test_launch_route_baseline.py
+++ b/packages/allocator/tests/test_launch_route_baseline.py
@@ -192,51 +192,101 @@ def launch_setup(app, monkeypatch, tmp_path):
 # Baseline tests
 # ---------------------------------------------------------------------------
 
-def test_launch_calls_aws_utils(launch_setup, client, admin_headers):
-    """Baseline: check_support_nvidia, current_instance_security_group,
-    and upload_to_s3 are all called during a successful /api/launch."""
-    with _provider_happy_path_patches() as mocks:
-        r = client.post("/api/launch", headers=admin_headers, data={"num_vms": "2"})
+def test_launch_submits_job_and_returns_202(launch_setup, client, admin_headers):
+    """The route no longer blocks on Terraform — it submits a job and
+    returns immediately with a job id.
 
-        assert r.status_code == 200, (
-            f"Expected 200, got {r.status_code}: {r.get_data(as_text=True)[:500]}"
-        )
-        mocks["nvidia"].assert_called()
-        mocks["sg"].assert_called()
-        mocks["s3"].assert_called()
-
-
-def test_launch_writes_runtime_tfvars_with_expected_keys(
-    launch_setup, client, admin_headers,
-):
-    """Baseline: terraform.runtime.tfvars contains the 14 expected keys."""
-    with _provider_happy_path_patches():
-        client.post("/api/launch", headers=admin_headers, data={"num_vms": "1"})
-
-    tfvars_path = launch_setup["tmp_path"] / "terraform.runtime.tfvars"
-    assert tfvars_path.exists(), "runtime tfvars was not written"
-    content = tfvars_path.read_text()
-
-    for key in [
-        "allocator_ip", "allocator_url", "machine_type", "image_name",
-        "repository", "client_ami_id", "subject_software", "resource_prefix",
-        "gpu_support", "cloud_init_output_log_group", "region",
-        "startup_on_error", "agent_token", "register_token",
-    ]:
-        assert f"{key} = " in content, (
-            f"key '{key}' missing from runtime tfvars; got:\n{content}"
+    `main.operations_worker` is patched here (like every other test below)
+    because the module-level global is `None` until the real allocator's
+    `main()` initializes it at process startup; tests never call `main()`,
+    so the route would otherwise hit `AttributeError` on `None.submit`.
+    """
+    with _provider_happy_path_patches(), patch(
+        "lablink_allocator_service.main.operations_worker"
+    ) as mock_worker:
+        mock_worker.submit.return_value = 42
+        r = client.post(
+            "/api/launch",
+            headers={**admin_headers, "Accept": "application/json"},
+            data={"num_vms": "2"},
         )
 
+    assert r.status_code == 202, (
+        f"Expected 202, got {r.status_code}: {r.get_data(as_text=True)[:500]}"
+    )
+    body = r.get_json()
+    assert body["status"] == "queued"
+    assert isinstance(body["job_id"], int)
 
-def test_launch_runs_terraform_plan_show_apply_sequence(
+
+def test_launch_redirects_browser_client_with_job_id(
     launch_setup, client, admin_headers,
 ):
-    """Baseline: terraform plan → show -json → apply in that order."""
-    with _provider_happy_path_patches() as mocks:
+    """A non-JSON (browser form) submit gets a redirect carrying the job id,
+    not a rendered terraform-output page."""
+    with _provider_happy_path_patches(), patch(
+        "lablink_allocator_service.main.operations_worker"
+    ) as mock_worker:
+        mock_worker.submit.return_value = 7
+        r = client.post(
+            "/api/launch", headers=admin_headers, data={"num_vms": "1"},
+            follow_redirects=False,
+        )
+
+    assert r.status_code == 302
+    assert r.headers["Location"].startswith("/admin/instances?job=")
+
+
+def test_launch_closure_calls_aws_utils_and_writes_timings(
+    launch_setup, client, admin_headers,
+):
+    """Capture the closure passed to operations_worker.submit(fn=...) and
+    invoke it directly — this is what actually runs on the background
+    thread, so it must still do everything the old inline route body did:
+    call the AWS utils, run plan/show/apply in order, audit the SG plan,
+    and write timing rows per host."""
+    from unittest.mock import patch
+
+    with _provider_happy_path_patches() as mocks, patch(
+        "lablink_allocator_service.main.operations_worker"
+    ) as mock_worker:
+        mock_worker.submit.return_value = 42
+        r = client.post(
+            "/api/launch", headers=admin_headers, data={"num_vms": "1"},
+        )
+        assert r.status_code == 302
+
+        mock_worker.submit.assert_called_once()
+        call_kwargs = mock_worker.submit.call_args.kwargs
+        assert call_kwargs["op_type"] == "apply"
+        assert call_kwargs["params"] == '{"num_vms": 1}'
+        fn = call_kwargs["fn"]
+
+        output = fn()
+
+    mocks["nvidia"].assert_called()
+    mocks["sg"].assert_called()
+    mocks["s3"].assert_called()
+    assert output == "apply success"
+
+    db = launch_setup["database"]
+    assert db.update_terraform_timing.call_count == 1
+
+
+def test_launch_closure_runs_plan_show_apply_in_order(
+    launch_setup, client, admin_headers,
+):
+    """Baseline preserved: terraform plan -> show -json -> apply, in order."""
+    from unittest.mock import patch
+
+    with _provider_happy_path_patches() as mocks, patch(
+        "lablink_allocator_service.main.operations_worker"
+    ) as mock_worker:
         client.post("/api/launch", headers=admin_headers, data={"num_vms": "1"})
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        fn()
 
         calls = mocks["run"].call_args_list
-        # Extract the command list from each call (first positional arg)
         cmds = [
             list(c.args[0])
             for c in calls
@@ -249,48 +299,92 @@ def test_launch_runs_terraform_plan_show_apply_sequence(
                     return i
             return -1
 
-        plan_idx = index_of("plan")
-        show_idx = index_of("show")
-        apply_idx = index_of("apply")
-
-        assert plan_idx != -1, f"terraform plan not called; cmds: {cmds}"
-        assert show_idx != -1, f"terraform show not called; cmds: {cmds}"
-        assert apply_idx != -1, f"terraform apply not called; cmds: {cmds}"
-        assert plan_idx < show_idx < apply_idx, (
-            f"terraform plan/show/apply not in order: "
-            f"plan={plan_idx}, show={show_idx}, apply={apply_idx}; cmds: {cmds}"
+        plan_idx, show_idx, apply_idx = (
+            index_of("plan"), index_of("show"), index_of("apply"),
         )
+        assert plan_idx != -1 and show_idx != -1 and apply_idx != -1
+        assert plan_idx < show_idx < apply_idx
 
 
-def test_launch_calls_sg_audit_with_plan_json(launch_setup, client, admin_headers):
-    """Baseline: audit_terraform_plan is called with the parsed plan JSON dict."""
-    with _provider_happy_path_patches():
-        with patch("lablink_allocator_service.providers.aws.audit_terraform_plan") as mock_audit:
-            mock_audit.return_value = None
-            client.post("/api/launch", headers=admin_headers, data={"num_vms": "1"})
-            mock_audit.assert_called_once()
-            call_arg = mock_audit.call_args[0][0]
-            assert isinstance(call_arg, dict), (
-                f"audit_terraform_plan expected a dict, got "
-                f"{type(call_arg).__name__}: {call_arg}"
-            )
+def test_launch_closure_wraps_sg_audit_failure(launch_setup, client, admin_headers):
+    """SGAuditFailure inside the closure is reformatted into a RuntimeError
+    with the same user-facing message the old synchronous route produced,
+    so it lands in operations.error with useful detail intact.
+
+    audit_terraform_plan runs between the `show -json` and `apply` calls
+    inside provider.provision_hosts, so this must override just that one
+    call while every other provider dependency stays mocked to the happy
+    path — and the closure must be invoked in the SAME `with` block that
+    sets those patches up, not after they've been torn down, or fn() will
+    hit unmocked subprocess.run/upload_to_s3/etc. calls."""
+    from unittest.mock import patch
+    from lablink_allocator_service.utils.sg_audit import SGAuditFailure
+
+    with _provider_happy_path_patches(), patch(
+        "lablink_allocator_service.providers.aws.audit_terraform_plan",
+        side_effect=SGAuditFailure("port 6080 exposed"),
+    ), patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        client.post("/api/launch", headers=admin_headers, data={"num_vms": "1"})
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+
+        with pytest.raises(
+            RuntimeError, match="Security-group audit refused the plan"
+        ):
+            fn()
 
 
-def test_launch_calls_update_terraform_timing_per_host(
+def test_launch_closure_wraps_terraform_failure(launch_setup, client, admin_headers):
+    """CalledProcessError inside the closure is reformatted with the
+    ANSI-stripped stderr, matching the old synchronous route's error text."""
+    import subprocess
+    from unittest.mock import patch
+
+    with patch(
+        "lablink_allocator_service.providers.aws.upload_to_s3", return_value=None,
+    ), patch(
+        "lablink_allocator_service.providers.aws.current_instance_security_group",
+        return_value="sg-allocator-test",
+    ), patch(
+        "lablink_allocator_service.providers.aws.check_support_nvidia",
+        return_value=True,
+    ), patch(
+        "lablink_allocator_service.providers.aws.subprocess.run",
+        side_effect=subprocess.CalledProcessError(
+            1, ["terraform", "apply"], stderr="\x1b[31mError: boom\x1b[0m",
+        ),
+    ), patch(
+        "lablink_allocator_service.main.operations_worker"
+    ) as mock_worker:
+        client.post("/api/launch", headers=admin_headers, data={"num_vms": "1"})
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+
+        # fn() must be invoked while the subprocess.run/upload_to_s3/etc.
+        # patches above are still active — calling it after this `with`
+        # block exits would hit real, unmocked subprocess/AWS calls.
+        with pytest.raises(RuntimeError, match="Terraform failed: Error: boom"):
+            fn()
+
+
+def test_launch_returns_409_when_operation_in_progress(
     launch_setup, client, admin_headers,
 ):
-    """Baseline: database.update_terraform_timing is called once per host
-    returned by get_instance_timings."""
-    with _provider_happy_path_patches():
-        client.post("/api/launch", headers=admin_headers, data={"num_vms": "1"})
+    from unittest.mock import patch
+    from lablink_allocator_service.operations_db import OperationInProgress
 
-    db = launch_setup["database"]
-    # _TIMING_DATA has one host ("vm-1"), so update_terraform_timing must be
-    # called exactly once.
-    assert db.update_terraform_timing.call_count == 1, (
-        f"Expected 1 update_terraform_timing call, "
-        f"got {db.update_terraform_timing.call_count}"
-    )
+    with patch(
+        "lablink_allocator_service.main.operations_worker"
+    ) as mock_worker:
+        mock_worker.submit.side_effect = OperationInProgress(job_id=3)
+        r = client.post(
+            "/api/launch",
+            headers={**admin_headers, "Accept": "application/json"},
+            data={"num_vms": "1"},
+        )
+
+    assert r.status_code == 409
+    body = r.get_json()
+    assert body["job_id"] == 3
+    assert "already in progress" in body["error"]
 
 
 def test_launch_returns_405_when_provider_cannot_provision(
@@ -299,7 +393,6 @@ def test_launch_returns_405_when_provider_cannot_provision(
     """After Task 6, the route returns 405 when the provider can't provision."""
     from lablink_allocator_service import main
 
-    # Force can_provision_hosts=False via a fake provider in app.config
     fake_provider = type("FakeProvider", (), {
         "can_provision_hosts": False,
         "can_destroy_hosts": True,

--- a/packages/allocator/tests/test_operations_routes.py
+++ b/packages/allocator/tests/test_operations_routes.py
@@ -1,0 +1,95 @@
+"""Tests for the GET /api/operations read endpoints."""
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def fake_operations_db(app, monkeypatch):
+    """Wire main.operations_db to a fresh mock for each test."""
+    from lablink_allocator_service import main
+
+    fake_db = MagicMock()
+    monkeypatch.setattr(main, "operations_db", fake_db, raising=False)
+    return fake_db
+
+
+def test_list_operations_returns_recent_operations(
+    fake_operations_db, client, admin_headers,
+):
+    fake_operations_db.list_operations.return_value = [
+        {"id": 2, "op_type": "destroy", "status": "succeeded"},
+        {"id": 1, "op_type": "apply", "status": "succeeded"},
+    ]
+
+    resp = client.get("/api/operations", headers=admin_headers)
+
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert [o["id"] for o in body] == [2, 1]
+    fake_operations_db.list_operations.assert_called_once_with(limit=50)
+
+
+def test_list_operations_requires_auth(fake_operations_db, client):
+    resp = client.get("/api/operations")
+    assert resp.status_code == 401
+
+
+def test_list_operations_in_progress_returns_current_job(
+    fake_operations_db, client, admin_headers,
+):
+    fake_operations_db.get_in_progress_operation.return_value = {
+        "id": 5, "op_type": "destroy", "status": "running",
+    }
+
+    resp = client.get(
+        "/api/operations?status=in_progress", headers=admin_headers
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json()["id"] == 5
+    fake_operations_db.get_in_progress_operation.assert_called_once()
+
+
+def test_list_operations_in_progress_returns_null_when_idle(
+    fake_operations_db, client, admin_headers,
+):
+    fake_operations_db.get_in_progress_operation.return_value = None
+
+    resp = client.get(
+        "/api/operations?status=in_progress", headers=admin_headers
+    )
+
+    assert resp.status_code == 200
+    assert resp.get_json() is None
+
+
+def test_get_operation_returns_the_operation(
+    fake_operations_db, client, admin_headers,
+):
+    fake_operations_db.get_operation.return_value = {
+        "id": 7, "op_type": "apply", "status": "succeeded", "output": "ok",
+    }
+
+    resp = client.get("/api/operations/7", headers=admin_headers)
+
+    assert resp.status_code == 200
+    assert resp.get_json()["id"] == 7
+    fake_operations_db.get_operation.assert_called_once_with(7)
+
+
+def test_get_operation_404_when_missing(
+    fake_operations_db, client, admin_headers,
+):
+    fake_operations_db.get_operation.return_value = None
+
+    resp = client.get("/api/operations/999", headers=admin_headers)
+
+    assert resp.status_code == 404
+
+
+def test_get_operation_requires_auth(fake_operations_db, client):
+    resp = client.get("/api/operations/7")
+    assert resp.status_code == 401

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -191,3 +191,31 @@ def test_view_instances_shows_vnc_error_banner(client, admin_headers):
         "/admin/instances?vnc_error=connect_raced", headers=admin_headers
     )
     assert b"claimed by someone else" in resp.data
+
+
+@patch("lablink_allocator_service.main.database")
+def test_view_instances_embeds_job_id_from_query_param(
+    mock_database, client, admin_headers,
+):
+    mock_database.get_all_vms.return_value = []
+
+    resp = client.get("/admin/instances?job=17", headers=admin_headers)
+
+    html = resp.data.decode()
+    assert 'id="operation-banner"' in html
+    assert "17" in html
+
+
+@patch("lablink_allocator_service.main.database")
+def test_view_instances_banner_absent_without_job_param(
+    mock_database, client, admin_headers,
+):
+    """No ?job= param and nothing in progress: the banner container exists
+    (for JS to fill in later) but starts with no job id embedded."""
+    mock_database.get_all_vms.return_value = []
+
+    resp = client.get("/admin/instances", headers=admin_headers)
+
+    html = resp.data.decode()
+    assert 'id="operation-banner"' in html
+    assert 'const initialJobId = "";' in html

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -219,3 +219,21 @@ def test_view_instances_banner_absent_without_job_param(
     html = resp.data.decode()
     assert 'id="operation-banner"' in html
     assert 'const initialJobId = "";' in html
+
+
+@patch("lablink_allocator_service.main.database")
+def test_instances_html_escapes_operation_output_and_error(
+    mock_database, client, admin_headers,
+):
+    """op.output/op.error (terraform stdout/stderr) must be HTML-escaped
+    before going into innerHTML, not interpolated raw — XSS risk otherwise."""
+    mock_database.get_all_vms.return_value = []
+
+    resp = client.get("/admin/instances", headers=admin_headers)
+    html = resp.data.decode()
+
+    assert "function escapeHtml(" in html
+    assert "${escapeHtml(op.output)}" in html
+    assert "${escapeHtml(op.error)}" in html
+    assert "${op.output}" not in html
+    assert "${op.error}" not in html

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -106,11 +106,28 @@ def test_admin_delete_instance(client, admin_headers):
     response = client.get("/admin/instances/delete", headers=admin_headers)
     assert response.status_code == 200
     assert b"Run terraform destroy" in response.data
+    assert b'href="/admin"' in response.data
+    assert "Back to Admin Dashboard".encode() in response.data
 
 
 def test_admin_delete_instance_no_auth(client):
     """Test deleting an instance without authentication."""
     response = client.get("/admin/instances/delete")
+    assert response.status_code == 401
+
+
+def test_admin_create_instance(client, admin_headers):
+    """Test the create-instances page as an admin."""
+    response = client.get("/admin/create", headers=admin_headers)
+    assert response.status_code == 200
+    assert b"Launch VMs" in response.data
+    assert b'href="/admin"' in response.data
+    assert "Back to Admin Dashboard".encode() in response.data
+
+
+def test_admin_create_instance_no_auth(client):
+    """Test the create-instances page without authentication."""
+    response = client.get("/admin/create")
     assert response.status_code == 401
 
 

--- a/packages/allocator/tests/test_scheduler.py
+++ b/packages/allocator/tests/test_scheduler.py
@@ -313,8 +313,13 @@ def test_execute_scheduled_destruction_success(
     fake_provider.list_hosts.return_value = []
     fake_provider.destroy_hosts.return_value = DestroyResult(stdout="Destroy complete!")
 
+    fake_operations_db = MagicMock()
+    fake_operations_db.get_in_progress_operation.return_value = None
+
     with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
          patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
+         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+               return_value=fake_operations_db), \
          patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
 
         mock_get_config.return_value = _make_mock_config()
@@ -354,8 +359,13 @@ def test_execute_scheduled_destruction_provider_cannot_destroy(
     fake_provider = MagicMock()
     fake_provider.can_destroy_hosts = False
 
+    fake_operations_db = MagicMock()
+    fake_operations_db.get_in_progress_operation.return_value = None
+
     with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
          patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
+         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+               return_value=fake_operations_db), \
          patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
 
         mock_get_config.return_value = _make_mock_config(provider_name="manual")
@@ -392,8 +402,13 @@ def test_execute_scheduled_destruction_destroy_failure(
         stderr="Error destroying resources",
     )
 
+    fake_operations_db = MagicMock()
+    fake_operations_db.get_in_progress_operation.return_value = None
+
     with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
          patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
+         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+               return_value=fake_operations_db), \
          patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
 
         mock_get_config.return_value = _make_mock_config()
@@ -411,6 +426,89 @@ def test_execute_scheduled_destruction_destroy_failure(
 
     # DB should NOT be cleared on failure
     mock_database.clear_database.assert_not_called()
+
+
+def test_execute_scheduled_destruction_skips_when_operation_in_progress(
+    scheduler_service, mock_database, tmp_path
+):
+    """A scheduled destruction must not run while an on-demand operation
+    (submitted via /destroy or /api/launch) is queued/running — it would
+    race the same Terraform state."""
+    from lablink_allocator_service.scheduler import execute_scheduled_destruction_job
+
+    schedule_id = 42
+    terraform_dir = str(tmp_path / "terraform")
+
+    fake_provider = MagicMock()
+    fake_provider.can_destroy_hosts = True
+
+    fake_operations_db = MagicMock()
+    fake_operations_db.get_in_progress_operation.return_value = {
+        "id": 17, "op_type": "apply", "status": "running",
+    }
+
+    with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
+         patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
+         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+               return_value=fake_operations_db), \
+         patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
+
+        mock_get_config.return_value = _make_mock_config()
+
+        execute_scheduled_destruction_job(
+            schedule_id=schedule_id,
+            terraform_dir=terraform_dir,
+        )
+
+    # destroy_hosts must NOT have been called — the in-progress operation
+    # wins.
+    fake_provider.destroy_hosts.assert_not_called()
+
+    # DB must NOT be cleared either — nothing was actually destroyed.
+    mock_database.clear_database.assert_not_called()
+
+    calls = mock_database.update_scheduled_destruction_status.call_args_list
+    failed_call = [c for c in calls if c[1].get("status") == "failed"][0]
+    assert failed_call[1]["schedule_id"] == schedule_id
+    assert "operation was in progress" in failed_call[1]["execution_result"]
+
+
+def test_execute_scheduled_destruction_proceeds_when_no_operation_in_progress(
+    scheduler_service, mock_database, tmp_path
+):
+    """Baseline unchanged: with no on-demand operation running, the
+    scheduled destruction proceeds exactly as before."""
+    from lablink_allocator_service.scheduler import execute_scheduled_destruction_job
+    from lablink_allocator_service.providers.protocol import DestroyResult
+
+    schedule_id = 43
+    terraform_dir = str(tmp_path / "terraform")
+
+    fake_provider = MagicMock()
+    fake_provider.can_destroy_hosts = True
+    fake_provider.list_hosts.return_value = []
+    fake_provider.destroy_hosts.return_value = DestroyResult(stdout="Destroy complete!")
+
+    fake_operations_db = MagicMock()
+    fake_operations_db.get_in_progress_operation.return_value = None
+
+    with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
+         patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
+         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+               return_value=fake_operations_db), \
+         patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
+
+        mock_get_config.return_value = _make_mock_config()
+
+        execute_scheduled_destruction_job(
+            schedule_id=schedule_id,
+            terraform_dir=terraform_dir,
+        )
+
+    fake_provider.destroy_hosts.assert_called_once()
+    mock_database.clear_database.assert_called_once()
+    last_call = mock_database.update_scheduled_destruction_status.call_args_list[-1]
+    assert last_call[1]["status"] == "completed"
 
 
 # NOTE: Retry tests removed - retry logic moved out of scheduler class

--- a/packages/allocator/tests/test_session_metrics_seal_on_destroy.py
+++ b/packages/allocator/tests/test_session_metrics_seal_on_destroy.py
@@ -65,7 +65,14 @@ def test_admin_destroy_route_seals_before_destroy(
     mock_run, mock_sg, mock_ids, mock_names,
     destroy_setup, client, admin_headers,
 ):
-    """POST /destroy must seal session-metrics rows before tear-down."""
+    """POST /destroy's closure must seal session-metrics rows before
+    tear-down.
+
+    Since the async rewrite, the route itself only submits a job; the
+    seal-then-destroy ordering is enforced inside the closure that runs
+    on OperationsWorker's background thread, so we capture and invoke
+    that closure directly.
+    """
     fake_db = destroy_setup["database"]
     call_order: list[str] = []
 
@@ -82,11 +89,18 @@ def test_admin_destroy_route_seals_before_destroy(
     fake_db.bulk_seal_session_metrics.side_effect = _seal
     mock_run.side_effect = _run
 
-    resp = client.post("/destroy", headers=admin_headers)
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post("/destroy", headers=admin_headers)
 
-    assert resp.status_code == 200, (
-        f"Expected 200, got {resp.status_code}: {resp.get_data(as_text=True)[:300]}"
-    )
+        assert resp.status_code == 302, (
+            f"Expected redirect, got {resp.status_code}: "
+            f"{resp.get_data(as_text=True)[:300]}"
+        )
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        fn()
+
     fake_db.bulk_seal_session_metrics.assert_called_once()
     assert call_order == ["seal", "destroy"], (
         f"Expected seal before destroy, got {call_order}"
@@ -104,16 +118,23 @@ def test_admin_destroy_route_continues_when_seal_fails(
     mock_run, mock_sg, mock_ids, mock_names,
     destroy_setup, client, admin_headers,
 ):
-    """If bulk_seal fails, /destroy logs a warning and continues to destroy."""
+    """If bulk_seal fails, the closure logs a warning and continues to
+    destroy."""
     mock_run.return_value = MagicMock(
         stdout="Destroy complete (mocked)", stderr="", returncode=0
     )
     fake_db = destroy_setup["database"]
     fake_db.bulk_seal_session_metrics.side_effect = RuntimeError("db blew up")
 
-    resp = client.post("/destroy", headers=admin_headers)
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post("/destroy", headers=admin_headers)
 
-    assert resp.status_code == 200
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        fn()
+
     fake_db.bulk_seal_session_metrics.assert_called_once()
     # Destroy still ran despite the seal failure.
     assert mock_run.called

--- a/packages/allocator/tests/test_terraform_api.py
+++ b/packages/allocator/tests/test_terraform_api.py
@@ -462,10 +462,20 @@ def test_destroy_success(mock_run, mock_sg, mock_ids, mock_names,
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
 
-    # Call the destroy endpoint
-    resp = client.post(DESTROY_ENDPOINT, headers=admin_headers)
-    assert resp.status_code == 200
-    assert b"resources destroyed" in resp.data
+    # Call the destroy endpoint -- now async: it submits a job and returns
+    # immediately instead of running terraform inline. Capture and invoke
+    # the closure (still within the scope of the @patch decorators above)
+    # to exercise the same destroy_hosts call the background thread would
+    # make.
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(DESTROY_ENDPOINT, headers=admin_headers)
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        output = fn()
+
+    assert "resources destroyed" in output
 
     # Correct terraform command called with cwd
     mock_run.assert_called_once()
@@ -501,9 +511,16 @@ def test_destroy_failure(mock_run, mock_sg, mock_ids, mock_names,
         returncode=1, cmd=["terraform", "destroy"], stderr="\x1b[31merror\x1b[0m"
     )
 
-    # Call the destroy endpoint
-    resp = client.post(DESTROY_ENDPOINT, headers=admin_headers)
-    assert b"error" in resp.data
+    # Call the destroy endpoint -- submission succeeds immediately (job
+    # queued); the terraform failure only surfaces once the closure runs.
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(DESTROY_ENDPOINT, headers=admin_headers)
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        with pytest.raises(RuntimeError, match="error"):
+            fn()
 
     # Ensure run was called correctly
     mock_run.assert_called_once()
@@ -560,13 +577,18 @@ def test_destroy_json_success(mock_run, mock_sg, mock_ids, mock_names,
     )
 
     headers = {**admin_headers, **JSON_ACCEPT}
-    resp = client.post(DESTROY_ENDPOINT, headers=headers)
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(DESTROY_ENDPOINT, headers=headers)
 
-    assert resp.status_code == 200
-    body = json.loads(resp.data)
-    assert body["status"] == "success"
-    assert "resources destroyed" in body["output"]
+        assert resp.status_code == 202
+        body = json.loads(resp.data)
+        assert body["status"] == "queued"
 
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        output = fn()
+
+    assert "resources destroyed" in output
     fake_db.clear_database.assert_called_once()
 
 
@@ -591,46 +613,67 @@ def test_destroy_json_failure(mock_run, mock_sg, mock_ids, mock_names,
     )
 
     headers = {**admin_headers, **JSON_ACCEPT}
-    resp = client.post(DESTROY_ENDPOINT, headers=headers)
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(DESTROY_ENDPOINT, headers=headers)
 
-    assert resp.status_code == 500
-    body = json.loads(resp.data)
-    assert body["status"] == "error"
-    assert "failed to destroy" in body["error"]
+        # Submission itself succeeds immediately (job queued); the
+        # terraform failure only surfaces once the closure runs.
+        assert resp.status_code == 202
+        body = json.loads(resp.data)
+        assert body["status"] == "queued"
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        with pytest.raises(RuntimeError, match="failed to destroy"):
+            fn()
 
 
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 def test_destroy_no_tfvars(mock_ids, mock_names,
                             client, admin_headers, monkeypatch, tmp_path):
-    """Test destroy returns 404 when tfvars does not exist (no VMs launched)."""
+    """Test destroy closure raises RuntimeError when tfvars does not exist
+    (no VMs launched) -- this now surfaces only when the background thread
+    runs the closure, not synchronously from the route."""
     terraform_dir = tmp_path / "terraform"
     terraform_dir.mkdir()
     # Do NOT create terraform.runtime.tfvars
     monkeypatch.setattr("lablink_allocator_service.main.TERRAFORM_DIR", terraform_dir)
     _wire_aws_provider(monkeypatch, terraform_dir)
 
-    resp = client.post(DESTROY_ENDPOINT, headers=admin_headers)
-    assert resp.status_code == 404
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(DESTROY_ENDPOINT, headers=admin_headers)
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        with pytest.raises(RuntimeError, match="tfvars does not exist"):
+            fn()
 
 
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 def test_destroy_no_tfvars_json(mock_ids, mock_names,
                                  client, admin_headers, monkeypatch, tmp_path):
-    """Test destroy returns JSON 404 when tfvars does not exist."""
+    """Test destroy closure raises RuntimeError (JSON client) when tfvars
+    does not exist -- submission itself still succeeds immediately."""
     terraform_dir = tmp_path / "terraform"
     terraform_dir.mkdir()
     monkeypatch.setattr("lablink_allocator_service.main.TERRAFORM_DIR", terraform_dir)
     _wire_aws_provider(monkeypatch, terraform_dir)
 
     headers = {**admin_headers, **JSON_ACCEPT}
-    resp = client.post(DESTROY_ENDPOINT, headers=headers)
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(DESTROY_ENDPOINT, headers=headers)
 
-    assert resp.status_code == 404
-    body = json.loads(resp.data)
-    assert body["status"] == "error"
-    assert "tfvars does not exist" in body["error"]
+        assert resp.status_code == 202
+        body = json.loads(resp.data)
+        assert body["status"] == "queued"
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        with pytest.raises(RuntimeError, match="tfvars does not exist"):
+            fn()
 
 
 @patch("lablink_allocator_service.providers.aws.upload_to_s3")

--- a/packages/allocator/tests/test_terraform_api.py
+++ b/packages/allocator/tests/test_terraform_api.py
@@ -2,6 +2,8 @@ from unittest.mock import patch, MagicMock
 import json
 import subprocess
 
+import pytest
+
 POST_ENDPOINT = "/api/launch"
 DESTROY_ENDPOINT = "/destroy"
 
@@ -121,10 +123,17 @@ def test_launch_vm_success(
         R("\x1b[32mapply success\x1b[0m"),   # terraform apply <planfile>
     ]
 
-    # Call route
-    resp = client.post(POST_ENDPOINT, headers=admin_headers, data={"num_vms": "2"})
-    assert resp.status_code == 200
-    assert b"Output Dashboard" in resp.data
+    # Call route -- now async: it submits a job and returns immediately
+    # instead of running terraform inline. Capture and invoke the closure
+    # (still within the scope of the @patch decorators above) to exercise
+    # the same provision_hosts call the background thread would make.
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(POST_ENDPOINT, headers=admin_headers, data={"num_vms": "2"})
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        fn()
 
     # Assert calls (plan + show -json + apply = 3; terraform output calls
     # are handled by patched get_instance_* functions)
@@ -238,9 +247,14 @@ def test_launch_vm_appends_allocator_sg_id_var(
         R("apply ok"),         # terraform apply <planfile>
     ]
 
-    resp = client.post(POST_ENDPOINT, headers=admin_headers,
-                        data={"num_vms": "1"})
-    assert resp.status_code == 200
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(POST_ENDPOINT, headers=admin_headers,
+                            data={"num_vms": "1"})
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        fn()
 
     # The allocator-SG var is supplied via terraform plan; apply runs
     # off the saved plan file and never sees -var flags directly.
@@ -320,9 +334,14 @@ def test_launch_vm_skips_sg_var_when_not_on_ec2(
         R("apply ok"),         # terraform apply <planfile>
     ]
 
-    resp = client.post(POST_ENDPOINT, headers=admin_headers,
-                        data={"num_vms": "1"})
-    assert resp.status_code == 200
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(POST_ENDPOINT, headers=admin_headers,
+                            data={"num_vms": "1"})
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        fn()
 
     # When IMDSv2 was unreachable, the plan must not include the
     # allocator-SG var. apply runs off the saved plan file and has
@@ -404,9 +423,14 @@ def test_launch_apply_failure(
 
     mock_run.side_effect = side_effect
 
-    resp = client.post(POST_ENDPOINT, headers=admin_headers, data={"num_vms": "4"})
-    assert resp.status_code == 200
-    assert b"boom" in resp.data  # stripped
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(POST_ENDPOINT, headers=admin_headers, data={"num_vms": "4"})
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        with pytest.raises(RuntimeError, match="Terraform failed: boom"):
+            fn()
 
     tfvars = (terraform_dir / "terraform.runtime.tfvars").read_text()
     assert 'gpu_support = "false"' in tfvars
@@ -660,12 +684,19 @@ def test_launch_json_success(
     ]
 
     headers = {**admin_headers, **JSON_ACCEPT}
-    resp = client.post(POST_ENDPOINT, headers=headers, data={"num_vms": "2"})
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 5
+        resp = client.post(POST_ENDPOINT, headers=headers, data={"num_vms": "2"})
 
-    assert resp.status_code == 200
-    body = json.loads(resp.data)
-    assert body["status"] == "success"
-    assert "apply success" in body["output"]
+        assert resp.status_code == 202
+        body = json.loads(resp.data)
+        assert body["status"] == "queued"
+        assert body["job_id"] == 5
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        output = fn()
+
+    assert output == "apply success"
 
 
 def test_launch_json_missing_num_vms(client, admin_headers):
@@ -759,12 +790,21 @@ def test_launch_json_apply_failure(
     mock_run.side_effect = side_effect
 
     headers = {**admin_headers, **JSON_ACCEPT}
-    resp = client.post(POST_ENDPOINT, headers=headers, data={"num_vms": "1"})
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(POST_ENDPOINT, headers=headers, data={"num_vms": "1"})
 
-    assert resp.status_code == 500
-    body = json.loads(resp.data)
-    assert body["status"] == "error"
-    assert "resource already exists" in body["error"]
+        # Submission itself succeeds immediately (job queued); the
+        # terraform failure only surfaces once the closure runs.
+        assert resp.status_code == 202
+        body = json.loads(resp.data)
+        assert body["status"] == "queued"
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        with pytest.raises(
+            RuntimeError, match="Terraform failed: Error: resource already exists"
+        ):
+            fn()
 
 
 @patch("lablink_allocator_service.providers.aws.upload_to_s3")
@@ -812,12 +852,21 @@ def test_launch_json_unexpected_error(
     mock_upload_to_s3.side_effect = Exception("AccessDenied: s3:PutObject")
 
     headers = {**admin_headers, **JSON_ACCEPT}
-    resp = client.post(POST_ENDPOINT, headers=headers, data={"num_vms": "1"})
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(POST_ENDPOINT, headers=headers, data={"num_vms": "1"})
 
-    assert resp.status_code == 500
-    body = json.loads(resp.data)
-    assert body["status"] == "error"
-    assert "AccessDenied" in body["error"]
+        # Submission succeeds immediately; unexpected errors (anything
+        # other than SGAuditFailure/CalledProcessError) are NOT reformatted
+        # by the closure -- they propagate as-is, to be recorded by
+        # OperationsWorker as the operation's error.
+        assert resp.status_code == 202
+        body = json.loads(resp.data)
+        assert body["status"] == "queued"
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        with pytest.raises(Exception, match="AccessDenied"):
+            fn()
 
 
 # ------------------------------------------------------------------
@@ -897,14 +946,24 @@ def test_launch_aborts_on_sg_audit_failure(
     ]
 
     headers = {**admin_headers, **JSON_ACCEPT}
-    resp = client.post(
-        POST_ENDPOINT, headers=headers, data={"num_vms": "1"}
-    )
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(
+            POST_ENDPOINT, headers=headers, data={"num_vms": "1"}
+        )
 
-    assert resp.status_code == 400
-    body = json.loads(resp.data)
-    assert body["status"] == "error"
-    assert "6080" in body["error"]  # error mentions the offending port
+        # Submission succeeds immediately; the SG audit gate now fires
+        # inside the closure, not synchronously in the route.
+        assert resp.status_code == 202
+        body = json.loads(resp.data)
+        assert body["status"] == "queued"
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        with pytest.raises(
+            RuntimeError, match="Security-group audit refused the plan"
+        ) as excinfo:
+            fn()
+        assert "6080" in str(excinfo.value)  # error mentions the offending port
 
     # Confirm apply was not invoked — only plan + show ran.
     assert mock_run.call_count == 2
@@ -959,11 +1018,23 @@ def test_launch_aborts_on_sg_audit_failure_html(
         R(VIOLATING_PLAN_JSON),   # terraform show -json (fed to audit)
     ]
 
-    resp = client.post(
-        POST_ENDPOINT, headers=admin_headers, data={"num_vms": "1"}
-    )
-    assert resp.status_code == 400
-    assert b"6080" in resp.data
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(
+            POST_ENDPOINT, headers=admin_headers, data={"num_vms": "1"}
+        )
+        # Browser-form submit gets a redirect carrying the job id, not a
+        # rendered error page — the audit failure now surfaces later, on
+        # the background thread.
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        with pytest.raises(
+            RuntimeError, match="Security-group audit refused the plan"
+        ) as excinfo:
+            fn()
+        assert "6080" in str(excinfo.value)
+
     # Plan + show ran; apply did not.
     assert mock_run.call_count == 2
     mock_upload_to_s3.assert_not_called()
@@ -1026,8 +1097,13 @@ def test_launch_writes_register_token_to_tfvars(
         R("\x1b[32mapply success\x1b[0m"),
     ]
 
-    resp = client.post(POST_ENDPOINT, headers=admin_headers, data={"num_vms": "1"})
-    assert resp.status_code == 200
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(POST_ENDPOINT, headers=admin_headers, data={"num_vms": "1"})
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        fn()
 
     tfvars = (terraform_dir / "terraform.runtime.tfvars").read_text()
     assert 'register_token = "test-register-token-value"' in tfvars
@@ -1092,8 +1168,13 @@ def test_launch_writes_agent_token_to_tfvars_additively(
         R("\x1b[32mapply success\x1b[0m"),
     ]
 
-    resp = client.post(POST_ENDPOINT, headers=admin_headers, data={"num_vms": "1"})
-    assert resp.status_code == 200
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(POST_ENDPOINT, headers=admin_headers, data={"num_vms": "1"})
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        fn()
 
     from lablink_allocator_service import main
 


### PR DESCRIPTION
## Summary

Second of a multi-PR roadmap fixing #379 (deleting/launching many VMs via the admin dashboard blocks the Flask request thread on `terraform destroy`/`apply`, causing Cloudflare gateway timeouts). PR 1 (#383, merged) built the foundation — this is the PR that actually closes the bug.

Design doc: `docs/superpowers/specs/2026-07-17-async-terraform-worker-design.md` (local, not committed)
Plan: `docs/superpowers/plans/2026-07-17-async-terraform-worker-pr2-wire-routes.md` (local, not committed)

- **`GET /api/operations`** (list, `?status=in_progress`) and **`GET /api/operations/<id>`** — new read endpoints backing status polling. `operations_db` promoted to a module global in `main.py` alongside the existing `operations_worker`.
- **`POST /api/launch`** and **`POST /destroy`** now wrap the actual Terraform-invoking work in a closure submitted to `OperationsWorker` instead of running it inline. Pre-submit validation (num_vms, provider capability) is unchanged. Success returns `202 {job_id}` (JSON) or redirects to `/admin/instances?job=N` (browser) almost immediately; a collision with an in-flight operation returns `409` instead of racing Terraform state.
- **`scheduler.py`**'s cron-based scheduled-destruction job now checks the same `operations` table before running, so it can't collide with an on-demand launch/destroy either.
- **`/admin/instances`** gained a small vanilla-JS polling banner (`fetch`+`setInterval`, matching the existing style already used elsewhere in this dashboard) showing queued → running → succeeded/failed.

## Notable fix found during review

A real XSS vector: the banner originally interpolated raw Terraform stdout/stderr into `innerHTML`. Fixed with a DOM-based `escapeHtml()` helper at both interpolation sites, verified by re-review and a regression test (`54fad7eb`).

## ⚠️ Release-sequencing note (not a code issue in this PR)

Per the final whole-branch review: **do not publish a new `lablink` CLI release between this PR merging and PR 3 (CLI polling) merging.** Until PR 3 lands, `lablink destroy` would get a `202 queued` response instantly, print a false "✓ client VMs destroyed", and proceed to tear down the allocator's own infrastructure while the background thread is still mid-destroy — orphaning client VMs. `lablink launch` degrades harmlessly by comparison (just returns early without a summary). Confirmed this risk is contained to the CLI only and not worsened by this diff — it's resolved by PR 3, not something to fix here.

## Test plan

- [x] `PYTHONPATH=. pytest` — 649 passed, 19 skipped (allocator package)
- [x] `ruff check src tests` clean
- [x] Every task individually reviewed (spec compliance + code quality); two fix rounds (a stuck-queued-job-style test gap in Task 4's coordination check tests, and the XSS fix above) plus a final whole-branch review — all Critical/Important findings resolved or explicitly accepted as out-of-scope process gates

🤖 Generated with [Claude Code](https://claude.com/claude-code)