### PR TITLE
feat(allocator): add "Back to Admin Dashboard" link to /admin/instances

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -80,6 +80,16 @@
         font-size: 13px;
       }
 
+      .back-link {
+        display: inline-block;
+        margin-bottom: 20px;
+        color: #007bff;
+        text-decoration: none;
+      }
+      .back-link:hover {
+        text-decoration: underline;
+      }
+
       #operation-banner {
         display: none;
         padding: 12px 16px;
@@ -119,6 +129,8 @@
     </style>
   </head>
   <body>
+    <a href="/admin" class="back-link">&larr; Back to Admin Dashboard</a>
+
     <h2>Existing VM Instances</h2>
 
     {% if request.args.get('vnc_error') %}

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -211,6 +211,17 @@ def test_view_instances_shows_vnc_error_banner(client, admin_headers):
 
 
 @patch("lablink_allocator_service.main.database")
+def test_view_instances_shows_back_to_admin_link(mock_database, client, admin_headers):
+    mock_database.get_all_vms.return_value = []
+
+    resp = client.get("/admin/instances", headers=admin_headers)
+
+    html = resp.data.decode()
+    assert 'href="/admin"' in html
+    assert "Back to Admin Dashboard" in html
+
+
+@patch("lablink_allocator_service.main.database")
 def test_view_instances_embeds_job_id_from_query_param(
     mock_database, client, admin_headers,
 ):


### PR DESCRIPTION
## Summary

- `/admin/instances` was the one admin page still missing a way back to `/admin` besides the browser back button — `create-instances.html`, `delete-instances.html`, and `scheduled-destruction.html` already have this.
- Adds the same `.back-link` style (plain blue text link above the page title, not a button) for consistency across all admin pages.

## Test plan

- [x] `PYTHONPATH=. pytest` — 652 passed, 19 skipped (allocator package)
- [x] `ruff check src tests` clean
- [x] Verified visually via a rendered screenshot before committing

🤖 Generated with [Claude Code](https://claude.com/claude-code)