### PR TITLE
fix(cli): revoke SG rules before delete to avoid DependencyViolation

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -224,6 +224,7 @@ Follow **principle of least privilege**.
         "ec2:DeleteSecurityGroup",
         "ec2:AuthorizeSecurityGroupIngress",
         "ec2:RevokeSecurityGroupIngress",
+        "ec2:RevokeSecurityGroupEgress",
         "ec2:CreateKeyPair",
         "ec2:DeleteKeyPair",
         "ec2:DescribeKeyPairs",

--- a/packages/cli/src/lablink_cli/commands/cleanup.py
+++ b/packages/cli/src/lablink_cli/commands/cleanup.py
@@ -114,34 +114,77 @@ def cleanup_ec2_instances(
 def cleanup_security_groups(
     ec2, deployment_name: str, environment: str, dry_run: bool
 ) -> None:
-    """Delete lablink security groups."""
+    """Delete lablink security groups.
+
+    Lablink SGs commonly cross-reference each other (e.g., the client SG has
+    an ingress rule sourcing the allocator SG). AWS rejects deletion while any
+    rule still references the SG, so revoke every matched SG's ingress and
+    egress rules first to break the cycle before attempting deletes. A single
+    SG with an external dependent (an ENI we don't own, a non-lablink SG) is
+    surfaced and skipped instead of aborting the rest of cleanup.
+    """
     console.print("[bold]Security Groups[/bold]")
-    found = False
+    matched: list[dict] = []
     for pattern in [
         f"{deployment_name}-allocator-sg-{environment}",
         f"*-lablink-client-{environment}-sg",
         f"{deployment_name}-alb-sg-{environment}",
     ]:
         resp = ec2.describe_security_groups(
-            Filters=[
-                {"Name": "group-name", "Values": [pattern]}
-            ]
+            Filters=[{"Name": "group-name", "Values": [pattern]}]
         )
-        for sg in resp["SecurityGroups"]:
-            found = True
-            if dry_run:
-                console.print(
-                    f"  [yellow]would delete[/yellow] "
-                    f"{sg['GroupName']} ({sg['GroupId']})"
-                )
-            else:
-                _delete_if_exists(
-                    f"{sg['GroupName']} ({sg['GroupId']})",
-                    ec2.delete_security_group,
-                    GroupId=sg["GroupId"],
-                )
-    if not found:
+        matched.extend(resp["SecurityGroups"])
+
+    if not matched:
         console.print("  [dim]none found[/dim]")
+        return
+
+    if dry_run:
+        for sg in matched:
+            console.print(
+                f"  [yellow]would delete[/yellow] "
+                f"{sg['GroupName']} ({sg['GroupId']})"
+            )
+        return
+
+    for sg in matched:
+        gid = sg["GroupId"]
+        if sg.get("IpPermissions"):
+            try:
+                ec2.revoke_security_group_ingress(
+                    GroupId=gid, IpPermissions=sg["IpPermissions"]
+                )
+            except ClientError:
+                pass
+        if sg.get("IpPermissionsEgress"):
+            try:
+                ec2.revoke_security_group_egress(
+                    GroupId=gid, IpPermissions=sg["IpPermissionsEgress"]
+                )
+            except ClientError:
+                pass
+
+    for sg in matched:
+        label = f"{sg['GroupName']} ({sg['GroupId']})"
+        try:
+            ec2.delete_security_group(GroupId=sg["GroupId"])
+            console.print(f"  [green]deleted[/green] {label}")
+        except ClientError as e:
+            code = e.response["Error"]["Code"]
+            if code == "DependencyViolation":
+                console.print(
+                    f"  [red]could not delete[/red] {label}: still has "
+                    f"dependents (likely an ENI or non-lablink SG rule); "
+                    f"investigate manually"
+                )
+            elif code in (
+                "InvalidGroup.NotFound",
+                "NotFoundException",
+                "404",
+            ):
+                console.print(f"  [dim]not found[/dim] {label}")
+            else:
+                raise
 
 
 def cleanup_key_pairs(

--- a/packages/cli/src/lablink_cli/commands/cleanup.py
+++ b/packages/cli/src/lablink_cli/commands/cleanup.py
@@ -154,15 +154,21 @@ def cleanup_security_groups(
                 ec2.revoke_security_group_ingress(
                     GroupId=gid, IpPermissions=sg["IpPermissions"]
                 )
-            except ClientError:
-                pass
+            except ClientError as e:
+                console.print(
+                    f"  [dim]revoke ingress failed on {gid}, continuing: "
+                    f"{e.response['Error']['Code']}[/dim]"
+                )
         if sg.get("IpPermissionsEgress"):
             try:
                 ec2.revoke_security_group_egress(
                     GroupId=gid, IpPermissions=sg["IpPermissionsEgress"]
                 )
-            except ClientError:
-                pass
+            except ClientError as e:
+                console.print(
+                    f"  [dim]revoke egress failed on {gid}, continuing: "
+                    f"{e.response['Error']['Code']}[/dim]"
+                )
 
     for sg in matched:
         label = f"{sg['GroupName']} ({sg['GroupId']})"

--- a/packages/cli/tests/test_cleanup.py
+++ b/packages/cli/tests/test_cleanup.py
@@ -183,6 +183,68 @@ class TestCleanupSecurityGroups:
         ec2.revoke_security_group_egress.assert_not_called()
         ec2.delete_security_group.assert_called_once_with(GroupId="sg-aaa")
 
+    def test_not_found_on_delete(self):
+        ec2 = MagicMock()
+        ec2.describe_security_groups.side_effect = [
+            {
+                "SecurityGroups": [
+                    {"GroupName": "mylab-allocator-sg-dev", "GroupId": "sg-aaa"}
+                ]
+            },
+            {"SecurityGroups": []},
+            {"SecurityGroups": []},
+        ]
+        ec2.delete_security_group.side_effect = ClientError(
+            {"Error": {"Code": "InvalidGroup.NotFound", "Message": "x"}},
+            "DeleteSecurityGroup",
+        )
+
+        cleanup_security_groups(ec2, "mylab", "dev", dry_run=False)
+        ec2.delete_security_group.assert_called_once_with(GroupId="sg-aaa")
+
+    def test_unexpected_error_on_delete_reraises(self):
+        ec2 = MagicMock()
+        ec2.describe_security_groups.side_effect = [
+            {
+                "SecurityGroups": [
+                    {"GroupName": "mylab-allocator-sg-dev", "GroupId": "sg-aaa"}
+                ]
+            },
+            {"SecurityGroups": []},
+            {"SecurityGroups": []},
+        ]
+        ec2.delete_security_group.side_effect = ClientError(
+            {"Error": {"Code": "UnauthorizedOperation", "Message": "x"}},
+            "DeleteSecurityGroup",
+        )
+
+        with pytest.raises(ClientError):
+            cleanup_security_groups(ec2, "mylab", "dev", dry_run=False)
+
+    def test_revoke_failure_does_not_block_delete(self):
+        ec2 = MagicMock()
+        ingress = [{"IpProtocol": "tcp", "FromPort": 80, "ToPort": 80}]
+        ec2.describe_security_groups.side_effect = [
+            {
+                "SecurityGroups": [
+                    {
+                        "GroupName": "mylab-allocator-sg-dev",
+                        "GroupId": "sg-aaa",
+                        "IpPermissions": ingress,
+                    }
+                ]
+            },
+            {"SecurityGroups": []},
+            {"SecurityGroups": []},
+        ]
+        ec2.revoke_security_group_ingress.side_effect = ClientError(
+            {"Error": {"Code": "AuthFailure", "Message": "x"}},
+            "RevokeSecurityGroupIngress",
+        )
+
+        cleanup_security_groups(ec2, "mylab", "dev", dry_run=False)
+        ec2.delete_security_group.assert_called_once_with(GroupId="sg-aaa")
+
 
 # ------------------------------------------------------------------
 # cleanup_key_pairs

--- a/packages/cli/tests/test_cleanup.py
+++ b/packages/cli/tests/test_cleanup.py
@@ -108,6 +108,80 @@ class TestCleanupSecurityGroups:
 
         cleanup_security_groups(ec2, "mylab", "dev", dry_run=True)
         ec2.delete_security_group.assert_not_called()
+        ec2.revoke_security_group_ingress.assert_not_called()
+        ec2.revoke_security_group_egress.assert_not_called()
+
+    def test_revokes_rules_before_delete(self):
+        ec2 = MagicMock()
+        ingress = [{"IpProtocol": "tcp", "FromPort": 80, "ToPort": 80}]
+        egress = [{"IpProtocol": "-1"}]
+        ec2.describe_security_groups.side_effect = [
+            {
+                "SecurityGroups": [
+                    {
+                        "GroupName": "mylab-allocator-sg-dev",
+                        "GroupId": "sg-aaa",
+                        "IpPermissions": ingress,
+                        "IpPermissionsEgress": egress,
+                    }
+                ]
+            },
+            {"SecurityGroups": []},
+            {"SecurityGroups": []},
+        ]
+
+        cleanup_security_groups(ec2, "mylab", "dev", dry_run=False)
+        ec2.revoke_security_group_ingress.assert_called_once_with(
+            GroupId="sg-aaa", IpPermissions=ingress
+        )
+        ec2.revoke_security_group_egress.assert_called_once_with(
+            GroupId="sg-aaa", IpPermissions=egress
+        )
+        ec2.delete_security_group.assert_called_once_with(GroupId="sg-aaa")
+
+    def test_dependency_violation_does_not_abort(self):
+        ec2 = MagicMock()
+        ec2.describe_security_groups.side_effect = [
+            {
+                "SecurityGroups": [
+                    {"GroupName": "mylab-allocator-sg-dev", "GroupId": "sg-aaa"}
+                ]
+            },
+            {
+                "SecurityGroups": [
+                    {"GroupName": "x-lablink-client-dev-sg", "GroupId": "sg-bbb"}
+                ]
+            },
+            {"SecurityGroups": []},
+        ]
+        ec2.delete_security_group.side_effect = [
+            ClientError(
+                {"Error": {"Code": "DependencyViolation", "Message": "x"}},
+                "DeleteSecurityGroup",
+            ),
+            None,
+        ]
+
+        cleanup_security_groups(ec2, "mylab", "dev", dry_run=False)
+        # Both SGs were attempted; second one succeeded.
+        assert ec2.delete_security_group.call_count == 2
+
+    def test_skips_revoke_when_no_rules(self):
+        ec2 = MagicMock()
+        ec2.describe_security_groups.side_effect = [
+            {
+                "SecurityGroups": [
+                    {"GroupName": "mylab-allocator-sg-dev", "GroupId": "sg-aaa"}
+                ]
+            },
+            {"SecurityGroups": []},
+            {"SecurityGroups": []},
+        ]
+
+        cleanup_security_groups(ec2, "mylab", "dev", dry_run=False)
+        ec2.revoke_security_group_ingress.assert_not_called()
+        ec2.revoke_security_group_egress.assert_not_called()
+        ec2.delete_security_group.assert_called_once_with(GroupId="sg-aaa")
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `lablink cleanup`'s security-group teardown deletes SGs inline as they're found, checking name patterns in this order: allocator SG, then per-client SG, then ALB SG.
- LabLink's per-client SG has ingress rules that source the allocator SG by ID (KasmVNC/agent ports, allocator-only) — a one-directional reference, not a true cycle. But AWS rejects `DeleteSecurityGroup` on any SG that's still named as a source in *another* SG's rule, and the pattern order above checks the *referenced* SG (allocator) before the *referencer* (client). So on a real deployment, the very first delete attempt fails with `DependencyViolation`.
- That error code wasn't in the caught-code list, so it propagated up and aborted the rest of `cleanup` — key pairs, IAM roles, EIPs, and local state never got cleaned up.
- `cleanup_security_groups` now revokes every matched SG's own ingress/egress rules first (removing the reference regardless of which direction it points) before attempting any deletes, and treats a residual `DependencyViolation` (e.g. an external ENI) as a warning-and-skip instead of a hard abort.

## Scenario
Where the reference comes from: when the allocator provisions a client VM, `providers/aws.py` looks up the allocator's own running SG ID (`current_instance_security_group`) and passes it into the per-client Terraform as `allocator_sg_id`. That's consumed in `packages/allocator/src/lablink_allocator_service/terraform/main.tf`, where the client VM's SG gets two ingress rules sourced from it (ports 6080/7070). The allocator SG and ALB SG are both pure CIDR-based (`0.0.0.0/0`) and don't reference anything back.

Concrete run — deployment `sleap`, environment `prod`, one client VM still up:
1. `cleanup` matches `sleap-allocator-sg-prod` (`sg-0abc123`) first (pattern order) and calls `delete_security_group` on it immediately.
2. `sleap-lablink-client-prod-sg` (`sg-0def456`) — whose ingress rules still source `sg-0abc123` — hasn't been reached by the loop yet.
3. AWS rejects the delete: `DependencyViolation: resource sg-0abc123 has a dependent object`.
4. Pre-fix, that code wasn't handled, so it re-raised and crashed `cleanup` before it ever got to the client SG, key pairs, IAM roles, EIPs, or local state.

## Changes Made
- `packages/cli/src/lablink_cli/commands/cleanup.py`:
  - `cleanup_security_groups` now collects all matched SGs up front, revokes each one's ingress/egress rules (best-effort — a revoke failure is logged and doesn't block the delete attempt), then deletes each, with explicit handling for `DependencyViolation` (warn + continue), not-found codes (already gone), and other errors (re-raise). Dry-run behavior unchanged (prints intent, no AWS calls).
- `packages/cli/tests/test_cleanup.py`: added `test_revokes_rules_before_delete`, `test_dependency_violation_does_not_abort`, `test_skips_revoke_when_no_rules`, `test_not_found_on_delete`, `test_unexpected_error_on_delete_reraises`, `test_revoke_failure_does_not_block_delete`; extended the existing dry-run test to assert no revoke calls happen.
- `docs/security.md`: added `ec2:RevokeSecurityGroupEgress` to the minimal IAM policy example — this PR is the first place the CLI calls `revoke_security_group_ingress`/`egress`, and the egress permission was missing from the documented policy.

## Testing
- `ruff check` on all changed files: clean.
- `PYTHONPATH=src pytest packages/cli/tests/test_cleanup.py`: 35/35 passed.
- CI (lint + test, all three packages): passing.

## Design Decisions
- Revoke-then-delete instead of computing a topological delete order: since revoking a SG's own rules removes any reference it makes to another SG, doing this for every matched SG up front handles the dependency generically without needing to know which direction it points.
- Kept `DependencyViolation` non-fatal (warn + continue) rather than re-raising, so an unexpected external dependent (e.g. a foreign ENI or non-lablink SG rule) doesn't block cleanup of everything else.
- Revoke failures are now logged (dim console line with the AWS error code) rather than silently swallowed, so a later `DependencyViolation` warning is debuggable instead of leaving the operator with no idea whether the cause was an external dependent or a failed revoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)