### PR TITLE
feat: add mesh-overlay connectivity for off-LAN manual clients

### DIFF
--- a/packages/allocator/lablink-nginx.conf
+++ b/packages/allocator/lablink-nginx.conf
@@ -25,7 +25,7 @@ server {
     location / {
         proxy_pass http://flask;
         proxy_http_version 1.1;
-        proxy_set_header Host              $host;
+        proxy_set_header Host              $http_host;
         proxy_set_header X-Real-IP         $remote_addr;
         proxy_set_header X-Forwarded-For   $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $http_x_forwarded_proto;

--- a/packages/allocator/lablink-nginx.conf
+++ b/packages/allocator/lablink-nginx.conf
@@ -58,6 +58,19 @@ server {
         auth_request_set       $upstream    $upstream_http_x_upstream;
         auth_request_set       $auth_basic  $upstream_http_x_auth_basic;
 
+        # $upstream is a literal IP for AWS/lan_direct (no resolution
+        # needed), but a Tailscale MagicDNS hostname for mesh_overlay
+        # (<overlay_hostname>.<tailnet>.ts.net). nginx does NOT consult
+        # the OS resolver or /etc/hosts for a variable-based proxy_pass
+        # — without an explicit resolver directive it fails outright
+        # with "no resolver defined to resolve ...", regardless of
+        # whether the Tailscale connection itself is healthy.
+        # 100.100.100.100 is Tailscale's well-known internal MagicDNS
+        # stub, reachable from any tailnet-joined device (harmless/
+        # unused for AWS/lan_direct, which never resolves a hostname
+        # here). ipv6=off matches this deployment's IPv4-only upstreams.
+        resolver                100.100.100.100 ipv6=off valid=30s;
+
         proxy_pass             http://$upstream/websockify;
         proxy_http_version     1.1;
         proxy_set_header       Upgrade        $http_upgrade;

--- a/packages/allocator/src/lablink_allocator_service/conf/structured_config.py
+++ b/packages/allocator/src/lablink_allocator_service/conf/structured_config.py
@@ -167,6 +167,31 @@ class StartupConfig:
 
 
 @dataclass
+class ManualConfig:
+    """Configuration for the manual provider's client connectivity strategy.
+
+    Attributes:
+        connectivity (str): How the browser reaches a manual client's
+            KasmVNC desktop. Options:
+            - "lan_direct": the browser opens a WebSocket straight to the
+              client's LAN IP (default; requires client on the allocator's
+              own LAN).
+            - "mesh_overlay": the client joins a Tailscale tailnet; the
+              allocator reaches it via that overlay and proxies the byte
+              path through its own nginx, same as the AWS path. For
+              clients that aren't on the allocator's LAN (e.g. a
+              Run:AI-hosted workload).
+        overlay_tailnet (str): The Tailscale tailnet's MagicDNS domain
+            suffix (e.g. "example.ts.net"), used to resolve a registered
+            client's overlay hostname. Required when connectivity is
+            "mesh_overlay"; ignored otherwise.
+    """
+
+    connectivity: str = field(default="lan_direct")
+    overlay_tailnet: str = field(default="")
+
+
+@dataclass
 class MonitoringConfig:
     enabled: bool = False
     # Optional override for window-bucket title matching. Empty/unset means
@@ -229,4 +254,5 @@ class Config:
     bucket_name: str = field(default="tf-state-lablink-allocator-bucket")
     startup_script: StartupConfig = field(default_factory=StartupConfig)
     monitoring: MonitoringConfig = field(default_factory=MonitoringConfig)
+    manual: ManualConfig = field(default_factory=ManualConfig)
 

--- a/packages/allocator/src/lablink_allocator_service/database.py
+++ b/packages/allocator/src/lablink_allocator_service/database.py
@@ -507,6 +507,24 @@ class PostgresqlDatabase:
             return urlsplit(endpoint_url).hostname
         return None
 
+    def get_overlay_hostname(self, hostname: str):
+        """Overlay hostname for a mesh-overlay client:
+        provider_metadata->>'overlay_hostname'. None if absent.
+
+        Unlike get_lan_ip, there is no endpoint_url fallback — mesh-overlay
+        clients don't set endpoint_url (see MeshOverlayClientConnectivity's
+        registration flow)."""
+        with self._cursor as cursor:
+            cursor.execute(
+                f"SELECT provider_metadata->>'overlay_hostname' "
+                f"FROM {self.table_name} WHERE hostname = %s;",
+                (hostname,),
+            )
+            row = cursor.fetchone()
+        if not row:
+            return None
+        return row[0]
+
     def list_hosts_by_provider(self, provider: str) -> list:
         with self._cursor as cursor:
             cursor.execute(

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -104,6 +104,7 @@ app.config["LABLINK_PROVIDER"] = get_provider(
     cfg.provider,
     region=cfg.app.region,
     terraform_dir=str(TERRAFORM_DIR),
+    connectivity=cfg.manual.connectivity,
 )
 
 os.environ["DATABASE_URL"] = (
@@ -277,6 +278,30 @@ def home():
     return render_template("index.html")
 
 
+def _tailscale_status() -> str:
+    """Return "ok" / "not joined" / "not installed" for the allocator
+    host's own Tailscale connection. Shelled out to rather than imported
+    as a library — Tailscale ships no supported Python bindings; `tailscale
+    status --json`'s exit code and BackendState are the documented way to
+    check this from a script."""
+    try:
+        result = subprocess.run(
+            ["tailscale", "status", "--json"],
+            capture_output=True, text=True, timeout=5,
+        )
+    except FileNotFoundError:
+        return "not installed"
+    except (subprocess.TimeoutExpired, OSError):
+        return "not joined"
+    if result.returncode != 0:
+        return "not joined"
+    try:
+        state = json.loads(result.stdout).get("BackendState", "")
+    except json.JSONDecodeError:
+        return "not joined"
+    return "ok" if state == "Running" else "not joined"
+
+
 @app.route("/api/health", methods=["GET"])
 def health_check():
     """Return structured readiness status."""
@@ -285,6 +310,8 @@ def health_check():
         "scheduler": "ok" if scheduler_service is not None else "not initialized",
         "reboot_service": "ok" if reboot_service is not None else "not initialized",
     }
+    if app.config["LABLINK_PROVIDER"].client_connectivity.requires_tailscale_check:
+        checks["tailscale"] = _tailscale_status()
 
     all_ready = all(v == "ok" for v in checks.values())
     status = "healthy" if all_ready else "starting"
@@ -411,7 +438,8 @@ def admin_connect_vm(hostname):
         session_id = uuid.uuid4()
         browser_token = secrets.token_urlsafe(16)
         provider = app.config.get("LABLINK_PROVIDER") or get_provider(
-            cfg.provider, region=cfg.app.region, terraform_dir=str(TERRAFORM_DIR)
+            cfg.provider, region=cfg.app.region, terraform_dir=str(TERRAFORM_DIR),
+            connectivity=cfg.manual.connectivity,
         )
         try:
             provider.client_connectivity.prepare_browser_session(
@@ -500,7 +528,8 @@ def submit_vm_details():
         browser_token = secrets.token_urlsafe(16)
         try:
             provider = app.config.get("LABLINK_PROVIDER") or get_provider(
-                cfg.provider, region=cfg.app.region, terraform_dir=str(TERRAFORM_DIR)
+                cfg.provider, region=cfg.app.region, terraform_dir=str(TERRAFORM_DIR),
+                connectivity=cfg.manual.connectivity,
             )
             provider.client_connectivity.prepare_browser_session(
                 database=database,

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -279,27 +279,34 @@ def home():
 
 
 def _tailscale_status() -> str:
-    """Return "ok" / "not joined" / "not installed" for the allocator
-    host's own Tailscale connection. Shelled out to rather than imported
-    as a library — Tailscale ships no supported Python bindings; `tailscale
-    status --json`'s exit code and BackendState are the documented way to
-    check this from a script."""
+    """Return "ok" / "not joined" for the allocator's own tailnet
+    connection.
+
+    The mesh-overlay sidecar shares the allocator's *network* namespace
+    (network_mode: service:allocator) but not its filesystem, so the
+    `tailscale` CLI binary — which lives only in the sidecar's image —
+    is never present here; shelling out to it would always report
+    "not installed" regardless of whether the sidecar actually joined.
+
+    Checking for the shared `tailscale0` interface's existence alone is
+    not enough either: confirmed live against a real tailnet, the kernel
+    interface stays up (`UP,LOWER_UP`, with a link-local IPv6 address)
+    even while the node is logged out and unauthenticated with the
+    control plane — a control-plane hiccup can leave the device node
+    behind with no working overlay path. Requiring an actual Tailscale
+    IPv4 address (only assigned once the control plane has authenticated
+    the node) avoids that false positive, still with no CLI and no
+    socket-sharing between the two containers."""
     try:
         result = subprocess.run(
-            ["tailscale", "status", "--json"],
-            capture_output=True, text=True, timeout=5,
+            ["ip", "-4", "-o", "addr", "show", "tailscale0"],
+            capture_output=True,
+            text=True,
+            timeout=5,
         )
-    except FileNotFoundError:
-        return "not installed"
-    except (subprocess.TimeoutExpired, OSError):
+    except (OSError, subprocess.TimeoutExpired):
         return "not joined"
-    if result.returncode != 0:
-        return "not joined"
-    try:
-        state = json.loads(result.stdout).get("BackendState", "")
-    except json.JSONDecodeError:
-        return "not joined"
-    return "ok" if state == "Running" else "not joined"
+    return "ok" if result.returncode == 0 and "inet " in result.stdout else "not joined"
 
 
 @app.route("/api/health", methods=["GET"])

--- a/packages/allocator/src/lablink_allocator_service/providers/connectivity/allocator_proxied.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/connectivity/allocator_proxied.py
@@ -36,6 +36,7 @@ def _aws_fallback_ip(hostname: str) -> str:
 
 class AllocatorProxiedClientConnectivity:
     name = "allocator_proxied"
+    requires_tailscale_check = False
 
     def prepare_browser_session(self, **kwargs) -> BrowserSessionTarget:
         # Inject AWS EC2 fallback resolver so client_session.py remains

--- a/packages/allocator/src/lablink_allocator_service/providers/connectivity/lan_direct.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/connectivity/lan_direct.py
@@ -15,6 +15,7 @@ from lablink_allocator_service.providers.protocol import ClientJoinMaterial
 
 class LANDirectClientConnectivity:
     name = "lan_direct"
+    requires_tailscale_check = False
 
     def make_join_material(
         self, *, allocator_url: str, client_image: str,

--- a/packages/allocator/src/lablink_allocator_service/providers/connectivity/mesh_overlay.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/connectivity/mesh_overlay.py
@@ -1,0 +1,62 @@
+"""Mesh-overlay connectivity: browser -> allocator nginx proxy -> client
+KasmVNC, reached over a Tailscale overlay instead of a routable LAN/VPC
+address. Not Run:AI-specific — any client that isn't on the allocator's
+own network fits this connectivity strategy; Run:AI-hosted client
+workloads are simply the motivating case."""
+from __future__ import annotations
+
+from lablink_allocator_service.client_session import (
+    BrowserSessionTarget,
+    RotationFailed,
+    prepare_browser_session,
+)
+from lablink_allocator_service.providers.protocol import ClientJoinMaterial
+from lablink_allocator_service.get_config import get_config
+
+
+def _db():
+    from lablink_allocator_service import main
+
+    return main.database
+
+
+def _resolve_overlay_host(hostname: str) -> str:
+    """Resolve *hostname*'s registered overlay hostname to its Tailscale
+    MagicDNS name. Used as ``prepare_browser_session``'s ``fallback_fn`` —
+    same extension point ``AllocatorProxiedClientConnectivity`` uses for
+    its EC2-private-IP fallback, so ``client_session`` stays free of any
+    Tailscale-specific import."""
+    overlay_hostname = _db().get_overlay_hostname(hostname)
+    if not overlay_hostname:
+        raise RotationFailed(f"no overlay hostname recorded for {hostname}")
+    tailnet = get_config().manual.overlay_tailnet
+    if not tailnet:
+        raise RotationFailed(
+            f"manual.overlay_tailnet is not configured; cannot resolve "
+            f"overlay hostname for {hostname}"
+        )
+    return f"{overlay_hostname}.{tailnet}"
+
+
+class MeshOverlayClientConnectivity:
+    name = "mesh_overlay"
+    requires_tailscale_check = True
+
+    def prepare_browser_session(self, **kwargs) -> BrowserSessionTarget:
+        kwargs.setdefault("fallback_fn", _resolve_overlay_host)
+        return prepare_browser_session(**kwargs)
+
+    def make_join_material(
+        self,
+        *,
+        allocator_url: str,
+        client_image: str,
+        register_token: str,
+        hostname_hint: str | None = None,
+    ) -> ClientJoinMaterial:
+        return ClientJoinMaterial(
+            register_token=register_token,
+            allocator_url=allocator_url,
+            connectivity=self.name,
+            client_image=client_image,
+        )

--- a/packages/allocator/src/lablink_allocator_service/providers/protocol.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/protocol.py
@@ -69,6 +69,7 @@ class ClientConnectivity(Protocol):
     """Provider-owned strategy for browser -> client KasmVNC reachability."""
 
     name: str
+    requires_tailscale_check: bool
 
     def prepare_browser_session(self, **kwargs) -> BrowserSessionTarget: ...
 

--- a/packages/allocator/src/lablink_allocator_service/providers/registry.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/registry.py
@@ -8,6 +8,12 @@ from importlib.metadata import entry_points
 
 from lablink_allocator_service.providers.aws import AWSProvider
 from lablink_allocator_service.providers.manual import ManualProvider
+from lablink_allocator_service.providers.connectivity.lan_direct import (
+    LANDirectClientConnectivity,
+)
+from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+    MeshOverlayClientConnectivity,
+)
 from lablink_allocator_service.providers.protocol import ComputeProvider
 
 logger = logging.getLogger(__name__)
@@ -17,6 +23,15 @@ DEFAULT_PROVIDER = "aws"
 # Built-in fallback so the allocator works in editable/test installs where
 # entry-point metadata may not be regenerated.
 _BUILTIN: dict[str, type] = {"aws": AWSProvider, "manual": ManualProvider}
+
+# Connectivity choices selectable for the "manual" provider only. Not an
+# entry-point-discovered registry (unlike _BUILTIN/providers) — this is a
+# small, closed set for now; see the mesh-overlay design spec's Forward
+# Path for how a second backend would slot in.
+_CONNECTIVITY_BUILTIN: dict[str, type] = {
+    "lan_direct": LANDirectClientConnectivity,
+    "mesh_overlay": MeshOverlayClientConnectivity,
+}
 
 
 def _discover() -> dict[str, type]:
@@ -35,7 +50,11 @@ def _discover() -> dict[str, type]:
 
 
 def get_provider(
-    name: str | None, *, region: str, terraform_dir: str
+    name: str | None,
+    *,
+    region: str,
+    terraform_dir: str,
+    connectivity: str | None = None,
 ) -> ComputeProvider:
     name = name or DEFAULT_PROVIDER
     providers = _discover()
@@ -43,5 +62,18 @@ def get_provider(
     if cls is None:
         raise ValueError(
             f"unknown provider '{name}'; available: {sorted(providers)}"
+        )
+    if name == "manual":
+        conn_name = connectivity or "lan_direct"
+        conn_cls = _CONNECTIVITY_BUILTIN.get(conn_name)
+        if conn_cls is None:
+            raise ValueError(
+                f"unknown connectivity '{conn_name}'; "
+                f"available: {sorted(_CONNECTIVITY_BUILTIN)}"
+            )
+        return cls(
+            region=region,
+            terraform_dir=terraform_dir,
+            client_connectivity=conn_cls(),
         )
     return cls(region=region, terraform_dir=terraform_dir)

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -50,6 +50,7 @@ def register_client():
         main.cfg.get("provider", None),
         region=main.cfg.app.region,
         terraform_dir=str(main.TERRAFORM_DIR),
+        connectivity=main.cfg.manual.connectivity,
     )
 
     # Manual/BYO clients pick their provider_metadata shape based on which

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -68,11 +68,12 @@ def register_client():
         terraform_dir=str(main.TERRAFORM_DIR),
     )
     allocator_url = request.host_url.rstrip("/")
-    client_image = (
-        f"{main.cfg.machine.repository}:{main.cfg.machine.image}"
-        if main.cfg.machine.get("repository", None)
-        else main.cfg.machine.image
-    )
+    # cfg.machine.repository is the tutorial-repo-to-clone URL (shipped to
+    # the AWS path as spec["repository"] -> TUTORIAL_REPO_TO_CLONE in
+    # client/start.sh) — unrelated to the docker image reference. The AWS
+    # path already uses cfg.machine.image verbatim (spec["image_name"]);
+    # match that here instead of prefixing repository onto it.
+    client_image = main.cfg.machine.image
     jm = prov.client_connectivity.make_join_material(
         allocator_url=allocator_url,
         client_image=client_image,

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -44,6 +44,42 @@ def register_client():
         return jsonify({"error": "hostname and machine_identity required."}), 400
 
     provider = body.get("provider", "aws")
+    provider_metadata = body.get("provider_metadata") or {}
+
+    prov = current_app.config.get("LABLINK_PROVIDER") or main.get_provider(
+        main.cfg.get("provider", None),
+        region=main.cfg.app.region,
+        terraform_dir=str(main.TERRAFORM_DIR),
+    )
+
+    # Manual/BYO clients pick their provider_metadata shape based on which
+    # CLI flag they used (--lan-ip auto-detect vs --overlay-hostname). That
+    # shape must match this deployment's configured connectivity strategy,
+    # or the client silently registers under the wrong byte-path -- e.g. a
+    # real-BYO lan_ip registration against a mesh_overlay allocator has the
+    # browser dial the client's private LAN IP directly, which is
+    # unreachable off that LAN. Caught here, at registration time, instead
+    # of failing opaquely at session-assignment time.
+    if provider == "manual":
+        expects_overlay = prov.client_connectivity.name == "mesh_overlay"
+        has_overlay = "overlay_hostname" in provider_metadata
+        if expects_overlay and not has_overlay:
+            return jsonify({
+                "error": (
+                    "This allocator is configured for mesh_overlay "
+                    "connectivity -- register with --overlay-hostname "
+                    "and --tailscale-authkey."
+                )
+            }), 400
+        if not expects_overlay and has_overlay:
+            return jsonify({
+                "error": (
+                    "This allocator is configured for lan_direct "
+                    "connectivity -- --overlay-hostname is not applicable "
+                    "here; omit it and let --lan-ip auto-detect."
+                )
+            }), 400
+
     client_secret = secrets.token_urlsafe(32)
 
     try:
@@ -52,7 +88,7 @@ def register_client():
             machine_identity=machine_identity,
             provider=provider,
             endpoint_url=body.get("endpoint_url"),
-            provider_metadata=body.get("provider_metadata") or {},
+            provider_metadata=provider_metadata,
             gpu_present=body.get("gpu_present"),
             gpu_model=body.get("gpu_model"),
             client_secret_hash=hash_secret(client_secret),
@@ -62,11 +98,6 @@ def register_client():
     if client_id is None:
         return jsonify({"error": "registration conflict"}), 409
 
-    prov = current_app.config.get("LABLINK_PROVIDER") or main.get_provider(
-        main.cfg.get("provider", None),
-        region=main.cfg.app.region,
-        terraform_dir=str(main.TERRAFORM_DIR),
-    )
     allocator_url = request.host_url.rstrip("/")
     # cfg.machine.repository is the tutorial-repo-to-clone URL (shipped to
     # the AWS path as spec["repository"] -> TUTORIAL_REPO_TO_CLONE in

--- a/packages/allocator/src/lablink_allocator_service/validate_config.py
+++ b/packages/allocator/src/lablink_allocator_service/validate_config.py
@@ -30,6 +30,11 @@ logger = logging.getLogger(__name__)
 # `lablink client register` CLI.
 VALID_PROVIDERS = ("aws", "manual")
 
+# manual.connectivity — must stay in sync with the connectivity registry
+# (_CONNECTIVITY_BUILTIN in providers/registry.py). "mesh_overlay" reaches
+# clients that aren't on the allocator's own LAN over a Tailscale tailnet.
+VALID_CONNECTIVITY = ("lan_direct", "mesh_overlay")
+
 
 def validate_domain_format(domain: str) -> Tuple[bool, str]:
     """Validate domain format to prevent malformed domains.
@@ -77,6 +82,25 @@ def get_config_errors(cfg) -> list:
             f"provider must be one of: {', '.join(VALID_PROVIDERS)} "
             f"(got '{provider}')"
         )
+
+    # manual.connectivity must be a known value, and mesh_overlay requires
+    # a tailnet domain to resolve overlay hostnames against (see
+    # MeshOverlayClientConnectivity._resolve_overlay_host).
+    manual_cfg = getattr(cfg, "manual", None)
+    if manual_cfg is not None:
+        connectivity = getattr(manual_cfg, "connectivity", "lan_direct")
+        if connectivity not in VALID_CONNECTIVITY:
+            errors.append(
+                f"manual.connectivity must be one of: "
+                f"{', '.join(VALID_CONNECTIVITY)} (got '{connectivity}')"
+            )
+        elif connectivity == "mesh_overlay" and not getattr(
+            manual_cfg, "overlay_tailnet", ""
+        ):
+            errors.append(
+                "manual.overlay_tailnet is required when manual.connectivity "
+                "is 'mesh_overlay' (e.g. 'example.ts.net')"
+            )
 
     # DNS enabled requires non-empty domain
     if cfg.dns.enabled and not cfg.dns.domain:

--- a/packages/allocator/tests/conftest.py
+++ b/packages/allocator/tests/conftest.py
@@ -41,6 +41,10 @@ def omega_config():
             "deployment_name": "test-lablink",
             "environment": "prod",
             "provider": "aws",
+            "manual": {
+                "connectivity": "lan_direct",
+                "overlay_tailnet": "",
+            },
             "eip": {
                 "strategy": "dynamic",
             },

--- a/packages/allocator/tests/providers/connectivity/test_mesh_overlay.py
+++ b/packages/allocator/tests/providers/connectivity/test_mesh_overlay.py
@@ -1,0 +1,139 @@
+import uuid
+from unittest.mock import patch
+
+from lablink_allocator_service.providers.protocol import (
+    ClientConnectivity,
+    BrowserSessionTarget,
+)
+
+
+def test_satisfies_protocol_and_name():
+    from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+        MeshOverlayClientConnectivity,
+    )
+
+    conn = MeshOverlayClientConnectivity()
+    assert isinstance(conn, ClientConnectivity)
+    assert conn.name == "mesh_overlay"
+
+
+def test_delegates_to_client_session_with_overlay_fallback():
+    """prepare_browser_session delegates to client_session.prepare_browser_session
+    and injects the overlay-hostname resolver via the fallback_fn kwarg —
+    same extension point AllocatorProxiedClientConnectivity uses for its
+    EC2 fallback (SR-F1: no AWS/Tailscale-specific imports in client_session)."""
+    from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+        MeshOverlayClientConnectivity,
+        _resolve_overlay_host,
+    )
+
+    sentinel = BrowserSessionTarget(ws_url="proxy/tok", browser_credential=None)
+    sid = uuid.uuid4()
+    with patch(
+        "lablink_allocator_service.providers.connectivity.mesh_overlay."
+        "prepare_browser_session",
+        return_value=sentinel,
+    ) as m:
+        conn = MeshOverlayClientConnectivity()
+        out = conn.prepare_browser_session(
+            database="DB",
+            hostname="vm-1",
+            session_id=sid,
+            browser_token="tok",
+            agent_token="api",
+        )
+    assert out is sentinel
+    m.assert_called_once_with(
+        database="DB",
+        hostname="vm-1",
+        session_id=sid,
+        browser_token="tok",
+        agent_token="api",
+        fallback_fn=_resolve_overlay_host,
+    )
+
+
+def test_resolve_overlay_host_builds_magicdns_name():
+    from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+        _resolve_overlay_host,
+    )
+
+    mock_db = type("DB", (), {"get_overlay_hostname": staticmethod(
+        lambda hostname: "classroom-gpu-3"
+    )})()
+    mock_cfg = type("Cfg", (), {"manual": type("M", (), {"overlay_tailnet": "example.ts.net"})()})()
+
+    with patch(
+        "lablink_allocator_service.providers.connectivity.mesh_overlay._db",
+        return_value=mock_db,
+    ), patch(
+        "lablink_allocator_service.providers.connectivity.mesh_overlay.get_config",
+        return_value=mock_cfg,
+    ):
+        result = _resolve_overlay_host("vm-1")
+    assert result == "classroom-gpu-3.example.ts.net"
+
+
+def test_resolve_overlay_host_raises_when_not_registered():
+    from lablink_allocator_service.client_session import RotationFailed
+    from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+        _resolve_overlay_host,
+    )
+
+    mock_db = type("DB", (), {"get_overlay_hostname": staticmethod(lambda hostname: None)})()
+
+    with patch(
+        "lablink_allocator_service.providers.connectivity.mesh_overlay._db",
+        return_value=mock_db,
+    ), patch(
+        "lablink_allocator_service.providers.connectivity.mesh_overlay.get_config",
+    ):
+        try:
+            _resolve_overlay_host("vm-1")
+            assert False, "expected RotationFailed"
+        except RotationFailed as e:
+            assert "vm-1" in str(e)
+
+
+def test_resolve_overlay_host_raises_when_tailnet_not_configured():
+    from lablink_allocator_service.client_session import RotationFailed
+    from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+        _resolve_overlay_host,
+    )
+
+    mock_db = type("DB", (), {"get_overlay_hostname": staticmethod(
+        lambda hostname: "classroom-gpu-3"
+    )})()
+    mock_cfg = type("Cfg", (), {"manual": type("M", (), {"overlay_tailnet": ""})()})()
+
+    with patch(
+        "lablink_allocator_service.providers.connectivity.mesh_overlay._db",
+        return_value=mock_db,
+    ), patch(
+        "lablink_allocator_service.providers.connectivity.mesh_overlay.get_config",
+        return_value=mock_cfg,
+    ):
+        try:
+            _resolve_overlay_host("vm-1")
+            assert False, "expected RotationFailed"
+        except RotationFailed as e:
+            assert "overlay_tailnet" in str(e)
+
+
+def test_make_join_material_returns_mesh_overlay():
+    from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+        MeshOverlayClientConnectivity,
+    )
+    from lablink_allocator_service.providers.protocol import ClientJoinMaterial
+
+    c = MeshOverlayClientConnectivity()
+    m = c.make_join_material(
+        allocator_url="http://a:5000",
+        client_image="img:1",
+        register_token="tk_1",
+    )
+    assert isinstance(m, ClientJoinMaterial)
+    assert m.connectivity == "mesh_overlay"
+    assert m.allocator_url == "http://a:5000"
+    assert m.client_image == "img:1"
+    assert m.register_token == "tk_1"

--- a/packages/allocator/tests/providers/test_protocol.py
+++ b/packages/allocator/tests/providers/test_protocol.py
@@ -27,6 +27,7 @@ def test_browser_session_target_is_reexported_singleton():
 def test_protocols_are_runtime_checkable():
     class GoodConn:
         name = "allocator_proxied"
+        requires_tailscale_check = False
 
         def prepare_browser_session(self, **kwargs):
             return BrowserSessionTarget(ws_url="proxy/tok", browser_credential=None)
@@ -81,6 +82,7 @@ def test_client_connectivity_protocol_requires_make_join_material():
 
     class Complete:
         name = "x"
+        requires_tailscale_check = False
 
         def prepare_browser_session(self, **kwargs):
             ...

--- a/packages/allocator/tests/providers/test_registry.py
+++ b/packages/allocator/tests/providers/test_registry.py
@@ -54,3 +54,37 @@ def test_get_provider_manual_returns_constructed_instance():
     from lablink_allocator_service.providers.manual import ManualProvider
     p = get_provider("manual", region=None, terraform_dir=None)
     assert isinstance(p, ManualProvider)
+
+
+def test_get_provider_manual_default_connectivity_is_lan_direct():
+    from lablink_allocator_service.providers.connectivity.lan_direct import (
+        LANDirectClientConnectivity,
+    )
+    p = get_provider("manual", region=None, terraform_dir=None)
+    assert isinstance(p.client_connectivity, LANDirectClientConnectivity)
+
+
+def test_get_provider_manual_mesh_overlay_connectivity():
+    from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+        MeshOverlayClientConnectivity,
+    )
+    p = get_provider(
+        "manual", region=None, terraform_dir=None, connectivity="mesh_overlay",
+    )
+    assert isinstance(p.client_connectivity, MeshOverlayClientConnectivity)
+
+
+def test_get_provider_manual_unknown_connectivity_raises():
+    with pytest.raises(ValueError, match="unknown connectivity 'bogus'"):
+        get_provider(
+            "manual", region=None, terraform_dir=None, connectivity="bogus",
+        )
+
+
+def test_get_provider_aws_ignores_connectivity_param():
+    """connectivity is a manual-provider-only concept; AWS must not choke
+    on it (nor change behavior) if it's passed."""
+    p = get_provider(
+        "aws", region="us-west-2", terraform_dir="/tf", connectivity="mesh_overlay",
+    )
+    assert isinstance(p, AWSProvider)

--- a/packages/allocator/tests/test_database.py
+++ b/packages/allocator/tests/test_database.py
@@ -1998,6 +1998,27 @@ def test_get_lan_ip_none_when_row_absent(db_instance, mock_db_connection):
     assert db_instance.get_lan_ip("nope") is None
 
 
+def test_get_overlay_hostname_present(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = ("classroom-gpu-3",)
+    assert db_instance.get_overlay_hostname("vm-1") == "classroom-gpu-3"
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "provider_metadata->>'overlay_hostname'" in sql
+    assert "WHERE hostname = %s" in sql
+
+
+def test_get_overlay_hostname_none_when_absent(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = (None,)
+    assert db_instance.get_overlay_hostname("vm-1") is None
+
+
+def test_get_overlay_hostname_none_when_row_absent(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = None
+    assert db_instance.get_overlay_hostname("nope") is None
+
+
 def test_list_hosts_by_provider(db_instance, mock_db_connection):
     _, mock_cursor, _ = mock_db_connection
     mock_cursor.fetchall.return_value = [("vm-1",), ("vm-2",)]

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -2,7 +2,74 @@
 
 from __future__ import annotations
 
+import subprocess
 from unittest.mock import MagicMock
+
+
+class TestTailscaleStatus:
+    """Unit tests for _tailscale_status(), which shells out to `ip` to
+    check for an actual Tailscale IPv4 address on tailscale0 rather than
+    just the interface's existence — confirmed live against a real
+    tailnet that the interface stays up with only a link-local IPv6
+    address while the node is logged out, which an existence-only check
+    would misreport as "ok"."""
+
+    def test_ok_when_ipv4_address_present(self, monkeypatch):
+        import lablink_allocator_service.main as main_mod
+
+        monkeypatch.setattr(
+            main_mod.subprocess,
+            "run",
+            lambda *a, **k: MagicMock(
+                returncode=0,
+                stdout="17: tailscale0 inet 100.87.100.2/32 scope global tailscale0\n",
+            ),
+        )
+
+        assert main_mod._tailscale_status() == "ok"
+
+    def test_not_joined_when_only_ipv6_link_local(self, monkeypatch):
+        """The false-positive case found live: interface up, no IPv4."""
+        import lablink_allocator_service.main as main_mod
+
+        monkeypatch.setattr(
+            main_mod.subprocess,
+            "run",
+            lambda *a, **k: MagicMock(returncode=0, stdout=""),
+        )
+
+        assert main_mod._tailscale_status() == "not joined"
+
+    def test_not_joined_when_interface_absent(self, monkeypatch):
+        import lablink_allocator_service.main as main_mod
+
+        monkeypatch.setattr(
+            main_mod.subprocess,
+            "run",
+            lambda *a, **k: MagicMock(returncode=1, stdout=""),
+        )
+
+        assert main_mod._tailscale_status() == "not joined"
+
+    def test_not_joined_when_ip_binary_missing(self, monkeypatch):
+        import lablink_allocator_service.main as main_mod
+
+        def _raise(*a, **k):
+            raise OSError("ip: command not found")
+
+        monkeypatch.setattr(main_mod.subprocess, "run", _raise)
+
+        assert main_mod._tailscale_status() == "not joined"
+
+    def test_not_joined_on_timeout(self, monkeypatch):
+        import lablink_allocator_service.main as main_mod
+
+        def _raise(*a, **k):
+            raise subprocess.TimeoutExpired(cmd="ip", timeout=5)
+
+        monkeypatch.setattr(main_mod.subprocess, "run", _raise)
+
+        assert main_mod._tailscale_status() == "not joined"
 
 
 class TestHealthEndpoint:

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -68,3 +68,58 @@ class TestHealthEndpoint:
         """Health endpoint should not require authentication."""
         resp = client.get("/api/health")
         assert resp.status_code != 401
+
+    def test_tailscale_check_absent_when_not_mesh_overlay(self, client, monkeypatch):
+        """A connectivity strategy that doesn't require a tailscale check
+        (e.g. lan_direct/allocator_proxied) must not add a tailscale key —
+        byte-identical health payload to today for every existing deployment."""
+        import lablink_allocator_service.main as main_mod
+
+        monkeypatch.setattr(main_mod, "database", MagicMock())
+        monkeypatch.setattr(main_mod, "scheduler_service", MagicMock())
+        monkeypatch.setattr(main_mod, "reboot_service", MagicMock())
+        monkeypatch.setattr(
+            main_mod.app.config["LABLINK_PROVIDER"].client_connectivity,
+            "requires_tailscale_check",
+            False,
+        )
+
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        assert "tailscale" not in resp.get_json()["checks"]
+
+    def test_tailscale_check_ok_when_joined(self, client, monkeypatch):
+        import lablink_allocator_service.main as main_mod
+
+        monkeypatch.setattr(main_mod, "database", MagicMock())
+        monkeypatch.setattr(main_mod, "scheduler_service", MagicMock())
+        monkeypatch.setattr(main_mod, "reboot_service", MagicMock())
+        monkeypatch.setattr(
+            main_mod.app.config["LABLINK_PROVIDER"].client_connectivity,
+            "requires_tailscale_check",
+            True,
+        )
+        monkeypatch.setattr(main_mod, "_tailscale_status", lambda: "ok")
+
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.get_json()["checks"]["tailscale"] == "ok"
+
+    def test_tailscale_check_not_joined_marks_unhealthy(self, client, monkeypatch):
+        import lablink_allocator_service.main as main_mod
+
+        monkeypatch.setattr(main_mod, "database", MagicMock())
+        monkeypatch.setattr(main_mod, "scheduler_service", MagicMock())
+        monkeypatch.setattr(main_mod, "reboot_service", MagicMock())
+        monkeypatch.setattr(
+            main_mod.app.config["LABLINK_PROVIDER"].client_connectivity,
+            "requires_tailscale_check",
+            True,
+        )
+        monkeypatch.setattr(main_mod, "_tailscale_status", lambda: "not joined")
+
+        resp = client.get("/api/health")
+        assert resp.status_code == 503
+        data = resp.get_json()
+        assert data["status"] == "starting"
+        assert data["checks"]["tailscale"] == "not joined"

--- a/packages/allocator/tests/test_manual_config.py
+++ b/packages/allocator/tests/test_manual_config.py
@@ -1,0 +1,23 @@
+"""Unit tests for ManualConfig (connectivity selection for the manual provider)."""
+
+from lablink_allocator_service.conf.structured_config import Config, ManualConfig
+
+
+class TestManualConfig:
+    def test_manual_config_defaults(self):
+        config = ManualConfig()
+        assert config.connectivity == "lan_direct"
+        assert config.overlay_tailnet == ""
+
+    def test_manual_config_mesh_overlay(self):
+        config = ManualConfig(
+            connectivity="mesh_overlay",
+            overlay_tailnet="example.ts.net",
+        )
+        assert config.connectivity == "mesh_overlay"
+        assert config.overlay_tailnet == "example.ts.net"
+
+    def test_config_has_manual_field(self):
+        cfg = Config()
+        assert isinstance(cfg.manual, ManualConfig)
+        assert cfg.manual.connectivity == "lan_direct"

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -649,6 +649,40 @@ def test_register_skips_connectivity_check_for_non_manual_provider(reg_client):
     fake_db.register_client.assert_called_once()
 
 
+def test_register_fallback_provider_construction_includes_connectivity(
+    reg_client, monkeypatch,
+):
+    """When LABLINK_PROVIDER isn't already cached in app.config, the
+    fallback ``main.get_provider(...)`` call in this view must still pass
+    ``connectivity=main.cfg.manual.connectivity`` through -- otherwise it
+    silently defaults to lan_direct regardless of the deployment's actual
+    configured connectivity, which would make the mismatched-metadata
+    check above reject legitimate --overlay-hostname registrations against
+    a mesh_overlay allocator. Mirrors the connectivity= fix already applied
+    to the admin_connect_vm/submit_vm_details fallback call sites in
+    main.py."""
+    from lablink_allocator_service import main
+
+    client, fake_db = reg_client
+    monkeypatch.delitem(client.application.config, "LABLINK_PROVIDER")
+    monkeypatch.setattr(main.cfg, "provider", "manual", raising=False)
+    monkeypatch.setattr(
+        main.cfg.manual, "connectivity", "mesh_overlay", raising=False
+    )
+
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual",
+            "provider_metadata": {"overlay_hostname": "classroom-1"},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    fake_db.register_client.assert_called_once()
+
+
 def test_list_clients_returns_safe_fields(reg_client, admin_headers):
     from datetime import datetime
 

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -536,6 +536,119 @@ def test_list_clients_accepts_admin_basic(reg_client, admin_headers):
     assert r.get_json() == {"clients": []}
 
 
+def test_register_rejects_lan_ip_metadata_against_mesh_overlay_allocator(
+    reg_client, monkeypatch,
+):
+    """A manual client that auto-detected --lan-ip (forgot
+    --overlay-hostname) must not silently register against a
+    mesh_overlay-configured allocator: the browser would end up trying
+    to dial the client's private LAN IP directly, which is unreachable
+    off that LAN -- exactly the failure mode this guards against."""
+    from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+        MeshOverlayClientConnectivity,
+    )
+
+    client, fake_db = reg_client
+    client.application.config["LABLINK_PROVIDER"].client_connectivity = (
+        MeshOverlayClientConnectivity()
+    )
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual", "provider_metadata": {"lan_ip": "1.2.3.4"},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 400
+    assert "overlay-hostname" in r.get_json()["error"]
+    fake_db.register_client.assert_not_called()
+
+
+def test_register_rejects_overlay_hostname_metadata_against_lan_direct_allocator(
+    reg_client,
+):
+    """The inverse mismatch: --overlay-hostname against a lan_direct
+    (real-BYO) allocator must also be rejected rather than silently
+    accepted -- this connectivity mode has no Tailscale sidecar to
+    resolve the hostname through."""
+    client, fake_db = reg_client
+    # reg_client's default stub is AllocatorProxiedClientConnectivity
+    # (name != "mesh_overlay"), matching a non-mesh_overlay deployment.
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual",
+            "provider_metadata": {"overlay_hostname": "classroom-1"},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 400
+    assert "overlay-hostname" in r.get_json()["error"]
+    fake_db.register_client.assert_not_called()
+
+
+def test_register_accepts_overlay_hostname_metadata_against_mesh_overlay_allocator(
+    reg_client,
+):
+    """The matching, correct case: --overlay-hostname against a
+    mesh_overlay-configured allocator registers normally."""
+    from lablink_allocator_service.providers.connectivity.mesh_overlay import (
+        MeshOverlayClientConnectivity,
+    )
+
+    client, fake_db = reg_client
+    client.application.config["LABLINK_PROVIDER"].client_connectivity = (
+        MeshOverlayClientConnectivity()
+    )
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual",
+            "provider_metadata": {"overlay_hostname": "classroom-1"},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    fake_db.register_client.assert_called_once()
+
+
+def test_register_accepts_lan_ip_metadata_against_lan_direct_allocator(reg_client):
+    """Regression guard: the ordinary real-BYO case (--lan-ip against a
+    non-mesh_overlay allocator) is unaffected by the new check."""
+    client, fake_db = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual", "provider_metadata": {"lan_ip": "1.2.3.4"},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    fake_db.register_client.assert_called_once()
+
+
+def test_register_skips_connectivity_check_for_non_manual_provider(reg_client):
+    """AWS-provisioned VMs never send lan_ip/overlay_hostname metadata
+    and don't go through this CLI-driven flow -- the check must not
+    fire for provider != 'manual' regardless of metadata shape."""
+    client, fake_db = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "aws",
+            "provider_metadata": {"overlay_hostname": "classroom-1"},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    fake_db.register_client.assert_called_once()
+
+
 def test_list_clients_returns_safe_fields(reg_client, admin_headers):
     from datetime import datetime
 

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -138,6 +138,26 @@ def test_register_success_mints_secret(reg_client):
     assert kw["machine_identity"] == "i-1"
 
 
+def test_register_client_image_is_machine_image_only(reg_client):
+    """cfg.machine.repository is the tutorial-repo-to-clone URL (see the
+    AWS spec dict in main.py and TUTORIAL_REPO_TO_CLONE in client/start.sh)
+    — an unrelated setting from cfg.machine.image (the actual docker image
+    reference used verbatim on the AWS path as spec["image_name"]).
+    client_image must never be built by prefixing repository onto image;
+    the omega_config fixture sets both fields to prove they don't get
+    concatenated for the manual/BYO registration path either."""
+    client, _ = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": "vm-1", "machine_identity": "i-1"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    from lablink_allocator_service import main
+    assert main.cfg.machine.repository, "fixture must set repository to exercise the bug"
+    assert r.get_json()["client_image"] == main.cfg.machine.image
+
+
 def test_status_requires_client_secret(reg_client):
     client, fake_db = reg_client
     fake_db.get_client_secret_hash.return_value = None

--- a/packages/cli/src/lablink_cli/api.py
+++ b/packages/cli/src/lablink_cli/api.py
@@ -258,22 +258,34 @@ class RegistrationClient:
         *,
         hostname: str,
         machine_identity: str,
-        lan_ip: str,
         gpu_present: bool,
         gpu_model: str | None,
+        lan_ip: str | None = None,
+        overlay_hostname: str | None = None,
     ) -> dict:
         """POST /api/v1/clients/register; return parsed JSON.
+
+        Exactly one of ``lan_ip`` (real BYO box, LAN-direct connectivity)
+        or ``overlay_hostname`` (mesh-overlay connectivity, e.g. a
+        Run:AI-hosted workload) is expected — enforced by the caller
+        (``run_register``), not here.
 
         Raises AllocatorAuthError on 401, AllocatorConflictError on 409,
         AllocatorUnavailableError on connection failure, AllocatorError
         on other HTTP error codes / malformed response.
         """
+        if overlay_hostname is not None:
+            provider_metadata = {"overlay_hostname": overlay_hostname}
+            endpoint_url = None
+        else:
+            provider_metadata = {"lan_ip": lan_ip}
+            endpoint_url = f"http://{lan_ip}:7070"
         body = {
             "hostname": hostname,
             "machine_identity": machine_identity,
             "provider": "manual",
-            "endpoint_url": f"http://{lan_ip}:7070",
-            "provider_metadata": {"lan_ip": lan_ip},
+            "endpoint_url": endpoint_url,
+            "provider_metadata": provider_metadata,
             "gpu_present": gpu_present,
             "gpu_model": gpu_model,
         }

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -185,13 +185,20 @@ def deploy(
         help="Skip confirmation prompts. Does not bypass credential prompts "
         "(admin password still required interactively).",
     ),
+    tailscale_authkey: str = typer.Option(
+        None, "--tailscale-authkey",
+        help="Tailscale auth key for the allocator's own tailnet sidecar. "
+        "Required on the first deploy when manual.connectivity is "
+        "'mesh_overlay'; optional on redeploys (the previous value is "
+        "carried forward). Manual provider only.",
+    ),
 ) -> None:
     """Deploy LabLink infrastructure (AWS Terraform or docker-compose)."""
     cfg = _load_cfg(config)
     if cfg.provider == "manual":
         from lablink_cli.commands.deploy_compose import run_deploy_compose
 
-        run_deploy_compose(cfg, yes=yes)
+        run_deploy_compose(cfg, yes=yes, tailscale_authkey=tailscale_authkey)
         return
 
     from lablink_cli.commands.deploy import run_deploy

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -405,15 +405,26 @@ def register(
     overlay_hostname: str = typer.Option(
         None, "--overlay-hostname",
         help="Register a mesh-overlay client (e.g. a Run:AI-hosted "
-        "workload) under this Tailscale hostname, chosen by you before "
-        "the workload exists. Requires --hostname, --machine-identity, "
-        "and --tailscale-authkey. No local container is started.",
+        "workload) under this Tailscale hostname, chosen by you. "
+        "Requires --tailscale-authkey. By default (see --run-locally) "
+        "docker-runs the client container on this box now; pass "
+        "--no-run-locally to instead print secrets for a separate "
+        "workload submission, which also requires --hostname and "
+        "--machine-identity.",
     ),
     tailscale_authkey: str = typer.Option(
         None, "--tailscale-authkey",
         help="Tailscale auth key the workload will use to join the "
-        "tailnet. Required with --overlay-hostname; echoed back in the "
-        "printed env block for you to paste into your workload spec.",
+        "tailnet. Required with --overlay-hostname.",
+    ),
+    run_locally: bool = typer.Option(
+        True, "--run-locally/--no-run-locally",
+        help="With --overlay-hostname: docker-run the client container "
+        "on this box now, auto-detecting hostname/machine-identity/GPU "
+        "like a real BYO box (default: on). Pass --no-run-locally to "
+        "instead just print secrets for pasting into a separate Run:AI "
+        "workload submission — for registering ahead of time, from "
+        "somewhere other than the workload itself.",
     ),
     force: bool = typer.Option(
         False, "--force",
@@ -432,9 +443,12 @@ def register(
 ) -> None:
     """Register this BYO box as a manual client and run the client container.
 
-    Always docker-runs the client container after registering. If docker
-    is missing, the env file is preserved so the user can install docker
-    and re-run with --force.
+    Docker-runs the client container after registering — for a real BYO
+    box, or for a mesh-overlay client (--overlay-hostname) with the
+    default --run-locally. Pass --overlay-hostname --no-run-locally to
+    instead print secrets for a separate Run:AI workload submission. If
+    docker is missing, the env file is preserved so the user can install
+    docker and re-run with --force.
     """
     from lablink_cli.commands.register import run_register
 
@@ -451,6 +465,7 @@ def register(
         insecure=insecure,
         overlay_hostname=overlay_hostname,
         tailscale_authkey=tailscale_authkey,
+        run_locally=run_locally,
     )
 
 

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -395,6 +395,19 @@ def register(
         None, "--gpu-model",
         help="Override auto-detected GPU model string.",
     ),
+    overlay_hostname: str = typer.Option(
+        None, "--overlay-hostname",
+        help="Register a mesh-overlay client (e.g. a Run:AI-hosted "
+        "workload) under this Tailscale hostname, chosen by you before "
+        "the workload exists. Requires --hostname, --machine-identity, "
+        "and --tailscale-authkey. No local container is started.",
+    ),
+    tailscale_authkey: str = typer.Option(
+        None, "--tailscale-authkey",
+        help="Tailscale auth key the workload will use to join the "
+        "tailnet. Required with --overlay-hostname; echoed back in the "
+        "printed env block for you to paste into your workload spec.",
+    ),
     force: bool = typer.Option(
         False, "--force",
         help="Overwrite an existing ~/.lablink/client.env. Mints a new "
@@ -429,6 +442,8 @@ def register(
         force=force,
         env_file=env_file,
         insecure=insecure,
+        overlay_hostname=overlay_hostname,
+        tailscale_authkey=tailscale_authkey,
     )
 
 

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -354,18 +354,18 @@ def _print_summary(cfg: Config) -> None:
     if mesh_overlay:
         # A mesh-overlay client (e.g. a Run:AI-hosted workload) isn't on
         # the allocator's LAN at all — "on each BYO box on the same LAN"
-        # is wrong here, and --overlay-hostname/--tailscale-authkey are
-        # required flags this connectivity has that lan_direct doesn't.
+        # is wrong here. --run-locally defaults to on, so hostname/
+        # machine-identity/GPU are auto-detected same as real BYO; only
+        # --overlay-hostname/--tailscale-authkey are required.
         console.print(
             "\n[bold]Next step:[/bold] for each mesh-overlay client "
-            "(e.g. a Run:AI-hosted workload), run this from anywhere "
-            "with network access to the allocator, choosing a unique "
-            "hostname and a Tailscale auth key for that client:"
+            "(e.g. a Run:AI-hosted workload), open a terminal inside "
+            "that workload and run (hostname/machine-identity/GPU are "
+            "auto-detected):"
         )
         register_cmd = (
             f"  lablink client register --allocator-url {register_url} "
             f"--register-token {register_token or '<token>'} "
-            "--hostname <name> --machine-identity <name> "
             "--overlay-hostname <name> --tailscale-authkey <key>"
         )
     else:
@@ -377,6 +377,13 @@ def _print_summary(cfg: Config) -> None:
             f"--register-token {register_token or '<token>'}"
         )
     console.print(register_cmd, soft_wrap=True, highlight=False)
+    if mesh_overlay:
+        console.print(
+            "  [dim]Registering ahead of time from elsewhere instead? "
+            "Add --no-run-locally to print secrets for your own "
+            "workload submission instead of running here, along with "
+            "--hostname/--machine-identity.[/dim]"
+        )
     if not lan_url:
         # If we fell back to localhost, the printed command only works
         # for a BYO client *on the operator host*. Call that out so the

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -346,16 +346,36 @@ def _print_summary(cfg: Config) -> None:
         )
 
     # Print a copy-paste-ready command using the LAN URL when available
-    # (BYO boxes can't reach localhost). The token-bearing line uses
-    # soft_wrap=True so narrow terminals don't insert a hard newline
-    # mid-command — that would break the operator's copy-paste.
-    console.print(
-        "\n[bold]Next step:[/bold] on each BYO box on the same LAN, run"
-    )
-    register_cmd = (
-        f"  lablink client register --allocator-url {register_url} "
-        f"--register-token {register_token or '<token>'}"
-    )
+    # (clients registering over the LAN can't reach localhost). The
+    # token-bearing line uses soft_wrap=True so narrow terminals don't
+    # insert a hard newline mid-command — that would break the
+    # operator's copy-paste.
+    mesh_overlay = cfg.manual.connectivity == "mesh_overlay"
+    if mesh_overlay:
+        # A mesh-overlay client (e.g. a Run:AI-hosted workload) isn't on
+        # the allocator's LAN at all — "on each BYO box on the same LAN"
+        # is wrong here, and --overlay-hostname/--tailscale-authkey are
+        # required flags this connectivity has that lan_direct doesn't.
+        console.print(
+            "\n[bold]Next step:[/bold] for each mesh-overlay client "
+            "(e.g. a Run:AI-hosted workload), run this from anywhere "
+            "with network access to the allocator, choosing a unique "
+            "hostname and a Tailscale auth key for that client:"
+        )
+        register_cmd = (
+            f"  lablink client register --allocator-url {register_url} "
+            f"--register-token {register_token or '<token>'} "
+            "--hostname <name> --machine-identity <name> "
+            "--overlay-hostname <name> --tailscale-authkey <key>"
+        )
+    else:
+        console.print(
+            "\n[bold]Next step:[/bold] on each BYO box on the same LAN, run"
+        )
+        register_cmd = (
+            f"  lablink client register --allocator-url {register_url} "
+            f"--register-token {register_token or '<token>'}"
+        )
     console.print(register_cmd, soft_wrap=True, highlight=False)
     if not lan_url:
         # If we fell back to localhost, the printed command only works

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -178,21 +178,29 @@ def run_deploy_compose(
 
     `yes=True` skips the interactive confirmation prompt.
     `workdir_root` overrides `DEFAULT_COMPOSE_DIR` (used by tests).
-    `tailscale_authkey` is required on the first deploy when
-    `cfg.manual.connectivity == "mesh_overlay"` (the sidecar has nothing
-    to join with otherwise) — optional on redeploys, since
-    `render_compose_dir` carries the previous value forward.
+    `tailscale_authkey` is required when `cfg.manual.connectivity ==
+    "mesh_overlay"` unless a value is already on record in this
+    deployment's existing `.env` (the sidecar has nothing to join with
+    otherwise) — carried forward on ordinary mesh-overlay redeploys by
+    `render_compose_dir`.
     """
     target = (workdir_root or DEFAULT_COMPOSE_DIR) / (
         cfg.deployment_name or "lablink"
     )
 
     if cfg.manual.connectivity == "mesh_overlay":
-        first_deploy = not (target / ".env").exists()
-        if first_deploy and not tailscale_authkey:
+        # Checking ".env exists" alone (i.e. "is this a redeploy") isn't
+        # enough: a redeploy that *switches* connectivity from lan_direct
+        # to mesh_overlay has an existing .env, but that .env has no
+        # TS_AUTHKEY line to carry forward. Read the actual prior value
+        # (if any) so that case still requires --tailscale-authkey
+        # instead of silently rendering an empty key.
+        previous_authkey = _read_env_value(target / ".env", "TS_AUTHKEY")
+        if not tailscale_authkey and not previous_authkey:
             console.print(
                 "[red]manual.connectivity is 'mesh_overlay' but no "
-                "--tailscale-authkey was given for this first deploy.[/red]\n"
+                "--tailscale-authkey was given, and no previous value is "
+                "on record for this deployment.[/red]\n"
                 "Generate an authkey from your Tailscale admin console "
                 "and re-run with --tailscale-authkey <key>."
             )

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -49,32 +49,74 @@ def compose_workdir(cfg: Config) -> Path:
     return DEFAULT_COMPOSE_DIR / name
 
 
-def render_compose_dir(cfg: Config, target: Path) -> None:
+def _read_env_value(env_path: Path, key: str) -> str | None:
+    """Read a single KEY=value line from an existing .env file.
+
+    Used to carry TS_AUTHKEY forward across redeploys without requiring
+    the admin to re-supply --tailscale-authkey every time — tailscaled's
+    own state (the tailscale_state volume) is what actually matters after
+    the first join, but the sidecar's compose environment still needs
+    *some* value on every render.
+    """
+    if not env_path.exists():
+        return None
+    prefix = f"{key}="
+    for line in env_path.read_text().splitlines():
+        if line.startswith(prefix):
+            return line[len(prefix):]
+    return None
+
+
+def render_compose_dir(
+    cfg: Config, target: Path, *, tailscale_authkey: str | None = None
+) -> None:
     """Render docker-compose.yml + .env + config.yaml into target.
 
     The allocator image is monolithic (bundles its own Postgres), so the
-    compose stack is single-service. The internal Postgres data is
-    persisted via a named volume on /var/lib/postgresql. Admin/DB creds
-    live in the saved config.yaml (NOT in env vars) — the caller is
+    compose stack is single-service — plus a `tailscale` sidecar service
+    when `cfg.manual.connectivity == "mesh_overlay"` (network_mode:
+    service:allocator, so the allocator's own nginx can route to a
+    mesh-overlay client's Tailscale hostname). The internal Postgres data
+    is persisted via a named volume on /var/lib/postgresql. Admin/DB
+    creds live in the saved config.yaml (NOT in env vars) — the caller is
     responsible for populating cfg.app.admin_user/admin_password (via
     `resolve_admin_credentials`) before invoking this helper.
+
+    `tailscale_authkey` is only meaningful when connectivity is
+    mesh_overlay. It is not persisted in config.yaml (unlike admin/DB
+    creds) — only into this deployment's .env, and only for as long as
+    the sidecar needs it to join for the first time.
     """
     target.mkdir(parents=True, exist_ok=True)
+    mesh_overlay = cfg.manual.connectivity == "mesh_overlay"
 
-    # 1. Copy the bundled docker-compose template.
-    template = resources.files("lablink_cli.templates").joinpath(
-        "docker-compose.yml"
+    # 1. Copy the bundled docker-compose template — the mesh-overlay
+    #    variant adds the Tailscale sidecar; otherwise identical.
+    template_name = (
+        "docker-compose-mesh-overlay.yml" if mesh_overlay else "docker-compose.yml"
     )
+    template = resources.files("lablink_cli.templates").joinpath(template_name)
     (target / "docker-compose.yml").write_text(template.read_text())
 
     # 2. Render .env — only the values the compose template substitutes.
-    #    No DB or admin creds here: they're inside config.yaml.
+    #    No DB or admin creds here: they're inside config.yaml. Read the
+    #    OLD .env (if any) before overwriting it, so a redeploy that
+    #    omits --tailscale-authkey carries the previous value forward
+    #    instead of blanking out an already-joined sidecar's key.
+    env_path = target / ".env"
+    previous_authkey = _read_env_value(env_path, "TS_AUTHKEY")
+
     allocator_image = _allocator_image(cfg)
     env_lines = [
         f"ALLOCATOR_IMAGE={allocator_image}",
         f"HTTP_PORT={DEFAULT_HTTP_PORT}",
     ]
-    env_path = target / ".env"
+    if mesh_overlay:
+        resolved_authkey = tailscale_authkey or previous_authkey or ""
+        env_lines.append(f"TS_AUTHKEY={resolved_authkey}")
+        env_lines.append(
+            f"TAILSCALE_HOSTNAME=lablink-allocator-{cfg.deployment_name or 'lablink'}"
+        )
     env_path.write_text("\n".join(env_lines) + "\n")
     env_path.chmod(0o600)
 
@@ -125,6 +167,7 @@ def run_deploy_compose(
     *,
     yes: bool = False,
     workdir_root: Path | None = None,
+    tailscale_authkey: str | None = None,
 ) -> None:
     """Bring up the allocator stack via docker-compose.
 
@@ -135,7 +178,25 @@ def run_deploy_compose(
 
     `yes=True` skips the interactive confirmation prompt.
     `workdir_root` overrides `DEFAULT_COMPOSE_DIR` (used by tests).
+    `tailscale_authkey` is required on the first deploy when
+    `cfg.manual.connectivity == "mesh_overlay"` (the sidecar has nothing
+    to join with otherwise) — optional on redeploys, since
+    `render_compose_dir` carries the previous value forward.
     """
+    target = (workdir_root or DEFAULT_COMPOSE_DIR) / (
+        cfg.deployment_name or "lablink"
+    )
+
+    if cfg.manual.connectivity == "mesh_overlay":
+        first_deploy = not (target / ".env").exists()
+        if first_deploy and not tailscale_authkey:
+            console.print(
+                "[red]manual.connectivity is 'mesh_overlay' but no "
+                "--tailscale-authkey was given for this first deploy.[/red]\n"
+                "Generate an authkey from your Tailscale admin console "
+                "and re-run with --tailscale-authkey <key>."
+            )
+            raise SystemExit(1)
     # Preflight: SSL provider must be one the compose template supports.
     # The allocator image has no TLS terminator, so only ssl=none works
     # out of the box. Operators who need TLS run their own reverse proxy
@@ -167,10 +228,6 @@ def run_deploy_compose(
     cfg.app.admin_user = admin_user
     cfg.app.admin_password = admin_pw
 
-    target = (workdir_root or DEFAULT_COMPOSE_DIR) / (
-        cfg.deployment_name or "lablink"
-    )
-
     if not yes:
         action = "create" if not target.exists() else "update"
         console.print(
@@ -183,7 +240,7 @@ def run_deploy_compose(
             console.print("Aborted.")
             raise SystemExit(1)
 
-    render_compose_dir(cfg, target)
+    render_compose_dir(cfg, target, tailscale_authkey=tailscale_authkey)
     console.print(f"[green]Rendered {target}[/green]")
 
     _compose_up(target)

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -255,7 +255,8 @@ def run_register(
     # Step 7 + 8: docker run (always)
     startup_script_path = _write_startup_script(response)
     cmd = _build_docker_run(
-        env_file, response, resolved_gpu_present, startup_script_path
+        env_file, response, resolved_gpu_present, startup_script_path,
+        overlay_hostname,
     )
     console.print(
         f"[green]Registered as client #{response['client_id']}[/green]"
@@ -401,6 +402,7 @@ def _build_docker_run(
     resp: dict,
     gpu_present: bool,
     startup_script: Path | None,
+    overlay_hostname: str | None,
 ) -> list[str]:
     cmd = [
         "docker", "run", "-d",
@@ -416,6 +418,19 @@ def _build_docker_run(
     ]
     if gpu_present:
         cmd += ["--gpus", "all"]
+    if overlay_hostname is not None:
+        # start.sh's `tailscaled` needs to create a TUN network interface
+        # to route tailnet traffic to this container's own listening
+        # sockets (6080/7070). Without these, tailscaled can't open
+        # /dev/net/tun, dies immediately, and the subsequent `tailscale
+        # up` fails with "failed to connect to local tailscaled; it
+        # doesn't appear to be running". Gated on overlay_hostname since
+        # lan_direct/allocator_proxied clients never invoke `tailscale up`.
+        cmd += [
+            "--cap-add", "NET_ADMIN",
+            "--cap-add", "NET_RAW",
+            "--device", "/dev/net/tun",
+        ]
     # Mount path mirrors the AWS terraform/user_data mount so the client
     # start.sh finds the script at /docker_scripts/custom-startup.sh
     # regardless of provider. Skipped when the allocator returned no

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -35,6 +35,38 @@ DEFAULT_STARTUP_SCRIPT = Path.home() / ".lablink" / "client-custom-startup.sh"
 PID_FILE = Path.home() / ".lablink" / "log_shipper.pid"
 
 
+def _detect_hostname(hostname: str | None, console: Console) -> str:
+    resolved = hostname or byo_detect.detect_hostname()
+    if not resolved:
+        console.print(
+            "[red]Could not detect hostname.[/red] "
+            "Pass --hostname explicitly."
+        )
+        raise SystemExit(1)
+    console.print(f"Detected hostname: {resolved}")
+    return resolved
+
+
+def _detect_machine_identity(machine_identity: str | None, console: Console) -> str:
+    resolved = machine_identity or byo_detect.resolve_machine_identity()
+    console.print(f"Detected machine identity: {resolved}")
+    return resolved
+
+
+def _detect_gpu(
+    gpu_present: bool | None, gpu_model: str | None, console: Console
+) -> tuple[bool, str | None]:
+    detected_present, detected_model = byo_detect.detect_gpu()
+    resolved_present = gpu_present if gpu_present is not None else detected_present
+    resolved_model = gpu_model or detected_model
+    console.print(
+        f"Detected GPU: {resolved_model}"
+        if resolved_present
+        else "Detected GPU: none"
+    )
+    return resolved_present, resolved_model
+
+
 def run_register(
     *,
     allocator_url: str,
@@ -49,67 +81,91 @@ def run_register(
     insecure: bool,
     overlay_hostname: str | None = None,
     tailscale_authkey: str | None = None,
+    run_locally: bool = True,
 ) -> None:
     """Orchestrate registration. Exits non-zero on any user-facing error.
 
-    Two shapes:
+    Three shapes:
     - Real BYO box (default): auto-detects hostname/LAN IP/machine
       identity/GPU, then docker-runs the client container after
       persisting secrets.
-    - Mesh-overlay (``overlay_hostname`` set, e.g. a Run:AI-hosted
-      workload): the box doesn't exist yet, so auto-detection is
-      skipped entirely (it would report *this* machine's own facts);
-      ``--hostname``/``--machine-identity`` are required. No docker
-      run — instead prints the secrets for the admin to paste into
-      their own workload submission.
+    - Mesh-overlay, run locally (``overlay_hostname`` set, ``run_locally``
+      true — the default): the box registering *is* the target client
+      right now (e.g. a terminal inside an already-running Run:AI
+      workload with docker-in-docker), so hostname/machine-identity/GPU
+      are auto-detected the same as real BYO, and the client container
+      is docker-run immediately, joining the Tailscale tailnet on start.
+    - Mesh-overlay, hand-off (``overlay_hostname`` set, ``run_locally``
+      false via ``--no-run-locally``): the box doesn't exist yet, so
+      auto-detection is skipped entirely (it would report *this*
+      machine's own facts); ``--hostname``/``--machine-identity`` are
+      required. No docker run — instead prints the secrets for the
+      admin to paste into their own workload submission.
     """
     console = Console()
     env_file = env_file or DEFAULT_ENV_FILE
 
-    if overlay_hostname is not None:
+    if overlay_hostname is None:
+        if not run_locally:
+            console.print(
+                "[red]--no-run-locally only applies with "
+                "--overlay-hostname.[/red]"
+            )
+            raise SystemExit(1)
+    else:
         if not tailscale_authkey:
             console.print(
                 "[red]--tailscale-authkey is required with "
                 "--overlay-hostname.[/red]"
             )
             raise SystemExit(1)
-        if not hostname:
-            console.print(
-                "[red]--hostname is required with --overlay-hostname.[/red] "
-                "Auto-detection would report this machine's own hostname, "
-                "not the future client's — the client doesn't exist yet."
-            )
-            raise SystemExit(1)
-        if not machine_identity:
-            console.print(
-                "[red]--machine-identity is required with "
-                "--overlay-hostname.[/red] Auto-detection would report "
-                "this machine's own identity, not the future client's."
-            )
-            raise SystemExit(1)
+        if not run_locally:
+            if not hostname:
+                console.print(
+                    "[red]--hostname is required with --overlay-hostname "
+                    "--no-run-locally.[/red] Auto-detection would report "
+                    "this machine's own hostname, not the future "
+                    "client's — the client doesn't exist yet."
+                )
+                raise SystemExit(1)
+            if not machine_identity:
+                console.print(
+                    "[red]--machine-identity is required with "
+                    "--overlay-hostname --no-run-locally.[/red] "
+                    "Auto-detection would report this machine's own "
+                    "identity, not the future client's."
+                )
+                raise SystemExit(1)
 
-    # Step 1: idempotency / resume (real-BYO path only — a mesh-overlay
-    # registration has no local container/env-file lifecycle to resume).
-    if overlay_hostname is None and env_file.exists() and not force:
+    # Step 1: idempotency / resume. Skipped only for the mesh-overlay
+    # hand-off case (overlay_hostname set, run_locally false) — that
+    # case has no local container/env-file lifecycle to resume.
+    if (
+        (overlay_hostname is None or run_locally)
+        and env_file.exists()
+        and not force
+    ):
         _resume(env_file, console)
         return
 
     if overlay_hostname is not None:
-        resolved_hostname = hostname
-        resolved_machine_identity = machine_identity
-        resolved_gpu_present = bool(gpu_present)
-        resolved_gpu_model = gpu_model
         console.print(f"Registering overlay hostname: {overlay_hostname}")
+        if run_locally:
+            resolved_hostname = _detect_hostname(hostname, console)
+            resolved_machine_identity = _detect_machine_identity(
+                machine_identity, console
+            )
+            resolved_gpu_present, resolved_gpu_model = _detect_gpu(
+                gpu_present, gpu_model, console
+            )
+        else:
+            resolved_hostname = hostname
+            resolved_machine_identity = machine_identity
+            resolved_gpu_present = bool(gpu_present)
+            resolved_gpu_model = gpu_model
     else:
         # Step 2: auto-detect (user overrides win)
-        resolved_hostname = hostname or byo_detect.detect_hostname()
-        if not resolved_hostname:
-            console.print(
-                "[red]Could not detect hostname.[/red] "
-                "Pass --hostname explicitly."
-            )
-            raise SystemExit(1)
-        console.print(f"Detected hostname: {resolved_hostname}")
+        resolved_hostname = _detect_hostname(hostname, console)
 
         resolved_lan_ip = lan_ip or byo_detect.detect_lan_ip()
         if not resolved_lan_ip:
@@ -120,23 +176,11 @@ def run_register(
             raise SystemExit(1)
         console.print(f"Detected LAN IP: {resolved_lan_ip}")
 
-        resolved_machine_identity = (
-            machine_identity or byo_detect.resolve_machine_identity()
+        resolved_machine_identity = _detect_machine_identity(
+            machine_identity, console
         )
-        console.print(
-            f"Detected machine identity: {resolved_machine_identity}"
-        )
-
-        # GPU: always detect; user flags override either field independently.
-        detected_present, detected_model = byo_detect.detect_gpu()
-        resolved_gpu_present = (
-            gpu_present if gpu_present is not None else detected_present
-        )
-        resolved_gpu_model = gpu_model or detected_model
-        console.print(
-            f"Detected GPU: {resolved_gpu_model}"
-            if resolved_gpu_present
-            else "Detected GPU: none"
+        resolved_gpu_present, resolved_gpu_model = _detect_gpu(
+            gpu_present, gpu_model, console
         )
 
     # Step 3 + 4: build + POST
@@ -176,16 +220,23 @@ def run_register(
         raise SystemExit(1) from e
 
     # Step 5: persist env file (0600)
-    _write_env_file(env_file, allocator_url, response)
+    _write_env_file(
+        env_file,
+        allocator_url,
+        response,
+        overlay_hostname=overlay_hostname,
+        tailscale_authkey=tailscale_authkey,
+    )
     console.print(
         f"[green]Secrets saved to {env_file} (mode 0600)[/green]"
     )
 
-    if overlay_hostname is not None:
+    if overlay_hostname is not None and not run_locally:
         # No host for the CLI to act on — the Run:AI workload doesn't
         # exist yet. Print everything the admin needs to paste into
         # their own workload submission instead of docker-running
-        # anything.
+        # anything. The loop below already emits OVERLAY_HOSTNAME/
+        # TAILSCALE_AUTHKEY since _write_env_file now includes them.
         console.print(
             "\n[bold]No local container will be started[/bold] — this "
             "box doesn't exist yet. Paste the following into your "
@@ -195,8 +246,6 @@ def run_register(
             if line.startswith("#"):
                 continue
             print(line)
-        print(f"OVERLAY_HOSTNAME={overlay_hostname}")
-        print(f"TAILSCALE_AUTHKEY={tailscale_authkey}")
         return
 
     # Step 6: GPU runtime pre-flight (only when --gpus all will be added)
@@ -212,6 +261,12 @@ def run_register(
         f"[green]Registered as client #{response['client_id']}[/green]"
     )
     _exec_docker(cmd, console)
+    if overlay_hostname is not None:
+        console.print(
+            "[dim]This container joins Tailscale as "
+            f"{overlay_hostname} on start — confirm with "
+            "`docker logs lablink-client`.[/dim]"
+        )
     _start_log_shipper(env_file, console)
 
 
@@ -280,7 +335,12 @@ def _resume(env_file: Path, console: Console) -> None:
 
 
 def _write_env_file(
-    env_file: Path, allocator_url: str, resp: dict
+    env_file: Path,
+    allocator_url: str,
+    resp: dict,
+    *,
+    overlay_hostname: str | None = None,
+    tailscale_authkey: str | None = None,
 ) -> None:
     env_file.parent.mkdir(parents=True, exist_ok=True)
     timestamp = datetime.now(timezone.utc).isoformat(timespec="seconds")
@@ -305,6 +365,13 @@ def _write_env_file(
         f"CLIENT_IMAGE={resp['client_image']}",
         f"REGISTER_RESPONSE={register_response_json}",
     ]
+    if overlay_hostname is not None:
+        # Written so a nested `docker run --env-file` (the run_locally
+        # path) carries these into the container automatically —
+        # start.sh's existing `if [ -n "$TAILSCALE_AUTHKEY" ]` gate then
+        # joins the tailnet with no client-image changes needed.
+        lines.append(f"OVERLAY_HOSTNAME={overlay_hostname}")
+        lines.append(f"TAILSCALE_AUTHKEY={tailscale_authkey}")
     env_file.write_text("\n".join(lines) + "\n")
     env_file.chmod(0o600)
 

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -47,58 +47,97 @@ def run_register(
     force: bool,
     env_file: Path | None,
     insecure: bool,
+    overlay_hostname: str | None = None,
+    tailscale_authkey: str | None = None,
 ) -> None:
     """Orchestrate registration. Exits non-zero on any user-facing error.
 
-    Always docker-runs the client container after persisting secrets.
-    If docker is missing, errors but preserves the env file so the user
-    can install docker and re-run with --force.
+    Two shapes:
+    - Real BYO box (default): auto-detects hostname/LAN IP/machine
+      identity/GPU, then docker-runs the client container after
+      persisting secrets.
+    - Mesh-overlay (``overlay_hostname`` set, e.g. a Run:AI-hosted
+      workload): the box doesn't exist yet, so auto-detection is
+      skipped entirely (it would report *this* machine's own facts);
+      ``--hostname``/``--machine-identity`` are required. No docker
+      run — instead prints the secrets for the admin to paste into
+      their own workload submission.
     """
     console = Console()
     env_file = env_file or DEFAULT_ENV_FILE
 
-    # Step 1: idempotency / resume
-    if env_file.exists() and not force:
+    if overlay_hostname is not None:
+        if not tailscale_authkey:
+            console.print(
+                "[red]--tailscale-authkey is required with "
+                "--overlay-hostname.[/red]"
+            )
+            raise SystemExit(1)
+        if not hostname:
+            console.print(
+                "[red]--hostname is required with --overlay-hostname.[/red] "
+                "Auto-detection would report this machine's own hostname, "
+                "not the future client's — the client doesn't exist yet."
+            )
+            raise SystemExit(1)
+        if not machine_identity:
+            console.print(
+                "[red]--machine-identity is required with "
+                "--overlay-hostname.[/red] Auto-detection would report "
+                "this machine's own identity, not the future client's."
+            )
+            raise SystemExit(1)
+
+    # Step 1: idempotency / resume (real-BYO path only — a mesh-overlay
+    # registration has no local container/env-file lifecycle to resume).
+    if overlay_hostname is None and env_file.exists() and not force:
         _resume(env_file, console)
         return
 
-    # Step 2: auto-detect (user overrides win)
-    resolved_hostname = hostname or byo_detect.detect_hostname()
-    if not resolved_hostname:
-        console.print(
-            "[red]Could not detect hostname.[/red] "
-            "Pass --hostname explicitly."
+    if overlay_hostname is not None:
+        resolved_hostname = hostname
+        resolved_machine_identity = machine_identity
+        resolved_gpu_present = bool(gpu_present)
+        resolved_gpu_model = gpu_model
+        console.print(f"Registering overlay hostname: {overlay_hostname}")
+    else:
+        # Step 2: auto-detect (user overrides win)
+        resolved_hostname = hostname or byo_detect.detect_hostname()
+        if not resolved_hostname:
+            console.print(
+                "[red]Could not detect hostname.[/red] "
+                "Pass --hostname explicitly."
+            )
+            raise SystemExit(1)
+        console.print(f"Detected hostname: {resolved_hostname}")
+
+        resolved_lan_ip = lan_ip or byo_detect.detect_lan_ip()
+        if not resolved_lan_ip:
+            console.print(
+                "[red]Could not detect LAN IP.[/red] "
+                "Pass --lan-ip explicitly."
+            )
+            raise SystemExit(1)
+        console.print(f"Detected LAN IP: {resolved_lan_ip}")
+
+        resolved_machine_identity = (
+            machine_identity or byo_detect.resolve_machine_identity()
         )
-        raise SystemExit(1)
-    console.print(f"Detected hostname: {resolved_hostname}")
-
-    resolved_lan_ip = lan_ip or byo_detect.detect_lan_ip()
-    if not resolved_lan_ip:
         console.print(
-            "[red]Could not detect LAN IP.[/red] "
-            "Pass --lan-ip explicitly."
+            f"Detected machine identity: {resolved_machine_identity}"
         )
-        raise SystemExit(1)
-    console.print(f"Detected LAN IP: {resolved_lan_ip}")
 
-    resolved_machine_identity = (
-        machine_identity or byo_detect.resolve_machine_identity()
-    )
-    console.print(
-        f"Detected machine identity: {resolved_machine_identity}"
-    )
-
-    # GPU: always detect; user flags override either field independently.
-    detected_present, detected_model = byo_detect.detect_gpu()
-    resolved_gpu_present = (
-        gpu_present if gpu_present is not None else detected_present
-    )
-    resolved_gpu_model = gpu_model or detected_model
-    console.print(
-        f"Detected GPU: {resolved_gpu_model}"
-        if resolved_gpu_present
-        else "Detected GPU: none"
-    )
+        # GPU: always detect; user flags override either field independently.
+        detected_present, detected_model = byo_detect.detect_gpu()
+        resolved_gpu_present = (
+            gpu_present if gpu_present is not None else detected_present
+        )
+        resolved_gpu_model = gpu_model or detected_model
+        console.print(
+            f"Detected GPU: {resolved_gpu_model}"
+            if resolved_gpu_present
+            else "Detected GPU: none"
+        )
 
     # Step 3 + 4: build + POST
     ssl_provider = "self_signed" if insecure else "none"
@@ -107,13 +146,22 @@ def run_register(
     )
     console.print(f"Registering with {allocator_url} …")
     try:
-        response = client.register(
-            hostname=resolved_hostname,
-            machine_identity=resolved_machine_identity,
-            lan_ip=resolved_lan_ip,
-            gpu_present=resolved_gpu_present,
-            gpu_model=resolved_gpu_model,
-        )
+        if overlay_hostname is not None:
+            response = client.register(
+                hostname=resolved_hostname,
+                machine_identity=resolved_machine_identity,
+                overlay_hostname=overlay_hostname,
+                gpu_present=resolved_gpu_present,
+                gpu_model=resolved_gpu_model,
+            )
+        else:
+            response = client.register(
+                hostname=resolved_hostname,
+                machine_identity=resolved_machine_identity,
+                lan_ip=resolved_lan_ip,
+                gpu_present=resolved_gpu_present,
+                gpu_model=resolved_gpu_model,
+            )
     except AllocatorAuthError as e:
         console.print(f"[red]{e}[/red]")
         raise SystemExit(1) from e
@@ -132,6 +180,24 @@ def run_register(
     console.print(
         f"[green]Secrets saved to {env_file} (mode 0600)[/green]"
     )
+
+    if overlay_hostname is not None:
+        # No host for the CLI to act on — the Run:AI workload doesn't
+        # exist yet. Print everything the admin needs to paste into
+        # their own workload submission instead of docker-running
+        # anything.
+        console.print(
+            "\n[bold]No local container will be started[/bold] — this "
+            "box doesn't exist yet. Paste the following into your "
+            "Run:AI workload's environment variables:\n"
+        )
+        for line in env_file.read_text().splitlines():
+            if line.startswith("#"):
+                continue
+            print(line)
+        print(f"OVERLAY_HOSTNAME={overlay_hostname}")
+        print(f"TAILSCALE_AUTHKEY={tailscale_authkey}")
+        return
 
     # Step 6: GPU runtime pre-flight (only when --gpus all will be added)
     if resolved_gpu_present:

--- a/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
+++ b/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
@@ -1,0 +1,78 @@
+# Rendered by `lablink deploy` (manual provider, connectivity: mesh_overlay)
+# — DO NOT edit by hand. Re-run `lablink deploy` to regenerate after config
+# changes.
+#
+# Identical to docker-compose.yml except for the added `tailscale` sidecar,
+# which shares the allocator's network namespace (network_mode:
+# service:allocator) so the allocator's own nginx can route to
+# <hostname>.<tailnet>.ts.net when proxying a mesh-overlay client's
+# KasmVNC connection. TS_AUTHKEY comes from `.env` (populated by `lablink
+# deploy --tailscale-authkey`, not persisted in config.yaml) — only needed
+# for the first join; tailscaled's own state (the tailscale_state volume)
+# carries the node's identity across restarts/redeploys after that.
+services:
+  allocator:
+    image: ${ALLOCATOR_IMAGE}
+    # Mutable tags like `linux-amd64-latest[-test]` are republished by CI
+    # without changing the tag string, so the local cache would otherwise
+    # mask updates. `always` makes `docker compose up -d` re-pull every
+    # time and is what makes "push a new image, re-run lablink deploy"
+    # actually deploy the new image.
+    pull_policy: always
+    # The allocator image is published amd64-only; pin the platform so
+    # Apple Silicon (and other arm64 hosts) emulate via Rosetta instead
+    # of failing with "no matching manifest for linux/arm64/v8". This is
+    # a no-op on native amd64 hosts. Drop this once multi-arch images
+    # are published from lablink-template's CI.
+    platform: linux/amd64
+    # Pin the container name so the CLI's logs/status/_extract_register_token
+    # helpers can address it without knowing the compose project name.
+    container_name: lablink-allocator
+    volumes:
+      - ./config.yaml:/config/config.yaml:ro
+      # The CLI's render_compose_dir always materializes custom-startup.sh
+      # in this directory (empty when disabled), so this bind mount
+      # always resolves. The allocator reads it at register time and
+      # ships its base64 content to BYO clients via the register
+      # response — matching the AWS path where Terraform/user_data
+      # delivers the same file to the client container.
+      - ./custom-startup.sh:/config/custom-startup.sh:ro
+      - allocator_pgdata:/var/lib/postgresql
+    ports:
+      # The container's nginx listens on :5000 (see lablink-nginx.conf in
+      # the allocator package). It is the only listener — there is no TLS
+      # terminator inside this image, so HTTPS is not exposed by the
+      # manual provider; front the stack with your own reverse proxy
+      # (Caddy, nginx, Cloudflare Tunnel) for public TLS.
+      - "${HTTP_PORT}:5000"
+    restart: unless-stopped
+
+  # Joins the allocator's host to the tailnet so its nginx can reach
+  # mesh-overlay clients. network_mode: service:allocator means this
+  # container shares the allocator's network namespace — the allocator's
+  # own process sees the tailscale0 interface directly, no separate
+  # networking setup needed on the allocator service itself. Depends on
+  # allocator (not the other way around): sharing a network namespace
+  # requires that namespace to already exist.
+  tailscale:
+    image: tailscale/tailscale:latest
+    container_name: lablink-allocator-tailscale
+    network_mode: "service:allocator"
+    depends_on:
+      - allocator
+    environment:
+      - TS_AUTHKEY=${TS_AUTHKEY:-}
+      - TS_HOSTNAME=${TAILSCALE_HOSTNAME:-lablink-allocator}
+      - TS_STATE_DIR=/var/lib/tailscale
+    cap_add:
+      - NET_ADMIN
+      - NET_RAW
+    devices:
+      - /dev/net/tun:/dev/net/tun
+    volumes:
+      - tailscale_state:/var/lib/tailscale
+    restart: unless-stopped
+
+volumes:
+  allocator_pgdata:
+  tailscale_state:

--- a/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
+++ b/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
@@ -64,6 +64,12 @@ services:
       - TS_AUTHKEY=${TS_AUTHKEY:-}
       - TS_HOSTNAME=${TAILSCALE_HOSTNAME:-lablink-allocator}
       - TS_STATE_DIR=/var/lib/tailscale
+      # containerboot defaults to --tun=userspace-networking, a
+      # software-only netstack with no real tailscale0 interface — nginx
+      # can't route to it. Confirmed live against a real tailnet: NET_ADMIN
+      # + /dev/net/tun alone were not enough; this must be set explicitly
+      # to get the kernel interface nginx depends on.
+      - TS_USERSPACE=false
     cap_add:
       - NET_ADMIN
       - NET_RAW

--- a/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
+++ b/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
@@ -56,6 +56,15 @@ services:
   # requires that namespace to already exist.
   tailscale:
     image: tailscale/tailscale:latest
+    # Without this, a locally cached image from a prior pull silently wins
+    # even when it's the wrong architecture for the current host — confirmed
+    # live: a stale amd64-cached image ran QEMU-emulated on an Apple Silicon
+    # host and corrupted the Noise-protocol handshake (surfaced as
+    # `chacha20poly1305: message authentication failed`), even though the
+    # image is genuinely published multi-arch and a native arm64 pull joins
+    # the tailnet immediately. Matches the allocator service's own
+    # pull_policy above.
+    pull_policy: always
     container_name: lablink-allocator-tailscale
     network_mode: "service:allocator"
     depends_on:

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -269,7 +269,107 @@ class ManualMachineScreen(Screen):
         cfg = self.app.config
         image = self.query_one("#client-image", Input).value.strip()
         cfg.machine.image = image or self.DEFAULT_IMAGE
-        # Skip Region + Machine instance-type + EIP — go straight to DNS/SSL
+        # Skip Region + Machine instance-type + EIP — go to connectivity.
+        self.app.push_screen(ManualConnectivityScreen())
+
+
+# ---------------------------------------------------------------------------
+# Screen 4 (Manual path only): Client connectivity
+# ---------------------------------------------------------------------------
+class ManualConnectivityScreen(Screen):
+    """How the student's browser reaches a manual client's KasmVNC desktop."""
+
+    BINDINGS = [Binding("escape", "back", "Back")]
+
+    def action_back(self) -> None:
+        self.app.pop_screen()
+
+    def compose(self) -> ComposeResult:
+        cfg = self.app.config
+        current = getattr(cfg.manual, "connectivity", "lan_direct") or "lan_direct"
+
+        yield Header()
+        with VerticalScroll():
+            # No "Step N:" prefix here deliberately — DnsScreen (the next
+            # screen on this path) hardcodes "Step 4: DNS & SSL" and is
+            # shared with the AWS path, so inserting a step between it and
+            # ManualMachineScreen's "Step 3" would collide with that label
+            # rather than shifting it. Renumbering DnsScreen is out of
+            # scope here (it's shared, and the AWS path already has its
+            # own pre-existing step-count drift across RegionScreen/
+            # MachineScreen).
+            yield Label(
+                "Client connectivity",
+                classes="step-title",
+            )
+            yield Label(
+                "How the student's browser reaches a client's KasmVNC desktop.\n"
+                "lan_direct: the client is on the allocator's own LAN (default).\n"
+                "mesh_overlay: the client isn't on the allocator's LAN (e.g. a\n"
+                "Run:AI-hosted workload) — reached over a Tailscale tailnet instead.",
+                classes="step-description",
+            )
+
+            yield Label("Connectivity", classes="field-label")
+            with RadioSet(id="connectivity-select"):
+                yield RadioButton(
+                    "lan_direct — client is on the allocator's LAN (default)",
+                    value=(current == "lan_direct"),
+                    id="connectivity-lan-direct",
+                )
+                yield RadioButton(
+                    "mesh_overlay — client reached over Tailscale",
+                    value=(current == "mesh_overlay"),
+                    id="connectivity-mesh-overlay",
+                )
+
+            yield Label(
+                "Tailscale tailnet domain (only used for mesh_overlay, "
+                "e.g. example.ts.net)",
+                classes="field-label",
+            )
+            yield Input(
+                value=cfg.manual.overlay_tailnet or "",
+                placeholder="example.ts.net",
+                id="overlay-tailnet",
+            )
+            yield Label("", id="connectivity-error", classes="error")
+        with Center():
+            with Horizontal(classes="nav-buttons"):
+                yield Button("Back", id="back")
+                yield Button("Next", variant="primary", id="next")
+        yield Footer()
+
+    def on_mount(self) -> None:
+        self.query_one("#connectivity-error").display = False
+
+    @on(Button.Pressed, "#back")
+    def _back(self) -> None:
+        self.app.pop_screen()
+
+    @on(Button.Pressed, "#next")
+    def _next(self) -> None:
+        cfg = self.app.config
+        rb = self.query_one("#connectivity-select", RadioSet)
+        chosen = "lan_direct"
+        if rb.pressed_button and rb.pressed_button.id == "connectivity-mesh-overlay":
+            chosen = "mesh_overlay"
+        cfg.manual.connectivity = chosen
+        cfg.manual.overlay_tailnet = self.query_one(
+            "#overlay-tailnet", Input
+        ).value.strip()
+
+        errors = [
+            e for e in validate_config(cfg)
+            if "connectivity" in e or "overlay_tailnet" in e
+        ]
+        error_label = self.query_one("#connectivity-error", Label)
+        if errors:
+            error_label.update("\n".join(errors))
+            error_label.display = True
+            return
+        error_label.display = False
+
         self.app.push_screen(DnsScreen())
 
 

--- a/packages/cli/tests/test_app.py
+++ b/packages/cli/tests/test_app.py
@@ -508,3 +508,29 @@ class TestDeployDispatch:
         runner.invoke(app, ["deploy", "-y"])
         mock_aws_run.assert_called_once()
         mock_compose_run.assert_not_called()
+
+
+# ------------------------------------------------------------------
+# client register command
+# ------------------------------------------------------------------
+class TestClientRegisterCommand:
+    def test_passes_overlay_flags_through(self):
+        runner = CliRunner()
+        with patch("lablink_cli.commands.register.run_register") as mock_run:
+            result = runner.invoke(
+                app,
+                [
+                    "client", "register",
+                    "--allocator-url", "https://a.example.com",
+                    "--register-token", "rtok",
+                    "--hostname", "classroom-gpu-3",
+                    "--machine-identity", "classroom-gpu-3",
+                    "--overlay-hostname", "classroom-gpu-3",
+                    "--tailscale-authkey", "tskey-abc",
+                ],
+            )
+        assert result.exit_code == 0, result.output
+        mock_run.assert_called_once()
+        kwargs = mock_run.call_args.kwargs
+        assert kwargs["overlay_hostname"] == "classroom-gpu-3"
+        assert kwargs["tailscale_authkey"] == "tskey-abc"

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -285,6 +285,49 @@ class TestDeployComposeMeshOverlayPreflight:
         run_deploy_compose(cfg, yes=True, workdir_root=tmp_path)
         assert mock_up.call_count == 2
 
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_switch_from_lan_direct_without_authkey_rejected(
+        self, mock_up, mock_poll, mock_summary, tmp_path
+    ):
+        """Regression guard: an existing lan_direct deployment (its .env
+        has no TS_AUTHKEY line) that switches manual.connectivity to
+        mesh_overlay must still be required to pass --tailscale-authkey.
+        ".env exists" alone is not a valid proxy for "an authkey is on
+        record" — without this guard the preflight silently skipped the
+        check and render_compose_dir wrote TS_AUTHKEY= (empty)."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        lan_cfg = _manual_cfg(connectivity="lan_direct")
+        run_deploy_compose(lan_cfg, yes=True, workdir_root=tmp_path)
+
+        mesh_cfg = _manual_cfg(
+            connectivity="mesh_overlay", overlay_tailnet="example.ts.net"
+        )
+        with pytest.raises(SystemExit):
+            run_deploy_compose(mesh_cfg, yes=True, workdir_root=tmp_path)
+        mock_up.assert_called_once()  # only the first (lan_direct) deploy ran
+
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_switch_from_lan_direct_with_authkey_proceeds(
+        self, mock_up, mock_poll, mock_summary, tmp_path
+    ):
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        lan_cfg = _manual_cfg(connectivity="lan_direct")
+        run_deploy_compose(lan_cfg, yes=True, workdir_root=tmp_path)
+
+        mesh_cfg = _manual_cfg(
+            connectivity="mesh_overlay", overlay_tailnet="example.ts.net"
+        )
+        run_deploy_compose(
+            mesh_cfg, yes=True, workdir_root=tmp_path, tailscale_authkey="tskey-abc",
+        )
+        assert mock_up.call_count == 2
+
 
 class TestStartupScriptStaging:
     """`render_compose_dir` is responsible for putting custom-startup.sh

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -177,6 +177,31 @@ class TestRenderComposeDirMeshOverlay:
         assert "TS_AUTHKEY=tskey-abc" in env_content
         assert "TAILSCALE_HOSTNAME=lablink-allocator-testlab" in env_content
 
+    def test_sidecar_always_pulls(self, tmp_path):
+        """Regression guard: without pull_policy: always, a locally cached
+        image from a prior pull silently wins even when it's the wrong
+        architecture for the current host. Confirmed live: a stale amd64-
+        cached tailscale/tailscale:latest ran QEMU-emulated on an Apple
+        Silicon host and corrupted the Noise-protocol handshake
+        (chacha20poly1305: message authentication failed), even though the
+        image is genuinely published multi-arch and a native arm64 pull
+        joins the tailnet immediately."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay", overlay_tailnet="example.ts.net"
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-abc")
+
+        compose_yaml = (target / "docker-compose.yml").read_text()
+        # Split on the service key itself (2-space indent), not the bare
+        # substring "tailscale:" — that also matches inside the image name
+        # "tailscale/tailscale:latest" a few characters later and would
+        # truncate the block before pull_policy.
+        tailscale_service = compose_yaml.split("\n  tailscale:\n")[1]
+        assert "pull_policy: always" in tailscale_service
+
     def test_redeploy_without_authkey_carries_previous_value_forward(
         self, tmp_path
     ):

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -652,7 +652,10 @@ class TestPrintSummaryMeshOverlay:
         lan_direct wording ('on each BYO box on the same LAN') is wrong
         here, and the command must include --overlay-hostname/
         --tailscale-authkey, which the lan_direct message never
-        mentions since that connectivity has no such flags."""
+        mentions since that connectivity has no such flags. hostname/machine-
+        identity are no longer shown as required — run_locally defaults
+        to on and auto-detects them; a --no-run-locally note points at
+        the opt-out instead."""
         from lablink_cli.commands.deploy_compose import _print_summary
 
         token = "abc123def456ghi789jklmnop"
@@ -667,6 +670,9 @@ class TestPrintSummaryMeshOverlay:
         assert "on the same LAN" not in out
         assert "--overlay-hostname" in out
         assert "--tailscale-authkey" in out
+        assert "--hostname <name>" not in out
+        assert "--machine-identity <name>" not in out
+        assert "--no-run-locally" in out
         assert (
             f"--allocator-url http://192.168.1.42 --register-token {token}"
             in out
@@ -689,6 +695,7 @@ class TestPrintSummaryMeshOverlay:
         assert "on each BYO box on the same LAN" in out
         assert "--overlay-hostname" not in out
         assert "--tailscale-authkey" not in out
+        assert "--no-run-locally" not in out
 
 
 class TestDetectLanIp:

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -16,6 +16,8 @@ def _manual_cfg(
     admin_password="pw",
     ssl_provider="none",
     image_tag="linux-amd64-latest",
+    connectivity="lan_direct",
+    overlay_tailnet="",
 ):
     cfg = Config()
     cfg.provider = "manual"
@@ -24,6 +26,8 @@ def _manual_cfg(
     cfg.app.admin_password = admin_password
     cfg.ssl.provider = ssl_provider
     cfg.allocator.image_tag = image_tag
+    cfg.manual.connectivity = connectivity
+    cfg.manual.overlay_tailnet = overlay_tailnet
     return cfg
 
 
@@ -140,6 +144,121 @@ class TestRenderComposeDir:
             "ALLOCATOR_IMAGE=ghcr.io/talmolab/lablink-allocator-image:v1.2.3"
             in env_content
         )
+
+
+class TestRenderComposeDirMeshOverlay:
+    def test_lan_direct_uses_plain_template_no_sidecar(self, tmp_path):
+        """Default connectivity must not render the sidecar — byte-identical
+        compose stack to every existing lan_direct deployment."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg()
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        compose_yaml = (target / "docker-compose.yml").read_text()
+        assert "tailscale" not in compose_yaml
+        env_content = (target / ".env").read_text()
+        assert "TS_AUTHKEY" not in env_content
+
+    def test_mesh_overlay_renders_sidecar_and_authkey(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay", overlay_tailnet="example.ts.net"
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-abc")
+
+        compose_yaml = (target / "docker-compose.yml").read_text()
+        assert "tailscale:" in compose_yaml
+        assert 'network_mode: "service:allocator"' in compose_yaml
+        env_content = (target / ".env").read_text()
+        assert "TS_AUTHKEY=tskey-abc" in env_content
+        assert "TAILSCALE_HOSTNAME=lablink-allocator-testlab" in env_content
+
+    def test_redeploy_without_authkey_carries_previous_value_forward(
+        self, tmp_path
+    ):
+        """A redeploy that omits --tailscale-authkey must not blank out an
+        already-joined sidecar's key."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay", overlay_tailnet="example.ts.net"
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-first")
+        render_compose_dir(cfg, target, tailscale_authkey=None)
+
+        env_content = (target / ".env").read_text()
+        assert "TS_AUTHKEY=tskey-first" in env_content
+
+    def test_redeploy_with_new_authkey_overrides_previous_value(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay", overlay_tailnet="example.ts.net"
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-first")
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-second")
+
+        env_content = (target / ".env").read_text()
+        assert "TS_AUTHKEY=tskey-second" in env_content
+        assert "tskey-first" not in env_content
+
+
+class TestDeployComposeMeshOverlayPreflight:
+    def test_first_deploy_without_authkey_rejected(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay", overlay_tailnet="example.ts.net"
+        )
+        with pytest.raises(SystemExit):
+            run_deploy_compose(cfg, yes=True, workdir_root=tmp_path)
+
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_first_deploy_with_authkey_proceeds(
+        self, mock_up, mock_poll, mock_summary, tmp_path
+    ):
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay", overlay_tailnet="example.ts.net"
+        )
+        run_deploy_compose(
+            cfg,
+            yes=True,
+            workdir_root=tmp_path,
+            tailscale_authkey="tskey-abc",
+        )
+        mock_up.assert_called_once()
+
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_redeploy_without_authkey_proceeds(
+        self, mock_up, mock_poll, mock_summary, tmp_path
+    ):
+        """Second deploy call must not require --tailscale-authkey again —
+        the .env from the first deploy already carries a value forward."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay", overlay_tailnet="example.ts.net"
+        )
+        run_deploy_compose(
+            cfg,
+            yes=True,
+            workdir_root=tmp_path,
+            tailscale_authkey="tskey-abc",
+        )
+        run_deploy_compose(cfg, yes=True, workdir_root=tmp_path)
+        assert mock_up.call_count == 2
 
 
 class TestStartupScriptStaging:

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -644,6 +644,53 @@ class TestPrintSummary:
         assert "docker logs lablink-allocator 2>&1 | grep" in out
 
 
+class TestPrintSummaryMeshOverlay:
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_next_step_shows_overlay_flags(self, mock_extract, mock_lan, capsys):
+        """mesh_overlay clients aren't on the allocator's LAN — the
+        lan_direct wording ('on each BYO box on the same LAN') is wrong
+        here, and the command must include --overlay-hostname/
+        --tailscale-authkey, which the lan_direct message never
+        mentions since that connectivity has no such flags."""
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        token = "abc123def456ghi789jklmnop"
+        mock_extract.return_value = token
+        mock_lan.return_value = "192.168.1.42"
+
+        _print_summary(
+            _manual_cfg(connectivity="mesh_overlay", overlay_tailnet="example.ts.net")
+        )
+
+        out = capsys.readouterr().out
+        assert "on the same LAN" not in out
+        assert "--overlay-hostname" in out
+        assert "--tailscale-authkey" in out
+        assert (
+            f"--allocator-url http://192.168.1.42 --register-token {token}"
+            in out
+        )
+
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_lan_direct_next_step_unchanged(self, mock_extract, mock_lan, capsys):
+        """Regression guard: the default lan_direct connectivity keeps
+        its original BYO-on-the-LAN wording, with no overlay flags
+        leaking into a connectivity mode that doesn't use them."""
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        mock_extract.return_value = "tok"
+        mock_lan.return_value = "192.168.1.42"
+
+        _print_summary(_manual_cfg(connectivity="lan_direct"))
+
+        out = capsys.readouterr().out
+        assert "on each BYO box on the same LAN" in out
+        assert "--overlay-hostname" not in out
+        assert "--tailscale-authkey" not in out
+
+
 class TestDetectLanIp:
     @patch("lablink_cli.commands.deploy_compose.socket.socket")
     def test_returns_routing_ip(self, mock_socket):

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -176,6 +176,102 @@ class TestResumePath:
             assert "CLIENT_SECRET=s" in tmp_env_file.read_text()
 
 
+class TestOverlayHostnamePath:
+    def test_requires_tailscale_authkey(self, tmp_env_file):
+        from lablink_cli.commands.register import run_register
+
+        try:
+            run_register(**_kwargs(
+                tmp_env_file,
+                overlay_hostname="classroom-gpu-3",
+                hostname="classroom-gpu-3",
+                machine_identity="classroom-gpu-3",
+            ))
+            assert False, "expected SystemExit"
+        except SystemExit as e:
+            assert e.code == 1
+        assert not tmp_env_file.exists()
+
+    def test_requires_hostname_no_autodetect(self, tmp_env_file):
+        """--hostname must be required with --overlay-hostname — auto-detect
+        would silently report the admin's own laptop, not the future client."""
+        from lablink_cli.commands.register import run_register
+
+        try:
+            run_register(**_kwargs(
+                tmp_env_file,
+                overlay_hostname="classroom-gpu-3",
+                tailscale_authkey="tskey-abc",
+                machine_identity="classroom-gpu-3",
+            ))
+            assert False, "expected SystemExit"
+        except SystemExit as e:
+            assert e.code == 1
+        assert not tmp_env_file.exists()
+
+    def test_requires_machine_identity_no_autodetect(self, tmp_env_file):
+        from lablink_cli.commands.register import run_register
+
+        try:
+            run_register(**_kwargs(
+                tmp_env_file,
+                overlay_hostname="classroom-gpu-3",
+                tailscale_authkey="tskey-abc",
+                hostname="classroom-gpu-3",
+            ))
+            assert False, "expected SystemExit"
+        except SystemExit as e:
+            assert e.code == 1
+        assert not tmp_env_file.exists()
+
+    @patch("lablink_cli.commands.register.byo_detect")
+    @patch("lablink_cli.commands.register.RegistrationClient")
+    def test_success_skips_docker_and_prints_env(
+        self, mock_client_cls, mock_detect, tmp_env_file, successful_response, capsys,
+    ):
+        from lablink_cli.commands.register import run_register
+
+        resp = dict(successful_response, connectivity="mesh_overlay")
+        mock_client = MagicMock()
+        mock_client.register.return_value = resp
+        mock_client_cls.return_value = mock_client
+
+        run_register(**_kwargs(
+            tmp_env_file,
+            overlay_hostname="classroom-gpu-3",
+            tailscale_authkey="tskey-abc",
+            hostname="classroom-gpu-3",
+            machine_identity="classroom-gpu-3",
+        ))
+
+        # byo_detect must never be consulted on this path — it would
+        # report facts about the admin's own laptop, not the future client.
+        mock_detect.detect_hostname.assert_not_called()
+        mock_detect.detect_lan_ip.assert_not_called()
+        mock_detect.resolve_machine_identity.assert_not_called()
+        mock_detect.detect_gpu.assert_not_called()
+
+        # register() called with overlay_hostname, no lan_ip.
+        mock_client.register.assert_called_once_with(
+            hostname="classroom-gpu-3",
+            machine_identity="classroom-gpu-3",
+            overlay_hostname="classroom-gpu-3",
+            gpu_present=False,
+            gpu_model=None,
+        )
+
+        # env file still written.
+        assert tmp_env_file.exists()
+
+        # No docker/container output — instead, the env block + overlay
+        # values are printed for the admin to paste into their own
+        # Run:AI workload submission.
+        out = capsys.readouterr().out
+        assert "OVERLAY_HOSTNAME=classroom-gpu-3" in out
+        assert "TAILSCALE_AUTHKEY=tskey-abc" in out
+        assert "CLIENT_SECRET=s" in out
+
+
 class TestSuccessFlow:
     @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -193,8 +193,10 @@ class TestOverlayHostnamePath:
         assert not tmp_env_file.exists()
 
     def test_requires_hostname_no_autodetect(self, tmp_env_file):
-        """--hostname must be required with --overlay-hostname — auto-detect
-        would silently report the admin's own laptop, not the future client."""
+        """--hostname is required with --overlay-hostname --no-run-locally
+        — auto-detect would silently report the admin's own laptop, not
+        the future client. (run_locally defaults to True, where hostname
+        IS auto-detected — this test exercises the hand-off opt-out.)"""
         from lablink_cli.commands.register import run_register
 
         try:
@@ -203,6 +205,7 @@ class TestOverlayHostnamePath:
                 overlay_hostname="classroom-gpu-3",
                 tailscale_authkey="tskey-abc",
                 machine_identity="classroom-gpu-3",
+                run_locally=False,
             ))
             assert False, "expected SystemExit"
         except SystemExit as e:
@@ -218,6 +221,7 @@ class TestOverlayHostnamePath:
                 overlay_hostname="classroom-gpu-3",
                 tailscale_authkey="tskey-abc",
                 hostname="classroom-gpu-3",
+                run_locally=False,
             ))
             assert False, "expected SystemExit"
         except SystemExit as e:
@@ -242,6 +246,7 @@ class TestOverlayHostnamePath:
             tailscale_authkey="tskey-abc",
             hostname="classroom-gpu-3",
             machine_identity="classroom-gpu-3",
+            run_locally=False,
         ))
 
         # byo_detect must never be consulted on this path — it would
@@ -270,6 +275,72 @@ class TestOverlayHostnamePath:
         assert "OVERLAY_HOSTNAME=classroom-gpu-3" in out
         assert "TAILSCALE_AUTHKEY=tskey-abc" in out
         assert "CLIENT_SECRET=s" in out
+
+    @patch("lablink_cli.commands.register.subprocess.Popen")
+    @patch("lablink_cli.commands.register.subprocess.run")
+    @patch("lablink_cli.commands.register.shutil.which")
+    @patch("lablink_cli.commands.register.RegistrationClient")
+    @patch("lablink_cli.commands.register.byo_detect")
+    def test_run_locally_default_autodetects_and_execs_docker(
+        self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
+        mock_popen, tmp_env_file, successful_response,
+    ):
+        """run_locally defaults to True: with --overlay-hostname alone
+        (no --hostname/--machine-identity), the client is auto-detected
+        exactly like real BYO, and the container is docker-run
+        immediately with OVERLAY_HOSTNAME/TAILSCALE_AUTHKEY wired into
+        its env file so start.sh's tailscale join fires."""
+        from lablink_cli.commands.register import run_register
+
+        mock_detect.detect_hostname.return_value = "runai-pod-7"
+        mock_detect.resolve_machine_identity.return_value = "mid-runai-7"
+        mock_detect.detect_gpu.return_value = (True, "NVIDIA A100")
+
+        resp = dict(successful_response, connectivity="mesh_overlay")
+        mock_client = MagicMock()
+        mock_client.register.return_value = resp
+        mock_client_cls.return_value = mock_client
+        mock_which.return_value = "/usr/bin/docker"
+        mock_subproc_run.return_value = MagicMock(
+            returncode=0, stdout="cgroupfs\n"
+        )
+
+        run_register(**_kwargs(
+            tmp_env_file,
+            overlay_hostname="classroom-gpu-3",
+            tailscale_authkey="tskey-abc",
+        ))
+
+        # lan_ip is never consulted for the overlay path, run_locally or not.
+        mock_detect.detect_lan_ip.assert_not_called()
+
+        mock_client.register.assert_called_once_with(
+            hostname="runai-pod-7",
+            machine_identity="mid-runai-7",
+            overlay_hostname="classroom-gpu-3",
+            gpu_present=True,
+            gpu_model="NVIDIA A100",
+        )
+
+        content = tmp_env_file.read_text()
+        assert "OVERLAY_HOSTNAME=classroom-gpu-3" in content
+        assert "TAILSCALE_AUTHKEY=tskey-abc" in content
+
+        all_cmds = [call.args[0] for call in mock_subproc_run.call_args_list]
+        run_cmds = [c for c in all_cmds if "run" in c and "--env-file" in c]
+        assert run_cmds, f"Expected a `docker run` call; got {all_cmds}"
+
+    def test_no_run_locally_without_overlay_hostname_aborts(self, tmp_env_file):
+        """--no-run-locally only makes sense alongside --overlay-hostname
+        — real BYO has no hand-off mode to opt into."""
+        from lablink_cli.commands.register import run_register
+
+        try:
+            run_register(**_kwargs(tmp_env_file, run_locally=False))
+            assert False, "expected SystemExit"
+        except SystemExit as e:
+            assert e.code == 1
+        assert not tmp_env_file.exists()
 
 
 class TestSuccessFlow:
@@ -1278,3 +1349,29 @@ class TestWriteEnvFile:
         assert "CLIENT_SECRET=s3cret" in text
         assert "VM_NAME=42" in text
         assert "ALLOCATOR_URL=https://lablink.example.com" in text
+
+    def test_overlay_fields_included_when_given(self, tmp_env_file):
+        from lablink_cli.commands.register import _write_env_file
+
+        _write_env_file(
+            tmp_env_file, "https://lablink.example.com",
+            self._resp_with_monitoring(),
+            overlay_hostname="classroom-gpu-3",
+            tailscale_authkey="tskey-abc",
+        )
+
+        content = tmp_env_file.read_text()
+        assert "OVERLAY_HOSTNAME=classroom-gpu-3" in content
+        assert "TAILSCALE_AUTHKEY=tskey-abc" in content
+
+    def test_overlay_fields_absent_when_not_given(self, tmp_env_file):
+        from lablink_cli.commands.register import _write_env_file
+
+        _write_env_file(
+            tmp_env_file, "https://lablink.example.com",
+            self._resp_with_monitoring(),
+        )
+
+        content = tmp_env_file.read_text()
+        assert "OVERLAY_HOSTNAME" not in content
+        assert "TAILSCALE_AUTHKEY" not in content

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -330,6 +330,21 @@ class TestOverlayHostnamePath:
         run_cmds = [c for c in all_cmds if "run" in c and "--env-file" in c]
         assert run_cmds, f"Expected a `docker run` call; got {all_cmds}"
 
+        # tailscaled (started by start.sh) needs to create a TUN network
+        # interface — without NET_ADMIN + /dev/net/tun it dies immediately
+        # and `tailscale up` fails with "failed to connect to local
+        # tailscaled; it doesn't appear to be running".
+        cmd = run_cmds[0]
+        cap_adds = [
+            cmd[i + 1] for i, v in enumerate(cmd)
+            if v == "--cap-add" and i + 1 < len(cmd)
+        ]
+        assert "NET_ADMIN" in cap_adds, f"missing --cap-add NET_ADMIN in {cmd}"
+        assert "NET_RAW" in cap_adds, f"missing --cap-add NET_RAW in {cmd}"
+        assert "--device" in cmd, f"missing --device in {cmd}"
+        device_idx = cmd.index("--device")
+        assert cmd[device_idx + 1] == "/dev/net/tun"
+
     def test_no_run_locally_without_overlay_hostname_aborts(self, tmp_env_file):
         """--no-run-locally only makes sense alongside --overlay-hostname
         — real BYO has no hand-off mode to opt into."""
@@ -601,6 +616,14 @@ class TestSuccessFlow:
         # Windows/macOS Docker Desktop and is unnecessary on Linux.
         assert "--network" not in cmd, (
             f"--network must not be passed (was: {cmd})"
+        )
+        # A real-BYO (lan_direct) client never runs `tailscale up` — the
+        # NET_ADMIN/tun grant is overlay-only and must not leak here.
+        assert "--cap-add" not in cmd, (
+            f"real-BYO docker run must not request any capabilities: {cmd}"
+        )
+        assert "--device" not in cmd, (
+            f"real-BYO docker run must not request any devices: {cmd}"
         )
 
 

--- a/packages/cli/tests/test_registration_client.py
+++ b/packages/cli/tests/test_registration_client.py
@@ -116,6 +116,46 @@ class TestRegister:
         with pytest.raises(AllocatorError):
             _make_client().register(**_payload())
 
+    @patch("lablink_cli.api.urlopen")
+    def test_overlay_hostname_sends_provider_metadata(self, mock_urlopen):
+        response = {"client_id": 1}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        _make_client().register(
+            hostname="classroom-gpu-3",
+            machine_identity="classroom-gpu-3",
+            overlay_hostname="classroom-gpu-3",
+            gpu_present=True,
+            gpu_model="A10G",
+        )
+
+        sent_req = mock_urlopen.call_args[0][0]
+        body = json.loads(sent_req.data.decode())
+        assert body["provider_metadata"] == {"overlay_hostname": "classroom-gpu-3"}
+        assert body["endpoint_url"] is None
+        assert body["provider"] == "manual"
+
+    @patch("lablink_cli.api.urlopen")
+    def test_lan_ip_shape_unchanged(self, mock_urlopen):
+        """Existing lan_ip callers must see byte-identical body shape."""
+        response = {"client_id": 1}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        _make_client().register(**_payload())
+
+        sent_req = mock_urlopen.call_args[0][0]
+        body = json.loads(sent_req.data.decode())
+        assert body["provider_metadata"] == {"lan_ip": "192.168.1.42"}
+        assert body["endpoint_url"] == "http://192.168.1.42:7070"
+
 
 class TestSslProvider:
     def test_default_strict_tls(self):

--- a/packages/cli/tests/test_schema.py
+++ b/packages/cli/tests/test_schema.py
@@ -97,6 +97,21 @@ class TestLoadSaveConfig:
         assert cfg.dns.enabled is True
         assert cfg.dns.domain == "test.example.com"
 
+    def test_round_trip_manual_connectivity(self, tmp_path):
+        from lablink_allocator_service.conf.structured_config import Config
+
+        cfg = Config()
+        cfg.provider = "manual"
+        cfg.manual.connectivity = "mesh_overlay"
+        cfg.manual.overlay_tailnet = "example.ts.net"
+
+        path = tmp_path / "config.yaml"
+        save_config(cfg, path)
+        loaded = load_config(path)
+
+        assert loaded.manual.connectivity == "mesh_overlay"
+        assert loaded.manual.overlay_tailnet == "example.ts.net"
+
 
 # ------------------------------------------------------------------
 # validate_config

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -485,3 +485,71 @@ def test_dns_advanced_eip_radio_is_scrollable_into_view():
         f"After scroll_to_widget, EIP radio at y={eip_y} is outside the "
         "30-row test viewport — scroll isn't bringing it into view."
     )
+
+
+# ---------------------------------------------------------------------------
+# ManualConnectivityScreen
+# ---------------------------------------------------------------------------
+def _drive_connectivity_screen(
+    *, choose_mesh_overlay: bool, overlay_tailnet: str = ""
+):
+    """Push ManualConnectivityScreen directly, drive it, return
+    (cfg.manual.connectivity, cfg.manual.overlay_tailnet, screen_stack_grew)."""
+    import asyncio
+    from textual.widgets import Input, RadioButton, RadioSet
+
+    cfg, app = _build_cfg_and_app()
+    cfg.provider = "manual"
+
+    async def _run() -> tuple[str, str, int]:
+        from lablink_cli.tui.wizard import ManualConnectivityScreen
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = ManualConnectivityScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            stack_before = len(app.screen_stack)
+
+            if choose_mesh_overlay:
+                radio_set = screen.query_one("#connectivity-select", RadioSet)
+                for btn in radio_set.query(RadioButton):
+                    if btn.id == "connectivity-mesh-overlay":
+                        btn.value = True
+                screen.query_one("#overlay-tailnet", Input).value = overlay_tailnet
+            await pilot.pause()
+            screen._next()
+            await pilot.pause()
+            return (
+                cfg.manual.connectivity,
+                cfg.manual.overlay_tailnet,
+                len(app.screen_stack) - stack_before,
+            )
+
+    return asyncio.run(_run())
+
+
+def test_connectivity_screen_defaults_to_lan_direct():
+    connectivity, tailnet, stack_delta = _drive_connectivity_screen(
+        choose_mesh_overlay=False
+    )
+    assert connectivity == "lan_direct"
+    assert stack_delta == 1, "valid submission should push DnsScreen"
+
+
+def test_connectivity_screen_writes_mesh_overlay_and_tailnet():
+    connectivity, tailnet, stack_delta = _drive_connectivity_screen(
+        choose_mesh_overlay=True, overlay_tailnet="example.ts.net"
+    )
+    assert connectivity == "mesh_overlay"
+    assert tailnet == "example.ts.net"
+    assert stack_delta == 1, "valid submission should push DnsScreen"
+
+
+def test_connectivity_screen_blocks_next_when_tailnet_missing():
+    """mesh_overlay chosen but no tailnet domain → validation error, no push."""
+    connectivity, tailnet, stack_delta = _drive_connectivity_screen(
+        choose_mesh_overlay=True, overlay_tailnet=""
+    )
+    assert connectivity == "mesh_overlay"
+    assert stack_delta == 0, "invalid submission must not push DnsScreen"

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -88,6 +88,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Tailscale — joined at container start (start.sh) only when a
+# mesh-overlay client was registered with TAILSCALE_AUTHKEY set;
+# lan_direct/allocator_proxied clients never invoke `tailscale up`.
+RUN curl -fsSL https://tailscale.com/install.sh | sh
 
 # KasmVNC standalone VNC server. Pin to a current stable release;
 # bump alongside client image releases.

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -74,6 +74,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 
+# Tailscale — joined at container start (start.sh) only when a
+# mesh-overlay client was registered with TAILSCALE_AUTHKEY set;
+# lan_direct/allocator_proxied clients never invoke `tailscale up`.
+RUN curl -fsSL https://tailscale.com/install.sh | sh
+
 # KasmVNC standalone VNC server (replaces Chrome Remote Desktop).
 # Pin to a current stable release; bump alongside client image releases.
 ARG KASMVNC_VERSION=1.4.0

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -79,6 +79,31 @@ else
   echo "No custom startup script found. Skipping."
 fi
 
+# Join the Tailscale overlay when this client was registered with an
+# overlay hostname (mesh-overlay connectivity — MeshOverlayClientConnectivity
+# on the allocator side). Gated purely on TAILSCALE_AUTHKEY's presence;
+# lan_direct/allocator_proxied clients never set it, so this is a no-op
+# for every existing deployment.
+if [ -n "$TAILSCALE_AUTHKEY" ]; then
+  echo "Starting tailscaled..."
+  sudo tailscaled >/tmp/tailscaled.log 2>&1 &
+  # Wait for tailscaled's local socket to come up before calling `tailscale up` —
+  # `tailscale status` exits 0 once the daemon is reachable, whether or not
+  # it's logged in yet, so this loop is purely "wait for the socket", not
+  # "wait for join".
+  for i in $(seq 1 30); do
+    sudo tailscale status >/dev/null 2>&1 && break
+    sleep 0.5
+  done
+  echo "Joining Tailscale as $OVERLAY_HOSTNAME..."
+  sudo tailscale up --authkey="$TAILSCALE_AUTHKEY" --hostname="$OVERLAY_HOSTNAME"
+  if [ $? -ne 0 ]; then
+    echo "Failed to join Tailscale overlay" >&2
+    send_status "error"
+    exit 1
+  fi
+fi
+
 # kasmvncserver wraps xauth, which expects ~/.Xauthority to exist; missing
 # file aborts the launch silently. Touch an empty one as the client user.
 touch /home/client/.Xauthority

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -30,11 +30,19 @@ echo "CLOUD_INIT_LOG_GROUP: $CLOUD_INIT_LOG_GROUP"
 send_status() {
   local status="$1"
   echo ">> Reporting status='$status' to allocator..."
+  # --retry-all-errors covers DNS-not-ready ("Could not resolve host") and
+  # connection-not-ready ("Connection timed out") alike — both observed for
+  # mesh-overlay clients, whose Tailscale route (especially over a DERP
+  # relay fallback) isn't actually usable for a few seconds after
+  # `tailscale up` returns. Without a retry here, this call's failure is
+  # permanent: nothing else in this script ever re-sets `status`, and
+  # assign_vm requires status='running', so a client that loses this race
+  # can never be handed to a student despite being otherwise healthy.
   curl -sS -X POST "$ALLOCATOR_URL/api/vm-status" \
     -H "Authorization: Bearer $CLIENT_SECRET" \
     -H "Content-Type: application/json" \
     -d "{\"hostname\":\"$VM_NAME\",\"status\":\"$status\"}" \
-    --max-time 5 \
+    --max-time 5 --retry 5 --retry-delay 2 --retry-all-errors \
     || echo ">> WARNING: failed to report status=$status (continuing)"
 }
 


### PR DESCRIPTION
## Summary

Widens the Manual/BYO provider family to clients that aren't on the allocator's own LAN — motivated by Run:AI-hosted GPU workloads, but deliberately generic (no Run:AI/Tailscale-specific naming in the public interface).

- **Allocator**: new `MeshOverlayClientConnectivity` resolves a client's Tailscale MagicDNS hostname (stored in `provider_metadata`, no DB migration) and reuses the existing AWS-shape byte path unchanged (`/desktop`, nginx, `internal_proxy_auth.py` all untouched). No new `ComputeProvider` — reuses `ManualProvider`. `/api/health` gains a Tailscale join-status check via a new `requires_tailscale_check` capability flag (not a connectivity-type string comparison, which would have violated — and initially did trip — the existing architectural cleanliness guard test). Registration now rejects a manual client whose `provider_metadata` shape (`lan_ip` vs `overlay_hostname`) doesn't match the allocator's configured connectivity, instead of silently routing the browser to an unreachable address.
- **CLI (client registration)**: `lablink client register --overlay-hostname <name> --tailscale-authkey <key>` registers a client that doesn't exist yet (e.g. a Run:AI workload about to be submitted) under an admin-chosen hostname, sidestepping the chicken-and-egg problem of auto-detecting an IP before the workload boots. `--run-locally` (default: on) docker-runs the client container immediately, auto-detecting hostname/machine-identity/GPU the same as real BYO — for registering ahead of time from elsewhere, `--no-run-locally` instead prints the secrets for the admin to paste into their own workload submission (requires `--hostname`/`--machine-identity` since auto-detection would report the wrong box).
- **CLI (allocator-side setup)**: `lablink deploy --tailscale-authkey <key>` renders a `tailscale` sidecar into the allocator's own compose stack (network_mode: service:allocator) when `manual.connectivity` is `mesh_overlay`, so the allocator's nginx can actually route to a mesh-overlay client's Tailscale hostname — this was a real gap discovered after the initial version of this PR (the manual `tailscale up`-on-the-host workaround wouldn't have worked at all, since Docker's default bridge networking isolates the container from the host's tailnet interface). The authkey is required on first deploy (or whenever no key is already on record for this deployment, e.g. after switching an existing `lan_direct` deployment over to `mesh_overlay`) and carried forward on ordinary redeploys. The `configure` wizard also gained a Connectivity step, so `connectivity`/`overlay_tailnet` no longer require hand-editing `config.yaml`.
- **Client image**: installs Tailscale and joins the tailnet at boot (starts `tailscaled`, then `tailscale up`) only when `TAILSCALE_AUTHKEY` is set — a no-op for every existing `lan_direct`/`allocator_proxied` client. The docker run for a mesh-overlay client grants `NET_ADMIN`/`NET_RAW`/`/dev/net/tun` (needed for `tailscaled`'s TUN interface); the vm-status report retries through the brief window after `tailscale up` returns but before the tailnet route is actually usable.

## Test plan

- [x] Full allocator suite: 683 passed, 19 skipped (terraform-plan tests need a live terraform binary/backend; failures there are pre-existing and identical on `main`)
- [x] Full CLI suite: 528 passed, 1 deselected, 1 pre-existing local-environment failure (Rich ANSI-highlighting assertion) confirmed identical on `main`
- [x] `test_cleanliness_guard.py` and `test_sr_f1_imports.py` (architectural guards) have a zero-line diff across this whole change — genuinely satisfied, not weakened
- [x] `docker compose config` validates the new mesh-overlay template (network_mode/depends_on ordering between the allocator and sidecar services)
- [x] Real end-to-end smoke test against a live Tailscale tailnet — run manually during development; surfaced the fixes listed above
- [x] Independent code review pass (`/review-pr` style) with two follow-up fixes applied and covered by new regression tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)
