### PR TITLE
feat(cli): poll operations instead of blocking on /destroy and /api/launch (PR 3/3)

### DIFF
--- a/packages/cli/src/lablink_cli/api.py
+++ b/packages/cli/src/lablink_cli/api.py
@@ -5,8 +5,10 @@ from __future__ import annotations
 import base64
 import json
 import ssl
+import time
 from typing import NoReturn
 from urllib.error import HTTPError, URLError
+from urllib.parse import urlencode
 from urllib.request import Request, urlopen
 
 try:
@@ -20,6 +22,26 @@ except Exception:  # pragma: no cover - package metadata unavailable
 # "Python-urllib/x.y" is blocked with HTTP 403 by Cloudflare-proxied
 # allocators, so every Request must identify itself with this instead.
 USER_AGENT = f"lablink-cli/{_CLI_VERSION}"
+
+# /destroy and /api/launch are async (they return a job id immediately;
+# the allocator runs Terraform on a background thread). Individual
+# requests (submit or poll) are fast, so a short per-request timeout
+# replaces the old single-request timeouts of up to 1800s;
+# _POLL_TIMEOUT_SECONDS is the new overall ceiling for how long we'll
+# keep polling before giving up (matches the old ceiling).
+_REQUEST_TIMEOUT_SECONDS = 30
+_POLL_INTERVAL_SECONDS = 2.0
+_POLL_TIMEOUT_SECONDS = 1800
+
+# The exact message providers/aws.py's destroy_hosts raises (wrapped by
+# main.py's /destroy route into a failed operation with this same text)
+# when no client VMs were ever launched. Matched here so destroy_vms()
+# can keep raising AllocatorNotFoundError for this one case, preserving
+# the contract deploy.py's callers already handle (non-fatal — continue
+# tearing down the allocator).
+_NO_VMS_LAUNCHED_ERROR = (
+    "tfvars does not exist — no client VMs were launched"
+)
 
 
 class AllocatorError(Exception):
@@ -36,6 +58,10 @@ class AllocatorNotFoundError(AllocatorError):
 
 class AllocatorUnavailableError(AllocatorError):
     """502 Bad Gateway or connection failure."""
+
+
+class AllocatorOperationTimeout(AllocatorError):
+    """An operation did not reach a terminal status within the poll deadline."""
 
 
 class AllocatorAPI:
@@ -59,14 +85,89 @@ class AllocatorAPI:
             self._ssl_ctx.verify_mode = ssl.CERT_NONE
 
     def destroy_vms(self) -> dict | None:
-        """POST /destroy to tear down client VMs."""
-        return self._request("POST", "/destroy")
+        """POST /destroy to tear down client VMs, then poll until the
+        job reaches a terminal status.
+
+        Returns {"status": "success", "output": <str>}. Raises
+        AllocatorNotFoundError if no client VMs were ever launched
+        (same as the old synchronous contract), or
+        AllocatorError/AllocatorOperationTimeout otherwise.
+        """
+        return self._submit_and_poll("POST", "/destroy")
+
+    def launch_vms(self, num_vms: int) -> dict | None:
+        """POST /api/launch to provision num_vms new client VMs, then
+        poll until the job reaches a terminal status.
+
+        Returns {"status": "success", "output": <str>} on success.
+        """
+        data = urlencode({"num_vms": str(num_vms)}).encode()
+        return self._submit_and_poll(
+            "POST",
+            "/api/launch",
+            data,
+            content_type="application/x-www-form-urlencoded",
+        )
+
+    def _submit_and_poll(
+        self,
+        method: str,
+        path: str,
+        data: bytes | None = b"",
+        *,
+        content_type: str | None = None,
+    ) -> dict | None:
+        """Submit an async apply/destroy job and poll GET
+        /api/operations/<id> until it reaches a terminal status."""
+        submitted = self._request(
+            method, path, data, content_type=content_type
+        )
+        if not submitted or "job_id" not in submitted:
+            raise AllocatorError(
+                f"Unexpected response from {path}: {submitted}"
+            )
+        job_id = submitted["job_id"]
+
+        deadline = time.monotonic() + _POLL_TIMEOUT_SECONDS
+        while True:
+            try:
+                op = self._request("GET", f"/api/operations/{job_id}")
+            except AllocatorUnavailableError:
+                # Transient network blip while polling — the job keeps
+                # running server-side regardless of whether our poll
+                # request succeeds, so retry rather than abort an
+                # operation that may still finish successfully.
+                op = None
+
+            if op is not None:
+                status = op.get("status")
+                if status == "succeeded":
+                    return {
+                        "status": "success",
+                        "output": op.get("output") or "",
+                    }
+                if status in ("failed", "interrupted"):
+                    error_text = (
+                        op.get("error") or f"Operation #{job_id} {status}"
+                    )
+                    if _NO_VMS_LAUNCHED_ERROR in error_text:
+                        raise AllocatorNotFoundError(error_text)
+                    raise AllocatorError(error_text)
+
+            if time.monotonic() > deadline:
+                raise AllocatorOperationTimeout(
+                    f"Operation #{job_id} did not finish within "
+                    f"{_POLL_TIMEOUT_SECONDS}s"
+                )
+            time.sleep(_POLL_INTERVAL_SECONDS)
 
     def _request(
         self,
         method: str,
         path: str,
         data: bytes | None = b"",
+        *,
+        content_type: str | None = None,
     ) -> dict | None:
         """Send an HTTP request to the allocator."""
         url = f"{self.base_url}{path}"
@@ -74,11 +175,15 @@ class AllocatorAPI:
         req.add_header("User-Agent", USER_AGENT)
         req.add_header("Authorization", self._auth_header)
         req.add_header("Accept", "application/json")
+        if content_type:
+            req.add_header("Content-Type", content_type)
 
         try:
             # S310: URL scheme is operator-supplied by design (allocator base
             # URL from the CLI config); skipping the scheme allowlist check.
-            with urlopen(req, timeout=1800, context=self._ssl_ctx) as resp:  # noqa: S310
+            with urlopen(
+                req, timeout=_REQUEST_TIMEOUT_SECONDS, context=self._ssl_ctx
+            ) as resp:  # noqa: S310
                 raw = resp.read().decode()
         except HTTPError as e:
             self._handle_http_error(e)

--- a/packages/cli/src/lablink_cli/api.py
+++ b/packages/cli/src/lablink_cli/api.py
@@ -165,7 +165,7 @@ class AllocatorAPI:
         self,
         method: str,
         path: str,
-        data: bytes | None = b"",
+        data: bytes | None = None,
         *,
         content_type: str | None = None,
     ) -> dict | None:

--- a/packages/cli/src/lablink_cli/commands/launch.py
+++ b/packages/cli/src/lablink_cli/commands/launch.py
@@ -2,20 +2,19 @@
 
 from __future__ import annotations
 
-import base64
-import json
 import re
-import ssl
 import time
-from urllib.error import HTTPError, URLError
-from urllib.parse import urlencode
-from urllib.request import Request, urlopen
 
 from rich.console import Console
 
 from lablink_allocator_service.conf.structured_config import Config
 
-from lablink_cli.api import USER_AGENT
+from lablink_cli.api import (
+    AllocatorAPI,
+    AllocatorAuthError,
+    AllocatorError,
+    AllocatorUnavailableError,
+)
 from lablink_cli.commands.utils import (
     get_allocator_url,
     resolve_admin_credentials,
@@ -62,7 +61,6 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
 
     console.print()
 
-    # Resolve allocator URL
     allocator_url = get_allocator_url(cfg)
     if not allocator_url:
         console.print(
@@ -72,29 +70,10 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
         raise SystemExit(1)
 
     admin_user, admin_pw = resolve_admin_credentials(cfg)
+    api = AllocatorAPI(allocator_url, admin_user, admin_pw, cfg.ssl.provider)
 
-    # Build request
-    url = f"{allocator_url}/api/launch"
-    data = urlencode({"num_vms": str(num_vms)}).encode()
-
-    credentials = base64.b64encode(
-        f"{admin_user}:{admin_pw}".encode()
-    ).decode()
-
-    req = Request(url, data=data, method="POST")
-    req.add_header("User-Agent", USER_AGENT)
-    req.add_header("Authorization", f"Basic {credentials}")
-    req.add_header("Content-Type", "application/x-www-form-urlencoded")
-    req.add_header("Accept", "application/json")
-
-    console.print(f"  [dim]POST {url}[/dim]")
+    console.print(f"  [dim]POST {allocator_url}/api/launch[/dim]")
     console.print()
-
-    # SSL context — handle self-signed certs
-    ctx = ssl.create_default_context()
-    if cfg.ssl.provider == "self_signed":
-        ctx.check_hostname = False
-        ctx.verify_mode = ssl.CERT_NONE
 
     started = time.monotonic()
     try:
@@ -102,57 +81,44 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
             f"[bold]Launching {num_vms} client VM(s)...[/bold]",
             spinner="dots",
         ):
-            resp = urlopen(req, timeout=600, context=ctx)  # noqa: S310
-            body = json.loads(resp.read().decode())
+            result = api.launch_vms(num_vms)
         elapsed = time.monotonic() - started
 
-        if body.get("status") == "success":
-            output = body.get("output", "")
-            summary = _summarize_apply(output)
-            console.print(
-                f"[green]✓ Launch successful[/green]  "
-                f"[dim]({_format_duration(elapsed)})[/dim]"
-            )
-            if summary:
-                console.print(f"  {summary}")
-            if verbose and output:
-                console.print()
-                console.print("[bold]Terraform output:[/bold]")
-                console.print(output)
-            elif output:
-                console.print(
-                    "  [dim]Pass --verbose to see full Terraform "
-                    "output.[/dim]"
-                )
-        else:
-            console.print(
-                f"[yellow]Unexpected response:[/yellow] {body}"
-            )
-
-    except HTTPError as e:
-        if e.code == 401:
-            console.print(
-                "[red]Authentication failed.[/red] "
-                "Check your admin credentials."
-            )
-        else:
-            # Try to parse JSON error body
-            try:
-                body = json.loads(e.read().decode())
-                error_msg = body.get("error", str(e))
-            except (json.JSONDecodeError, UnicodeDecodeError):
-                error_msg = str(e)
-            console.print(
-                f"[red]Launch failed (HTTP {e.code}):[/red] {error_msg}"
-            )
-        raise SystemExit(1)
-
-    except URLError as e:
+        output = (result or {}).get("output", "")
+        summary = _summarize_apply(output)
         console.print(
-            f"[red]Could not connect to allocator:[/red] {e.reason}"
+            f"[green]✓ Launch successful[/green]  "
+            f"[dim]({_format_duration(elapsed)})[/dim]"
+        )
+        if summary:
+            console.print(f"  {summary}")
+        if verbose and output:
+            console.print()
+            console.print("[bold]Terraform output:[/bold]")
+            console.print(output)
+        elif output:
+            console.print(
+                "  [dim]Pass --verbose to see full Terraform "
+                "output.[/dim]"
+            )
+
+    except AllocatorAuthError:
+        console.print(
+            "[red]Authentication failed.[/red] "
+            "Check your admin credentials."
+        )
+        raise SystemExit(1)
+    except AllocatorUnavailableError as e:
+        console.print(
+            f"[red]Could not connect to allocator:[/red] {e}"
         )
         console.print(
             "  Check that the allocator is running with 'lablink status'."
+        )
+        raise SystemExit(1)
+    except AllocatorError as e:
+        console.print(
+            f"[red]Launch failed:[/red] {e}"
         )
         raise SystemExit(1)
 

--- a/packages/cli/tests/test_api.py
+++ b/packages/cli/tests/test_api.py
@@ -13,6 +13,7 @@ from lablink_cli.api import (
     AllocatorAuthError,
     AllocatorError,
     AllocatorNotFoundError,
+    AllocatorOperationTimeout,
     AllocatorUnavailableError,
 )
 
@@ -26,29 +27,63 @@ def _make_api(
     return AllocatorAPI(base_url, admin_user, admin_password, ssl_provider)
 
 
+def _mock_response(body: dict) -> MagicMock:
+    """Build a mock urlopen() context-manager response for a JSON body."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = json.dumps(body).encode()
+    mock_resp.__enter__ = lambda s: s
+    mock_resp.__exit__ = MagicMock(return_value=False)
+    return mock_resp
+
+
 class TestDestroyVms:
+    @patch("lablink_cli.api.time.sleep")
     @patch("lablink_cli.api.urlopen")
-    def test_success(self, mock_urlopen):
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(
-            {"status": "ok"}
-        ).encode()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_resp
+    def test_success(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 7, "status": "queued"}),
+            _mock_response(
+                {"id": 7, "status": "succeeded", "output": "Destroy complete!"}
+            ),
+        ]
 
         api = _make_api()
         result = api.destroy_vms()
 
-        assert result["status"] == "ok"
-        call_args = mock_urlopen.call_args
-        req = call_args[0][0]
-        assert req.full_url == "https://allocator.example.com/destroy"
-        assert req.method == "POST"
-        assert "Basic" in req.get_header("Authorization")
+        assert result == {"status": "success", "output": "Destroy complete!"}
+        submit_req = mock_urlopen.call_args_list[0][0][0]
+        assert submit_req.full_url == "https://allocator.example.com/destroy"
+        assert submit_req.method == "POST"
+        assert "Basic" in submit_req.get_header("Authorization")
+        poll_req = mock_urlopen.call_args_list[1][0][0]
+        assert (
+            poll_req.full_url
+            == "https://allocator.example.com/api/operations/7"
+        )
+        mock_sleep.assert_not_called()
 
+    @patch("lablink_cli.api.time.sleep")
     @patch("lablink_cli.api.urlopen")
-    def test_401_raises_auth_error(self, mock_urlopen):
+    def test_polls_while_queued_and_running(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 7, "status": "queued"}),
+            _mock_response({"id": 7, "status": "queued"}),
+            _mock_response({"id": 7, "status": "running"}),
+            _mock_response(
+                {"id": 7, "status": "succeeded", "output": "done"}
+            ),
+        ]
+
+        api = _make_api()
+        result = api.destroy_vms()
+
+        assert result == {"status": "success", "output": "done"}
+        assert mock_urlopen.call_count == 4
+        assert mock_sleep.call_count == 2
+
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_401_on_submit_raises_auth_error(self, mock_urlopen, mock_sleep):
         mock_urlopen.side_effect = HTTPError(
             "url", 401, "Unauthorized", {}, None
         )
@@ -56,17 +91,64 @@ class TestDestroyVms:
         with pytest.raises(AllocatorAuthError):
             api.destroy_vms()
 
+    @patch("lablink_cli.api.time.sleep")
     @patch("lablink_cli.api.urlopen")
-    def test_404_raises_not_found(self, mock_urlopen):
-        mock_urlopen.side_effect = HTTPError(
-            "url", 404, "Not Found", {}, None
-        )
+    def test_no_vms_launched_raises_not_found(self, mock_urlopen, mock_sleep):
+        """The 'no terraform.runtime.tfvars' failure now surfaces as a
+        failed operation rather than a synchronous 404 — destroy_vms()
+        must still map it to AllocatorNotFoundError so deploy.py's
+        existing handling (continue tearing down the allocator) applies
+        unchanged."""
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 9, "status": "queued"}),
+            _mock_response(
+                {
+                    "id": 9,
+                    "status": "failed",
+                    "error": (
+                        "tfvars does not exist — no client VMs were "
+                        "launched"
+                    ),
+                }
+            ),
+        ]
         api = _make_api()
         with pytest.raises(AllocatorNotFoundError):
             api.destroy_vms()
 
+    @patch("lablink_cli.api.time.sleep")
     @patch("lablink_cli.api.urlopen")
-    def test_502_raises_unavailable(self, mock_urlopen):
+    def test_terraform_failure_raises_allocator_error(
+        self, mock_urlopen, mock_sleep
+    ):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 9, "status": "queued"}),
+            _mock_response(
+                {
+                    "id": 9,
+                    "status": "failed",
+                    "error": "Terraform failed: some real error",
+                }
+            ),
+        ]
+        api = _make_api()
+        with pytest.raises(AllocatorError, match="some real error"):
+            api.destroy_vms()
+
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_interrupted_raises_allocator_error(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 9, "status": "queued"}),
+            _mock_response({"id": 9, "status": "interrupted"}),
+        ]
+        api = _make_api()
+        with pytest.raises(AllocatorError, match="interrupted"):
+            api.destroy_vms()
+
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_502_on_submit_raises_unavailable(self, mock_urlopen, mock_sleep):
         mock_urlopen.side_effect = HTTPError(
             "url", 502, "Bad Gateway", {}, None
         )
@@ -74,45 +156,123 @@ class TestDestroyVms:
         with pytest.raises(AllocatorUnavailableError):
             api.destroy_vms()
 
+    @patch("lablink_cli.api.time.sleep")
     @patch("lablink_cli.api.urlopen")
-    def test_connection_error_raises_unavailable(self, mock_urlopen):
+    def test_connection_error_on_submit_raises_unavailable(
+        self, mock_urlopen, mock_sleep
+    ):
         mock_urlopen.side_effect = URLError("connection refused")
         api = _make_api()
         with pytest.raises(AllocatorUnavailableError):
             api.destroy_vms()
 
+    @patch("lablink_cli.api.time.sleep")
     @patch("lablink_cli.api.urlopen")
-    def test_error_status_in_body_raises(self, mock_urlopen):
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(
-            {"status": "error", "error": "terraform failed"}
-        ).encode()
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_resp
-
+    def test_transient_poll_failure_is_retried(self, mock_urlopen, mock_sleep):
+        """A connection error during a POLL (not the initial submit)
+        must not abort the operation — the job keeps running
+        server-side regardless of whether our poll request succeeds."""
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 7, "status": "queued"}),
+            URLError("temporary network blip"),
+            _mock_response(
+                {"id": 7, "status": "succeeded", "output": "done"}
+            ),
+        ]
         api = _make_api()
-        with pytest.raises(AllocatorError, match="terraform failed"):
+        result = api.destroy_vms()
+        assert result == {"status": "success", "output": "done"}
+        assert mock_urlopen.call_count == 3
+
+    @patch("lablink_cli.api.time.monotonic")
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_poll_timeout_raises(self, mock_urlopen, mock_sleep, mock_monotonic):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 7, "status": "queued"}),
+            _mock_response({"id": 7, "status": "running"}),
+        ]
+        # First monotonic() call establishes the deadline (t=0); the
+        # second (checked after the one poll above) is already past it.
+        mock_monotonic.side_effect = [0.0, 1801.0]
+        api = _make_api()
+        with pytest.raises(AllocatorOperationTimeout):
             api.destroy_vms()
 
+    @patch("lablink_cli.api.time.sleep")
     @patch("lablink_cli.api.urlopen")
-    def test_other_http_error_raises_allocator_error(self, mock_urlopen):
-        mock_urlopen.side_effect = HTTPError(
-            "url", 500, "Internal Server Error", {}, None
-        )
-        api = _make_api()
-        with pytest.raises(AllocatorError):
-            api.destroy_vms()
-
-    @patch("lablink_cli.api.urlopen")
-    def test_self_signed_ssl(self, mock_urlopen):
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = b'{"status": "ok"}'
-        mock_resp.__enter__ = lambda s: s
-        mock_resp.__exit__ = MagicMock(return_value=False)
-        mock_urlopen.return_value = mock_resp
-
+    def test_self_signed_ssl(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 1, "status": "queued"}),
+            _mock_response({"id": 1, "status": "succeeded", "output": ""}),
+        ]
         api = _make_api(ssl_provider="self_signed")
         api.destroy_vms()
+        assert mock_urlopen.call_count == 2
 
-        mock_urlopen.assert_called_once()
+
+class TestLaunchVms:
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_success(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 3, "status": "queued"}),
+            _mock_response(
+                {"id": 3, "status": "succeeded", "output": "apply success"}
+            ),
+        ]
+        api = _make_api()
+        result = api.launch_vms(2)
+
+        assert result == {"status": "success", "output": "apply success"}
+        submit_req = mock_urlopen.call_args_list[0][0][0]
+        assert (
+            submit_req.full_url
+            == "https://allocator.example.com/api/launch"
+        )
+        assert (
+            submit_req.get_header("Content-type")
+            == "application/x-www-form-urlencoded"
+        )
+        assert submit_req.data == b"num_vms=2"
+
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_failure_raises_allocator_error(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 3, "status": "queued"}),
+            _mock_response(
+                {
+                    "id": 3,
+                    "status": "failed",
+                    "error": (
+                        "Security-group audit refused the plan: bad"
+                    ),
+                }
+            ),
+        ]
+        api = _make_api()
+        with pytest.raises(AllocatorError, match="Security-group audit"):
+            api.launch_vms(2)
+
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_409_raises_allocator_error(self, mock_urlopen, mock_sleep):
+        """A conflict (another operation already in progress) surfaces
+        as a plain HTTPError from the submit call — the existing
+        _handle_http_error fallback already produces a clear message."""
+        error_body = json.dumps(
+            {
+                "status": "error",
+                "error": "An operation is already in progress (job #5)",
+                "job_id": 5,
+            }
+        ).encode()
+        from io import BytesIO
+
+        mock_urlopen.side_effect = HTTPError(
+            "url", 409, "Conflict", {}, BytesIO(error_body)
+        )
+        api = _make_api()
+        with pytest.raises(AllocatorError, match="already in progress"):
+            api.launch_vms(1)

--- a/packages/cli/tests/test_launch.py
+++ b/packages/cli/tests/test_launch.py
@@ -2,11 +2,15 @@
 
 from __future__ import annotations
 
-import json
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+from lablink_cli.api import (
+    AllocatorAuthError,
+    AllocatorError,
+    AllocatorUnavailableError,
+)
 from lablink_cli.commands.launch import run_launch
 
 
@@ -19,91 +23,92 @@ class TestRunLaunch:
         with pytest.raises(SystemExit):
             run_launch(mock_cfg, num_vms=1)
 
-    @patch("lablink_cli.commands.launch.urlopen")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
     @patch("lablink_cli.commands.launch.resolve_admin_credentials")
     @patch("lablink_cli.commands.launch.get_allocator_url")
-    def test_successful_launch(self, mock_url, mock_creds, mock_urlopen, mock_cfg):
+    def test_successful_launch(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg
+    ):
         mock_url.return_value = "http://1.2.3.4"
         mock_creds.return_value = ("admin", "password")
-
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(
-            {"status": "success", "output": "Created 2 VMs"}
-        ).encode()
-        mock_urlopen.return_value = mock_resp
+        mock_api = MagicMock()
+        mock_api.launch_vms.return_value = {
+            "status": "success", "output": "Created 2 VMs",
+        }
+        mock_api_cls.return_value = mock_api
 
         # Should not raise
         run_launch(mock_cfg, num_vms=2)
 
-        # Verify the request was made to the correct URL
-        call_args = mock_urlopen.call_args
-        req = call_args[0][0]
-        assert "/api/launch" in req.full_url
+        mock_api_cls.assert_called_once_with(
+            "http://1.2.3.4", "admin", "password", mock_cfg.ssl.provider
+        )
+        mock_api.launch_vms.assert_called_once_with(2)
 
-    @patch("lablink_cli.commands.launch.urlopen")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
     @patch("lablink_cli.commands.launch.resolve_admin_credentials")
     @patch("lablink_cli.commands.launch.get_allocator_url")
-    def test_auth_failure(self, mock_url, mock_creds, mock_urlopen, mock_cfg):
-        from urllib.error import HTTPError
-
+    def test_auth_failure(self, mock_url, mock_creds, mock_api_cls, mock_cfg):
         mock_url.return_value = "http://1.2.3.4"
         mock_creds.return_value = ("admin", "wrong")
-
-        mock_urlopen.side_effect = HTTPError(
-            "http://1.2.3.4/api/launch", 401, "Unauthorized", {}, None
+        mock_api = MagicMock()
+        mock_api.launch_vms.side_effect = AllocatorAuthError(
+            "Authentication failed"
         )
+        mock_api_cls.return_value = mock_api
 
         with pytest.raises(SystemExit):
             run_launch(mock_cfg, num_vms=1)
 
-    @patch("lablink_cli.commands.launch.urlopen")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
     @patch("lablink_cli.commands.launch.resolve_admin_credentials")
     @patch("lablink_cli.commands.launch.get_allocator_url")
-    def test_connection_error(self, mock_url, mock_creds, mock_urlopen, mock_cfg):
-        from urllib.error import URLError
-
+    def test_connection_error(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg
+    ):
         mock_url.return_value = "http://1.2.3.4"
         mock_creds.return_value = ("admin", "password")
-        mock_urlopen.side_effect = URLError("connection refused")
+        mock_api = MagicMock()
+        mock_api.launch_vms.side_effect = AllocatorUnavailableError(
+            "connection refused"
+        )
+        mock_api_cls.return_value = mock_api
 
         with pytest.raises(SystemExit):
             run_launch(mock_cfg, num_vms=1)
 
-    @patch("lablink_cli.commands.launch.urlopen")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
     @patch("lablink_cli.commands.launch.resolve_admin_credentials")
     @patch("lablink_cli.commands.launch.get_allocator_url")
-    def test_self_signed_ssl(self, mock_url, mock_creds, mock_urlopen, mock_cfg):
+    def test_self_signed_ssl(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg
+    ):
         mock_url.return_value = "https://1.2.3.4"
         mock_creds.return_value = ("admin", "password")
         mock_cfg.ssl.provider = "self_signed"
-
-        mock_resp = MagicMock()
-        mock_resp.read.return_value = json.dumps(
-            {"status": "success"}
-        ).encode()
-        mock_urlopen.return_value = mock_resp
+        mock_api = MagicMock()
+        mock_api.launch_vms.return_value = {"status": "success", "output": ""}
+        mock_api_cls.return_value = mock_api
 
         run_launch(mock_cfg, num_vms=1)
 
-        # Verify SSL context was created (urlopen called with context kwarg)
-        call_kwargs = mock_urlopen.call_args[1]
-        assert "context" in call_kwargs
+        mock_api_cls.assert_called_once_with(
+            "https://1.2.3.4", "admin", "password", "self_signed"
+        )
 
-    @patch("lablink_cli.commands.launch.urlopen")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
     @patch("lablink_cli.commands.launch.resolve_admin_credentials")
     @patch("lablink_cli.commands.launch.get_allocator_url")
-    def test_http_server_error(self, mock_url, mock_creds, mock_urlopen, mock_cfg):
-        from io import BytesIO
-        from urllib.error import HTTPError
-
+    def test_http_server_error(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg
+    ):
         mock_url.return_value = "http://1.2.3.4"
         mock_creds.return_value = ("admin", "password")
-
-        error_body = BytesIO(json.dumps({"error": "out of capacity"}).encode())
-        mock_urlopen.side_effect = HTTPError(
-            "http://1.2.3.4/api/launch", 500, "Internal Server Error",
-            {}, error_body
+        mock_api = MagicMock()
+        mock_api.launch_vms.side_effect = AllocatorError(
+            "HTTP 500: out of capacity"
         )
+        mock_api_cls.return_value = mock_api
 
         with pytest.raises(SystemExit):
             run_launch(mock_cfg, num_vms=1)
@@ -120,14 +125,14 @@ class TestManualLaunchNoOp:
         assert "Manual provider" in out
         assert "lablink client register" in " ".join(out.split())
 
-    @patch("lablink_cli.commands.launch.urlopen")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
     @patch("lablink_cli.commands.launch.resolve_admin_credentials")
     @patch("lablink_cli.commands.launch.get_allocator_url")
     def test_manual_provider_does_not_touch_allocator(
-        self, mock_url, mock_creds, mock_urlopen, mock_cfg,
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg,
     ):
         mock_cfg.provider = "manual"
         run_launch(mock_cfg, num_vms=3, verbose=False)
         mock_url.assert_not_called()
         mock_creds.assert_not_called()
-        mock_urlopen.assert_not_called()
+        mock_api_cls.assert_not_called()


### PR DESCRIPTION
## Summary

Third of a multi-PR roadmap fixing #379. PR 2 (#384, merged) made the allocator's `POST /destroy` and `POST /api/launch` async — they now return `202 {job_id}` immediately instead of blocking until Terraform finishes. This broke the CLI: `lablink launch`/`lablink destroy` expected one blocking response and would have misreported success the instant a job was merely queued. Worse, `lablink destroy` would proceed to tear down the allocator's own infrastructure while the background destroy job was still running, orphaning client VMs — exactly the risk PR 2's final review flagged. This PR closes that gap.

Design doc: `docs/superpowers/specs/2026-07-17-async-terraform-worker-design.md` (local, not committed)
Plan: `docs/superpowers/plans/2026-07-17-async-terraform-worker-pr3-cli-polling.md` (local, not committed)

- **`AllocatorAPI`** (`api.py`) gains a `_submit_and_poll` helper: submit the job, then poll `GET /api/operations/<id>` every ~2s until terminal, returning the same `{"status": "success", "output": ...}` shape and raising the same typed exceptions callers already handle. `destroy_vms()`'s external contract is unchanged; a new `launch_vms(num_vms)` method was added.
- **`launch.py`**'s `run_launch` now calls `AllocatorAPI.launch_vms(...)` instead of hand-rolled `urllib` request/SSL/error-handling code — same console output, same UX, less duplication.
- **`deploy.py` needed zero changes** — verified structurally (no diff hunks) and behaviorally (`test_deploy.py`'s destroy tests pass unmodified), which is what actually closes the orphaned-VM risk: `_destroy_client_vms` already blocks on `api.destroy_vms()` before tearing down the allocator, and that call now genuinely blocks until the destroy job finishes.
- The "no client VMs were ever launched" case (previously a synchronous `404`) is now a `failed` operation; `destroy_vms()` detects the specific error text and still raises `AllocatorNotFoundError` so `deploy.py`'s existing non-fatal handling applies unchanged.

## Fix from final review

GET polls were sending a spurious empty body (`_request`'s `data` defaulted to `b""` instead of `None`) — harmless but improper; fixed by defaulting to `None` (commit `4133fa89`).

## Test plan

- [x] `PYTHONPATH=src pytest` — 501 passed, 1 deselected (CLI package)
- [x] One pre-existing, unrelated failure confirmed to also fail on `main` (`test_deploy_compose.py` rich-formatting assertion) — not touched
- [x] `ruff check src tests` clean
- [x] Both tasks individually reviewed (spec compliance + code quality); final whole-branch review traced the ordering-safety property end-to-end in the real code — Ready to merge: Yes

🤖 Generated with [Claude Code](https://claude.com/claude-code)