### PR TITLE
fix(cli): lablink cleanup must never release a persistent EIP

### DIFF
--- a/packages/cli/src/lablink_cli/commands/cleanup.py
+++ b/packages/cli/src/lablink_cli/commands/cleanup.py
@@ -174,9 +174,18 @@ def cleanup_key_pairs(
 
 
 def cleanup_elastic_ips(
-    ec2, deployment_name: str, environment: str, dry_run: bool
+    ec2,
+    deployment_name: str,
+    environment: str,
+    eip_strategy: str,
+    dry_run: bool,
 ) -> None:
-    """Release lablink elastic IPs."""
+    """Release lablink elastic IPs.
+
+    Never releases when eip_strategy is "persistent" — the whole point
+    of that strategy is reuse across deployments (and, commonly, a DNS
+    record pointed at it), regardless of dry_run.
+    """
     console.print("[bold]Elastic IPs[/bold]")
     resp = ec2.describe_addresses(
         Filters=[
@@ -188,6 +197,16 @@ def cleanup_elastic_ips(
     )
     if not resp["Addresses"]:
         console.print("  [dim]none found[/dim]")
+        return
+
+    if eip_strategy == "persistent":
+        for addr in resp["Addresses"]:
+            ip = addr.get("PublicIp", "")
+            alloc_id = addr["AllocationId"]
+            console.print(
+                f"  [dim]skipping[/dim] {ip} ({alloc_id}) — "
+                "eip.strategy is 'persistent', reused across deployments"
+            )
         return
 
     for addr in resp["Addresses"]:
@@ -508,7 +527,9 @@ def run_cleanup(
     console.print()
     cleanup_key_pairs(ec2, deployment_name, environment, software, dry_run)
     console.print()
-    cleanup_elastic_ips(ec2, deployment_name, environment, dry_run)
+    cleanup_elastic_ips(
+        ec2, deployment_name, environment, cfg.eip.strategy, dry_run
+    )
     console.print()
     cleanup_iam(session, deployment_name, environment, software, dry_run)
     console.print()

--- a/packages/cli/tests/test_cleanup.py
+++ b/packages/cli/tests/test_cleanup.py
@@ -140,7 +140,7 @@ class TestCleanupElasticIps:
         ec2 = MagicMock()
         ec2.describe_addresses.return_value = {"Addresses": []}
 
-        cleanup_elastic_ips(ec2, "mylab", "dev", dry_run=False)
+        cleanup_elastic_ips(ec2, "mylab", "dev", "dynamic", dry_run=False)
         ec2.release_address.assert_not_called()
 
     def test_release_ip(self):
@@ -151,7 +151,7 @@ class TestCleanupElasticIps:
             ]
         }
 
-        cleanup_elastic_ips(ec2, "mylab", "dev", dry_run=False)
+        cleanup_elastic_ips(ec2, "mylab", "dev", "dynamic", dry_run=False)
         ec2.release_address.assert_called_once_with(AllocationId="eipalloc-123")
 
     def test_disassociate_before_release(self):
@@ -166,11 +166,42 @@ class TestCleanupElasticIps:
             ]
         }
 
-        cleanup_elastic_ips(ec2, "mylab", "dev", dry_run=False)
+        cleanup_elastic_ips(ec2, "mylab", "dev", "dynamic", dry_run=False)
         ec2.disassociate_address.assert_called_once_with(
             AssociationId="eipassoc-456"
         )
         ec2.release_address.assert_called_once()
+
+    def test_skips_release_when_persistent_strategy(self):
+        """The whole point of eip.strategy=persistent is reuse across
+        deployments — cleanup must never release it, regardless of
+        dry_run. Regression test for the incident where `lablink cleanup`
+        released a persistent, DNS-pointed production EIP."""
+        ec2 = MagicMock()
+        ec2.describe_addresses.return_value = {
+            "Addresses": [
+                {
+                    "AllocationId": "eipalloc-123",
+                    "PublicIp": "1.2.3.4",
+                    "AssociationId": "eipassoc-456",
+                }
+            ]
+        }
+
+        cleanup_elastic_ips(ec2, "mylab", "dev", "persistent", dry_run=False)
+        ec2.disassociate_address.assert_not_called()
+        ec2.release_address.assert_not_called()
+
+    def test_skips_release_when_persistent_strategy_even_in_dry_run(self):
+        ec2 = MagicMock()
+        ec2.describe_addresses.return_value = {
+            "Addresses": [
+                {"AllocationId": "eipalloc-123", "PublicIp": "1.2.3.4"}
+            ]
+        }
+
+        cleanup_elastic_ips(ec2, "mylab", "dev", "persistent", dry_run=True)
+        ec2.release_address.assert_not_called()
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `cleanup_elastic_ips` (in `lablink cleanup`) released **any** EIP matching the deployment's tag, with no check on `eip.strategy` — even when the strategy is `persistent`, whose entire purpose is to survive across deploy/cleanup cycles (commonly because a DNS record points at it).
- This caused a real production incident: `lablink cleanup` released a persistent, DNS-pointed EIP for a live deployment (`lablink.sleap.ai`), requiring a new IP allocation and a manual DNS update to recover.
- Fix: `cleanup_elastic_ips` now skips release entirely whenever `eip_strategy == "persistent"` (prints a "skipping" message instead), regardless of `dry_run`. No override flag — releasing a persistent EIP on purpose is a deliberate, manual AWS action outside this command, not something to reintroduce as a footgun.

## Test plan
- [x] New regression tests: `test_skips_release_when_persistent_strategy` and `test_skips_release_when_persistent_strategy_even_in_dry_run` (TDD: written first, watched fail with the old unconditional-release behavior, then implemented)
- [x] Existing `TestCleanupElasticIps` tests updated to pass `eip_strategy="dynamic"` explicitly, preserving today's release behavior for the (much more common) dynamic strategy
- [x] Full CLI suite: 526 passed, 1 deselected
- [x] `ruff check` clean on both changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)