### PR TITLE
fix: copy button on BYO onboarding page fails without a secure context

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/templates/byo-onboarding.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/byo-onboarding.html
@@ -120,14 +120,31 @@
       function copyCmd() {
         const txt = document.getElementById("cmd").innerText;
         const btn = document.getElementById("copyBtn");
-        navigator.clipboard.writeText(txt).then(() => {
+        const onCopied = () => {
           btn.textContent = "Copied!";
           btn.classList.add("copied");
           setTimeout(() => {
             btn.textContent = "Copy";
             btn.classList.remove("copied");
           }, 1500);
-        });
+        };
+        if (navigator.clipboard && navigator.clipboard.writeText) {
+          navigator.clipboard.writeText(txt).then(onCopied);
+          return;
+        }
+        // navigator.clipboard only exists in a secure context (HTTPS or
+        // localhost). The manual provider has no TLS terminator of its
+        // own (ssl.provider is forced to none/self_signed), so an admin
+        // on a plain-HTTP LAN deployment always hits this fallback.
+        const ta = document.createElement("textarea");
+        ta.value = txt;
+        ta.style.position = "fixed";
+        ta.style.opacity = "0";
+        document.body.appendChild(ta);
+        ta.select();
+        document.execCommand("copy");
+        document.body.removeChild(ta);
+        onCopied();
       }
     </script>
   </body>


### PR DESCRIPTION
## Summary
- `navigator.clipboard` only exists in a secure context (HTTPS or `localhost`). The manual provider deliberately has no TLS terminator of its own — `configure`'s wizard forces `ssl.provider` to `none`/`self_signed` for `provider=manual` — so any admin viewing `/admin/byo-onboarding` over plain HTTP from a non-localhost address (the common case for a LAN-only BYO deployment) hits `navigator.clipboard === undefined` and the copy click silently does nothing.
- Falls back to the legacy `document.execCommand("copy")` approach (temporary off-screen textarea) when `navigator.clipboard` isn't available, which works without a secure context.
- Found live while testing a real manual/BYO deployment (`ssl.provider: none`, plain HTTP) — unrelated to the mesh-overlay work in #387, so filed as its own fix.

## Test plan
- [x] `pytest tests/test_pages.py` — 21 passed (unchanged; no test pins the JS content, so behavior was verified by reading the diff and reasoning about the two code paths)
- [x] `ruff check` — n/a (template file, no Python changes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)