### PR TITLE
fix: lablink destroy wipes Postgres data by default

### DIFF
--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -232,11 +232,12 @@ def destroy(
         "-v",
         help="Show the full Terraform output instead of a summary.",
     ),
-    purge: bool = typer.Option(
+    keep_data: bool = typer.Option(
         False,
-        "--purge",
-        help="Manual provider only: also delete the Postgres data volume. "
-        "Ignored for AWS.",
+        "--keep-data",
+        help="Manual provider only: preserve the Postgres data volume "
+        "instead of the default full wipe (registration history, "
+        "sessions, etc. survive a subsequent redeploy). Ignored for AWS.",
     ),
 ) -> None:
     """Tear down LabLink infrastructure."""
@@ -244,7 +245,7 @@ def destroy(
     if cfg.provider == "manual":
         from lablink_cli.commands.deploy_compose import run_destroy_compose
 
-        run_destroy_compose(cfg, yes=yes, purge=purge)
+        run_destroy_compose(cfg, yes=yes, keep_data=keep_data)
         return
 
     from lablink_cli.commands.deploy import run_destroy

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -471,17 +471,25 @@ def run_destroy_compose(
     cfg: Config,
     *,
     yes: bool = False,
-    purge: bool = False,
+    keep_data: bool = False,
     workdir_root: Path | None = None,
 ) -> None:
     """Tear down a manual-provider compose stack.
 
-    Default behavior: `docker compose down` (preserves the Postgres
-    data volume and the working directory — re-deploying restores the
-    DB state).
+    Default behavior: wipes everything — `docker compose down --volumes`
+    (deletes the Postgres data volume: all registration history,
+    sessions, etc.) plus the working directory. A subsequent
+    `lablink deploy` with the same deployment_name then starts from a
+    genuinely empty database, matching what "destroy" means for every
+    other provider — previously the default silently preserved the old
+    volume, so a "fresh" redeploy kept showing every client registered
+    under a prior deployment.
 
-    With `purge=True`: also runs `--volumes` and removes the working
-    directory, wiping all registration history. Destructive.
+    With `keep_data=True`: only `docker compose down` (no `--volumes`),
+    and the working directory is left in place — re-deploying with the
+    same deployment_name restores the previous DB state instead of
+    starting fresh. Opt into this only if that's specifically what you
+    want (e.g. a deliberate maintenance restart, not a real teardown).
 
     `yes=True` skips the interactive confirmation prompt.
     `workdir_root` overrides `DEFAULT_COMPOSE_DIR` (used by tests).
@@ -497,10 +505,11 @@ def run_destroy_compose(
         return
 
     if not yes:
-        if purge:
+        if not keep_data:
             console.print(
-                "[red bold]--purge will DELETE the Postgres data volume "
-                "(all registration history, sessions, etc.).[/red bold]"
+                "[red bold]This will DELETE the Postgres data volume "
+                "(all registration history, sessions, etc.). Pass "
+                "--keep-data to preserve it instead.[/red bold]"
             )
         confirmation = typer.prompt(
             f"Type 'yes' to tear down compose stack at {target}",
@@ -512,7 +521,7 @@ def run_destroy_compose(
             raise SystemExit(1)
 
     cmd = ["docker", "compose", "down"]
-    if purge:
+    if not keep_data:
         cmd.append("--volumes")
 
     result = subprocess.run(cmd, cwd=target, check=False)
@@ -520,7 +529,7 @@ def run_destroy_compose(
         console.print("[red]docker compose down failed.[/red]")
         raise SystemExit(result.returncode or 1)
 
-    if purge:
+    if not keep_data:
         shutil.rmtree(target)
         console.print(f"[green]Removed {target}.[/green]")
     else:

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -504,7 +504,10 @@ class TestDeployComposePreflight:
 
 class TestDestroyCompose:
     @patch("lablink_cli.commands.deploy_compose.subprocess.run")
-    def test_default_compose_down_no_volumes(self, mock_run, tmp_path):
+    def test_default_wipes_volumes_and_workdir(self, mock_run, tmp_path):
+        """Default behavior is now a full wipe — matches what "destroy"
+        means for every other provider, and what most operators expect
+        (a subsequent `lablink deploy` starts from an empty database)."""
         from lablink_cli.commands.deploy_compose import run_destroy_compose
 
         cfg = _manual_cfg()
@@ -513,18 +516,16 @@ class TestDestroyCompose:
         (workdir / "docker-compose.yml").write_text("")
         mock_run.return_value = MagicMock(returncode=0)
 
-        run_destroy_compose(
-            cfg, yes=True, purge=False, workdir_root=tmp_path / "compose"
-        )
+        run_destroy_compose(cfg, yes=True, workdir_root=tmp_path / "compose")
 
         mock_run.assert_called_once()
         cmd = mock_run.call_args[0][0]
         assert "down" in cmd
-        assert "--volumes" not in cmd
-        assert workdir.exists()  # NOT removed without --purge
+        assert "--volumes" in cmd
+        assert not workdir.exists()  # removed by default
 
     @patch("lablink_cli.commands.deploy_compose.subprocess.run")
-    def test_purge_removes_volumes_and_workdir(self, mock_run, tmp_path):
+    def test_keep_data_preserves_volumes_and_workdir(self, mock_run, tmp_path):
         from lablink_cli.commands.deploy_compose import run_destroy_compose
 
         cfg = _manual_cfg()
@@ -534,22 +535,20 @@ class TestDestroyCompose:
         mock_run.return_value = MagicMock(returncode=0)
 
         run_destroy_compose(
-            cfg, yes=True, purge=True, workdir_root=tmp_path / "compose"
+            cfg, yes=True, keep_data=True, workdir_root=tmp_path / "compose"
         )
 
         cmd = mock_run.call_args[0][0]
         assert "down" in cmd
-        assert "--volumes" in cmd
-        assert not workdir.exists()  # removed on purge
+        assert "--volumes" not in cmd
+        assert workdir.exists()  # NOT removed with --keep-data
 
     def test_noop_when_workdir_missing(self, tmp_path):
         from lablink_cli.commands.deploy_compose import run_destroy_compose
 
         cfg = _manual_cfg()
         # No directory created — should just print a message and return.
-        run_destroy_compose(
-            cfg, yes=True, purge=False, workdir_root=tmp_path / "compose"
-        )
+        run_destroy_compose(cfg, yes=True, workdir_root=tmp_path / "compose")
 
     def test_destroy_compose_prints_unregister_reminder_on_success(
         self, tmp_path, capsys, monkeypatch
@@ -567,7 +566,7 @@ class TestDestroyCompose:
         monkeypatch.setattr(deploy_compose.subprocess, "run", fake_run)
 
         deploy_compose.run_destroy_compose(
-            cfg, yes=True, purge=False, workdir_root=workdir_root,
+            cfg, yes=True, workdir_root=workdir_root,
         )
 
         out = capsys.readouterr().out
@@ -584,7 +583,7 @@ class TestDestroyCompose:
         cfg = _manual_cfg()
 
         deploy_compose.run_destroy_compose(
-            cfg, yes=True, purge=False, workdir_root=workdir_root,
+            cfg, yes=True, workdir_root=workdir_root,
         )
 
         out = capsys.readouterr().out
@@ -607,7 +606,7 @@ class TestDestroyCompose:
 
         with pytest.raises(SystemExit):
             deploy_compose.run_destroy_compose(
-                cfg, yes=True, purge=False, workdir_root=workdir_root,
+                cfg, yes=True, workdir_root=workdir_root,
             )
 
         out = capsys.readouterr().out


### PR DESCRIPTION
## Summary

`lablink destroy` (manual/BYO provider) previously preserved the Postgres data volume by default — only `--purge` wiped it. A subsequent `lablink deploy` with the same `deployment_name` resolves to the same Docker Compose project, reattaches to that same volume, and every client that was registered under the *previous* deployment reappears in the admin panel — even though the operator expected a genuinely fresh deployment.

- `run_destroy_compose` now wipes the Postgres volume and removes the working directory **by default** (`docker compose down --volumes`), matching what "destroy" means for every other provider.
- Replaced `--purge` with `--keep-data` as the explicit opt-in to preserve data across a redeploy (e.g. a deliberate maintenance restart rather than a real teardown).
- Updated `TestDestroyCompose` to match the flipped default; added coverage for the new `--keep-data` path.

This is a behavior change for anyone currently relying on the old default (data silently preserved) — they'll now need to pass `--keep-data` explicitly. No other code references the old `--purge` flag or `purge=` parameter (checked across `packages/cli` and `docs/`, excluding historical/untracked design docs).

## Test plan

- [x] `packages/cli`: 528 passed, 1 pre-existing unrelated failure (`TestPrintSummary::test_next_step_uses_lan_url_when_detected`, a Rich ANSI-formatting artifact, confirmed untouched by this diff)
- [x] `ruff check` clean on all changed files
- [x] Manual smoke test: `lablink deploy` → register a client → `lablink destroy` (no flags) → `lablink deploy` again → confirm the admin panel shows zero instances

🤖 Generated with [Claude Code](https://claude.com/claude-code)