### PR TITLE
fix(cli): wizard layout unusable on small terminals — collapsed radio options, oversized editors

### DIFF
--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -1634,7 +1634,15 @@ class ConfigWizard(App):
     }
     TextArea {
         margin: 0 2;
-        height: 20;
+        /* Scale with the terminal instead of a hard 20 rows, which on a
+           short terminal was taller than the whole form viewport and buried
+           the fields below it. The percentage resolves against the scroll
+           viewport; `1fr` would not work here — like RadioSet above it only
+           gets the space fixed-size siblings leave over, which on the
+           startup-script form is nothing. */
+        height: 60%;
+        min-height: 6;
+        max-height: 24;
     }
     .nav-buttons {
         margin: 1 0;

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -1590,7 +1590,12 @@ class ConfigWizard(App):
     Screen {
         align: center middle;
     }
-    VerticalScroll {
+    /* Only the screen's own scroll viewport claims the available height.
+       Must stay scoped to a direct child of Screen: Textual's RadioSet is
+       itself a VerticalScroll subclass, and a bare `VerticalScroll` type
+       selector matches subclasses — that overrode every RadioSet's
+       `height: auto` with `1fr`, collapsing the radio boxes to 0 rows. */
+    Screen > VerticalScroll {
         height: 1fr;
     }
     #dns-guided, #dns-advanced {
@@ -1623,6 +1628,9 @@ class ConfigWizard(App):
     }
     RadioSet {
         margin: 0 2;
+        /* Redundant with Textual's default, stated explicitly so a future
+           container rule can't silently collapse the options again. */
+        height: auto;
     }
     TextArea {
         margin: 0 2;


### PR DESCRIPTION
## Summary

Two CSS fixes making the `lablink configure` wizard usable on a small terminal:

- **Radio options could not be selected** — a single over-broad CSS type selector collapsed every `RadioSet` in the wizard to 0 rows, rendering them as empty bordered boxes.
- **The `TextArea` editors were a hard `height: 20`**, taller than the entire form viewport on a short terminal, burying every field below them.

Reported against "Step 4: DNS & SSL" (Access Method) and "Step 5: Client Startup Script" (Startup Script / On error), where the options showed as empty grey bands.

CSS-only: 1 file, 18 insertions, 2 deletions.

## Commit 1 — RadioSet collapsed to 0 rows

`ConfigWizard.CSS` carried a bare type selector:

```css
VerticalScroll { height: 1fr; }
```

Textual's `RadioSet` **is** a `VerticalScroll` subclass (`RadioSet → VerticalScroll → ScrollableContainer → Widget`), and Textual type selectors match subclasses. App-level CSS beats widget `DEFAULT_CSS`, so this silently overrode every RadioSet's own `height: auto` with `1fr`. A `1fr` widget only receives space its fixed-size siblings leave over — on these long forms, zero rows.

That rule came from #373, which needed the screen's scroll viewport to claim available height. The RadioSets were collateral damage.

**The two reported screens were the visible symptom; the cause hit every RadioSet in the wizard.** Measured `container_size.height` vs. option count before the fix:

| RadioSet | Viewport rows | Options needed | Broken at |
|---|---|---|---|
| `dns-screen-mode` (Guided/Advanced toggle) | 0 | 2 | **every size** |
| all four `adv-*` radios (Advanced pane) | 0 | 2–5 | **every size** |
| `startup-mode`, `on-error` | 0 | 3, 2 | **every size** |
| `dns-mode` (Access Method) | 0 | 5 | ≤ 24 rows |
| `env`, `provider`, `connectivity`, `participant-exposure`, `monitoring` | 0 | 2–4 | small terminals |

So the Guided/Advanced toggle and the whole Advanced pane were unreachable at *any* terminal size — in the report's own large-terminal screenshot, the thin empty line under "Step 4: DNS & SSL" is that collapsed toggle. `dns-mode` over-expanding to fill a tall terminal was the same bug's other face: inside a `height: auto` container the `1fr` claimed all available slack.

**Fix** — scope the rule to the screen's own scroll viewport, preserving #373's intent while leaving RadioSet on its default `height: auto`:

```css
Screen > VerticalScroll { height: 1fr; }
```

Also states `height: auto` explicitly on the `RadioSet` rule. Redundant with Textual's default, but this trap has now caused two bugs in this file, and the explicit value stops a future container rule from silently collapsing the options again.

## Commit 2 — TextArea editors made responsive

`height: 20` meant one widget was taller than the whole scrollable form area on a short terminal (20 rows inside a 9-row viewport at 16 terminal rows). Replaced with `height: 60%; min-height: 6; max-height: 24;`:

| Terminal rows | Form viewport | Before | After |
|---|---|---|---|
| 16 | 9 | 20 (**222% of viewport**) | 6 |
| 20 | 13 | 20 (154%) | 7 |
| 24 | 17 | 20 (118%) | 10 |
| 30 | 23 | 20 | 13 |
| 40 | 33 | 20 | 19 |
| 60 | 53 | 20 | 24 |

It shrinks where it must and grows *past* the old fixed 20 on tall terminals, so nothing regresses where this already worked.

Side effect on `ReviewScreen`'s `#review-yaml`: at 24 terminal rows the YAML pane consumed the whole viewport and pushed the validation errors — the ones explaining why **Save & Exit** does nothing — 11 rows below the fold. They are now on screen:

```
before  max_scroll_y=11  errors_label_y=26  on_screen=False
after   max_scroll_y=1   errors_label_y=16  on_screen=True
```

## Verification

No new tests — TUI layout is verified by hand here rather than with automated UI tests. What was checked:

- **Widget geometry measured directly** via Textual's `Pilot` harness across 6 wizard screens × terminal sizes from 20×6 up to 100×50, comparing `container_size.height` against each RadioSet's option count and each TextArea against its form viewport. That produced the two tables above; after the fix, zero collapsed RadioSets and zero oversized editors at any size.
- **Real compositor output rendered** (the actual visible text, not just computed geometry): at 92×26 the empty box becomes all five Access Method options plus the previously invisible Guided/Advanced toggle; at 92×24 the Startup Script options and editor both fit.
- **Existing suite unaffected**: `593 passed` in the CLI package, `ruff check src tests` clean. #373's `test_dns_advanced_eip_radio_is_scrollable_into_view` still passes, confirming `max_scroll_y` stays > 0 and the Advanced pane remains scrollable.

Note the flip side of not adding a test here: this bug originally slipped through because #373's regression test asserted the Advanced pane could be *scrolled to* but never that its radios had any height. Nothing in CI will catch a future recurrence of RadioSet collapse.

## Design decisions

- **`Screen > VerticalScroll` over keeping the bare selector and overriding `RadioSet`.** The root cause is the selector matching subclasses it was never meant to; scoping it fixes the cause rather than patching one victim. The explicit `RadioSet { height: auto }` is defense-in-depth, not the fix.
- **Percentage over `1fr` for the TextArea.** `1fr` is the obvious first instinct and fails the *same way* the RadioSets did — inside the scroll container it only gets what fixed-size siblings leave over, which pinned the startup-script editor to its min-height at every terminal size. A percentage resolves against the scroll viewport, which is deterministic here. Four candidates were measured across six terminal sizes before picking this one.
- **`max-height: 24` rather than uncapped growth**, so a tall terminal doesn't push the retry fields (max attempts, base delay, success check) far down the form.

## Related issues

No existing issue — reported directly. Regression from #373 (`d2c54d51`).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)