### PR TITLE
feat(allocator+cli): real-time progress tracking for launch/destroy operations

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
+++ b/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
@@ -66,7 +66,9 @@ CREATE TABLE IF NOT EXISTS operations (
     started_at TIMESTAMP,
     finished_at TIMESTAMP,
     output TEXT,
-    error TEXT
+    error TEXT,
+    resources_total INTEGER,
+    resources_completed INTEGER
 );
 
 CREATE INDEX idx_operations_created_at ON operations(created_at);

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -10,6 +10,7 @@ from datetime import datetime
 import re
 import atexit
 from functools import wraps
+from typing import Callable, Optional
 
 from flask import (
     Flask,
@@ -660,13 +661,17 @@ def launch():
         "deployment_name": getattr(cfg, "deployment_name", "lablink"),
     }
 
-    def _run_launch() -> str:
+    def _run_launch(
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> str:
         """Runs on OperationsWorker's background thread, not the request
         thread. Reformats known failure types into RuntimeError with the
         same user-facing text the old synchronous route used, so that
         text ends up in the operation's `error` column."""
         try:
-            result = provider.provision_hosts(count=total_vms, spec=spec)
+            result = provider.provision_hosts(
+                count=total_vms, spec=spec, progress_callback=progress_callback,
+            )
         except SGAuditFailure as exc:
             raise RuntimeError(
                 f"Security-group audit refused the plan: {exc}"
@@ -722,7 +727,9 @@ def destroy():
             return jsonify({"status": "error", "error": error_msg}), 405
         return redirect("/admin/instances?error=destroy_unsupported")
 
-    def _run_destroy() -> str:
+    def _run_destroy(
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> str:
         """Runs on OperationsWorker's background thread, not the request
         thread."""
         # Seal any open session-metrics rows before tearing down VMs, so the
@@ -738,7 +745,9 @@ def destroy():
         # destroy_hosts ignores the handles arg (terraform destroy operates
         # on the whole workspace); skip the list_hosts() call.
         try:
-            result = provider.destroy_hosts([])
+            result = provider.destroy_hosts(
+                [], progress_callback=progress_callback,
+            )
         except FileNotFoundError as e:
             # No terraform.runtime.tfvars → no client VMs were ever launched.
             raise RuntimeError(str(e)) from e

--- a/packages/allocator/src/lablink_allocator_service/operations.py
+++ b/packages/allocator/src/lablink_allocator_service/operations.py
@@ -42,7 +42,7 @@ class OperationsWorker:
     def submit(
         self,
         op_type: str,
-        fn: Callable[[], str],
+        fn: Callable[..., str],
         params: Optional[str] = None,
         created_by: Optional[str] = None,
     ) -> int:
@@ -63,10 +63,15 @@ class OperationsWorker:
         ).start()
         return operation_id
 
-    def _run(self, operation_id: int, fn: Callable[[], str]) -> None:
+    def _run(self, operation_id: int, fn: Callable[..., str]) -> None:
+        def _progress_callback(completed: int, total: int) -> None:
+            self.database.update_operation_progress(
+                operation_id, completed, total
+            )
+
         try:
             self.database.start_operation(operation_id)
-            output = fn()
+            output = fn(_progress_callback)
         except Exception as e:
             logger.error(
                 "Operation #%d failed: %s", operation_id, e, exc_info=True

--- a/packages/allocator/src/lablink_allocator_service/operations.py
+++ b/packages/allocator/src/lablink_allocator_service/operations.py
@@ -64,10 +64,28 @@ class OperationsWorker:
         return operation_id
 
     def _run(self, operation_id: int, fn: Callable[..., str]) -> None:
+        progress_disabled = False
+
         def _progress_callback(completed: int, total: int) -> None:
-            self.database.update_operation_progress(
-                operation_id, completed, total
-            )
+            # Best-effort: a transient DB failure here must never abort a
+            # live terraform apply/destroy (which _run_streamed would do by
+            # killing the subprocess if this raised). Once a write fails,
+            # stop trying for the rest of this operation rather than
+            # hammering an already-struggling database on every resource.
+            nonlocal progress_disabled
+            if progress_disabled:
+                return
+            try:
+                self.database.update_operation_progress(
+                    operation_id, completed, total
+                )
+            except Exception as e:
+                progress_disabled = True
+                logger.warning(
+                    "Operation #%d: failed to record progress (%d/%d), "
+                    "disabling further progress updates: %s",
+                    operation_id, completed, total, e,
+                )
 
         try:
             self.database.start_operation(operation_id)

--- a/packages/allocator/src/lablink_allocator_service/operations_db.py
+++ b/packages/allocator/src/lablink_allocator_service/operations_db.py
@@ -32,6 +32,8 @@ _OPERATION_COLUMNS = (
     "finished_at",
     "output",
     "error",
+    "resources_total",
+    "resources_completed",
 )
 
 
@@ -163,6 +165,21 @@ class OperationsDatabase:
         with self._cursor as cursor:
             cursor.execute(query, (operation_id,))
 
+    def update_operation_progress(
+        self, operation_id: int, completed: int, total: int
+    ) -> None:
+        """Update an operation's incremental resource-completion progress.
+        Called from OperationsWorker as resources finish creating/
+        destroying during a launch/destroy job still in `running` status.
+        """
+        query = """
+            UPDATE operations
+            SET resources_completed = %s, resources_total = %s
+            WHERE id = %s;
+        """
+        with self._cursor as cursor:
+            cursor.execute(query, (completed, total, operation_id))
+
     def finish_operation(
         self,
         operation_id: int,
@@ -170,14 +187,24 @@ class OperationsDatabase:
         output: Optional[str] = None,
         error: Optional[str] = None,
     ) -> None:
-        """Mark an operation succeeded or failed."""
+        """Mark an operation succeeded or failed. A successful finish also
+        snaps resources_completed to resources_total (if a total was ever
+        recorded), so a completed job never displays a stale partial count
+        from a missed final progress update."""
         query = """
             UPDATE operations
-            SET status = %s, output = %s, error = %s, finished_at = NOW()
+            SET status = %s, output = %s, error = %s, finished_at = NOW(),
+                resources_completed = CASE
+                    WHEN %s = 'succeeded' AND resources_total IS NOT NULL
+                    THEN resources_total
+                    ELSE resources_completed
+                END
             WHERE id = %s;
         """
         with self._cursor as cursor:
-            cursor.execute(query, (status, output, error, operation_id))
+            cursor.execute(
+                query, (status, output, error, status, operation_id)
+            )
 
     def sweep_interrupted_operations(self) -> int:
         """Mark any queued/running operation as interrupted.

--- a/packages/allocator/src/lablink_allocator_service/providers/aws.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/aws.py
@@ -78,16 +78,20 @@ def _run_streamed(
     stderr_thread.start()
 
     stdout_lines: list[str] = []
-    for line in proc.stdout:
-        stdout_lines.append(line)
-        if on_resource_complete and resource_complete_re.search(
-            _ANSI_ESCAPE.sub("", line)
-        ):
-            on_resource_complete()
-
-    proc.stdout.close()
-    returncode = proc.wait()
-    stderr_thread.join()
+    try:
+        for line in proc.stdout:
+            stdout_lines.append(line)
+            if on_resource_complete and resource_complete_re.search(
+                _ANSI_ESCAPE.sub("", line)
+            ):
+                on_resource_complete()
+    except BaseException:
+        proc.kill()
+        raise
+    finally:
+        proc.stdout.close()
+        returncode = proc.wait()
+        stderr_thread.join()
 
     stdout_text = "".join(stdout_lines)
     stderr_text = "".join(stderr_chunks)

--- a/packages/allocator/src/lablink_allocator_service/providers/aws.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/aws.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 import json
 import re
 import subprocess
+import threading
 from pathlib import Path
+from typing import Callable, Optional
 
 from lablink_allocator_service.providers.connectivity.allocator_proxied import (
     AllocatorProxiedClientConnectivity,
@@ -34,6 +36,69 @@ from lablink_allocator_service.utils.terraform_utils import (
 # ANSI escape sequence stripper — moved from main.py to keep the
 # provider self-contained for SR-F1.
 _ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
+
+# Matches Terraform's per-resource completion lines in `apply`/`destroy`
+# streamed output (see _run_streamed below). Matched against an
+# ANSI-stripped copy of each line, since `terraform apply`/`destroy` (run
+# without -no-color) include color codes around resource names/durations.
+_CREATE_COMPLETE_RE = re.compile(r": Creation complete after \d+s")
+_DESTROY_COMPLETE_RE = re.compile(r": Destruction complete after \d+s")
+
+
+def _run_streamed(
+    cmd: list[str],
+    cwd: Path,
+    resource_complete_re: "re.Pattern[str]",
+    on_resource_complete: Optional[Callable[[], None]] = None,
+) -> subprocess.CompletedProcess:
+    """Run cmd via Popen, invoking on_resource_complete once for each
+    stdout line matching resource_complete_re (ANSI-stripped before
+    matching only — the returned CompletedProcess's stdout/stderr are
+    raw, unstripped, exactly like subprocess.run(capture_output=True,
+    text=True) would return, so callers' existing ANSI-stripping code
+    is unaffected).
+
+    Raises subprocess.CalledProcessError on nonzero exit, with .output
+    and .stderr populated — matching subprocess.run(..., check=True).
+    """
+    proc = subprocess.Popen(
+        cmd,
+        cwd=cwd,
+        stdout=subprocess.PIPE,
+        stderr=subprocess.PIPE,
+        text=True,
+    )
+
+    stderr_chunks: list[str] = []
+
+    def _drain_stderr() -> None:
+        stderr_chunks.append(proc.stderr.read())
+
+    stderr_thread = threading.Thread(target=_drain_stderr, daemon=True)
+    stderr_thread.start()
+
+    stdout_lines: list[str] = []
+    for line in proc.stdout:
+        stdout_lines.append(line)
+        if on_resource_complete and resource_complete_re.search(
+            _ANSI_ESCAPE.sub("", line)
+        ):
+            on_resource_complete()
+
+    proc.stdout.close()
+    returncode = proc.wait()
+    stderr_thread.join()
+
+    stdout_text = "".join(stdout_lines)
+    stderr_text = "".join(stderr_chunks)
+
+    if returncode != 0:
+        raise subprocess.CalledProcessError(
+            returncode, cmd, output=stdout_text, stderr=stderr_text,
+        )
+    return subprocess.CompletedProcess(
+        cmd, returncode, stdout=stdout_text, stderr=stderr_text,
+    )
 
 
 class AWSProvider:

--- a/packages/allocator/src/lablink_allocator_service/providers/aws.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/aws.py
@@ -300,11 +300,18 @@ class AWSProvider:
             handles=handles, timings=timings, apply_stdout=clean_stdout,
         )
 
-    def destroy_hosts(self, handles: list[ClientHandle]) -> DestroyResult:
-        """Run `terraform destroy -auto-approve -var-file=...` for the entire
-        workspace. Terraform destroy operates against the state file as a
-        whole; `handles` is accepted for protocol consistency but not used
-        for per-handle filtering.
+    def destroy_hosts(
+        self,
+        handles: list[ClientHandle],
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> DestroyResult:
+        """Plan, then apply, a full-workspace destroy. `handles` is
+        accepted for protocol consistency but not used for per-handle
+        filtering — Terraform destroy operates against the whole state
+        file. Mirrors provision_hosts's plan+show+apply sequence (added
+        so resources_total can be computed exactly the same way
+        provision_hosts computes it for creates) instead of the single
+        `terraform destroy` call this method used before.
 
         Raises FileNotFoundError if no runtime tfvars exists (signals
         "no client VMs were ever launched" — route handler maps this to 404).
@@ -320,18 +327,50 @@ class AWSProvider:
                 "tfvars does not exist — no client VMs were launched"
             )
 
-        cmd = [
-            "terraform", "destroy", "-auto-approve",
-            "-var-file=terraform.runtime.tfvars",
-        ]
+        var_args = ["-var-file=terraform.runtime.tfvars"]
         try:
             sg_id = current_instance_security_group(region=self._region)
-            cmd.append(f"-var=allocator_sg_id={sg_id}")
+            var_args.append(f"-var=allocator_sg_id={sg_id}")
         except NotOnEC2Error:
             # Caller may log; we just skip the SG var.
             pass
 
-        result = subprocess.run(
-            cmd, cwd=terraform_dir, check=True, capture_output=True, text=True,
-        )
+        plan_file = "tfplan-destroy.binary"
+        plan_file_path = terraform_dir / plan_file
+        try:
+            subprocess.run(
+                ["terraform", "plan", "-destroy", "-no-color",
+                 "-out", plan_file, *var_args],
+                cwd=terraform_dir, check=True, capture_output=True, text=True,
+            )
+            show = subprocess.run(
+                ["terraform", "show", "-json", plan_file],
+                cwd=terraform_dir, check=True, capture_output=True, text=True,
+            )
+            plan_json = json.loads(show.stdout)
+            resources_total = sum(
+                1
+                for rc in plan_json.get("resource_changes", [])
+                if "delete" in (rc.get("change") or {}).get("actions", [])
+            )
+            if progress_callback:
+                progress_callback(0, resources_total)
+
+            completed = 0
+
+            def _on_resource_complete() -> None:
+                nonlocal completed
+                completed += 1
+                if progress_callback:
+                    progress_callback(completed, resources_total)
+
+            result = _run_streamed(
+                ["terraform", "apply", "-auto-approve", plan_file],
+                cwd=terraform_dir,
+                resource_complete_re=_DESTROY_COMPLETE_RE,
+                on_resource_complete=_on_resource_complete,
+            )
+        finally:
+            plan_file_path.unlink(missing_ok=True)
+
         return DestroyResult(stdout=_ANSI_ESCAPE.sub("", result.stdout))

--- a/packages/allocator/src/lablink_allocator_service/providers/aws.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/aws.py
@@ -41,8 +41,15 @@ _ANSI_ESCAPE = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
 # streamed output (see _run_streamed below). Matched against an
 # ANSI-stripped copy of each line, since `terraform apply`/`destroy` (run
 # without -no-color) include color codes around resource names/durations.
-_CREATE_COMPLETE_RE = re.compile(r": Creation complete after \d+s")
-_DESTROY_COMPLETE_RE = re.compile(r": Destruction complete after \d+s")
+#
+# The duration Terraform prints is NOT always plain seconds: under a
+# minute it's "12s", but a minute or longer it's "5m2s", and past an hour
+# "1h2m3s" — found via a real destroy where 5 VMs each took 5-7 minutes,
+# so a \d+s-only pattern silently never matched their completion lines
+# (only the sub-minute supporting resources incremented the counter).
+_DURATION_RE = r"(?:\d+h)?(?:\d+m)?\d+s"
+_CREATE_COMPLETE_RE = re.compile(rf": Creation complete after {_DURATION_RE}")
+_DESTROY_COMPLETE_RE = re.compile(rf": Destruction complete after {_DURATION_RE}")
 
 
 def _run_streamed(

--- a/packages/allocator/src/lablink_allocator_service/providers/aws.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/aws.py
@@ -161,7 +161,12 @@ class AWSProvider:
             for i, n in zip(ids, names)
         ]
 
-    def provision_hosts(self, count: int, spec: dict) -> ProvisionResult:
+    def provision_hosts(
+        self,
+        count: int,
+        spec: dict,
+        progress_callback: Optional[Callable[[int, int], None]] = None,
+    ) -> ProvisionResult:
         """Run `terraform plan + audit + apply` for `count` new client hosts.
 
         Moves the inline logic that used to live in main.py's /api/launch
@@ -242,9 +247,28 @@ class AWSProvider:
             )
             plan_json = json.loads(show.stdout)
             audit_terraform_plan(plan_json)  # may raise SGAuditFailure
-            apply_result = subprocess.run(
+
+            resources_total = sum(
+                1
+                for rc in plan_json.get("resource_changes", [])
+                if "create" in (rc.get("change") or {}).get("actions", [])
+            )
+            if progress_callback:
+                progress_callback(0, resources_total)
+
+            completed = 0
+
+            def _on_resource_complete() -> None:
+                nonlocal completed
+                completed += 1
+                if progress_callback:
+                    progress_callback(completed, resources_total)
+
+            apply_result = _run_streamed(
                 ["terraform", "apply", "-auto-approve", plan_file],
-                cwd=terraform_dir, check=True, capture_output=True, text=True,
+                cwd=terraform_dir,
+                resource_complete_re=_CREATE_COMPLETE_RE,
+                on_resource_complete=_on_resource_complete,
             )
         finally:
             plan_file_path.unlink(missing_ok=True)

--- a/packages/allocator/src/lablink_allocator_service/providers/manual.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/manual.py
@@ -31,13 +31,13 @@ class ManualProvider:
             else LANDirectClientConnectivity()
         )
 
-    def provision_hosts(self, count, spec):
+    def provision_hosts(self, count, spec, progress_callback=None):
         raise ProvisioningNotSupported(
             "ManualProvider doesn't provision — instructor brings the "
             "machines. Use 'lablink launch' for the registration command."
         )
 
-    def destroy_hosts(self, handles):
+    def destroy_hosts(self, handles, progress_callback=None):
         raise ProvisioningNotSupported(
             "ManualProvider cannot destroy BYO machines."
         )

--- a/packages/allocator/src/lablink_allocator_service/providers/protocol.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/protocol.py
@@ -4,7 +4,7 @@ so routes/internal_proxy_auth.py and existing tests are unaffected."""
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Protocol, runtime_checkable
+from typing import Callable, Protocol, runtime_checkable
 
 from lablink_allocator_service.client_session import (  # single canonical type
     BrowserSessionTarget as BrowserSessionTarget,
@@ -84,8 +84,17 @@ class ComputeProvider(Protocol):
     can_destroy_hosts: bool
     can_recover_hosts: bool
 
-    def provision_hosts(self, count: int, spec: dict) -> ProvisionResult: ...
-    def destroy_hosts(self, handles: list[ClientHandle]) -> DestroyResult: ...
+    def provision_hosts(
+        self,
+        count: int,
+        spec: dict,
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> ProvisionResult: ...
+    def destroy_hosts(
+        self,
+        handles: list[ClientHandle],
+        progress_callback: Callable[[int, int], None] | None = None,
+    ) -> DestroyResult: ...
     # recover_hosts returns True iff every handle recycled OK
     def recover_hosts(self, handles: list[ClientHandle]) -> bool: ...
     def list_hosts(self) -> list[ClientHandle]: ...

--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -534,7 +534,8 @@
           const errorBlock = op.error
             ? `<details><summary>Show error</summary><pre>${escapeHtml(op.error)}</pre></details>`
             : '';
-          const progressBlock = op.resources_total
+          const isActive = op.status === 'queued' || op.status === 'running';
+          const progressBlock = (op.resources_total && isActive)
             ? `<div class="op-progress-bar"><div class="op-progress-bar-fill" style="width: ${(100 * (op.resources_completed || 0) / op.resources_total).toFixed(0)}%;"></div></div>
                <div class="op-progress-text">${op.resources_completed || 0}/${op.resources_total} resources</div>`
             : '';

--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -257,6 +257,24 @@
       .history-row.status-succeeded {
         color: #14532d;
       }
+      .op-progress-bar {
+        margin-top: 6px;
+        height: 6px;
+        background: #e9ecef;
+        border-radius: 3px;
+        overflow: hidden;
+      }
+      .op-progress-bar-fill {
+        height: 100%;
+        background: #007bff;
+        border-radius: 3px;
+        transition: width 0.3s ease;
+      }
+      .op-progress-text {
+        font-size: 12px;
+        color: #6c757d;
+        margin-top: 2px;
+      }
     </style>
   </head>
   <body>
@@ -516,6 +534,10 @@
           const errorBlock = op.error
             ? `<details><summary>Show error</summary><pre>${escapeHtml(op.error)}</pre></details>`
             : '';
+          const progressBlock = op.resources_total
+            ? `<div class="op-progress-bar"><div class="op-progress-bar-fill" style="width: ${(100 * (op.resources_completed || 0) / op.resources_total).toFixed(0)}%;"></div></div>
+               <div class="op-progress-text">${op.resources_completed || 0}/${op.resources_total} resources</div>`
+            : '';
           return `
             <div class="history-row status-${op.status}">
               <span>#${op.id}</span>
@@ -525,6 +547,7 @@
               <span>${op.created_at || '—'}</span>
               <span>${duration}</span>
             </div>
+            ${progressBlock}
             ${errorBlock}`;
         }).join('');
       }
@@ -572,8 +595,12 @@
 
         if (op.status === "queued" || op.status === "running") {
           banner.className = "state-active";
+          const progressBlock = op.resources_total
+            ? `<div class="op-progress-bar"><div class="op-progress-bar-fill" style="width: ${(100 * (op.resources_completed || 0) / op.resources_total).toFixed(0)}%;"></div></div>
+               <div class="op-progress-text">${op.resources_completed || 0}/${op.resources_total} resources</div>`
+            : '';
           banner.innerHTML =
-            `${label} job #${op.id}: ${op.status}…`;
+            `${label} job #${op.id}: ${op.status}…` + progressBlock;
         } else if (op.status === "succeeded") {
           banner.className = "state-succeeded";
           banner.innerHTML =

--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -195,7 +195,7 @@
 
       .view-toggle {
         display: flex;
-        justify-content: center;
+        justify-content: space-between;
         align-items: center;
         flex-wrap: wrap;
         gap: 20px;
@@ -381,7 +381,6 @@
             <th>In Use</th>
             <th>VM Status</th>
             <th>GPU Health Status</th>
-            <th>Container Startup Duration</th>
             <th>Total Startup Duration</th>
             <th>Logs</th>
             <th>Access</th>
@@ -396,7 +395,6 @@
             <td>{{ "Yes" if vm.inuse else "No" }}</td>
             <td>{{ vm.status or "Unknown" }}</td>
             <td>{{ vm.healthy or "—" }}</td>
-            <td>{{ "%.1f"|format(vm.containerstartupdurationseconds or 0) }}s</td>
             <td>
               <strong
                 >{{ "%.1f"|format(vm.totalstartupdurationseconds or 0) }}s</strong

--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -93,29 +93,94 @@
 
       #operation-banner {
         display: none;
-        padding: 12px 16px;
+        align-items: flex-start;
+        justify-content: space-between;
+        gap: 12px;
+        padding: 14px 16px;
         margin-bottom: 16px;
         border-radius: 6px;
-        font-size: 14px;
+        border-left: 4px solid transparent;
+        font-size: 16px;
+      }
+
+      #operation-banner.state-active,
+      #operation-banner.state-succeeded,
+      #operation-banner.state-failed,
+      #operation-banner.state-interrupted {
+        display: flex;
       }
 
       #operation-banner.state-active {
-        display: block;
         background: #e7f1ff;
         color: #004085;
+        border-left-color: #0d6efd;
       }
 
       #operation-banner.state-succeeded {
-        display: block;
         background: #e2f6e9;
         color: #14532d;
+        border-left-color: #198754;
       }
 
-      #operation-banner.state-failed,
-      #operation-banner.state-interrupted {
-        display: block;
+      #operation-banner.state-failed {
         background: #ffe0e0;
         color: #900;
+        border-left-color: #dc3545;
+      }
+
+      #operation-banner.state-interrupted {
+        background: #fff6e0;
+        color: #7a4a00;
+        border-left-color: #ffc107;
+      }
+
+      #operation-banner .banner-body {
+        flex: 1;
+        min-width: 0;
+      }
+
+      #operation-banner .banner-header {
+        display: flex;
+        align-items: center;
+        gap: 6px;
+        margin-bottom: 4px;
+      }
+
+      #operation-banner .banner-icon {
+        font-size: 1.15em;
+        line-height: 1;
+      }
+
+      #operation-banner .banner-icon-spin {
+        display: inline-block;
+        animation: vm-spin 1s linear infinite;
+      }
+
+      #operation-banner .banner-state-label {
+        font-size: 0.8em;
+        font-weight: 700;
+        letter-spacing: 0.05em;
+        text-transform: uppercase;
+      }
+
+      #operation-banner .banner-message {
+        font-size: 1em;
+      }
+
+      #operation-banner .banner-close {
+        appearance: none;
+        border: none;
+        background: transparent;
+        color: inherit;
+        font-size: 1.4em;
+        line-height: 1;
+        padding: 0 2px;
+        cursor: pointer;
+        opacity: 0.6;
+      }
+
+      #operation-banner .banner-close:hover {
+        opacity: 1;
       }
 
       #operation-banner details {
@@ -584,44 +649,78 @@
         return div.innerHTML;
       }
 
+      let bannerDismissedJobId = null;
+
+      function _bannerHeader(icon, stateLabel, spinning) {
+        const spinClass = spinning ? " banner-icon-spin" : "";
+        return `<div class="banner-header">` +
+          `<span class="banner-icon${spinClass}">${icon}</span>` +
+          `<strong class="banner-state-label">${stateLabel}</strong>` +
+          `</div>`;
+      }
+
+      function dismissOperationBanner(jobId) {
+        bannerDismissedJobId = jobId;
+        const banner = document.getElementById("operation-banner");
+        banner.className = "";
+        banner.innerHTML = "";
+      }
+
       function renderOperationBanner(op) {
         const banner = document.getElementById("operation-banner");
-        if (!op) {
+        if (!op || op.id === bannerDismissedJobId) {
           banner.className = "";
           banner.innerHTML = "";
           return;
         }
 
         const label = op.op_type === "apply" ? "Launch" : "Destroy";
+        let stateClass;
+        let bodyHtml;
 
         if (op.status === "queued" || op.status === "running") {
-          banner.className = "state-active";
+          stateClass = "state-active";
           const progressBlock = op.resources_total
             ? `<div class="op-progress-bar"><div class="op-progress-bar-fill" style="width: ${(100 * (op.resources_completed || 0) / op.resources_total).toFixed(0)}%;"></div></div>
                <div class="op-progress-text">${op.resources_completed || 0}/${op.resources_total} resources</div>`
             : '';
-          banner.innerHTML =
-            `${label} job #${op.id}: ${op.status}…` + progressBlock;
+          bodyHtml =
+            _bannerHeader("&#8635;", op.status.toUpperCase(), true) +
+            `<div class="banner-message">${label} job #${op.id}: ${op.status}…</div>` +
+            progressBlock;
         } else if (op.status === "succeeded") {
-          banner.className = "state-succeeded";
-          banner.innerHTML =
-            `${label} job #${op.id}: succeeded` +
+          stateClass = "state-succeeded";
+          bodyHtml =
+            _bannerHeader("&#10003;", "SUCCEEDED", false) +
+            `<div class="banner-message">${label} job #${op.id} succeeded</div>` +
             (op.output
               ? `<details><summary>Show output</summary><pre>${escapeHtml(op.output)}</pre></details>`
               : "");
         } else if (op.status === "failed") {
-          banner.className = "state-failed";
-          banner.innerHTML =
-            `${label} job #${op.id}: failed` +
+          stateClass = "state-failed";
+          bodyHtml =
+            _bannerHeader("&#10007;", "FAILED", false) +
+            `<div class="banner-message">${label} job #${op.id} failed</div>` +
             (op.error
               ? `<details><summary>Show error</summary><pre>${escapeHtml(op.error)}</pre></details>`
               : "");
         } else if (op.status === "interrupted") {
-          banner.className = "state-interrupted";
-          banner.innerHTML =
-            `${label} job #${op.id}: interrupted — the allocator ` +
-            `restarted mid-job. Check Terraform state manually.`;
+          stateClass = "state-interrupted";
+          bodyHtml =
+            _bannerHeader("&#9888;", "INTERRUPTED", false) +
+            `<div class="banner-message">${label} job #${op.id} interrupted — the allocator ` +
+            `restarted mid-job. Check Terraform state manually.</div>`;
+        } else {
+          banner.className = "";
+          banner.innerHTML = "";
+          return;
         }
+
+        banner.className = stateClass;
+        banner.innerHTML =
+          `<div class="banner-body">${bodyHtml}</div>` +
+          `<button type="button" class="banner-close" aria-label="Dismiss notification" ` +
+          `title="Dismiss" onclick="dismissOperationBanner(${op.id})">&times;</button>`;
       }
 
       function pollOperation(jobId) {

--- a/packages/allocator/tests/providers/test_aws_destroy_hosts.py
+++ b/packages/allocator/tests/providers/test_aws_destroy_hosts.py
@@ -1,8 +1,10 @@
-"""AWSProvider.destroy_hosts after wiring: runs `terraform destroy
--auto-approve -var-file=...` (+ allocator_sg_id var on EC2), returns
-a DestroyResult with ANSI-stripped stdout."""
+"""AWSProvider.destroy_hosts after wiring: runs a `terraform plan -destroy`
++ `terraform show -json` + `terraform apply <planfile>` sequence (+
+allocator_sg_id var on EC2), returns a DestroyResult with ANSI-stripped
+stdout, and reports progress via progress_callback."""
 from __future__ import annotations
 
+import json
 from unittest.mock import patch, MagicMock
 import pytest
 from lablink_allocator_service.providers.aws import AWSProvider
@@ -13,6 +15,21 @@ from lablink_allocator_service.providers.protocol import (
 from lablink_allocator_service.utils.aws_utils import NotOnEC2Error
 
 
+class _FakeCompletedPopen:
+    """Minimal stand-in for subprocess.Popen matching _run_streamed's
+    expected surface — see providers/test_run_streamed.py for the
+    canonical version."""
+
+    def __init__(self, stdout_text="", stderr_text="", returncode=0):
+        import io
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
 @pytest.fixture
 def aws_provider_with_tfvars(tmp_path):
     """Provider with a stub runtime tfvars file present (so destroy proceeds)."""
@@ -20,11 +37,29 @@ def aws_provider_with_tfvars(tmp_path):
     return AWSProvider(region="us-west-2", terraform_dir=tmp_path)
 
 
+def _fake_run_factory(show_json='{"resource_changes": []}'):
+    """Builds a subprocess.run side_effect that returns valid plan JSON for
+    the `terraform show -json ...` call and a generic "OK" stdout for any
+    other call (e.g. `terraform plan -destroy ...`)."""
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = show_json if "show" in cmd else "OK"
+        result.stderr = ""
+        result.returncode = 0
+        return result
+
+    return fake_run
+
+
 def test_destroy_hosts_returns_destroy_result(aws_provider_with_tfvars):
     handles = [ClientHandle(id="i-1", hostname="h-1")]
     with patch(
         "lablink_allocator_service.providers.aws.subprocess.run",
-        return_value=MagicMock(stdout="Destroy complete", stderr="", returncode=0),
+        side_effect=_fake_run_factory(),
+    ), patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakeCompletedPopen(stdout_text="Destroy complete"),
     ), patch(
         "lablink_allocator_service.providers.aws.current_instance_security_group",
         return_value="sg-allocator",
@@ -40,38 +75,64 @@ def test_destroy_hosts_runs_terraform_destroy_with_sg_var_on_ec2(
     handles = [ClientHandle(id="i-1", hostname="h-1")]
     with patch(
         "lablink_allocator_service.providers.aws.subprocess.run",
-        return_value=MagicMock(stdout="ok", stderr="", returncode=0),
+        side_effect=_fake_run_factory(),
     ) as run_mock, patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakeCompletedPopen(stdout_text="ok"),
+    ) as popen_mock, patch(
         "lablink_allocator_service.providers.aws.current_instance_security_group",
         return_value="sg-allocator",
     ):
         aws_provider_with_tfvars.destroy_hosts(handles)
-    cmd = run_mock.call_args_list[0].args[0]
-    assert cmd[:3] == ["terraform", "destroy", "-auto-approve"]
-    assert "-var-file=terraform.runtime.tfvars" in cmd
-    assert "-var=allocator_sg_id=sg-allocator" in cmd
+
+    # plan -destroy carries the var-file and sg var.
+    plan_cmd = run_mock.call_args_list[0].args[0]
+    assert plan_cmd[:3] == ["terraform", "plan", "-destroy"]
+    assert "-var-file=terraform.runtime.tfvars" in plan_cmd
+    assert "-var=allocator_sg_id=sg-allocator" in plan_cmd
+
+    # apply (of the saved destroy plan) streams via Popen.
+    apply_cmd = popen_mock.call_args.args[0]
+    assert apply_cmd[:2] == ["terraform", "apply"]
+    assert "-auto-approve" in apply_cmd
 
 
 def test_destroy_hosts_skips_sg_var_off_ec2(aws_provider_with_tfvars):
     handles = [ClientHandle(id="i-1", hostname="h-1")]
     with patch(
         "lablink_allocator_service.providers.aws.subprocess.run",
-        return_value=MagicMock(stdout="ok", stderr="", returncode=0),
+        side_effect=_fake_run_factory(),
     ) as run_mock, patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakeCompletedPopen(stdout_text="ok"),
+    ), patch(
         "lablink_allocator_service.providers.aws.current_instance_security_group",
         side_effect=NotOnEC2Error("not on EC2"),
     ):
         aws_provider_with_tfvars.destroy_hosts(handles)
-    cmd = run_mock.call_args_list[0].args[0]
-    assert all("allocator_sg_id" not in arg for arg in cmd)
+    plan_cmd = run_mock.call_args_list[0].args[0]
+    assert all("allocator_sg_id" not in arg for arg in plan_cmd)
 
 
 def test_destroy_hosts_ansi_strips_stdout(aws_provider_with_tfvars):
     """ANSI escape codes in terraform output should be removed."""
     ansi_output = "\x1b[32mDestroy complete!\x1b[0m"
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = (
+            '{"resource_changes": []}' if "show" in cmd else "OK"
+        )
+        result.stderr = ""
+        result.returncode = 0
+        return result
+
     with patch(
         "lablink_allocator_service.providers.aws.subprocess.run",
-        return_value=MagicMock(stdout=ansi_output, stderr="", returncode=0),
+        side_effect=fake_run,
+    ), patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakeCompletedPopen(stdout_text=ansi_output),
     ), patch(
         "lablink_allocator_service.providers.aws.current_instance_security_group",
         return_value="sg-foo",
@@ -88,3 +149,51 @@ def test_destroy_hosts_raises_filenotfound_when_no_tfvars(tmp_path):
     p = AWSProvider(region="us-west-2", terraform_dir=tmp_path)
     with pytest.raises(FileNotFoundError):
         p.destroy_hosts([])
+
+
+def test_destroy_hosts_reports_progress_via_callback(aws_provider_with_tfvars):
+    plan_json = json.dumps({
+        "resource_changes": [
+            {"type": "aws_instance", "address": "aws_instance.client[0]",
+             "change": {"actions": ["delete"]}},
+            {"type": "aws_security_group", "address": "aws_security_group.client",
+             "change": {"actions": ["delete"]}},
+        ]
+    })
+    destroy_stdout = (
+        "aws_instance.client[0]: Destruction complete after 8s\n"
+        "aws_security_group.client: Destruction complete after 2s\n"
+    )
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        if "show" in cmd:
+            result.stdout = plan_json
+        else:
+            result.stdout = "OK"
+        result.stderr = ""
+        result.returncode = 0
+        return result
+
+    progress_calls = []
+
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.run",
+        side_effect=fake_run,
+    ), patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakeCompletedPopen(stdout_text=destroy_stdout),
+    ), patch(
+        "lablink_allocator_service.providers.aws.current_instance_security_group",
+        return_value="sg-foo",
+    ):
+        aws_provider_with_tfvars.destroy_hosts(
+            [],
+            progress_callback=lambda done, total: progress_calls.append(
+                (done, total)
+            ),
+        )
+
+    assert progress_calls[0] == (0, 2)
+    assert progress_calls[-1] == (2, 2)
+    assert len(progress_calls) == 3

--- a/packages/allocator/tests/providers/test_aws_provision_hosts.py
+++ b/packages/allocator/tests/providers/test_aws_provision_hosts.py
@@ -2,6 +2,7 @@
 boto3/terraform calls /api/launch did, returning a ProvisionResult."""
 from __future__ import annotations
 
+import json
 from unittest.mock import patch, MagicMock
 import pytest
 from lablink_allocator_service.providers.aws import AWSProvider
@@ -39,6 +40,22 @@ def aws_provider(tmp_path):
     return AWSProvider(region="us-west-2", terraform_dir=tmp_path)
 
 
+class _FakeCompletedPopen:
+    """Minimal stand-in for subprocess.Popen, matching _run_streamed's
+    expected surface (see test_run_streamed.py for the canonical version;
+    duplicated here in full per this test file's existing convention of
+    being self-contained rather than sharing fixtures across files)."""
+
+    def __init__(self, stdout_text="", stderr_text="", returncode=0):
+        import io
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
 @pytest.fixture
 def all_aws_mocks():
     """Patch every external dep AWSProvider.provision_hosts touches."""
@@ -52,10 +69,17 @@ def all_aws_mocks():
         result.returncode = 0
         return result
 
+    def fake_popen(cmd, **kwargs):
+        return _FakeCompletedPopen(stdout_text="Apply complete (mocked)\n")
+
     patches = {
         "subprocess_run": patch(
             "lablink_allocator_service.providers.aws.subprocess.run",
             side_effect=fake_subprocess,
+        ),
+        "subprocess_popen": patch(
+            "lablink_allocator_service.providers.aws.subprocess.Popen",
+            side_effect=fake_popen,
         ),
         "upload_to_s3": patch(
             "lablink_allocator_service.providers.aws.upload_to_s3"
@@ -121,16 +145,100 @@ def test_provision_hosts_runs_terraform_plan_show_apply(
     aws_provider, all_aws_mocks,
 ):
     aws_provider.provision_hosts(count=1, spec=_make_spec())
-    cmds = [list(c.args[0]) for c in all_aws_mocks["subprocess_run"].call_args_list
-            if c.args and isinstance(c.args[0], list)]
-    def find(verb):
+
+    def find(cmds, verb):
         for i, cmd in enumerate(cmds):
             if cmd and cmd[0] == "terraform" and verb in cmd:
                 return i
         return -1
-    plan_idx, show_idx, apply_idx = find("plan"), find("show"), find("apply")
-    assert -1 not in (plan_idx, show_idx, apply_idx)
-    assert plan_idx < show_idx < apply_idx
+
+    run_cmds = [
+        list(c.args[0])
+        for c in all_aws_mocks["subprocess_run"].call_args_list
+        if c.args and isinstance(c.args[0], list)
+    ]
+    plan_idx, show_idx = find(run_cmds, "plan"), find(run_cmds, "show")
+    assert -1 not in (plan_idx, show_idx)
+    assert plan_idx < show_idx
+
+    popen_cmds = [
+        list(c.args[0])
+        for c in all_aws_mocks["subprocess_popen"].call_args_list
+        if c.args and isinstance(c.args[0], list)
+    ]
+    assert find(popen_cmds, "apply") != -1
+
+
+def test_provision_hosts_reports_progress_via_callback(aws_provider):
+    plan_json = json.dumps({
+        "resource_changes": [
+            {"type": "aws_instance", "address": "aws_instance.client[0]",
+             "change": {"actions": ["create"]}},
+            {"type": "aws_instance", "address": "aws_instance.client[1]",
+             "change": {"actions": ["create"]}},
+        ]
+    })
+    apply_stdout = (
+        "aws_instance.client[0]: Creation complete after 12s [id=i-1]\n"
+        "aws_instance.client[1]: Creation complete after 15s [id=i-2]\n"
+    )
+
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        if "show" in cmd:
+            result.stdout = plan_json
+        else:
+            result.stdout = "OK"
+        result.stderr = ""
+        result.returncode = 0
+        return result
+
+    progress_calls = []
+
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.run",
+        side_effect=fake_run,
+    ), patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakeCompletedPopen(stdout_text=apply_stdout),
+    ), patch(
+        "lablink_allocator_service.providers.aws.upload_to_s3"
+    ), patch(
+        "lablink_allocator_service.providers.aws.current_instance_security_group",
+        return_value="sg-foo",
+    ), patch(
+        "lablink_allocator_service.providers.aws.check_support_nvidia",
+        return_value=True,
+    ), patch(
+        "lablink_allocator_service.providers.aws.get_instance_timings",
+        return_value={},
+    ), patch(
+        "lablink_allocator_service.providers.aws.get_instance_ids",
+        return_value=["i-1", "i-2"],
+    ), patch(
+        "lablink_allocator_service.providers.aws.get_instance_names",
+        return_value=["host-1", "host-2"],
+    ), patch(
+        "lablink_allocator_service.providers.aws.audit_terraform_plan",
+        return_value=None,
+    ):
+        aws_provider.provision_hosts(
+            count=2,
+            spec=_make_spec(),
+            progress_callback=lambda done, total: progress_calls.append(
+                (done, total)
+            ),
+        )
+
+    assert progress_calls[0] == (0, 2)
+    assert progress_calls[-1] == (2, 2)
+    assert len(progress_calls) == 3
+
+
+def test_provision_hosts_progress_callback_is_optional(aws_provider, all_aws_mocks):
+    """Omitting progress_callback (the pre-existing call shape) must not
+    raise — this is the backward-compatible default path."""
+    aws_provider.provision_hosts(count=1, spec=_make_spec())
 
 
 def test_provision_hosts_uploads_to_s3(aws_provider, all_aws_mocks):
@@ -169,6 +277,9 @@ def test_provision_hosts_skips_sg_id_off_ec2(aws_provider):
         "lablink_allocator_service.providers.aws.subprocess.run",
         side_effect=fake_subprocess,
     ) as run_mock, patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakeCompletedPopen(stdout_text="Apply complete\n"),
+    ), patch(
         "lablink_allocator_service.providers.aws.upload_to_s3"
     ), patch(
         "lablink_allocator_service.providers.aws.current_instance_security_group",

--- a/packages/allocator/tests/providers/test_run_streamed.py
+++ b/packages/allocator/tests/providers/test_run_streamed.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 
 import io
 import subprocess
+import threading
+import time
 from unittest.mock import patch
 
 import pytest
@@ -15,18 +17,43 @@ from lablink_allocator_service.providers.aws import (
 )
 
 
+class _DelayedReader:
+    """Wraps a StringIO's .read() with an optional sleep, so tests can
+    force the stderr-draining background thread to still be in-flight
+    when the main thread raises -- proving _run_streamed's
+    stderr_thread.join() in its finally block actually waits for it
+    rather than leaking a running thread."""
+
+    def __init__(self, text="", delay=0.0):
+        self._io = io.StringIO(text)
+        self._delay = delay
+
+    def read(self):
+        if self._delay:
+            time.sleep(self._delay)
+        return self._io.read()
+
+
 class _FakePopen:
     """Minimal stand-in for subprocess.Popen exposing just the surface
     _run_streamed uses: an iterable, closeable .stdout, a .stderr with
-    .read(), and .wait() returning a returncode."""
+    .read(), .wait() returning a returncode, and .kill()."""
 
-    def __init__(self, stdout_text="", stderr_text="", returncode=0):
+    def __init__(
+        self, stdout_text="", stderr_text="", returncode=0, stderr_delay=0.0
+    ):
         self.stdout = io.StringIO(stdout_text)
-        self.stderr = io.StringIO(stderr_text)
+        self.stderr = _DelayedReader(stderr_text, delay=stderr_delay)
         self._returncode = returncode
+        self.killed = False
+        self.wait_called = False
 
     def wait(self):
+        self.wait_called = True
         return self._returncode
+
+    def kill(self):
+        self.killed = True
 
 
 def test_run_streamed_invokes_callback_per_matching_line():
@@ -105,3 +132,65 @@ def test_run_streamed_works_with_no_callback():
             resource_complete_re=_CREATE_COMPLETE_RE,
         )
     assert result.stdout == "line one\n"
+
+
+def test_run_streamed_kills_process_and_still_cleans_up_when_callback_raises():
+    """Mirrors subprocess.run's `with Popen(...): ... except: process.kill();
+    raise` contract: if on_resource_complete raises (e.g. a transient DB
+    write failure while recording progress during a long terraform apply),
+    the child process must be killed immediately rather than left running
+    to keep mutating real infrastructure, and cleanup (stdout close,
+    proc.wait(), stderr-thread join) must still happen so nothing is
+    leaked -- while the original exception propagates unchanged."""
+    stdout_text = (
+        "aws_instance.client[0]: Creation complete after 12s [id=i-1]\n"
+        "aws_instance.client[1]: Creation complete after 15s [id=i-2]\n"
+    )
+    # stderr_delay keeps the background drain thread asleep long enough
+    # that it is still alive when the callback raises, so joining it
+    # afterwards is a meaningful assertion rather than a no-op race.
+    fake_popen = _FakePopen(
+        stdout_text=stdout_text,
+        stderr_text="some stderr output",
+        returncode=0,
+        stderr_delay=0.05,
+    )
+
+    boom = RuntimeError("transient DB error")
+
+    def _on_complete():
+        raise boom
+
+    started_threads: list[threading.Thread] = []
+    real_thread = threading.Thread
+
+    def _spy_thread(*args, **kwargs):
+        t = real_thread(*args, **kwargs)
+        started_threads.append(t)
+        return t
+
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=fake_popen,
+    ), patch(
+        "lablink_allocator_service.providers.aws.threading.Thread",
+        side_effect=_spy_thread,
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            _run_streamed(
+                ["terraform", "apply"],
+                cwd="/tmp",
+                resource_complete_re=_CREATE_COMPLETE_RE,
+                on_resource_complete=_on_complete,
+            )
+
+    # (a) the original exception propagates unchanged
+    assert exc_info.value is boom
+    # (b) the child process was killed rather than left running
+    assert fake_popen.killed is True
+    # (c) cleanup still happened: stdout closed, wait() called, and the
+    # stderr-draining thread was joined (not left running / leaked)
+    assert fake_popen.stdout.closed
+    assert fake_popen.wait_called is True
+    assert len(started_threads) == 1
+    assert not started_threads[0].is_alive()

--- a/packages/allocator/tests/providers/test_run_streamed.py
+++ b/packages/allocator/tests/providers/test_run_streamed.py
@@ -13,6 +13,7 @@ import pytest
 
 from lablink_allocator_service.providers.aws import (
     _CREATE_COMPLETE_RE,
+    _DESTROY_COMPLETE_RE,
     _run_streamed,
 )
 
@@ -132,6 +133,62 @@ def test_run_streamed_works_with_no_callback():
             resource_complete_re=_CREATE_COMPLETE_RE,
         )
     assert result.stdout == "line one\n"
+
+
+def test_run_streamed_matches_multi_minute_durations():
+    """Terraform formats durations under a minute as plain seconds
+    ('12s'), but a minute or longer as 'MmSs' (e.g. '5m2s'), and past an
+    hour as 'HhMmSs'. A regex anchored on \\d+s alone silently never
+    matches the longer forms — this is a real bug found via an actual
+    destroy of 5 VMs: the VMs each took 5-7 minutes to destroy, so their
+    "Destruction complete after 5m2s"-style lines never matched and the
+    progress counter never incremented for them, while the sub-minute
+    supporting resources (key pair, IAM role, etc. — "0s"/"1s") did,
+    producing a progress bar that looked stuck despite real progress."""
+    stdout_text = (
+        "aws_instance.lablink_vm[4]: Destruction complete after 5m2s\n"
+        "aws_instance.lablink_vm[3]: Destruction complete after 5m53s\n"
+        "aws_instance.lablink_vm[1]: Destruction complete after 6m43s\n"
+        "aws_instance.lablink_vm[0]: Destruction complete after 6m53s\n"
+        "aws_instance.lablink_vm[2]: Destruction complete after 7m3s\n"
+        "aws_key_pair.lablink_key_pair: Destruction complete after 0s\n"
+    )
+    calls = []
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakePopen(stdout_text=stdout_text, returncode=0),
+    ):
+        _run_streamed(
+            ["terraform", "apply"],
+            cwd="/tmp",
+            resource_complete_re=_DESTROY_COMPLETE_RE,
+            on_resource_complete=lambda: calls.append(1),
+        )
+    assert len(calls) == 6
+
+
+def test_run_streamed_matches_multi_minute_durations_for_create_too():
+    """Companion to the destroy-side multi-minute test above: the same
+    duration format applies to `terraform apply` (VM creation can also
+    exceed a minute), and _CREATE_COMPLETE_RE shares _DURATION_RE with
+    _DESTROY_COMPLETE_RE — this guards against a future edit that fixes
+    one pattern but not the other."""
+    stdout_text = (
+        "aws_instance.client[0]: Creation complete after 1m36s [id=i-1]\n"
+        "aws_instance.client[1]: Creation complete after 45s [id=i-2]\n"
+    )
+    calls = []
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakePopen(stdout_text=stdout_text, returncode=0),
+    ):
+        _run_streamed(
+            ["terraform", "apply"],
+            cwd="/tmp",
+            resource_complete_re=_CREATE_COMPLETE_RE,
+            on_resource_complete=lambda: calls.append(1),
+        )
+    assert len(calls) == 2
 
 
 def test_run_streamed_kills_process_and_still_cleans_up_when_callback_raises():

--- a/packages/allocator/tests/providers/test_run_streamed.py
+++ b/packages/allocator/tests/providers/test_run_streamed.py
@@ -1,0 +1,107 @@
+"""Tests for AWSProvider's _run_streamed helper — the Popen-based
+streaming replacement for subprocess.run(capture_output=True) used by
+provision_hosts/destroy_hosts to report incremental progress."""
+from __future__ import annotations
+
+import io
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from lablink_allocator_service.providers.aws import (
+    _CREATE_COMPLETE_RE,
+    _run_streamed,
+)
+
+
+class _FakePopen:
+    """Minimal stand-in for subprocess.Popen exposing just the surface
+    _run_streamed uses: an iterable, closeable .stdout, a .stderr with
+    .read(), and .wait() returning a returncode."""
+
+    def __init__(self, stdout_text="", stderr_text="", returncode=0):
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
+def test_run_streamed_invokes_callback_per_matching_line():
+    stdout_text = (
+        "aws_instance.client[0]: Creating...\n"
+        "aws_instance.client[0]: Still creating... [10s elapsed]\n"
+        "aws_instance.client[0]: Creation complete after 12s [id=i-1]\n"
+        "aws_instance.client[1]: Creating...\n"
+        "aws_instance.client[1]: Creation complete after 15s [id=i-2]\n"
+    )
+    calls = []
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakePopen(stdout_text=stdout_text, returncode=0),
+    ):
+        result = _run_streamed(
+            ["terraform", "apply"],
+            cwd="/tmp",
+            resource_complete_re=_CREATE_COMPLETE_RE,
+            on_resource_complete=lambda: calls.append(1),
+        )
+
+    assert len(calls) == 2
+    assert result.stdout == stdout_text
+    assert result.returncode == 0
+
+
+def test_run_streamed_strips_ansi_before_matching():
+    """A 'Creation complete after' line wrapped in ANSI color codes must
+    still match — matching is done on an ANSI-stripped copy of each
+    line, not the raw line."""
+    stdout_text = (
+        "\x1b[32maws_instance.client[0]: Creation complete after 12s "
+        "[id=i-1]\x1b[0m\n"
+    )
+    calls = []
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakePopen(stdout_text=stdout_text, returncode=0),
+    ):
+        _run_streamed(
+            ["terraform", "apply"],
+            cwd="/tmp",
+            resource_complete_re=_CREATE_COMPLETE_RE,
+            on_resource_complete=lambda: calls.append(1),
+        )
+    assert len(calls) == 1
+
+
+def test_run_streamed_raises_on_nonzero_exit_with_stdout_stderr_populated():
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakePopen(
+            stdout_text="some output\n", stderr_text="boom", returncode=1,
+        ),
+    ):
+        with pytest.raises(subprocess.CalledProcessError) as exc_info:
+            _run_streamed(
+                ["terraform", "apply"],
+                cwd="/tmp",
+                resource_complete_re=_CREATE_COMPLETE_RE,
+            )
+    assert exc_info.value.output == "some output\n"
+    assert exc_info.value.stderr == "boom"
+
+
+def test_run_streamed_works_with_no_callback():
+    """on_resource_complete is optional — omitting it must not raise."""
+    with patch(
+        "lablink_allocator_service.providers.aws.subprocess.Popen",
+        return_value=_FakePopen(stdout_text="line one\n", returncode=0),
+    ):
+        result = _run_streamed(
+            ["terraform", "apply"],
+            cwd="/tmp",
+            resource_complete_re=_CREATE_COMPLETE_RE,
+        )
+    assert result.stdout == "line one\n"

--- a/packages/allocator/tests/test_destroy_route_baseline.py
+++ b/packages/allocator/tests/test_destroy_route_baseline.py
@@ -4,22 +4,51 @@ Since the async rewrite (PR 2 of the async-terraform-worker roadmap), the
 route no longer runs terraform synchronously — it submits a job to
 OperationsWorker and returns immediately. These tests assert:
 - current_instance_security_group + NotOnEC2Error catch (in provider)
-- terraform destroy -auto-approve -var-file=terraform.runtime.tfvars
-  [-var=allocator_sg_id=<sg>] — via the captured closure, not the route directly
+- terraform plan -destroy -var-file=terraform.runtime.tfvars
+  [-var=allocator_sg_id=<sg>] (subprocess.run) + terraform show -json
+  (subprocess.run) + terraform apply -auto-approve <planfile> (streamed via
+  subprocess.Popen) — via the captured closure, not the route directly
 - ANSI-strip of output (in provider, DestroyResult.stdout is already clean)
 - database.clear_database() after success, inside the closure
 
-All AWS-specific calls (current_instance_security_group, subprocess.run for
-terraform destroy) execute inside AWSProvider.destroy_hosts — patch them in
-the providers.aws namespace, not the main namespace. list_hosts() calls
-get_instance_ids / get_instance_names (terraform output), which must also
-be patched to avoid real terraform invocations.
+All AWS-specific calls (current_instance_security_group, subprocess.run /
+subprocess.Popen for the destroy plan+apply sequence) execute inside
+AWSProvider.destroy_hosts — patch them in the providers.aws namespace, not
+the main namespace. list_hosts() calls get_instance_ids / get_instance_names
+(terraform output), which must also be patched to avoid real terraform
+invocations.
 """
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+class _FakeCompletedPopen:
+    """Minimal stand-in for subprocess.Popen matching _run_streamed's
+    expected surface — see providers/test_run_streamed.py for the
+    canonical version."""
+
+    def __init__(self, stdout_text="", stderr_text="", returncode=0):
+        import io
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
+def _fake_run(cmd, **kwargs):
+    """subprocess.run side_effect: valid plan JSON for `terraform show
+    -json ...`, generic "OK" stdout for any other call (e.g. `terraform
+    plan -destroy ...`)."""
+    result = MagicMock()
+    result.stdout = '{"resource_changes": []}' if "show" in cmd else "OK"
+    result.stderr = ""
+    result.returncode = 0
+    return result
 
 
 @pytest.fixture
@@ -100,15 +129,17 @@ def test_destroy_redirects_browser_client_with_job_id(client, admin_headers):
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.current_instance_security_group",
        return_value="sg-allocator-test")
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_destroy_closure_runs_terraform_destroy_and_clears_db(
-    mock_run, mock_sg, mock_ids, mock_names,
+    mock_run, mock_popen, mock_sg, mock_ids, mock_names,
     destroy_setup, client, admin_headers,
 ):
     """Capture the closure and invoke it directly — this is what actually
     runs on the background thread."""
-    mock_run.return_value = MagicMock(
-        stdout="Destroy complete (mocked)", stderr="", returncode=0
+    mock_run.side_effect = _fake_run
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="Destroy complete (mocked)\n", returncode=0,
     )
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
@@ -118,17 +149,16 @@ def test_destroy_closure_runs_terraform_destroy_and_clears_db(
 
     assert "Destroy complete" in output
 
-    calls = mock_run.call_args_list
-    cmds = [
-        list(c.args[0]) for c in calls
-        if c.args and isinstance(c.args[0], (list, tuple))
-    ]
-    destroy_cmds = [c for c in cmds if c and c[0] == "terraform" and "destroy" in c]
-    assert destroy_cmds, f"terraform destroy not called; cmds: {cmds}"
-    cmd = destroy_cmds[0]
-    assert "-auto-approve" in cmd
-    assert "-var-file=terraform.runtime.tfvars" in cmd
-    assert any("allocator_sg_id" in arg for arg in cmd)
+    # plan -destroy carries the var-file and sg var.
+    plan_cmd = mock_run.call_args_list[0].args[0]
+    assert plan_cmd[:3] == ["terraform", "plan", "-destroy"]
+    assert "-var-file=terraform.runtime.tfvars" in plan_cmd
+    assert any("allocator_sg_id" in arg for arg in plan_cmd)
+
+    # apply (of the saved destroy plan) streams via Popen.
+    apply_cmd = mock_popen.call_args.args[0]
+    assert apply_cmd[:2] == ["terraform", "apply"]
+    assert "-auto-approve" in apply_cmd
 
     destroy_setup["database"].clear_database.assert_called_once()
 
@@ -137,13 +167,15 @@ def test_destroy_closure_runs_terraform_destroy_and_clears_db(
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.current_instance_security_group",
        return_value="sg-allocator-test")
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_destroy_closure_strips_ansi_from_output(
-    mock_run, mock_sg, mock_ids, mock_names,
+    mock_run, mock_popen, mock_sg, mock_ids, mock_names,
     destroy_setup, client, admin_headers,
 ):
-    mock_run.return_value = MagicMock(
-        stdout="\x1b[32mresources destroyed\x1b[0m", stderr="", returncode=0
+    mock_run.side_effect = _fake_run
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="\x1b[32mresources destroyed\x1b[0m\n", returncode=0,
     )
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:

--- a/packages/allocator/tests/test_launch_route_baseline.py
+++ b/packages/allocator/tests/test_launch_route_baseline.py
@@ -510,7 +510,7 @@ def test_launch_closure_base64_encodes_success_check(
     class _FakeProvider:
         can_provision_hosts = True
 
-        def provision_hosts(self, count, spec):
+        def provision_hosts(self, count, spec, progress_callback=None):
             captured["spec"] = spec
             return ProvisionResult(handles=[], timings={}, apply_stdout="ok")
 

--- a/packages/allocator/tests/test_launch_route_baseline.py
+++ b/packages/allocator/tests/test_launch_route_baseline.py
@@ -93,17 +93,32 @@ class _FakeResult:
         self.returncode = returncode
 
 
+class _FakeCompletedPopen:
+    """Minimal stand-in for subprocess.Popen, matching _run_streamed's
+    expected surface (see providers/test_run_streamed.py for the
+    canonical version). Post-Task-5, AWSProvider.provision_hosts's apply
+    step streams via subprocess.Popen instead of subprocess.run."""
+
+    def __init__(self, stdout_text="", stderr_text="", returncode=0):
+        import io
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
 def _provider_subprocess_side_effects(plan_json=_CLEAN_PLAN_JSON):
     """Return FakeResult objects in the order AWSProvider.provision_hosts
     calls subprocess.run:
     1. terraform plan -no-color -out tfplan.binary ...
     2. terraform show -json tfplan.binary
-    3. terraform apply -auto-approve tfplan.binary
+    (apply now streams via subprocess.Popen — see _FakeCompletedPopen.)
     """
     return [
         _FakeResult("OK"),             # plan
         _FakeResult(plan_json),        # show -json → SG audit
-        _FakeResult("apply success"),  # apply
     ]
 
 
@@ -118,7 +133,8 @@ def _provider_happy_path_patches():
     - providers.aws.upload_to_s3
     - providers.aws.current_instance_security_group
     - providers.aws.check_support_nvidia
-    - providers.aws.subprocess.run  (plan/show/apply only)
+    - providers.aws.subprocess.run  (plan/show only)
+    - providers.aws.subprocess.Popen  (apply — streamed post-Task-5)
     - providers.aws.get_instance_timings
     - providers.aws.get_instance_ids
     - providers.aws.get_instance_names
@@ -133,6 +149,7 @@ def _provider_happy_path_patches():
              patch("lablink_allocator_service.providers.aws.check_support_nvidia",
                    return_value=True) as mnv, \
              patch("lablink_allocator_service.providers.aws.subprocess.run") as mrun, \
+             patch("lablink_allocator_service.providers.aws.subprocess.Popen") as mpopen, \
              patch("lablink_allocator_service.providers.aws.get_instance_timings",
                    return_value=_TIMING_DATA) as mtimings, \
              patch("lablink_allocator_service.providers.aws.get_instance_ids",
@@ -140,9 +157,10 @@ def _provider_happy_path_patches():
              patch("lablink_allocator_service.providers.aws.get_instance_names",
                    return_value=[]) as mnames:
             mrun.side_effect = _provider_subprocess_side_effects()
+            mpopen.return_value = _FakeCompletedPopen(stdout_text="apply success")
             yield {
                 "s3": ms3, "sg": msg, "nvidia": mnv,
-                "run": mrun, "timings": mtimings,
+                "run": mrun, "popen": mpopen, "timings": mtimings,
                 "ids": mids, "names": mnames,
             }
     return _stack()
@@ -286,24 +304,28 @@ def test_launch_closure_runs_plan_show_apply_in_order(
         fn = mock_worker.submit.call_args.kwargs["fn"]
         fn()
 
-        calls = mocks["run"].call_args_list
-        cmds = [
-            list(c.args[0])
-            for c in calls
-            if c.args and isinstance(c.args[0], (list, tuple))
-        ]
-
-        def index_of(verb):
+        def index_of(cmds, verb):
             for i, cmd in enumerate(cmds):
                 if cmd and cmd[0] == "terraform" and verb in cmd:
                     return i
             return -1
 
-        plan_idx, show_idx, apply_idx = (
-            index_of("plan"), index_of("show"), index_of("apply"),
-        )
-        assert plan_idx != -1 and show_idx != -1 and apply_idx != -1
-        assert plan_idx < show_idx < apply_idx
+        run_cmds = [
+            list(c.args[0])
+            for c in mocks["run"].call_args_list
+            if c.args and isinstance(c.args[0], (list, tuple))
+        ]
+        plan_idx, show_idx = index_of(run_cmds, "plan"), index_of(run_cmds, "show")
+        assert plan_idx != -1 and show_idx != -1
+        assert plan_idx < show_idx
+
+        # apply now streams via subprocess.Popen, checked separately.
+        popen_cmds = [
+            list(c.args[0])
+            for c in mocks["popen"].call_args_list
+            if c.args and isinstance(c.args[0], (list, tuple))
+        ]
+        assert index_of(popen_cmds, "apply") != -1
 
 
 def test_launch_closure_wraps_sg_audit_failure(launch_setup, client, admin_headers):

--- a/packages/allocator/tests/test_manual_provider.py
+++ b/packages/allocator/tests/test_manual_provider.py
@@ -1,0 +1,23 @@
+import pytest
+from unittest.mock import MagicMock
+
+from lablink_allocator_service.providers.manual import ManualProvider
+from lablink_allocator_service.providers.protocol import (
+    ProvisioningNotSupported,
+)
+
+
+def test_provision_hosts_ignores_progress_callback():
+    provider = ManualProvider()
+    callback = MagicMock()
+    with pytest.raises(ProvisioningNotSupported):
+        provider.provision_hosts(count=1, spec={}, progress_callback=callback)
+    callback.assert_not_called()
+
+
+def test_destroy_hosts_ignores_progress_callback():
+    provider = ManualProvider()
+    callback = MagicMock()
+    with pytest.raises(ProvisioningNotSupported):
+        provider.destroy_hosts([], progress_callback=callback)
+    callback.assert_not_called()

--- a/packages/allocator/tests/test_operations.py
+++ b/packages/allocator/tests/test_operations.py
@@ -126,3 +126,20 @@ def test_submit_does_not_block_caller_on_slow_fn(worker, mock_database):
         f"submit() blocked for {elapsed:.2f}s waiting on fn() — "
         f"it must return immediately"
     )
+
+
+def test_submit_passes_progress_callback_that_updates_database(
+    worker, mock_database
+):
+    mock_database.create_operation.return_value = 3
+    captured = {}
+
+    def fn(progress_callback):
+        captured["callback"] = progress_callback
+        progress_callback(2, 5)
+        return "done"
+
+    worker.submit(op_type="apply", fn=fn, params=None, created_by="admin")
+
+    assert _wait_until(lambda: mock_database.finish_operation.called)
+    mock_database.update_operation_progress.assert_called_once_with(3, 2, 5)

--- a/packages/allocator/tests/test_operations.py
+++ b/packages/allocator/tests/test_operations.py
@@ -115,7 +115,7 @@ def test_submit_does_not_block_caller_on_slow_fn(worker, mock_database):
     mock_database.create_operation.return_value = 3
     started = time.monotonic()
 
-    def slow_fn():
+    def slow_fn(progress_callback):
         time.sleep(0.3)
         return "done"
 
@@ -143,3 +143,34 @@ def test_submit_passes_progress_callback_that_updates_database(
 
     assert _wait_until(lambda: mock_database.finish_operation.called)
     mock_database.update_operation_progress.assert_called_once_with(3, 2, 5)
+
+
+def test_progress_callback_write_failure_does_not_abort_operation(
+    worker, mock_database
+):
+    """A transient DB error (e.g. pool exhaustion) while recording progress
+    must not propagate into fn — that would kill a live terraform
+    apply/destroy subprocess (see _run_streamed's except BaseException:
+    proc.kill()) over a failure that has nothing to do with terraform
+    itself. The callback should swallow it and let fn keep running."""
+    mock_database.create_operation.return_value = 6
+    mock_database.update_operation_progress.side_effect = RuntimeError(
+        "pool exhausted"
+    )
+    captured = {}
+
+    def fn(progress_callback):
+        captured["callback"] = progress_callback
+        progress_callback(1, 5)  # must not raise
+        progress_callback(2, 5)  # still disabled, must not raise either
+        return "done"
+
+    worker.submit(op_type="apply", fn=fn, params=None, created_by="admin")
+
+    assert _wait_until(lambda: mock_database.finish_operation.called)
+    mock_database.finish_operation.assert_called_once_with(
+        6, status="succeeded", output="done"
+    )
+    # Only the first attempt is tried — once it fails, further progress
+    # writes for this operation are skipped rather than retried per call.
+    mock_database.update_operation_progress.assert_called_once_with(6, 1, 5)

--- a/packages/allocator/tests/test_operations_db.py
+++ b/packages/allocator/tests/test_operations_db.py
@@ -182,13 +182,23 @@ def test_start_operation_updates_status_and_started_at(operations_db):
     assert args[1] == (4,)
 
 
+_FINISH_OPERATION_QUERY = """
+            UPDATE operations
+            SET status = %s, output = %s, error = %s, finished_at = NOW(),
+                resources_completed = CASE
+                    WHEN %s = 'succeeded' AND resources_total IS NOT NULL
+                    THEN resources_total
+                    ELSE resources_completed
+                END
+            WHERE id = %s;
+        """
+
+
 def test_finish_operation_succeeded(operations_db):
     operations_db.finish_operation(4, status="succeeded", output="terraform output")
 
     args = operations_db.cursor.execute.call_args[0]
-    # Query now includes CASE guard for resources_completed snapping on success
-    assert "CASE" in args[0]
-    assert "resources_completed" in args[0]
+    assert "".join(args[0].split()) == "".join(_FINISH_OPERATION_QUERY.split())
     assert args[1] == ("succeeded", "terraform output", None, "succeeded", 4)
 
 
@@ -196,6 +206,7 @@ def test_finish_operation_failed(operations_db):
     operations_db.finish_operation(4, status="failed", error="terraform exploded")
 
     args = operations_db.cursor.execute.call_args[0]
+    assert "".join(args[0].split()) == "".join(_FINISH_OPERATION_QUERY.split())
     assert args[1] == ("failed", None, "terraform exploded", "failed", 4)
 
 
@@ -246,8 +257,7 @@ def test_finish_operation_succeeded_passes_status_twice_for_case_guard(operation
     operations_db.finish_operation(7, status="succeeded", output="ok")
 
     args = operations_db.cursor.execute.call_args[0]
-    assert "CASE" in args[0]
-    assert "resources_completed" in args[0]
+    assert "".join(args[0].split()) == "".join(_FINISH_OPERATION_QUERY.split())
     assert args[1] == ("succeeded", "ok", None, "succeeded", 7)
 
 
@@ -255,6 +265,7 @@ def test_finish_operation_failed_passes_status_twice_for_case_guard(operations_d
     operations_db.finish_operation(7, status="failed", error="boom")
 
     args = operations_db.cursor.execute.call_args[0]
+    assert "".join(args[0].split()) == "".join(_FINISH_OPERATION_QUERY.split())
     assert args[1] == ("failed", None, "boom", "failed", 7)
 
 

--- a/packages/allocator/tests/test_operations_db.py
+++ b/packages/allocator/tests/test_operations_db.py
@@ -186,20 +186,17 @@ def test_finish_operation_succeeded(operations_db):
     operations_db.finish_operation(4, status="succeeded", output="terraform output")
 
     args = operations_db.cursor.execute.call_args[0]
-    expected_query = """
-            UPDATE operations
-            SET status = %s, output = %s, error = %s, finished_at = NOW()
-            WHERE id = %s;
-        """
-    assert "".join(args[0].split()) == "".join(expected_query.split())
-    assert args[1] == ("succeeded", "terraform output", None, 4)
+    # Query now includes CASE guard for resources_completed snapping on success
+    assert "CASE" in args[0]
+    assert "resources_completed" in args[0]
+    assert args[1] == ("succeeded", "terraform output", None, "succeeded", 4)
 
 
 def test_finish_operation_failed(operations_db):
     operations_db.finish_operation(4, status="failed", error="terraform exploded")
 
     args = operations_db.cursor.execute.call_args[0]
-    assert args[1] == ("failed", None, "terraform exploded", 4)
+    assert args[1] == ("failed", None, "terraform exploded", "failed", 4)
 
 
 def test_sweep_interrupted_operations_returns_count(operations_db):
@@ -224,3 +221,53 @@ def test_sweep_interrupted_operations_returns_zero_when_none_in_progress(
     operations_db.cursor.fetchall.return_value = []
 
     assert operations_db.sweep_interrupted_operations() == 0
+
+
+def test_update_operation_progress_executes_expected_query(operations_db):
+    operations_db.update_operation_progress(7, completed=3, total=8)
+
+    args = operations_db.cursor.execute.call_args[0]
+    expected_query = """
+            UPDATE operations
+            SET resources_completed = %s, resources_total = %s
+            WHERE id = %s;
+        """
+    assert "".join(args[0].split()) == "".join(expected_query.split())
+    assert args[1] == (3, 8, 7)
+
+
+def test_finish_operation_succeeded_passes_status_twice_for_case_guard(operations_db):
+    """finish_operation's UPDATE uses a SQL CASE keyed on status to snap
+    resources_completed to resources_total only when status='succeeded' —
+    this test verifies the query shape and that `status` is bound both as
+    the SET value and as the CASE condition; the CASE branching itself is
+    SQL semantics, not something a mocked cursor can prove, matching this
+    file's existing style of asserting query shape + params."""
+    operations_db.finish_operation(7, status="succeeded", output="ok")
+
+    args = operations_db.cursor.execute.call_args[0]
+    assert "CASE" in args[0]
+    assert "resources_completed" in args[0]
+    assert args[1] == ("succeeded", "ok", None, "succeeded", 7)
+
+
+def test_finish_operation_failed_passes_status_twice_for_case_guard(operations_db):
+    operations_db.finish_operation(7, status="failed", error="boom")
+
+    args = operations_db.cursor.execute.call_args[0]
+    assert args[1] == ("failed", None, "boom", "failed", 7)
+
+
+def test_get_operation_includes_progress_columns(operations_db):
+    """A regression guard for _OPERATION_COLUMNS: get_operation's dict
+    construction (dict(zip(_OPERATION_COLUMNS, row))) must stay in sync
+    with the CREATE TABLE column order — this proves the two new columns
+    actually surface in the returned dict, not just that the SQL text
+    looks right."""
+    operations_db.cursor.fetchone.return_value = (
+        7, "apply", "running", None, "admin",
+        None, None, None, None, None, 8, 3,
+    )
+    operation = operations_db.get_operation(7)
+    assert operation["resources_total"] == 8
+    assert operation["resources_completed"] == 3

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -484,10 +484,10 @@ def test_view_instances_table_scrolls_horizontally_on_narrow_viewports(mock_data
     """Found via a 390px-viewport mockup review: with no overflow-x:auto
     container and no white-space:nowrap, narrow viewports wrapped cell text
     mid-word (e.g. "gpu-vm-01" split across two lines) instead of scrolling
-    the table. The table has 10 columns, several with long headers (GPU
-    Health Status, Container Startup Duration, Total Startup Duration), so
-    this isn't cosmetic — it's the table's normal-width behavior on anything
-    narrower than a small laptop."""
+    the table. The table has several columns with long headers (GPU Health
+    Status, Total Startup Duration), so this isn't cosmetic — it's the
+    table's normal-width behavior on anything narrower than a small
+    laptop."""
     mock_database.get_all_vms.return_value = []
     resp = client.get("/admin/instances", headers=admin_headers)
     html = resp.data.decode()

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -549,3 +549,13 @@ def test_view_instances_progress_bar_guards_on_resources_total(client, admin_hea
     resp = client.get("/admin/instances", headers=admin_headers)
     html = resp.data.decode()
     assert "op.resources_total" in html
+
+
+def test_view_instances_progress_bar_hidden_when_operation_finished(client, admin_headers):
+    """Once an operation reaches a terminal status (succeeded/failed/
+    interrupted), the Recent Operations row stops showing a progress bar
+    — only queued/running operations are still "in progress" in any
+    meaningful sense."""
+    resp = client.get("/admin/instances", headers=admin_headers)
+    html = resp.data.decode()
+    assert "op.status === 'queued' || op.status === 'running'" in html

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -533,3 +533,19 @@ def test_view_instances_card_view_styles_rebooting_status(mock_database, client,
 
     assert "status-badge status-rebooting" in html
     assert ".status-badge.status-rebooting" in html
+
+
+def test_view_instances_renders_progress_bar_markup(client, admin_headers):
+    resp = client.get("/admin/instances", headers=admin_headers)
+    html = resp.data.decode()
+    assert "op-progress-bar" in html
+    assert "op-progress-bar-fill" in html
+
+
+def test_view_instances_progress_bar_guards_on_resources_total(client, admin_headers):
+    """The progress bar block must be conditional on op.resources_total
+    being truthy — otherwise a job with no known total would render a
+    bar reading against `undefined`."""
+    resp = client.get("/admin/instances", headers=admin_headers)
+    html = resp.data.decode()
+    assert "op.resources_total" in html

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -267,6 +267,46 @@ def test_instances_html_escapes_operation_output_and_error(
     assert "${op.error}" not in html
 
 
+def test_view_instances_banner_has_close_button(client, admin_headers):
+    resp = client.get("/admin/instances", headers=admin_headers)
+    html = resp.data.decode()
+    assert "banner-close" in html
+    assert "function dismissOperationBanner(" in html
+    assert "onclick=\"dismissOperationBanner(" in html
+
+
+def test_view_instances_banner_font_size_increased(client, admin_headers):
+    """Banner text (14px originally) was too small — bumped to 16px,
+    matching the rest of the page's readable text sizes."""
+    resp = client.get("/admin/instances", headers=admin_headers)
+    html = resp.data.decode()
+    banner_rule = html.split("#operation-banner {", 1)[1].split("}", 1)[0]
+    assert "font-size: 16px;" in banner_rule
+
+
+def test_view_instances_banner_shows_state_icons_and_labels(client, admin_headers):
+    """Each banner state (active/succeeded/failed/interrupted) gets its
+    own icon + bold uppercase label, not just a background color — a
+    color-only distinction is hard to scan at a glance and inaccessible
+    to colorblind users."""
+    resp = client.get("/admin/instances", headers=admin_headers)
+    html = resp.data.decode()
+    assert "banner-state-label" in html
+    assert "banner-icon" in html
+    assert '"SUCCEEDED"' in html
+    assert '"FAILED"' in html
+    assert '"INTERRUPTED"' in html
+    # interrupted must be visually distinguishable from failed, not just
+    # sharing the exact same CSS rule as before.
+    interrupted_rule = html.split(
+        "#operation-banner.state-interrupted {", 1
+    )[1].split("}", 1)[0]
+    failed_rule = html.split(
+        "#operation-banner.state-failed {", 1
+    )[1].split("}", 1)[0]
+    assert interrupted_rule != failed_rule
+
+
 @patch("lablink_allocator_service.main.database")
 def test_view_instances_shows_error_banner(mock_database, client, admin_headers):
     mock_database.get_all_vms.return_value = []

--- a/packages/allocator/tests/test_session_metrics_seal_on_destroy.py
+++ b/packages/allocator/tests/test_session_metrics_seal_on_destroy.py
@@ -5,6 +5,21 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 
+class _FakeCompletedPopen:
+    """Minimal stand-in for subprocess.Popen matching _run_streamed's
+    expected surface — see providers/test_run_streamed.py for the
+    canonical version."""
+
+    def __init__(self, stdout_text="", stderr_text="", returncode=0):
+        import io
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
 @pytest.fixture
 def destroy_setup(app, monkeypatch, tmp_path):
     """Wire fakes for the /destroy route so we can observe its calls.
@@ -60,9 +75,10 @@ def test_scheduled_destroy_seals_before_destroy():
     "lablink_allocator_service.providers.aws.current_instance_security_group",
     return_value="sg-allocator-test",
 )
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_admin_destroy_route_seals_before_destroy(
-    mock_run, mock_sg, mock_ids, mock_names,
+    mock_run, mock_popen, mock_sg, mock_ids, mock_names,
     destroy_setup, client, admin_headers,
 ):
     """POST /destroy's closure must seal session-metrics rows before
@@ -80,14 +96,24 @@ def test_admin_destroy_route_seals_before_destroy(
         call_order.append("seal")
         return 5
 
-    def _run(*args, **kwargs):
-        call_order.append("destroy")
-        return MagicMock(
-            stdout="Destroy complete (mocked)", stderr="", returncode=0
-        )
+    def _run(cmd, **kwargs):
+        # Record "destroy" once, on the first subprocess.run call
+        # (`terraform plan -destroy ...`) — the start of the destroy
+        # sequence — so call_order still reflects a single seal-then-destroy
+        # ordering rather than one entry per plan/show call.
+        if not call_order or call_order[-1] != "destroy":
+            call_order.append("destroy")
+        result = MagicMock()
+        result.stdout = '{"resource_changes": []}' if "show" in cmd else "OK"
+        result.stderr = ""
+        result.returncode = 0
+        return result
 
     fake_db.bulk_seal_session_metrics.side_effect = _seal
     mock_run.side_effect = _run
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="Destroy complete (mocked)\n", returncode=0,
+    )
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.return_value = 1
@@ -113,15 +139,25 @@ def test_admin_destroy_route_seals_before_destroy(
     "lablink_allocator_service.providers.aws.current_instance_security_group",
     return_value="sg-allocator-test",
 )
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_admin_destroy_route_continues_when_seal_fails(
-    mock_run, mock_sg, mock_ids, mock_names,
+    mock_run, mock_popen, mock_sg, mock_ids, mock_names,
     destroy_setup, client, admin_headers,
 ):
     """If bulk_seal fails, the closure logs a warning and continues to
     destroy."""
-    mock_run.return_value = MagicMock(
-        stdout="Destroy complete (mocked)", stderr="", returncode=0
+
+    def _run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = '{"resource_changes": []}' if "show" in cmd else "OK"
+        result.stderr = ""
+        result.returncode = 0
+        return result
+
+    mock_run.side_effect = _run
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="Destroy complete (mocked)\n", returncode=0,
     )
     fake_db = destroy_setup["database"]
     fake_db.bulk_seal_session_metrics.side_effect = RuntimeError("db blew up")
@@ -138,3 +174,4 @@ def test_admin_destroy_route_continues_when_seal_fails(
     fake_db.bulk_seal_session_metrics.assert_called_once()
     # Destroy still ran despite the seal failure.
     assert mock_run.called
+    assert mock_popen.called

--- a/packages/allocator/tests/test_terraform_api.py
+++ b/packages/allocator/tests/test_terraform_api.py
@@ -1337,3 +1337,77 @@ def test_terraform_threads_agent_token_through_user_data():
     assert '-e AGENT_TOKEN="${agent_token}"' in user_data
     # After PR D4, api_token is retired from the bundled terraform template.
     assert '-e API_TOKEN="${api_token}"' not in user_data
+
+
+def test_run_launch_forwards_progress_callback_to_provider(
+    client, admin_headers, monkeypatch, tmp_path,
+):
+    from lablink_allocator_service import main
+
+    terraform_dir = tmp_path / "terraform"
+    terraform_dir.mkdir()
+    monkeypatch.setattr(main, "TERRAFORM_DIR", terraform_dir)
+
+    fake_provider = MagicMock()
+    fake_provider.can_provision_hosts = True
+    fake_provider.provision_hosts.return_value = MagicMock(
+        timings={}, apply_stdout="ok",
+    )
+    monkeypatch.setitem(main.app.config, "LABLINK_PROVIDER", fake_provider)
+    monkeypatch.setattr(
+        main, "database",
+        MagicMock(get_row_count=MagicMock(return_value=0)),
+        raising=False,
+    )
+    monkeypatch.setattr(main, "allocator_ip", "1.2.3.4", raising=False)
+    monkeypatch.setattr(main, "key_name", "my-key", raising=False)
+    monkeypatch.setattr(main, "ENVIRONMENT", "test", raising=False)
+
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(
+            POST_ENDPOINT, headers=admin_headers, data={"num_vms": "1"}
+        )
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        sentinel_callback = MagicMock()
+        fn(sentinel_callback)
+
+    fake_provider.provision_hosts.assert_called_once()
+    assert (
+        fake_provider.provision_hosts.call_args.kwargs["progress_callback"]
+        is sentinel_callback
+    )
+
+
+def test_run_destroy_forwards_progress_callback_to_provider(
+    client, admin_headers, monkeypatch, tmp_path,
+):
+    from lablink_allocator_service import main
+
+    terraform_dir = tmp_path / "terraform"
+    terraform_dir.mkdir()
+    monkeypatch.setattr(main, "TERRAFORM_DIR", terraform_dir)
+
+    fake_provider = MagicMock()
+    fake_provider.can_destroy_hosts = True
+    fake_provider.destroy_hosts.return_value = MagicMock(stdout="ok")
+    monkeypatch.setitem(main.app.config, "LABLINK_PROVIDER", fake_provider)
+    fake_db = MagicMock()
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
+        mock_worker.submit.return_value = 1
+        resp = client.post(DESTROY_ENDPOINT, headers=admin_headers)
+        assert resp.status_code == 302
+
+        fn = mock_worker.submit.call_args.kwargs["fn"]
+        sentinel_callback = MagicMock()
+        fn(sentinel_callback)
+
+    fake_provider.destroy_hosts.assert_called_once()
+    assert (
+        fake_provider.destroy_hosts.call_args.kwargs["progress_callback"]
+        is sentinel_callback
+    )

--- a/packages/allocator/tests/test_terraform_api.py
+++ b/packages/allocator/tests/test_terraform_api.py
@@ -478,33 +478,33 @@ def test_launch_apply_failure(
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.current_instance_security_group",
        return_value="sg-test")
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
-def test_destroy_success(mock_run, mock_sg, mock_ids, mock_names,
+def test_destroy_success(mock_run, mock_popen, mock_sg, mock_ids, mock_names,
                          client, admin_headers, monkeypatch, tmp_path):
-    """Test successful VM destruction via terraform destroy."""
-    # Create a fake terraform directory with tfvars
+    """Test successful VM destruction via a plan+apply destroy sequence."""
     terraform_dir = tmp_path / "terraform"
     terraform_dir.mkdir()
     (terraform_dir / "terraform.runtime.tfvars").write_text("num_vms = 2")
     monkeypatch.setattr("lablink_allocator_service.main.TERRAFORM_DIR", terraform_dir)
     _wire_aws_provider(monkeypatch, terraform_dir)
 
-    # Mock subprocess.run
-    mock_run.return_value = type(
-        "R", (), {"stdout": "\x1b[32mresources destroyed\x1b[0m", "stderr": ""}
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = '{"resource_changes": []}' if "show" in cmd else "OK"
+        result.stderr = ""
+        return result
+
+    mock_run.side_effect = fake_run
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="\x1b[32mresources destroyed\x1b[0m\n", returncode=0,
     )
 
-    # Mock DB and attach to app module via string target
     fake_db = MagicMock()
     monkeypatch.setattr(
         "lablink_allocator_service.main.database", fake_db, raising=False
     )
 
-    # Call the destroy endpoint -- now async: it submits a job and returns
-    # immediately instead of running terraform inline. Capture and invoke
-    # the closure (still within the scope of the @patch decorators above)
-    # to exercise the same destroy_hosts call the background thread would
-    # make.
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.return_value = 1
         resp = client.post(DESTROY_ENDPOINT, headers=admin_headers)
@@ -515,16 +515,21 @@ def test_destroy_success(mock_run, mock_sg, mock_ids, mock_names,
 
     assert "resources destroyed" in output
 
-    # Correct terraform command called with cwd
-    mock_run.assert_called_once()
-    args, kwargs = mock_run.call_args
-    assert args[0][:2] == ["terraform", "destroy"]
-    assert "-auto-approve" in args[0]
-    assert "-var-file=terraform.runtime.tfvars" in args[0]
-    assert kwargs["cwd"] == terraform_dir
-    assert kwargs["check"] is True
-    assert kwargs["capture_output"] is True
-    assert kwargs["text"] is True
+    # plan -destroy, then show -json (2 subprocess.run calls)
+    assert mock_run.call_count == 2
+    plan_args, plan_kwargs = mock_run.call_args_list[0]
+    assert plan_args[0][:3] == ["terraform", "plan", "-destroy"]
+    assert "-var-file=terraform.runtime.tfvars" in plan_args[0]
+    assert plan_kwargs["cwd"] == terraform_dir
+
+    show_args, _ = mock_run.call_args_list[1]
+    assert show_args[0][1] == "show"
+
+    # apply (of the saved destroy plan) streams via Popen
+    mock_popen.assert_called_once()
+    popen_args, popen_kwargs = mock_popen.call_args
+    assert popen_args[0][:2] == ["terraform", "apply"]
+    assert popen_kwargs["cwd"] == terraform_dir
 
     # DB cleared exactly once
     fake_db.clear_database.assert_called_once()
@@ -534,23 +539,28 @@ def test_destroy_success(mock_run, mock_sg, mock_ids, mock_names,
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.current_instance_security_group",
        return_value="sg-test")
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
-def test_destroy_failure(mock_run, mock_sg, mock_ids, mock_names,
+def test_destroy_failure(mock_run, mock_popen, mock_sg, mock_ids, mock_names,
                          client, admin_headers, monkeypatch, tmp_path):
-    # Create a fake terraform directory with tfvars
     terraform_dir = tmp_path / "terraform"
     terraform_dir.mkdir()
     (terraform_dir / "terraform.runtime.tfvars").write_text("num_vms = 2")
     monkeypatch.setattr("lablink_allocator_service.main.TERRAFORM_DIR", terraform_dir)
     _wire_aws_provider(monkeypatch, terraform_dir)
 
-    # Mock subprocess.run to raise an error
-    mock_run.side_effect = subprocess.CalledProcessError(
-        returncode=1, cmd=["terraform", "destroy"], stderr="\x1b[31merror\x1b[0m"
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = '{"resource_changes": []}' if "show" in cmd else "OK"
+        result.stderr = ""
+        return result
+
+    mock_run.side_effect = fake_run
+    # The apply-of-the-destroy-plan step fails.
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="", stderr_text="\x1b[31merror\x1b[0m", returncode=1,
     )
 
-    # Call the destroy endpoint -- submission succeeds immediately (job
-    # queued); the terraform failure only surfaces once the closure runs.
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.return_value = 1
         resp = client.post(DESTROY_ENDPOINT, headers=admin_headers)
@@ -560,8 +570,7 @@ def test_destroy_failure(mock_run, mock_sg, mock_ids, mock_names,
         with pytest.raises(RuntimeError, match="error"):
             fn()
 
-    # Ensure run was called correctly
-    mock_run.assert_called_once()
+    mock_popen.assert_called_once()
 
 
 def test_launch_invalid_num_vms(client, admin_headers):
@@ -596,8 +605,9 @@ def test_launch_missing_num_vms(client, admin_headers):
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.current_instance_security_group",
        return_value="sg-test")
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
-def test_destroy_json_success(mock_run, mock_sg, mock_ids, mock_names,
+def test_destroy_json_success(mock_run, mock_popen, mock_sg, mock_ids, mock_names,
                                client, admin_headers, monkeypatch, tmp_path):
     """Test successful destroy returns JSON when Accept header is set."""
     terraform_dir = tmp_path / "terraform"
@@ -606,8 +616,15 @@ def test_destroy_json_success(mock_run, mock_sg, mock_ids, mock_names,
     monkeypatch.setattr("lablink_allocator_service.main.TERRAFORM_DIR", terraform_dir)
     _wire_aws_provider(monkeypatch, terraform_dir)
 
-    mock_run.return_value = type(
-        "R", (), {"stdout": "\x1b[32mresources destroyed\x1b[0m", "stderr": ""}
+    def fake_run(cmd, **kwargs):
+        result = MagicMock()
+        result.stdout = '{"resource_changes": []}' if "show" in cmd else "OK"
+        result.stderr = ""
+        return result
+
+    mock_run.side_effect = fake_run
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="\x1b[32mresources destroyed\x1b[0m\n", returncode=0,
     )
 
     fake_db = MagicMock()

--- a/packages/allocator/tests/test_terraform_api.py
+++ b/packages/allocator/tests/test_terraform_api.py
@@ -66,6 +66,23 @@ CLEAN_PLAN_JSON = json.dumps({
 })
 
 
+class _FakeCompletedPopen:
+    """Minimal stand-in for subprocess.Popen matching _run_streamed's
+    expected surface — see providers/test_run_streamed.py for the
+    canonical version; duplicated here since this file already follows
+    a self-contained-fixtures convention rather than importing test
+    helpers across files."""
+
+    def __init__(self, stdout_text="", stderr_text="", returncode=0):
+        import io
+        self.stdout = io.StringIO(stdout_text)
+        self.stderr = io.StringIO(stderr_text)
+        self._returncode = returncode
+
+    def wait(self):
+        return self._returncode
+
+
 @patch("lablink_allocator_service.providers.aws.upload_to_s3")
 @patch("lablink_allocator_service.providers.aws.check_support_nvidia", return_value=True)
 @patch("lablink_allocator_service.providers.aws.get_instance_timings",
@@ -74,9 +91,11 @@ CLEAN_PLAN_JSON = json.dumps({
                               "seconds": 60.0}})
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_launch_vm_success(
     mock_run,
+    mock_popen,
     mock_get_names,
     mock_get_ids,
     mock_get_timings,
@@ -120,8 +139,10 @@ def test_launch_vm_success(
     mock_run.side_effect = [
         R("OK"),                             # terraform plan -out (writes plan file)
         R(CLEAN_PLAN_JSON),                  # terraform show -json (feeds the SG audit)
-        R("\x1b[32mapply success\x1b[0m"),   # terraform apply <planfile>
     ]
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="\x1b[32mapply success\x1b[0m\n", returncode=0,
+    )
 
     # Call route -- now async: it submits a job and returns immediately
     # instead of running terraform inline. Capture and invoke the closure
@@ -135,9 +156,9 @@ def test_launch_vm_success(
         fn = mock_worker.submit.call_args.kwargs["fn"]
         fn()
 
-    # Assert calls (plan + show -json + apply = 3; terraform output calls
-    # are handled by patched get_instance_* functions)
-    assert mock_run.call_count == 3
+    # Assert calls: plan + show -json via subprocess.run (2); apply via
+    # Popen (streamed, checked separately below).
+    assert mock_run.call_count == 2
 
     # Check plan call (must come first; writes the plan file)
     plan_args, plan_kwargs = mock_run.call_args_list[0]
@@ -155,11 +176,12 @@ def test_launch_vm_success(
     assert "-json" in show_cmd_list
     assert show_kwargs["cwd"] == terraform_dir
 
-    # Check apply call (applies the saved plan file; vars are baked in)
-    apply_args, apply_kwargs = mock_run.call_args_list[2]
+    # Check apply call (applies the saved plan file; vars are baked in;
+    # now streamed via Popen instead of subprocess.run)
+    mock_popen.assert_called_once()
+    apply_args, apply_kwargs = mock_popen.call_args
     apply_cmd_list = apply_args[0]
     assert "apply" in apply_cmd_list
-    # apply consumes a saved plan file rather than fresh -var flags
     assert not any(a.startswith("-var=") for a in apply_cmd_list)
     assert apply_kwargs["cwd"] == terraform_dir
 
@@ -199,9 +221,11 @@ def test_launch_vm_success(
                               "seconds": 60.0}})
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_launch_vm_appends_allocator_sg_id_var(
     mock_run,
+    mock_popen,
     mock_get_names,
     mock_get_ids,
     mock_get_timings,
@@ -244,8 +268,10 @@ def test_launch_vm_appends_allocator_sg_id_var(
     mock_run.side_effect = [
         R("OK"),               # terraform plan -out
         R(CLEAN_PLAN_JSON),    # terraform show -json
-        R("apply ok"),         # terraform apply <planfile>
     ]
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="apply ok\n", returncode=0,
+    )
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.return_value = 1
@@ -263,7 +289,7 @@ def test_launch_vm_appends_allocator_sg_id_var(
     assert "plan" in plan_cmd_list
     assert "-var=allocator_sg_id=sg-fake-allocator" in plan_cmd_list
 
-    apply_args, _ = mock_run.call_args_list[2]
+    apply_args, _ = mock_popen.call_args
     apply_cmd_list = apply_args[0]
     assert "apply" in apply_cmd_list
     assert not any(a.startswith("-var=") for a in apply_cmd_list)
@@ -281,9 +307,11 @@ def test_launch_vm_appends_allocator_sg_id_var(
                               "seconds": 60.0}})
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_launch_vm_skips_sg_var_when_not_on_ec2(
     mock_run,
+    mock_popen,
     mock_get_names,
     mock_get_ids,
     mock_get_timings,
@@ -331,8 +359,10 @@ def test_launch_vm_skips_sg_var_when_not_on_ec2(
     mock_run.side_effect = [
         R("OK"),               # terraform plan -out
         R(CLEAN_PLAN_JSON),    # terraform show -json
-        R("apply ok"),         # terraform apply <planfile>
     ]
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="apply ok\n", returncode=0,
+    )
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.return_value = 1
@@ -353,7 +383,7 @@ def test_launch_vm_skips_sg_var_when_not_on_ec2(
         a.startswith("-var=allocator_sg_id=") for a in plan_cmd_list
     )
 
-    apply_args, _ = mock_run.call_args_list[2]
+    apply_args, _ = mock_popen.call_args
     apply_cmd_list = apply_args[0]
     assert "apply" in apply_cmd_list
     assert not any(a.startswith("-var=") for a in apply_cmd_list)
@@ -386,9 +416,11 @@ def test_launch_missing_allocator_outputs_returns_error(
 
 
 @patch("lablink_allocator_service.providers.aws.check_support_nvidia", return_value=False)
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_launch_apply_failure(
-    mock_run, mock_check_support_nvidia, client, admin_headers, monkeypatch, tmp_path
+    mock_run, mock_popen, mock_check_support_nvidia, client, admin_headers,
+    monkeypatch, tmp_path,
 ):
     """Test VM launch failure during apply."""
     # Create a fake terraform directory
@@ -422,6 +454,12 @@ def test_launch_apply_failure(
         raise subprocess.CalledProcessError(1, cmd, stderr="\x1b[31mboom\x1b[0m")
 
     mock_run.side_effect = side_effect
+    # apply now streams via Popen; simulate its failure the way
+    # _run_streamed detects one -- a nonzero return code, with stderr
+    # available on the (mocked) process's .stderr stream.
+    mock_popen.return_value = _FakeCompletedPopen(
+        stderr_text="\x1b[31mboom\x1b[0m", returncode=1,
+    )
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.return_value = 1
@@ -685,9 +723,11 @@ def test_destroy_no_tfvars_json(mock_ids, mock_names,
                               "seconds": 60.0}})
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_launch_json_success(
     mock_run,
+    mock_popen,
     mock_get_names,
     mock_get_ids,
     mock_get_timings,
@@ -724,8 +764,10 @@ def test_launch_json_success(
     mock_run.side_effect = [
         R("OK"),               # terraform plan -out
         R(CLEAN_PLAN_JSON),    # terraform show -json
-        R("apply success"),    # terraform apply <planfile>
     ]
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="apply success", returncode=0,
+    )
 
     headers = {**admin_headers, **JSON_ACCEPT}
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
@@ -799,9 +841,11 @@ def test_launch_json_missing_allocator_outputs(
 
 
 @patch("lablink_allocator_service.providers.aws.check_support_nvidia", return_value=False)
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_launch_json_apply_failure(
-    mock_run, mock_check_support_nvidia, client, admin_headers, monkeypatch, tmp_path
+    mock_run, mock_popen, mock_check_support_nvidia, client, admin_headers,
+    monkeypatch, tmp_path,
 ):
     """Test Terraform apply failure returns JSON 500."""
     terraform_dir = tmp_path / "terraform"
@@ -832,6 +876,11 @@ def test_launch_json_apply_failure(
         )
 
     mock_run.side_effect = side_effect
+    # apply now streams via Popen; simulate its failure via a nonzero
+    # return code, with stderr available on the mocked process.
+    mock_popen.return_value = _FakeCompletedPopen(
+        stderr_text="Error: resource already exists", returncode=1,
+    )
 
     headers = {**admin_headers, **JSON_ACCEPT}
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
@@ -853,9 +902,11 @@ def test_launch_json_apply_failure(
 
 @patch("lablink_allocator_service.providers.aws.upload_to_s3")
 @patch("lablink_allocator_service.providers.aws.check_support_nvidia", return_value=True)
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_launch_json_unexpected_error(
     mock_run,
+    mock_popen,
     mock_check_support_nvidia,
     mock_upload_to_s3,
     client,
@@ -891,8 +942,10 @@ def test_launch_json_unexpected_error(
     mock_run.side_effect = [
         R("OK"),               # terraform plan -out
         R(CLEAN_PLAN_JSON),    # terraform show -json
-        R("apply success"),    # terraform apply <planfile>
     ]
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="apply success\n", returncode=0,
+    )
     mock_upload_to_s3.side_effect = Exception("AccessDenied: s3:PutObject")
 
     headers = {**admin_headers, **JSON_ACCEPT}
@@ -1092,9 +1145,11 @@ def test_launch_aborts_on_sg_audit_failure_html(
                               "seconds": 60.0}})
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_launch_writes_register_token_to_tfvars(
     mock_run,
+    mock_popen,
     mock_get_names,
     mock_get_ids,
     mock_get_timings,
@@ -1138,8 +1193,10 @@ def test_launch_writes_register_token_to_tfvars(
     mock_run.side_effect = [
         R("OK"),
         R(CLEAN_PLAN_JSON),
-        R("\x1b[32mapply success\x1b[0m"),
     ]
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="\x1b[32mapply success\x1b[0m\n", returncode=0,
+    )
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.return_value = 1
@@ -1162,9 +1219,11 @@ def test_launch_writes_register_token_to_tfvars(
                               "seconds": 60.0}})
 @patch("lablink_allocator_service.providers.aws.get_instance_ids", return_value=[])
 @patch("lablink_allocator_service.providers.aws.get_instance_names", return_value=[])
+@patch("lablink_allocator_service.providers.aws.subprocess.Popen")
 @patch("lablink_allocator_service.providers.aws.subprocess.run")
 def test_launch_writes_agent_token_to_tfvars_additively(
     mock_run,
+    mock_popen,
     mock_get_names,
     mock_get_ids,
     mock_get_timings,
@@ -1209,8 +1268,10 @@ def test_launch_writes_agent_token_to_tfvars_additively(
     mock_run.side_effect = [
         R("OK"),
         R(CLEAN_PLAN_JSON),
-        R("\x1b[32mapply success\x1b[0m"),
     ]
+    mock_popen.return_value = _FakeCompletedPopen(
+        stdout_text="\x1b[32mapply success\x1b[0m\n", returncode=0,
+    )
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.return_value = 1

--- a/packages/cli/src/lablink_cli/api.py
+++ b/packages/cli/src/lablink_cli/api.py
@@ -6,7 +6,7 @@ import base64
 import json
 import ssl
 import time
-from typing import NoReturn
+from typing import Callable, NoReturn
 from urllib.error import HTTPError, URLError
 from urllib.parse import urlencode
 from urllib.request import Request, urlopen
@@ -120,7 +120,10 @@ class AllocatorAPI:
             self._ssl_ctx.check_hostname = False
             self._ssl_ctx.verify_mode = ssl.CERT_NONE
 
-    def destroy_vms(self) -> dict | None:
+    def destroy_vms(
+        self,
+        on_progress: Callable[[int | None, int | None], None] | None = None,
+    ) -> dict | None:
         """POST /destroy to tear down client VMs, then poll until the
         job reaches a terminal status.
 
@@ -129,9 +132,15 @@ class AllocatorAPI:
         (same as the old synchronous contract), or
         AllocatorError/AllocatorOperationTimeout otherwise.
         """
-        return self._submit_and_poll("POST", "/destroy")
+        return self._submit_and_poll(
+            "POST", "/destroy", on_progress=on_progress,
+        )
 
-    def launch_vms(self, num_vms: int) -> dict | None:
+    def launch_vms(
+        self,
+        num_vms: int,
+        on_progress: Callable[[int | None, int | None], None] | None = None,
+    ) -> dict | None:
         """POST /api/launch to provision num_vms new client VMs, then
         poll until the job reaches a terminal status.
 
@@ -143,6 +152,7 @@ class AllocatorAPI:
             "/api/launch",
             data,
             content_type="application/x-www-form-urlencoded",
+            on_progress=on_progress,
         )
 
     def _submit_and_poll(
@@ -152,9 +162,16 @@ class AllocatorAPI:
         data: bytes | None = b"",
         *,
         content_type: str | None = None,
+        on_progress: Callable[[int | None, int | None], None] | None = None,
     ) -> dict | None:
         """Submit an async apply/destroy job and poll GET
-        /api/operations/<id> until it reaches a terminal status."""
+        /api/operations/<id> until it reaches a terminal status.
+
+        If on_progress is given, it's called once per poll tick with
+        (resources_completed, resources_total) read off the operation
+        response. Both are None if the allocator predates progress
+        reporting (the keys are simply absent from its response) —
+        callers must handle that, not assume real numbers."""
         submitted = self._request(
             method, path, data, content_type=content_type
         )
@@ -176,6 +193,11 @@ class AllocatorAPI:
                 op = None
 
             if op is not None:
+                if on_progress:
+                    on_progress(
+                        op.get("resources_completed"),
+                        op.get("resources_total"),
+                    )
                 status = op.get("status")
                 if status == "succeeded":
                     return {

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -11,6 +11,7 @@ from pathlib import Path
 
 from rich.console import Console
 from rich.panel import Panel
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 
 from lablink_allocator_service.conf.structured_config import Config
 
@@ -661,10 +662,30 @@ def _destroy_client_vms(
     )
     started = time.monotonic()
     try:
-        with console.status(
-            "  [bold]waiting for allocator...[/bold]", spinner="dots"
-        ):
-            result = api.destroy_vms()
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            console=console,
+            transient=True,
+        ) as progress:
+            task = progress.add_task(
+                "  [bold]waiting for allocator...[/bold]", total=None,
+            )
+
+            def _on_progress(done, total):
+                if total:
+                    progress.update(
+                        task,
+                        completed=done,
+                        total=total,
+                        description=(
+                            f"  [bold]waiting for allocator...[/bold] "
+                            f"({done}/{total} resources)"
+                        ),
+                    )
+
+            result = api.destroy_vms(on_progress=_on_progress)
         elapsed = time.monotonic() - started
         console.print(
             f"  [green]✓ client VMs destroyed[/green]  "

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -674,7 +674,7 @@ def _destroy_client_vms(
             )
 
             def _on_progress(done, total):
-                if total:
+                if done is not None and total is not None:
                     progress.update(
                         task,
                         completed=done,

--- a/packages/cli/src/lablink_cli/commands/launch.py
+++ b/packages/cli/src/lablink_cli/commands/launch.py
@@ -91,7 +91,7 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
             )
 
             def _on_progress(done, total):
-                if total:
+                if done is not None and total is not None:
                     progress.update(
                         task,
                         completed=done,

--- a/packages/cli/src/lablink_cli/commands/launch.py
+++ b/packages/cli/src/lablink_cli/commands/launch.py
@@ -6,6 +6,7 @@ import re
 import time
 
 from rich.console import Console
+from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 
 from lablink_allocator_service.conf.structured_config import Config
 
@@ -77,11 +78,31 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
 
     started = time.monotonic()
     try:
-        with console.status(
-            f"[bold]Launching {num_vms} client VM(s)...[/bold]",
-            spinner="dots",
-        ):
-            result = api.launch_vms(num_vms)
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            console=console,
+            transient=True,
+        ) as progress:
+            task = progress.add_task(
+                f"[bold]Launching {num_vms} client VM(s)...[/bold]",
+                total=None,
+            )
+
+            def _on_progress(done, total):
+                if total:
+                    progress.update(
+                        task,
+                        completed=done,
+                        total=total,
+                        description=(
+                            f"[bold]Launching {num_vms} client VM(s)...[/bold] "
+                            f"({done}/{total} resources)"
+                        ),
+                    )
+
+            result = api.launch_vms(num_vms, on_progress=_on_progress)
         elapsed = time.monotonic() - started
 
         output = (result or {}).get("output", "")

--- a/packages/cli/tests/test_api.py
+++ b/packages/cli/tests/test_api.py
@@ -276,3 +276,67 @@ class TestLaunchVms:
         api = _make_api()
         with pytest.raises(AllocatorError, match="already in progress"):
             api.launch_vms(1)
+
+
+class TestSubmitAndPollProgress:
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_on_progress_called_with_fields_when_present(
+        self, mock_urlopen, mock_sleep,
+    ):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 7, "status": "queued"}),
+            _mock_response({
+                "id": 7, "status": "running",
+                "resources_completed": 1, "resources_total": 3,
+            }),
+            _mock_response({
+                "id": 7, "status": "succeeded", "output": "done",
+                "resources_completed": 3, "resources_total": 3,
+            }),
+        ]
+        calls = []
+        api = _make_api()
+        api.destroy_vms(
+            on_progress=lambda done, total: calls.append((done, total))
+        )
+
+        assert calls == [(1, 3), (3, 3)]
+
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_on_progress_called_with_none_when_fields_absent(
+        self, mock_urlopen, mock_sleep,
+    ):
+        """An allocator that predates progress reporting simply omits
+        these keys — on_progress must still be called, with (None, None),
+        not skipped or erroring."""
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 7, "status": "queued"}),
+            _mock_response({"id": 7, "status": "succeeded", "output": "done"}),
+        ]
+        calls = []
+        api = _make_api()
+        api.destroy_vms(
+            on_progress=lambda done, total: calls.append((done, total))
+        )
+
+        assert calls == [(None, None)]
+
+    @patch("lablink_cli.api.time.sleep")
+    @patch("lablink_cli.api.urlopen")
+    def test_launch_vms_also_accepts_on_progress(self, mock_urlopen, mock_sleep):
+        mock_urlopen.side_effect = [
+            _mock_response({"job_id": 9, "status": "queued"}),
+            _mock_response({
+                "id": 9, "status": "succeeded", "output": "ok",
+                "resources_completed": 2, "resources_total": 2,
+            }),
+        ]
+        calls = []
+        api = _make_api()
+        api.launch_vms(
+            2, on_progress=lambda done, total: calls.append((done, total))
+        )
+
+        assert calls == [(2, 2)]

--- a/packages/cli/tests/test_deploy.py
+++ b/packages/cli/tests/test_deploy.py
@@ -261,6 +261,40 @@ class TestDestroyClientVms:
         captured["on_progress"](None, None)
         mock_progress.update.assert_not_called()
 
+    @patch("lablink_cli.commands.deploy.Progress")
+    @patch("lablink_cli.commands.deploy.AllocatorAPI")
+    @patch(
+        "lablink_cli.commands.deploy.get_allocator_url",
+        return_value="https://allocator.example.com",
+    )
+    def test_progress_bar_not_updated_when_only_one_field_present(
+        self, mock_url, mock_api_cls, mock_progress_cls, mock_cfg,
+    ):
+        """resources_total and resources_completed are independent optional
+        fields — a response carrying one without the other must not render
+        a literal "None" into the description."""
+        mock_progress = MagicMock()
+        mock_progress.add_task.return_value = "task-id"
+        mock_progress_cls.return_value.__enter__.return_value = mock_progress
+
+        captured = {}
+
+        def fake_destroy_vms(on_progress=None):
+            captured["on_progress"] = on_progress
+            return {"status": "ok"}
+
+        mock_api = MagicMock()
+        mock_api.destroy_vms.side_effect = fake_destroy_vms
+        mock_api_cls.return_value = mock_api
+
+        _destroy_client_vms(mock_cfg, "admin", "pass")
+
+        captured["on_progress"](None, 4)
+        mock_progress.update.assert_not_called()
+
+        captured["on_progress"](2, None)
+        mock_progress.update.assert_not_called()
+
 
 # ------------------------------------------------------------------
 # _terraform_destroy

--- a/packages/cli/tests/test_deploy.py
+++ b/packages/cli/tests/test_deploy.py
@@ -198,6 +198,69 @@ class TestDestroyClientVms:
     def test_no_url_skips(self, mock_url, mock_cfg):
         _destroy_client_vms(mock_cfg, "admin", "pass")
 
+    @patch("lablink_cli.commands.deploy.Progress")
+    @patch("lablink_cli.commands.deploy.AllocatorAPI")
+    @patch(
+        "lablink_cli.commands.deploy.get_allocator_url",
+        return_value="https://allocator.example.com",
+    )
+    def test_progress_bar_updates_from_on_progress_callback(
+        self, mock_url, mock_api_cls, mock_progress_cls, mock_cfg,
+    ):
+        mock_progress = MagicMock()
+        mock_progress.add_task.return_value = "task-id"
+        mock_progress_cls.return_value.__enter__.return_value = mock_progress
+
+        captured = {}
+
+        def fake_destroy_vms(on_progress=None):
+            captured["on_progress"] = on_progress
+            return {"status": "ok"}
+
+        mock_api = MagicMock()
+        mock_api.destroy_vms.side_effect = fake_destroy_vms
+        mock_api_cls.return_value = mock_api
+
+        _destroy_client_vms(mock_cfg, "admin", "pass")
+
+        captured["on_progress"](2, 4)
+        mock_progress.update.assert_called_with(
+            "task-id",
+            completed=2,
+            total=4,
+            description=(
+                "  [bold]waiting for allocator...[/bold] (2/4 resources)"
+            ),
+        )
+
+    @patch("lablink_cli.commands.deploy.Progress")
+    @patch("lablink_cli.commands.deploy.AllocatorAPI")
+    @patch(
+        "lablink_cli.commands.deploy.get_allocator_url",
+        return_value="https://allocator.example.com",
+    )
+    def test_progress_bar_not_updated_when_total_unknown(
+        self, mock_url, mock_api_cls, mock_progress_cls, mock_cfg,
+    ):
+        mock_progress = MagicMock()
+        mock_progress.add_task.return_value = "task-id"
+        mock_progress_cls.return_value.__enter__.return_value = mock_progress
+
+        captured = {}
+
+        def fake_destroy_vms(on_progress=None):
+            captured["on_progress"] = on_progress
+            return {"status": "ok"}
+
+        mock_api = MagicMock()
+        mock_api.destroy_vms.side_effect = fake_destroy_vms
+        mock_api_cls.return_value = mock_api
+
+        _destroy_client_vms(mock_cfg, "admin", "pass")
+
+        captured["on_progress"](None, None)
+        mock_progress.update.assert_not_called()
+
 
 # ------------------------------------------------------------------
 # _terraform_destroy

--- a/packages/cli/tests/test_launch.py
+++ b/packages/cli/tests/test_launch.py
@@ -183,6 +183,41 @@ class TestRunLaunch:
         captured["on_progress"](None, None)
         mock_progress.update.assert_not_called()
 
+    @patch("lablink_cli.commands.launch.Progress")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_progress_bar_not_updated_when_only_one_field_present(
+        self, mock_url, mock_creds, mock_api_cls, mock_progress_cls, mock_cfg,
+    ):
+        """resources_total and resources_completed are independent optional
+        fields — a response carrying one without the other (e.g. total=5,
+        completed=None) must not render a literal "None" into the
+        description."""
+        mock_url.return_value = "http://1.2.3.4"
+        mock_creds.return_value = ("admin", "password")
+        mock_progress = MagicMock()
+        mock_progress.add_task.return_value = "task-id"
+        mock_progress_cls.return_value.__enter__.return_value = mock_progress
+
+        captured = {}
+
+        def fake_launch_vms(num_vms, on_progress=None):
+            captured["on_progress"] = on_progress
+            return {"status": "success", "output": ""}
+
+        mock_api = MagicMock()
+        mock_api.launch_vms.side_effect = fake_launch_vms
+        mock_api_cls.return_value = mock_api
+
+        run_launch(mock_cfg, num_vms=1)
+
+        captured["on_progress"](None, 5)
+        mock_progress.update.assert_not_called()
+
+        captured["on_progress"](3, None)
+        mock_progress.update.assert_not_called()
+
 
 class TestManualLaunchNoOp:
     def test_manual_provider_prints_explanation_and_exits_zero(

--- a/packages/cli/tests/test_launch.py
+++ b/packages/cli/tests/test_launch.py
@@ -43,7 +43,9 @@ class TestRunLaunch:
         mock_api_cls.assert_called_once_with(
             "http://1.2.3.4", "admin", "password", mock_cfg.ssl.provider
         )
-        mock_api.launch_vms.assert_called_once_with(2)
+        mock_api.launch_vms.assert_called_once()
+        assert mock_api.launch_vms.call_args.args == (2,)
+        assert callable(mock_api.launch_vms.call_args.kwargs["on_progress"])
 
     @patch("lablink_cli.commands.launch.AllocatorAPI")
     @patch("lablink_cli.commands.launch.resolve_admin_credentials")
@@ -112,6 +114,74 @@ class TestRunLaunch:
 
         with pytest.raises(SystemExit):
             run_launch(mock_cfg, num_vms=1)
+
+
+    @patch("lablink_cli.commands.launch.Progress")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_progress_bar_updates_from_on_progress_callback(
+        self, mock_url, mock_creds, mock_api_cls, mock_progress_cls, mock_cfg,
+    ):
+        mock_url.return_value = "http://1.2.3.4"
+        mock_creds.return_value = ("admin", "password")
+
+        mock_progress = MagicMock()
+        mock_progress.add_task.return_value = "task-id"
+        mock_progress_cls.return_value.__enter__.return_value = mock_progress
+
+        captured = {}
+
+        def fake_launch_vms(num_vms, on_progress=None):
+            captured["on_progress"] = on_progress
+            return {"status": "success", "output": ""}
+
+        mock_api = MagicMock()
+        mock_api.launch_vms.side_effect = fake_launch_vms
+        mock_api_cls.return_value = mock_api
+
+        run_launch(mock_cfg, num_vms=2)
+
+        captured["on_progress"](3, 5)
+        mock_progress.update.assert_called_with(
+            "task-id",
+            completed=3,
+            total=5,
+            description=(
+                "[bold]Launching 2 client VM(s)...[/bold] (3/5 resources)"
+            ),
+        )
+
+    @patch("lablink_cli.commands.launch.Progress")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_progress_bar_not_updated_when_total_unknown(
+        self, mock_url, mock_creds, mock_api_cls, mock_progress_cls, mock_cfg,
+    ):
+        """Polling an allocator that predates progress reporting sends
+        (None, None) — the progress bar must stay in its indeterminate
+        state, not attempt an update with a None total."""
+        mock_url.return_value = "http://1.2.3.4"
+        mock_creds.return_value = ("admin", "password")
+        mock_progress = MagicMock()
+        mock_progress.add_task.return_value = "task-id"
+        mock_progress_cls.return_value.__enter__.return_value = mock_progress
+
+        captured = {}
+
+        def fake_launch_vms(num_vms, on_progress=None):
+            captured["on_progress"] = on_progress
+            return {"status": "success", "output": ""}
+
+        mock_api = MagicMock()
+        mock_api.launch_vms.side_effect = fake_launch_vms
+        mock_api_cls.return_value = mock_api
+
+        run_launch(mock_cfg, num_vms=1)
+
+        captured["on_progress"](None, None)
+        mock_progress.update.assert_not_called()
 
 
 class TestManualLaunchNoOp:


### PR DESCRIPTION
## Summary

Adds real `N/total` resource-completion progress to launch/destroy operations, replacing the indeterminate spinner/elapsed-time-only treatment in both the web dashboard's operations panel and the CLI's `lablink deploy`/`lablink cleanup` commands — by parsing Terraform's streamed output instead of discarding it until the job completes.

**Rebased onto `main` now that #397 has merged.** This branch was previously stacked on `feat/admin-instances-dashboard-377` because the frontend piece (Task 8) builds on that PR's operations-history panel and job-status banner. #397's 13 commits have been dropped from this branch (they arrived on `main` as squash-merge 396935a8) and the 18 progress-tracking commits replayed on top — so the diff below is now this PR's work only.

## ⚠️ This PR changes two things #397 just shipped

Reviewers of #397 should be aware that commit `151f1806` ("match instances view-toggle layout to mockup, drop container-startup column") adjusts the `/admin/instances` page that #397 landed hours ago. Both changes came from a mockup review on this branch, and neither is required by the progress-tracking work — they're separable if you'd rather they didn't ride along:

- **`Container Startup Duration` removed from the Table view** (`<th>` + `<td>`), taking the table from 10 columns to 9. **Card view still displays it** (`Container Startup: N.Ns`), so the metric is not gone from the UI — only from the wide table, which was the column-count driver behind the horizontal-scroll fix.
- **`.view-toggle` changed from `justify-content: center` to `space-between`**, grouping the view toggle and refresh controls to opposite ends instead of centering them.

The corresponding `test_pages.py` assertions were updated in the same commit (the horizontal-scroll test's docstring no longer claims 10 columns).

## Changes

### Allocator backend
- `operations` table gains `resources_total`/`resources_completed` columns (no migration — fresh-per-deployment DB), plus `OperationsDatabase.update_operation_progress` and a `finish_operation` update that snaps `resources_completed` to `resources_total` on success.
- `OperationsWorker` builds and threads a progress callback into the operation-running closure.
- `ComputeProvider` protocol (and `ManualProvider`) gain an optional `progress_callback` parameter; `ManualProvider` never calls it (it never runs Terraform).
- New `_run_streamed` helper in `AWSProvider`: streams `terraform apply`/`terraform apply <destroy-plan>` via `Popen` instead of blocking `subprocess.run`, invoking a callback as each resource's completion line streams past — with proper cleanup (kill + join) if the callback itself raises.
- `provision_hosts` computes `resources_total` from the plan JSON it already parses for the security-group audit (no new Terraform call). `destroy_hosts` gains a new `terraform plan -destroy` step to get the same exact-count treatment for destroys (small added latency, accepted trade-off for an exact count over an approximation).
- `main.py`'s `_run_launch`/`_run_destroy` forward the callback through, with a backward-compatible `None` default.

### Web dashboard
- `/admin/instances`'s operations-history panel and job-status banner render a real filled progress bar + `"N/total resources"` text once a total is known, falling back to the existing indeterminate bar when it isn't.
- Progress bars disappear once an operation reaches a terminal status — only `queued`/`running` operations show one.
- Job-status banner also gains a close button, larger text, and per-state icons + labels (so states aren't distinguished by background color alone).
- Table-view column and view-toggle adjustments — see the ⚠️ section above.

### CLI
- `AllocatorAPI._submit_and_poll` (and `launch_vms`/`destroy_vms`) gain an `on_progress` callback, read off the same 2-second poll loop that already existed — no new HTTP calls.
- `lablink deploy`/`lablink cleanup` swap their indeterminate `rich` spinner for a real `rich.progress.Progress` bar.
- Graceful degradation verified both ways: an older allocator's response simply lacks the two new fields, and both the API layer and CLI commands degrade to today's indeterminate look rather than erroring.

## Testing

Re-run after the rebase onto `main`:

- [x] Allocator suite (`PYTHONPATH=src pytest --ignore=tests/terraform`) — **752 passed, 19 skipped**
- [x] CLI suite (`PYTHONPATH=src pytest`) — **593 passed, 1 deselected** (the `test_deploy_compose.py` rich-formatting failure noted earlier is no longer present)
- [x] `ruff check src tests` clean in both packages
- [x] CI green on the rebased branch — all 3 lint jobs, all 3 test jobs, and the allocator image build pass
- [x] Manual end-to-end (launch/destroy a real VM, watch the bar move 0→N in both the web dashboard and the CLI)

Note: `tests/terraform` fails locally for want of a Terraform binary/credentials — identical failures on a clean `main` checkout, and it passes in CI.

## Related Issues

Builds on #397 (merged).
