### PR TITLE
fix(cli): report auth failures instead of empty results

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -139,6 +139,12 @@ Shows four sections:
 3. **Client VMs** — per-VM state and current hourly burn rate.
 4. **Cost Estimate** — daily and monthly dollar estimates, pulled from the AWS Pricing API with a fallback table.
 
+If your AWS credentials are missing, expired, or lack permission, an **AWS
+credentials** section is printed first with the reason and how to
+authenticate. The Terraform state and Client VM sections then say they're
+unavailable rather than showing an empty result, and costs fall back to the
+built-in price table.
+
 | Option | Description |
 |---|---|
 | `-c`, `--config PATH` | Path to `config.yaml`. |

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -139,11 +139,15 @@ Shows four sections:
 3. **Client VMs** — per-VM state and current hourly burn rate.
 4. **Cost Estimate** — daily and monthly dollar estimates, pulled from the AWS Pricing API with a fallback table.
 
-If your AWS credentials are missing, expired, or lack permission, an **AWS
-credentials** section is printed first with the reason and how to
-authenticate. The Terraform state and Client VM sections then say they're
-unavailable rather than showing an empty result, and costs fall back to the
-built-in price table.
+If your AWS credentials are missing or expired, an **AWS credentials**
+section is printed first with the reason and how to authenticate. The
+Terraform state and Client VM sections then say they're unavailable rather
+than showing an empty result, and costs fall back to the built-in price
+table.
+
+If the credentials are valid but lack a required IAM permission — or any
+other AWS error occurs — the affected section reports that error in place,
+with guidance to fix the policy rather than to re-authenticate.
 
 | Option | Description |
 |---|---|

--- a/packages/cli/src/lablink_cli/commands/export_metrics.py
+++ b/packages/cli/src/lablink_cli/commands/export_metrics.py
@@ -23,6 +23,7 @@ from rich.console import Console
 from lablink_cli.api import authenticated_json_request
 from lablink_cli.commands.utils import (
     get_allocator_url,
+    print_admin_credentials_hint,
     resolve_admin_credentials,
 )
 from lablink_cli.deployment_metrics import load_all_metrics
@@ -65,7 +66,14 @@ def _export_client_metrics(
             url, admin_user, admin_pw, ssl_provider=cfg.ssl.provider
         )
     except HTTPError as e:
-        console.print(f"[red]HTTP {e.code}: {e.reason}[/red]")
+        if e.code == 401:
+            console.print(
+                f"[red]The allocator rejected admin user "
+                f"'{admin_user}' (HTTP 401).[/red]"
+            )
+            print_admin_credentials_hint()
+        else:
+            console.print(f"[red]HTTP {e.code}: {e.reason}[/red]")
         raise SystemExit(1) from e
     except URLError as e:
         console.print(f"[red]Connection error: {e.reason}[/red]")

--- a/packages/cli/src/lablink_cli/commands/logs.py
+++ b/packages/cli/src/lablink_cli/commands/logs.py
@@ -14,10 +14,12 @@ from lablink_allocator_service.conf.structured_config import Config
 
 from lablink_cli.api import authenticated_json_request
 from lablink_cli.commands.utils import (
+    AwsQueryError,
     get_allocator_url,
     get_deploy_dir,
     get_terraform_outputs,
     list_all_vms,
+    print_aws_error,
     resolve_admin_credentials,
 )
 
@@ -402,7 +404,12 @@ def run_logs(cfg: Config) -> None:
         f"'{cfg.deployment_name}' ({cfg.environment})...[/dim]"
     )
 
-    vms = list_all_vms(cfg)
+    try:
+        vms = list_all_vms(cfg)
+    except AwsQueryError as e:
+        print_aws_error(e, prefix="Could not list VMs")
+        raise SystemExit(1) from e
+
     if not vms:
         console.print(
             f"[red]No running VMs found for deployment "

--- a/packages/cli/src/lablink_cli/commands/stats.py
+++ b/packages/cli/src/lablink_cli/commands/stats.py
@@ -16,6 +16,7 @@ from rich.table import Table
 from lablink_cli.api import authenticated_json_request
 from lablink_cli.commands.utils import (
     get_allocator_url,
+    print_admin_credentials_hint,
     resolve_admin_credentials,
 )
 
@@ -37,7 +38,19 @@ def _fetch(cfg) -> dict:
             admin_pw,
             ssl_provider=cfg.ssl.provider,
         )
-    except (HTTPError, URLError) as e:
+    # HTTPError first: it subclasses URLError, and a rejected login is not
+    # an unreachable allocator — we reached it and it said no.
+    except HTTPError as e:
+        if e.code == 401:
+            console.print(
+                f"[red]The allocator rejected admin user "
+                f"'{admin_user}' (HTTP 401).[/red]"
+            )
+            print_admin_credentials_hint()
+        else:
+            console.print(f"[red]Could not reach allocator: {e}[/red]")
+        raise SystemExit(1) from e
+    except URLError as e:
         console.print(f"[red]Could not reach allocator: {e}[/red]")
         raise SystemExit(1) from e
 

--- a/packages/cli/src/lablink_cli/commands/stats.py
+++ b/packages/cli/src/lablink_cli/commands/stats.py
@@ -68,8 +68,8 @@ def run_stats(cfg) -> None:
     if not body.get("enabled", False):
         console.print(
             "[yellow]Session metrics collection is disabled for this "
-            "deployment. Set monitoring.enabled: true in lablink.yaml "
-            "to enable.[/yellow]"
+            "deployment. Set monitoring.enabled: true in "
+            "~/.lablink/config.yaml to enable.[/yellow]"
         )
         return
 

--- a/packages/cli/src/lablink_cli/commands/status.py
+++ b/packages/cli/src/lablink_cli/commands/status.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import base64
 import json
+import os
 import socket
 import ssl
 import subprocess
@@ -22,9 +23,12 @@ from lablink_allocator_service.conf.structured_config import Config
 
 from lablink_cli.api import USER_AGENT
 from lablink_cli.commands.utils import (
+    AwsQueryError,
+    aws_credentials_error,
     get_client_vms,
     get_deploy_dir as _get_deploy_dir,
     get_terraform_outputs,
+    print_aws_error,
 )
 
 console = Console()
@@ -277,21 +281,31 @@ def _get_ec2_price(
     return None
 
 
-def estimate_costs(cfg: Config) -> list[dict]:
-    """Estimate daily costs for the deployment."""
+def estimate_costs(
+    cfg: Config, use_pricing_api: bool = True
+) -> list[dict]:
+    """Estimate daily costs for the deployment.
+
+    Pass ``use_pricing_api=False`` when AWS credentials are known to be
+    unusable, to skip Pricing API calls that can only fail and fall
+    straight through to FALLBACK_COSTS.
+    """
     region = cfg.app.region
     location = REGION_NAME_MAP.get(region, region)
     costs: list[dict] = []
 
     # Try AWS Pricing API (only available in us-east-1)
-    try:
-        pricing = boto3.client(
-            "pricing", region_name="us-east-1"
-        )
-        use_api = True
-    except Exception:
-        use_api = False
-        pricing = None
+    pricing = None
+    use_api = False
+    if use_pricing_api:
+        try:
+            pricing = boto3.client(
+                "pricing", region_name="us-east-1"
+            )
+            use_api = True
+        except Exception:
+            use_api = False
+            pricing = None
 
     # Allocator EC2 (always t3.large)
     alloc_type = "t3.large"
@@ -378,8 +392,14 @@ def estimate_costs(cfg: Config) -> list[dict]:
     return costs
 
 
-def _render_terraform_state(deploy_dir: Path) -> dict:
-    """Read and display Terraform outputs. Returns outputs dict."""
+def _render_terraform_state(
+    deploy_dir: Path, aws_unavailable: bool = False
+) -> dict:
+    """Read and display Terraform outputs. Returns outputs dict.
+
+    ``aws_unavailable`` changes only the empty-state wording: with dead
+    credentials an S3-backend read fails, so "no state" would be a guess.
+    """
     if not deploy_dir.exists():
         return {}
 
@@ -394,6 +414,11 @@ def _render_terraform_state(deploy_dir: Path) -> dict:
                 v = "(sensitive)"
             state_table.add_row(k, str(v))
         console.print(state_table)
+    elif aws_unavailable:
+        console.print(
+            "  [yellow]State unreadable — see AWS credentials "
+            "above[/yellow]"
+        )
     else:
         console.print(
             "  [yellow]No Terraform state found[/yellow]"
@@ -473,10 +498,28 @@ def _render_health_checks(cfg: Config, outputs: dict) -> None:
     console.print()
 
 
-def _render_client_vms(cfg: Config) -> None:
-    """Query and display client VM status."""
+def _render_client_vms(cfg: Config, aws_unavailable: bool = False) -> None:
+    """Query and display client VM status.
+
+    "No client VMs found" is reserved for a query that succeeded and
+    matched nothing. A failed query says so instead.
+    """
     console.print("[bold]Client VMs[/bold]")
-    vms = get_client_vms(cfg)
+    if aws_unavailable:
+        console.print(
+            "  [dim]Inventory unavailable — see AWS credentials "
+            "above[/dim]"
+        )
+        console.print()
+        return
+
+    try:
+        vms = get_client_vms(cfg)
+    except AwsQueryError as e:
+        print_aws_error(e, prefix="Could not query EC2")
+        console.print()
+        return
+
     if not vms:
         console.print(
             "  [dim]No client VMs found[/dim]"
@@ -541,10 +584,10 @@ def _render_client_vms(cfg: Config) -> None:
     console.print()
 
 
-def _render_cost_estimate(cfg: Config) -> None:
+def _render_cost_estimate(cfg: Config, live_pricing: bool = True) -> None:
     """Calculate and display cost estimate."""
     console.print("[bold]Cost Estimate (daily)[/bold]")
-    costs = estimate_costs(cfg)
+    costs = estimate_costs(cfg, use_pricing_api=live_pricing)
 
     cost_table = Table(show_header=True)
     cost_table.add_column("Resource")
@@ -572,10 +615,16 @@ def _render_cost_estimate(cfg: Config) -> None:
         "excl. client VMs",
     )
     console.print(cost_table)
-    console.print(
-        "  [dim]Prices are on-demand estimates. "
-        "Actual costs may vary.[/dim]"
-    )
+    if live_pricing:
+        console.print(
+            "  [dim]Prices are on-demand estimates. "
+            "Actual costs may vary.[/dim]"
+        )
+    else:
+        console.print(
+            "  [dim]Fallback prices (Feb 2025 on-demand) — live "
+            "pricing needs working AWS credentials.[/dim]"
+        )
 
 
 # ------------------------------------------------------------------
@@ -628,6 +677,16 @@ def _fetch_registered_clients(
         body = json.loads(resp.read().decode())
         return body.get("clients", []) or [], ""
     except HTTPError as e:
+        if e.code == 401:
+            # A bare "HTTP 401" reads like an allocator fault. It's the
+            # admin credentials, and they live in one of two files.
+            return None, (
+                f"the allocator rejected admin user '{admin_user}' "
+                "(HTTP 401). Check app.admin_user / app.admin_password "
+                "in your lablink.yaml or in the rendered "
+                "~/.lablink/compose/<deployment>/config.yaml — a "
+                "redeploy can change them."
+            )
         return None, f"HTTP {e.code} from {url}"
     except URLError as e:
         return None, f"{url} → {e.reason}"
@@ -754,6 +813,31 @@ def _run_status_manual(cfg: Config) -> None:
     )
 
 
+def _render_aws_credentials_error(
+    err: AwsQueryError, region: str
+) -> None:
+    """Report unusable AWS credentials and what it costs this report."""
+    console.print("[bold]AWS credentials[/bold]")
+    print_aws_error(err)
+    profile = os.environ.get("AWS_PROFILE")
+    if profile is None:
+        profile_desc = "default"
+    elif profile == "":
+        # An exported-but-empty AWS_PROFILE fails every AWS call; saying
+        # "default" here would contradict the error printed above.
+        profile_desc = "(AWS_PROFILE is set but empty)"
+    else:
+        profile_desc = profile
+    console.print(
+        f"  [dim]Region: {region}, profile: {profile_desc}[/dim]"
+    )
+    console.print(
+        "  [dim]Terraform state, VM inventory and live pricing are "
+        "unavailable until this is fixed.[/dim]"
+    )
+    console.print()
+
+
 def run_status(cfg: Config) -> None:
     """Run health checks and show cost estimate."""
     if getattr(cfg, "provider", "aws") == "manual":
@@ -773,7 +857,16 @@ def run_status(cfg: Config) -> None:
     )
     console.print()
 
-    outputs = _render_terraform_state(deploy_dir)
+    # Probed up front: every AWS-backed section below degrades to an
+    # empty result on a credential failure, which reads as "nothing is
+    # deployed". Reported once here instead of three times below.
+    aws_error = aws_credentials_error(cfg.app.region)
+    if aws_error is not None:
+        _render_aws_credentials_error(aws_error, cfg.app.region)
+
+    aws_down = aws_error is not None
+    outputs = _render_terraform_state(deploy_dir, aws_unavailable=aws_down)
+    # DNS/HTTP/SSL checks need no AWS credentials, so they still run.
     _render_health_checks(cfg, outputs)
-    _render_client_vms(cfg)
-    _render_cost_estimate(cfg)
+    _render_client_vms(cfg, aws_unavailable=aws_down)
+    _render_cost_estimate(cfg, live_pricing=not aws_down)

--- a/packages/cli/src/lablink_cli/commands/status.py
+++ b/packages/cli/src/lablink_cli/commands/status.py
@@ -683,7 +683,7 @@ def _fetch_registered_clients(
             return None, (
                 f"the allocator rejected admin user '{admin_user}' "
                 "(HTTP 401). Check app.admin_user / app.admin_password "
-                "in your lablink.yaml or in the rendered "
+                "in ~/.lablink/config.yaml or in the rendered "
                 "~/.lablink/compose/<deployment>/config.yaml — a "
                 "redeploy can change them."
             )
@@ -831,10 +831,17 @@ def _render_aws_credentials_error(
     console.print(
         f"  [dim]Region: {region}, profile: {profile_desc}[/dim]"
     )
-    console.print(
-        "  [dim]Terraform state, VM inventory and live pricing are "
-        "unavailable until this is fixed.[/dim]"
-    )
+    if err.is_auth:
+        console.print(
+            "  [dim]Terraform state, VM inventory and live pricing are "
+            "unavailable until this is fixed.[/dim]"
+        )
+    else:
+        # Not a credential problem, so the AWS-backed sections below may
+        # still work. Claiming they're unavailable would be a guess.
+        console.print(
+            "  [dim]Sections below may be incomplete.[/dim]"
+        )
     console.print()
 
 
@@ -864,7 +871,12 @@ def run_status(cfg: Config) -> None:
     if aws_error is not None:
         _render_aws_credentials_error(aws_error, cfg.app.region)
 
-    aws_down = aws_error is not None
+    # Only a *credential* failure dooms every AWS-backed section below. A
+    # non-auth probe failure (transient blip, or STS blocked by a proxy or
+    # VPC endpoint policy while EC2 answers fine) proves nothing about
+    # EC2, so let the real queries run and report for themselves —
+    # _render_client_vms already handles AwsQueryError.
+    aws_down = aws_error is not None and aws_error.is_auth
     outputs = _render_terraform_state(deploy_dir, aws_unavailable=aws_down)
     # DNS/HTTP/SSL checks need no AWS credentials, so they still run.
     _render_health_checks(cfg, outputs)

--- a/packages/cli/src/lablink_cli/commands/utils.py
+++ b/packages/cli/src/lablink_cli/commands/utils.py
@@ -19,33 +19,54 @@ console = Console()
 class AwsQueryError(Exception):
     """An AWS query could not be answered.
 
-    ``is_auth`` marks the failures an operator fixes by authenticating —
-    missing/expired credentials, or an identity without the required IAM
-    permission. Those get remediation steps; anything else (throttling,
-    endpoint trouble) is reported verbatim, since telling someone to run
-    'aws configure' over a throttling error just wastes their time.
+    Two flags, at most one of which is set, because they have different
+    fixes and so must produce different advice:
+
+    ``is_auth``
+        Authentication — we cannot establish who the caller is (absent,
+        expired, or invalid credentials). Fixed by supplying credentials.
+    ``is_permission``
+        Authorization — the caller is known, but not allowed to make this
+        call. Fixed by an IAM policy change; re-authenticating with the
+        same identity changes nothing.
+
+    Neither set means something else went wrong (throttling, endpoint
+    trouble) and the error is reported verbatim with no advice, since
+    telling someone to run 'aws configure' over a throttling error just
+    wastes their time.
     """
 
-    def __init__(self, message: str, *, is_auth: bool = False) -> None:
+    def __init__(
+        self,
+        message: str,
+        *,
+        is_auth: bool = False,
+        is_permission: bool = False,
+    ) -> None:
         super().__init__(message)
         self.is_auth = is_auth
+        self.is_permission = is_permission
 
 
-# ClientError codes meaning "who you are is the problem" — both
-# unauthenticated (expired/invalid keys) and unauthorized (valid identity,
-# missing IAM permission), because the operator's next step is the same
-# for both: fix the credentials or the role behind them.
-_AUTH_ERROR_CODES = frozenset({
-    "AccessDenied",
-    "AccessDeniedException",
+# "We cannot establish who you are" — the fix is new/refreshed credentials.
+_AUTHENTICATION_ERROR_CODES = frozenset({
     "AuthFailure",
     "ExpiredToken",
     "ExpiredTokenException",
     "InvalidClientTokenId",
     "RequestExpired",
     "SignatureDoesNotMatch",
-    "UnauthorizedOperation",
     "UnrecognizedClientException",
+})
+
+# "We know who you are, and you may not do this" — the fix is an IAM
+# policy change. Kept separate from the codes above because the credential
+# remedies cannot resolve these, and offering them sends the operator in
+# circles re-authenticating an identity that was never the problem.
+_AUTHORIZATION_ERROR_CODES = frozenset({
+    "AccessDenied",
+    "AccessDeniedException",
+    "UnauthorizedOperation",
 })
 
 # Printed one per line: Rich wraps at the console width, and a hint
@@ -54,6 +75,14 @@ AWS_CREDENTIALS_REMEDIES = (
     "aws configure",
     "export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...",
     "aws sso login   (if this account uses SSO)",
+)
+
+# Deliberately does not name the credential commands, even to dismiss
+# them — a skimming operator would try them anyway.
+AWS_PERMISSION_REMEDY_LINES = (
+    "These credentials are valid but lack permission for this call.",
+    "Grant the calling identity the action named above (for example",
+    "ec2:DescribeInstances), or switch to a role or profile that has it.",
 )
 
 
@@ -85,7 +114,12 @@ def _classify_aws_error(e: Exception) -> AwsQueryError:
         err = (getattr(e, "response", None) or {}).get("Error", {}) or {}
         code = err.get("Code", "") or "Unknown"
         msg = err.get("Message", "") or str(e)
-        if code in _AUTH_ERROR_CODES:
+        if code in _AUTHORIZATION_ERROR_CODES:
+            return AwsQueryError(
+                f"AWS denied the request: {code} — {msg}",
+                is_permission=True,
+            )
+        if code in _AUTHENTICATION_ERROR_CODES:
             return AwsQueryError(
                 f"AWS rejected the request: {code} — {msg}", is_auth=True
             )
@@ -111,13 +145,16 @@ def aws_credentials_error(region: str) -> AwsQueryError | None:
 
 
 def print_aws_error(err: AwsQueryError, *, prefix: str | None = None) -> None:
-    """Print an AwsQueryError, with authentication steps when relevant."""
+    """Print an AwsQueryError with advice matching the kind of failure."""
     label = f"[red]{prefix}:[/red] " if prefix else "[red]✗[/red] "
     console.print(f"  {label}{err}")
     if err.is_auth:
         console.print("  [dim]Authenticate with one of:[/dim]")
         for remedy in AWS_CREDENTIALS_REMEDIES:
             console.print(f"    [dim]{remedy}[/dim]")
+    elif err.is_permission:
+        for line in AWS_PERMISSION_REMEDY_LINES:
+            console.print(f"  [dim]{line}[/dim]")
 
 
 # ------------------------------------------------------------------

--- a/packages/cli/src/lablink_cli/commands/utils.py
+++ b/packages/cli/src/lablink_cli/commands/utils.py
@@ -14,6 +14,113 @@ console = Console()
 
 
 # ------------------------------------------------------------------
+# AWS error reporting
+# ------------------------------------------------------------------
+class AwsQueryError(Exception):
+    """An AWS query could not be answered.
+
+    ``is_auth`` marks the failures an operator fixes by authenticating —
+    missing/expired credentials, or an identity without the required IAM
+    permission. Those get remediation steps; anything else (throttling,
+    endpoint trouble) is reported verbatim, since telling someone to run
+    'aws configure' over a throttling error just wastes their time.
+    """
+
+    def __init__(self, message: str, *, is_auth: bool = False) -> None:
+        super().__init__(message)
+        self.is_auth = is_auth
+
+
+# ClientError codes meaning "who you are is the problem" — both
+# unauthenticated (expired/invalid keys) and unauthorized (valid identity,
+# missing IAM permission), because the operator's next step is the same
+# for both: fix the credentials or the role behind them.
+_AUTH_ERROR_CODES = frozenset({
+    "AccessDenied",
+    "AccessDeniedException",
+    "AuthFailure",
+    "ExpiredToken",
+    "ExpiredTokenException",
+    "InvalidClientTokenId",
+    "RequestExpired",
+    "SignatureDoesNotMatch",
+    "UnauthorizedOperation",
+    "UnrecognizedClientException",
+})
+
+# Printed one per line: Rich wraps at the console width, and a hint
+# folded mid-command is a hint the operator can't copy-paste.
+AWS_CREDENTIALS_REMEDIES = (
+    "aws configure",
+    "export AWS_ACCESS_KEY_ID=... AWS_SECRET_ACCESS_KEY=...",
+    "aws sso login   (if this account uses SSO)",
+)
+
+
+def _classify_aws_error(e: Exception) -> AwsQueryError:
+    """Translate a boto3/botocore exception into an AwsQueryError."""
+    from botocore.exceptions import (
+        ClientError,
+        NoCredentialsError,
+        PartialCredentialsError,
+        ProfileNotFound,
+        SSOTokenLoadError,
+        TokenRetrievalError,
+        UnauthorizedSSOTokenError,
+    )
+
+    if isinstance(e, (NoCredentialsError, PartialCredentialsError)):
+        return AwsQueryError(
+            f"No usable AWS credentials found ({e})", is_auth=True
+        )
+    if isinstance(
+        e, (TokenRetrievalError, UnauthorizedSSOTokenError, SSOTokenLoadError)
+    ):
+        return AwsQueryError(
+            f"AWS SSO session is not usable ({e})", is_auth=True
+        )
+    if isinstance(e, ProfileNotFound):
+        return AwsQueryError(f"AWS profile not found ({e})", is_auth=True)
+    if isinstance(e, ClientError):
+        err = (getattr(e, "response", None) or {}).get("Error", {}) or {}
+        code = err.get("Code", "") or "Unknown"
+        msg = err.get("Message", "") or str(e)
+        if code in _AUTH_ERROR_CODES:
+            return AwsQueryError(
+                f"AWS rejected the request: {code} — {msg}", is_auth=True
+            )
+        return AwsQueryError(f"AWS API error: {code} — {msg}")
+    return AwsQueryError(f"AWS query failed: {e}")
+
+
+def aws_credentials_error(region: str) -> AwsQueryError | None:
+    """Probe STS for the caller identity. Return None if credentials work.
+
+    Deliberately silent, unlike ``setup.check_credentials``, which prints
+    a remediation block and raises SystemExit (which is why
+    ``doctor._check_aws_credentials`` has to catch SystemExit). Callers
+    render their own message so the probe can be used mid-report.
+    """
+    from lablink_cli.commands.setup import _get_session
+
+    try:
+        _get_session(region).client("sts").get_caller_identity()
+    except Exception as e:  # boto3 raises many types; classified below
+        return _classify_aws_error(e)
+    return None
+
+
+def print_aws_error(err: AwsQueryError, *, prefix: str | None = None) -> None:
+    """Print an AwsQueryError, with authentication steps when relevant."""
+    label = f"[red]{prefix}:[/red] " if prefix else "[red]✗[/red] "
+    console.print(f"  {label}{err}")
+    if err.is_auth:
+        console.print("  [dim]Authenticate with one of:[/dim]")
+        for remedy in AWS_CREDENTIALS_REMEDIES:
+            console.print(f"    [dim]{remedy}[/dim]")
+
+
+# ------------------------------------------------------------------
 # EC2 instance helpers
 # ------------------------------------------------------------------
 def _parse_instances(resp: dict) -> list[dict]:
@@ -52,7 +159,14 @@ def query_ec2_instances(
         states: Instance states to match. Defaults to ``["running"]``.
 
     Returns:
-        List of VM info dicts.
+        List of VM info dicts. Empty only when the query succeeded and
+        matched nothing.
+
+    Raises:
+        AwsQueryError: the query could not be answered. Callers must not
+            report this as "no instances" — that conflation is what made
+            ``lablink status`` print an empty inventory when the real
+            problem was an unauthenticated caller.
     """
     from lablink_cli.commands.setup import _get_session
 
@@ -60,26 +174,25 @@ def query_ec2_instances(
         states = ["running"]
 
     try:
-        session = _get_session(region)
-        ec2 = session.client("ec2")
-    except Exception:
-        return []
-
-    try:
+        ec2 = _get_session(region).client("ec2")
         resp = ec2.describe_instances(
             Filters=[
                 {"Name": "tag:Name", "Values": [tag_pattern]},
                 {"Name": "instance-state-name", "Values": states},
             ]
         )
-    except Exception:
-        return []
+    except Exception as e:  # boto3 raises many types; classified below
+        raise _classify_aws_error(e) from e
 
     return _parse_instances(resp)
 
 
 def get_allocator_vm(cfg: Config) -> dict | None:
-    """Find the allocator EC2 instance for this deployment."""
+    """Find the allocator EC2 instance for this deployment.
+
+    Propagates AwsQueryError from the underlying query — None means the
+    instance genuinely isn't there.
+    """
     tag = f"{cfg.deployment_name}-allocator-{cfg.environment}"
     vms = query_ec2_instances(cfg.app.region, tag)
     if vms:
@@ -89,7 +202,10 @@ def get_allocator_vm(cfg: Config) -> dict | None:
 
 
 def get_client_vms(cfg: Config) -> list[dict]:
-    """Query EC2 for LabLink client VMs."""
+    """Query EC2 for LabLink client VMs.
+
+    Propagates AwsQueryError — an empty list means no client VMs exist.
+    """
     tag = (
         f"{cfg.machine.software}-lablink-client-"
         f"{cfg.environment}-vm-*"
@@ -165,6 +281,23 @@ def get_allocator_url(cfg: Config) -> str:
 
 
 _MISSING = ("MISSING", "")
+
+# The places resolve_admin_credentials draws from, quoted back to the
+# operator when the allocator rejects what it produced — a bare "HTTP 401"
+# doesn't say which file to go edit. Pre-split into short lines: Rich
+# wraps at the console width but does not carry the indent onto
+# continuation lines, which looks ragged under an indented bullet.
+ADMIN_CREDENTIALS_HINT_LINES = (
+    "Check app.admin_user / app.admin_password in your config, or in",
+    "~/.lablink/deploy/<deployment>/<environment>/config/config.yaml",
+    "(saved at deploy time — a redeploy can change them).",
+)
+
+
+def print_admin_credentials_hint() -> None:
+    """Print where admin credentials come from, after a rejected login."""
+    for line in ADMIN_CREDENTIALS_HINT_LINES:
+        console.print(f"  [dim]{line}[/dim]")
 
 
 def _resolve_from_config(

--- a/packages/cli/tests/test_export_metrics.py
+++ b/packages/cli/tests/test_export_metrics.py
@@ -169,6 +169,75 @@ class TestRunExportMetrics:
         ):
             run_export_metrics(mock_cfg, output=str(output_path))
 
+    def test_401_names_the_rejected_admin_credentials(
+        self, mock_cfg, tmp_path, capsys
+    ):
+        """A bare "HTTP 401: Unauthorized" doesn't say what to fix."""
+        error = HTTPError(
+            url="http://1.2.3.4/api/export-metrics",
+            code=401,
+            msg="Unauthorized",
+            hdrs={},
+            fp=BytesIO(b""),
+        )
+
+        with (
+            patch(
+                "lablink_cli.commands.export_metrics.get_allocator_url",
+                return_value="http://1.2.3.4",
+            ),
+            patch(
+                "lablink_cli.commands.export_metrics.resolve_admin_credentials",
+                return_value=("admin", "wrong-pw"),
+            ),
+            patch(
+                "lablink_cli.api.urlopen",
+                side_effect=error,
+            ),
+            pytest.raises(SystemExit) as exc,
+        ):
+            run_export_metrics(mock_cfg, output=str(tmp_path / "m.csv"))
+
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "401" in out
+        assert "admin" in out
+        assert "admin_user" in out
+        assert "admin_password" in out
+
+    def test_non_401_http_error_stays_generic(
+        self, mock_cfg, tmp_path, capsys
+    ):
+        error = HTTPError(
+            url="http://1.2.3.4/api/export-metrics",
+            code=500,
+            msg="Internal Server Error",
+            hdrs={},
+            fp=BytesIO(b""),
+        )
+
+        with (
+            patch(
+                "lablink_cli.commands.export_metrics.get_allocator_url",
+                return_value="http://1.2.3.4",
+            ),
+            patch(
+                "lablink_cli.commands.export_metrics.resolve_admin_credentials",
+                return_value=("admin", "secret"),
+            ),
+            patch(
+                "lablink_cli.api.urlopen",
+                side_effect=error,
+            ),
+            pytest.raises(SystemExit),
+        ):
+            run_export_metrics(mock_cfg, output=str(tmp_path / "m.csv"))
+
+        out = capsys.readouterr().out
+        assert "500" in out
+        # Credential guidance would be misleading here.
+        assert "admin_password" not in out
+
     def test_no_allocator_url(self, mock_cfg, tmp_path):
         """Test error when allocator URL can't be determined."""
         with (

--- a/packages/cli/tests/test_logs.py
+++ b/packages/cli/tests/test_logs.py
@@ -332,3 +332,34 @@ class TestRunLogsManualTui:
 
         mock_deploy_dir.assert_not_called()
         mock_list_vms.assert_not_called()
+
+
+class TestRunLogsAwsQueryFailure:
+    def test_credential_failure_exits_cleanly(self, mock_cfg, tmp_path, capsys):
+        """list_all_vms now raises instead of returning [] — run_logs must
+        report it, not traceback."""
+        import pytest
+
+        from lablink_cli.commands.logs import run_logs
+        from lablink_cli.commands.utils import AwsQueryError
+
+        deploy_dir = tmp_path / "deploy"
+        deploy_dir.mkdir()
+
+        with patch(
+            "lablink_cli.commands.logs.get_deploy_dir",
+            return_value=deploy_dir,
+        ), patch(
+            "lablink_cli.commands.logs.list_all_vms",
+            side_effect=AwsQueryError(
+                "AWS credentials are expired (ExpiredToken)", is_auth=True
+            ),
+        ):
+            with pytest.raises(SystemExit) as exc:
+                run_logs(mock_cfg)
+
+        assert exc.value.code == 1
+        out = capsys.readouterr().out
+        assert "ExpiredToken" in out
+        assert "aws configure" in out
+        assert "No running VMs found" not in out

--- a/packages/cli/tests/test_stats.py
+++ b/packages/cli/tests/test_stats.py
@@ -148,3 +148,84 @@ def test_stats_hits_summary_endpoint_not_export_metrics(mock_cfg):
 
     called_url = mock_urlopen.call_args[0][0].full_url
     assert called_url.endswith("/api/session-metrics/summary"), called_url
+
+
+def _http_error(code: int):
+    from email.message import Message
+    from urllib.error import HTTPError
+
+    return HTTPError(
+        "https://alloc.example/api/session-metrics/summary",
+        code,
+        "Unauthorized" if code == 401 else "Server Error",
+        Message(),
+        BytesIO(b""),
+    )
+
+
+def test_stats_401_names_the_rejected_admin_credentials(mock_cfg, capsys):
+    """A bare "HTTP Error 401: Unauthorized" doesn't say what to fix."""
+    from lablink_cli.commands.stats import run_stats
+
+    with patch(
+        "lablink_cli.commands.stats.get_allocator_url",
+        return_value="https://alloc.example",
+    ), patch(
+        "lablink_cli.commands.stats.resolve_admin_credentials",
+        return_value=("admin", "wrong-pw"),
+    ), patch(
+        "lablink_cli.api.urlopen", side_effect=_http_error(401)
+    ):
+        with pytest.raises(SystemExit) as exc:
+            run_stats(mock_cfg)
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "401" in out
+    assert "admin" in out
+    assert "admin_user" in out
+    assert "admin_password" in out
+    # "Could not reach allocator" is wrong: we reached it, it said no.
+    assert "Could not reach allocator" not in out
+
+
+def test_stats_non_401_http_error_stays_generic(mock_cfg, capsys):
+    from lablink_cli.commands.stats import run_stats
+
+    with patch(
+        "lablink_cli.commands.stats.get_allocator_url",
+        return_value="https://alloc.example",
+    ), patch(
+        "lablink_cli.commands.stats.resolve_admin_credentials",
+        return_value=("admin", "pw"),
+    ), patch(
+        "lablink_cli.api.urlopen", side_effect=_http_error(500)
+    ):
+        with pytest.raises(SystemExit) as exc:
+            run_stats(mock_cfg)
+
+    assert exc.value.code == 1
+    out = capsys.readouterr().out
+    assert "500" in out
+    # Credential guidance would be misleading here.
+    assert "admin_password" not in out
+
+
+def test_stats_connection_error_still_reported(mock_cfg, capsys):
+    from lablink_cli.commands.stats import run_stats
+    from urllib.error import URLError
+
+    with patch(
+        "lablink_cli.commands.stats.get_allocator_url",
+        return_value="https://alloc.example",
+    ), patch(
+        "lablink_cli.commands.stats.resolve_admin_credentials",
+        return_value=("admin", "pw"),
+    ), patch(
+        "lablink_cli.api.urlopen", side_effect=URLError("connection refused")
+    ):
+        with pytest.raises(SystemExit) as exc:
+            run_stats(mock_cfg)
+
+    assert exc.value.code == 1
+    assert "connection refused" in capsys.readouterr().out

--- a/packages/cli/tests/test_status.py
+++ b/packages/cli/tests/test_status.py
@@ -305,13 +305,30 @@ class TestRenderTerraformState:
         mock_outputs.assert_not_called()
 
     @patch("lablink_cli.commands.status.get_terraform_outputs")
-    def test_empty_outputs(self, mock_outputs, tmp_path):
+    def test_empty_outputs(self, mock_outputs, tmp_path, capsys):
         mock_outputs.return_value = {}
         deploy_dir = tmp_path / "deploy"
         deploy_dir.mkdir()
 
         result = _render_terraform_state(deploy_dir)
         assert result == {}
+        assert "No Terraform state found" in capsys.readouterr().out
+
+    @patch("lablink_cli.commands.status.get_terraform_outputs")
+    def test_empty_outputs_with_dead_credentials(
+        self, mock_outputs, tmp_path, capsys
+    ):
+        """An S3-backend read needs credentials, so "no state" would be a
+        guess when they're broken."""
+        mock_outputs.return_value = {}
+        deploy_dir = tmp_path / "deploy"
+        deploy_dir.mkdir()
+
+        result = _render_terraform_state(deploy_dir, aws_unavailable=True)
+        assert result == {}
+        out = capsys.readouterr().out
+        assert "unreadable" in out
+        assert "No Terraform state found" not in out
 
 
 # ------------------------------------------------------------------
@@ -376,6 +393,42 @@ class TestRenderClientVms:
             },
         ]
         _render_client_vms(mock_cfg)
+
+    @patch("lablink_cli.commands.status.get_client_vms")
+    def test_auth_failure_is_not_reported_as_empty(
+        self, mock_vms, mock_cfg, capsys
+    ):
+        """A failed EC2 query must never read as "no VMs exist"."""
+        from lablink_cli.commands.utils import AwsQueryError
+
+        mock_vms.side_effect = AwsQueryError(
+            "No AWS credentials found", is_auth=True
+        )
+
+        _render_client_vms(mock_cfg)
+
+        out = capsys.readouterr().out
+        assert "No client VMs found" not in out
+        assert "No AWS credentials found" in out
+        # Auth failures get remediation; other API errors don't.
+        assert "aws configure" in out
+
+    @patch("lablink_cli.commands.status.get_client_vms")
+    def test_non_auth_query_failure_is_surfaced(
+        self, mock_vms, mock_cfg, capsys
+    ):
+        from lablink_cli.commands.utils import AwsQueryError
+
+        mock_vms.side_effect = AwsQueryError(
+            "ThrottlingException: slow down", is_auth=False
+        )
+
+        _render_client_vms(mock_cfg)
+
+        out = capsys.readouterr().out
+        assert "No client VMs found" not in out
+        assert "ThrottlingException" in out
+        assert "aws configure" not in out
 
 
 # ------------------------------------------------------------------

--- a/packages/cli/tests/test_status.py
+++ b/packages/cli/tests/test_status.py
@@ -414,6 +414,28 @@ class TestRenderClientVms:
         assert "aws configure" in out
 
     @patch("lablink_cli.commands.status.get_client_vms")
+    def test_permission_failure_gets_iam_guidance(
+        self, mock_vms, mock_cfg, capsys
+    ):
+        """Valid credentials without ec2:DescribeInstances is the case the
+        upfront STS probe cannot catch, and 'aws configure' cannot fix."""
+        from lablink_cli.commands.utils import AwsQueryError
+
+        mock_vms.side_effect = AwsQueryError(
+            "AWS denied the request: UnauthorizedOperation — not "
+            "authorized to perform ec2:DescribeInstances",
+            is_permission=True,
+        )
+
+        _render_client_vms(mock_cfg)
+
+        out = capsys.readouterr().out
+        assert "No client VMs found" not in out
+        assert "ec2:DescribeInstances" in out
+        assert "lack permission" in out
+        assert "aws configure" not in out
+
+    @patch("lablink_cli.commands.status.get_client_vms")
     def test_non_auth_query_failure_is_surfaced(
         self, mock_vms, mock_cfg, capsys
     ):

--- a/packages/cli/tests/test_status_full.py
+++ b/packages/cli/tests/test_status_full.py
@@ -211,7 +211,7 @@ class TestRunStatusAwsCredentialsFailure:
     table as if healthy, while the real problem was an unauthenticated
     caller."""
 
-    def _run(self, mock_cfg, tmp_path, err):
+    def _run(self, mock_cfg, tmp_path, err, vms_side_effect=None):
         with patch(
             "lablink_cli.commands.status.aws_credentials_error",
             return_value=err,
@@ -225,6 +225,9 @@ class TestRunStatusAwsCredentialsFailure:
         ) as mock_health, patch(
             "lablink_cli.commands.status.estimate_costs"
         ) as mock_costs:
+            mock_vms.return_value = []
+            if vms_side_effect is not None:
+                mock_vms.side_effect = vms_side_effect
             mock_health.return_value = {
                 "healthy": True,
                 "status": "pass",
@@ -291,6 +294,48 @@ class TestRunStatusAwsCredentialsFailure:
         out = capsys.readouterr().out
         assert "Could not connect to STS endpoint" in out
         assert "aws configure" not in out
+
+    def test_non_auth_probe_failure_still_queries_ec2(
+        self, mock_cfg, tmp_path, capsys
+    ):
+        """A failed STS probe does not prove EC2 is unreachable.
+
+        STS can be blocked by a proxy or VPC endpoint policy while EC2
+        answers fine, so a non-credential probe failure must not skip the
+        inventory the way an auth failure does.
+        """
+        err = AwsQueryError("Could not connect to STS endpoint", is_auth=False)
+        mock_vms, _, mock_costs = self._run(mock_cfg, tmp_path, err)
+
+        mock_vms.assert_called_once()
+        # Pricing is only doomed when credentials are the problem.
+        assert mock_costs.call_args.kwargs.get("use_pricing_api") is True
+        out = capsys.readouterr().out
+        assert "Inventory unavailable" not in out
+        # The query succeeded and matched nothing — say so honestly.
+        assert "No client VMs found" in out
+
+    def test_non_auth_probe_then_failing_ec2_query_reports_the_query_error(
+        self, mock_cfg, tmp_path, capsys
+    ):
+        """The _render_client_vms except branch must stay reachable.
+
+        Gating the skip on "any probe failure" made this path dead: the
+        inventory was skipped before the query could report for itself.
+        """
+        probe_err = AwsQueryError("STS endpoint unreachable", is_auth=False)
+        query_err = AwsQueryError(
+            "AWS rejected the request: AuthFailure — bad creds", is_auth=True
+        )
+        mock_vms, _, _ = self._run(
+            mock_cfg, tmp_path, probe_err, vms_side_effect=query_err
+        )
+
+        mock_vms.assert_called_once()
+        out = capsys.readouterr().out
+        assert "Could not query EC2" in out
+        assert "AuthFailure" in out
+        assert "No client VMs found" not in out
 
 
 # ------------------------------------------------------------------

--- a/packages/cli/tests/test_status_full.py
+++ b/packages/cli/tests/test_status_full.py
@@ -4,12 +4,15 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
+import pytest
 
 from lablink_cli.commands.status import (
     REGION_NAME_MAP,
     _get_ec2_price,
+    _render_aws_credentials_error,
     run_status,
 )
+from lablink_cli.commands.utils import AwsQueryError
 
 
 # ------------------------------------------------------------------
@@ -75,6 +78,18 @@ class TestRegionNameMap:
 # run_status (integration-level)
 # ------------------------------------------------------------------
 class TestRunStatus:
+    @pytest.fixture(autouse=True)
+    def _valid_aws_credentials(self):
+        """Keep run_status offline: the credential probe is a real STS call.
+
+        Tests that exercise the failure path patch over this.
+        """
+        with patch(
+            "lablink_cli.commands.status.aws_credentials_error",
+            return_value=None,
+        ):
+            yield
+
     @patch("lablink_cli.commands.status.estimate_costs")
     @patch("lablink_cli.commands.status.get_client_vms")
     @patch("lablink_cli.commands.status.get_terraform_outputs")
@@ -186,3 +201,128 @@ class TestRunStatus:
         ]
 
         run_status(mock_cfg)
+
+
+# ------------------------------------------------------------------
+# run_status when AWS credentials are missing / expired
+# ------------------------------------------------------------------
+class TestRunStatusAwsCredentialsFailure:
+    """The reported bug: status reported "No client VMs found" and a cost
+    table as if healthy, while the real problem was an unauthenticated
+    caller."""
+
+    def _run(self, mock_cfg, tmp_path, err):
+        with patch(
+            "lablink_cli.commands.status.aws_credentials_error",
+            return_value=err,
+        ), patch(
+            "lablink_cli.commands.status._get_deploy_dir",
+            return_value=tmp_path / "nonexistent",
+        ), patch(
+            "lablink_cli.commands.status.get_client_vms"
+        ) as mock_vms, patch(
+            "lablink_cli.commands.status.check_health_endpoint"
+        ) as mock_health, patch(
+            "lablink_cli.commands.status.estimate_costs"
+        ) as mock_costs:
+            mock_health.return_value = {
+                "healthy": True,
+                "status": "pass",
+                "detail": "ok",
+                "uptime_seconds": None,
+            }
+            mock_costs.return_value = [
+                {"resource": "EC2", "daily": 2.0, "note": "always on"}
+            ]
+            mock_cfg.dns.enabled = True
+            mock_cfg.dns.domain = "test.example.com"
+            mock_cfg.ssl.provider = "none"
+
+            with patch("lablink_cli.commands.status.check_dns") as mock_dns:
+                mock_dns.return_value = {
+                    "check": "DNS", "status": "pass", "detail": "ok",
+                }
+                run_status(mock_cfg)
+
+            return mock_vms, mock_health, mock_costs
+
+    def test_reports_credential_failure_instead_of_empty_inventory(
+        self, mock_cfg, tmp_path, capsys
+    ):
+        err = AwsQueryError(
+            "AWS credentials are expired (ExpiredToken)", is_auth=True
+        )
+        mock_vms, _, _ = self._run(mock_cfg, tmp_path, err)
+
+        out = capsys.readouterr().out
+        assert "ExpiredToken" in out
+        assert "aws configure" in out
+        # The two lies from the bug report must be gone.
+        assert "No client VMs found" not in out
+        assert "No Terraform state found" not in out
+        # And we must not waste a doomed EC2 round-trip.
+        mock_vms.assert_not_called()
+
+    def test_still_runs_network_health_checks(
+        self, mock_cfg, tmp_path, capsys
+    ):
+        """DNS/HTTP/SSL need no AWS credentials, so they stay useful."""
+        err = AwsQueryError("No AWS credentials found", is_auth=True)
+        _, mock_health, _ = self._run(mock_cfg, tmp_path, err)
+
+        mock_health.assert_called_once()
+        assert "Health Checks" in capsys.readouterr().out
+
+    def test_costs_marked_as_fallback(self, mock_cfg, tmp_path, capsys):
+        err = AwsQueryError("No AWS credentials found", is_auth=True)
+        _, _, mock_costs = self._run(mock_cfg, tmp_path, err)
+
+        out = capsys.readouterr().out
+        assert "fallback" in out.lower()
+        # Don't attempt the AWS Pricing API we know will fail.
+        assert mock_costs.call_args.kwargs.get("use_pricing_api") is False
+
+    def test_non_auth_probe_failure_omits_credential_remedy(
+        self, mock_cfg, tmp_path, capsys
+    ):
+        err = AwsQueryError("Could not connect to STS endpoint", is_auth=False)
+        self._run(mock_cfg, tmp_path, err)
+
+        out = capsys.readouterr().out
+        assert "Could not connect to STS endpoint" in out
+        assert "aws configure" not in out
+
+
+# ------------------------------------------------------------------
+# _render_aws_credentials_error — which profile is being blamed
+# ------------------------------------------------------------------
+class TestRenderAwsCredentialsError:
+    def test_unset_profile_reads_as_default(self, monkeypatch, capsys):
+        monkeypatch.delenv("AWS_PROFILE", raising=False)
+        _render_aws_credentials_error(
+            AwsQueryError("No usable AWS credentials found", is_auth=True),
+            "us-west-2",
+        )
+        out = capsys.readouterr().out
+        assert "profile: default" in out
+        assert "us-west-2" in out
+
+    def test_named_profile_is_reported(self, monkeypatch, capsys):
+        monkeypatch.setenv("AWS_PROFILE", "salk-research")
+        _render_aws_credentials_error(
+            AwsQueryError("AWS SSO session is not usable", is_auth=True),
+            "us-east-1",
+        )
+        assert "profile: salk-research" in capsys.readouterr().out
+
+    def test_empty_profile_is_called_out(self, monkeypatch, capsys):
+        """An exported-but-empty AWS_PROFILE breaks every AWS call, so
+        reporting it as "default" would contradict the error above it."""
+        monkeypatch.setenv("AWS_PROFILE", "")
+        _render_aws_credentials_error(
+            AwsQueryError("AWS profile not found", is_auth=True),
+            "us-east-1",
+        )
+        out = capsys.readouterr().out
+        assert "set but empty" in out
+        assert "profile: default" not in out

--- a/packages/cli/tests/test_status_manual.py
+++ b/packages/cli/tests/test_status_manual.py
@@ -109,6 +109,11 @@ class TestFetchRegisteredClients:
         # credentials that were rejected and where they come from.
         assert "admin_user" in err
         assert "admin_password" in err
+        # Must name a file that actually exists: the config is
+        # ~/.lablink/config.yaml (app.DEFAULT_CONFIG). "lablink.yaml"
+        # appears nowhere in the project and sends people hunting.
+        assert "config.yaml" in err
+        assert "lablink.yaml" not in err
 
     @patch("lablink_cli.commands.status.urlopen")
     def test_non_401_http_error_stays_generic(self, mock_urlopen):

--- a/packages/cli/tests/test_status_manual.py
+++ b/packages/cli/tests/test_status_manual.py
@@ -105,6 +105,30 @@ class TestFetchRegisteredClients:
         )
         assert clients is None
         assert "401" in err
+        # A bare "HTTP 401" leaves the operator guessing. Name the
+        # credentials that were rejected and where they come from.
+        assert "admin_user" in err
+        assert "admin_password" in err
+
+    @patch("lablink_cli.commands.status.urlopen")
+    def test_non_401_http_error_stays_generic(self, mock_urlopen):
+        from email.message import Message
+        from urllib.error import HTTPError
+
+        mock_urlopen.side_effect = HTTPError(
+            "http://localhost/api/v1/clients",
+            500,
+            "Server Error",
+            Message(),
+            io.BytesIO(b""),
+        )
+        clients, err = _fetch_registered_clients(
+            "http://localhost", "admin", "pw"
+        )
+        assert clients is None
+        assert "500" in err
+        # Credential guidance would be misleading here.
+        assert "admin_password" not in err
 
     @patch("lablink_cli.commands.status.urlopen")
     def test_returns_error_on_url_failure(self, mock_urlopen):

--- a/packages/cli/tests/test_utils.py
+++ b/packages/cli/tests/test_utils.py
@@ -6,15 +6,32 @@ import json
 import subprocess
 from unittest.mock import MagicMock, patch
 
+import pytest
+from botocore.exceptions import (
+    ClientError,
+    NoCredentialsError,
+    ProfileNotFound,
+    TokenRetrievalError,
+)
 
 from lablink_cli.commands.utils import (
+    AwsQueryError,
+    _classify_aws_error,
     _parse_instances,
+    aws_credentials_error,
     get_terraform_outputs,
     query_ec2_instances,
     get_allocator_vm,
     get_client_vms,
     list_all_vms,
 )
+
+
+def _client_error(code: str) -> ClientError:
+    return ClientError(
+        {"Error": {"Code": code, "Message": f"{code} message"}},
+        "DescribeInstances",
+    )
 
 
 # ------------------------------------------------------------------
@@ -147,28 +164,168 @@ class TestQueryEc2Instances:
         assert state_filter["Values"] == ["running", "stopped"]
 
     @patch("lablink_cli.commands.utils._get_session", create=True)
-    def test_session_error_returns_empty(self, mock_get_session):
-        mock_get_session.side_effect = Exception("no credentials")
+    def test_session_error_raises_auth_error(self, mock_get_session):
+        """A credential failure must not masquerade as "no instances"."""
+        mock_get_session.side_effect = NoCredentialsError()
 
         with patch(
             "lablink_cli.commands.setup._get_session", mock_get_session
         ):
-            result = query_ec2_instances("us-east-1", "tag")
+            with pytest.raises(AwsQueryError) as exc:
+                query_ec2_instances("us-east-1", "tag")
 
-        assert result == []
+        assert exc.value.is_auth is True
 
     @patch("lablink_cli.commands.utils._get_session", create=True)
-    def test_describe_error_returns_empty(self, mock_get_session):
+    def test_describe_auth_error_raises_auth_error(self, mock_get_session):
         mock_ec2 = MagicMock()
         mock_get_session.return_value.client.return_value = mock_ec2
-        mock_ec2.describe_instances.side_effect = Exception("API error")
+        mock_ec2.describe_instances.side_effect = _client_error("AuthFailure")
 
         with patch(
             "lablink_cli.commands.setup._get_session", mock_get_session
         ):
-            result = query_ec2_instances("us-east-1", "tag")
+            with pytest.raises(AwsQueryError) as exc:
+                query_ec2_instances("us-east-1", "tag")
 
-        assert result == []
+        assert exc.value.is_auth is True
+
+    @patch("lablink_cli.commands.utils._get_session", create=True)
+    def test_describe_other_error_raises_non_auth(self, mock_get_session):
+        """Non-credential API failures still surface, just not as auth."""
+        mock_ec2 = MagicMock()
+        mock_get_session.return_value.client.return_value = mock_ec2
+        mock_ec2.describe_instances.side_effect = _client_error(
+            "ThrottlingException"
+        )
+
+        with patch(
+            "lablink_cli.commands.setup._get_session", mock_get_session
+        ):
+            with pytest.raises(AwsQueryError) as exc:
+                query_ec2_instances("us-east-1", "tag")
+
+        assert exc.value.is_auth is False
+
+
+# ------------------------------------------------------------------
+# _classify_aws_error
+# ------------------------------------------------------------------
+class TestClassifyAwsError:
+    def test_no_credentials_is_auth(self):
+        err = _classify_aws_error(NoCredentialsError())
+        assert err.is_auth is True
+        assert "credential" in str(err).lower()
+
+    def test_sso_token_expiry_is_auth(self):
+        err = _classify_aws_error(
+            TokenRetrievalError(provider="sso", error_msg="token expired")
+        )
+        assert err.is_auth is True
+        assert "sso" in str(err).lower()
+
+    def test_profile_not_found_is_auth(self):
+        err = _classify_aws_error(ProfileNotFound(profile="nope"))
+        assert err.is_auth is True
+        assert "profile" in str(err).lower()
+
+    @pytest.mark.parametrize(
+        "code",
+        [
+            "AuthFailure",
+            "UnauthorizedOperation",
+            "AccessDenied",
+            "AccessDeniedException",
+            "ExpiredToken",
+            "ExpiredTokenException",
+            "RequestExpired",
+            "InvalidClientTokenId",
+            "SignatureDoesNotMatch",
+            "UnrecognizedClientException",
+        ],
+    )
+    def test_auth_client_error_codes(self, code):
+        err = _classify_aws_error(_client_error(code))
+        assert err.is_auth is True, code
+        assert code in str(err)
+
+    def test_unrelated_client_error_is_not_auth(self):
+        err = _classify_aws_error(_client_error("InvalidParameterValue"))
+        assert err.is_auth is False
+
+    def test_arbitrary_exception_is_not_auth(self):
+        err = _classify_aws_error(RuntimeError("boom"))
+        assert err.is_auth is False
+        assert "boom" in str(err)
+
+
+# ------------------------------------------------------------------
+# aws_credentials_error
+# ------------------------------------------------------------------
+class TestAwsCredentialsError:
+    @patch("lablink_cli.commands.utils._get_session", create=True)
+    def test_returns_none_when_valid(self, mock_get_session):
+        mock_sts = MagicMock()
+        mock_get_session.return_value.client.return_value = mock_sts
+        mock_sts.get_caller_identity.return_value = {
+            "Account": "123456789012",
+            "Arn": "arn:aws:iam::123456789012:user/me",
+            "UserId": "AIDA",
+        }
+
+        with patch(
+            "lablink_cli.commands.setup._get_session", mock_get_session
+        ):
+            assert aws_credentials_error("us-east-1") is None
+
+    @patch("lablink_cli.commands.utils._get_session", create=True)
+    def test_returns_auth_error_when_missing(self, mock_get_session):
+        mock_sts = MagicMock()
+        mock_get_session.return_value.client.return_value = mock_sts
+        mock_sts.get_caller_identity.side_effect = NoCredentialsError()
+
+        with patch(
+            "lablink_cli.commands.setup._get_session", mock_get_session
+        ):
+            err = aws_credentials_error("us-east-1")
+
+        assert isinstance(err, AwsQueryError)
+        assert err.is_auth is True
+
+    @patch("lablink_cli.commands.utils._get_session", create=True)
+    def test_returns_auth_error_when_expired(self, mock_get_session):
+        mock_sts = MagicMock()
+        mock_get_session.return_value.client.return_value = mock_sts
+        mock_sts.get_caller_identity.side_effect = _client_error(
+            "ExpiredToken"
+        )
+
+        with patch(
+            "lablink_cli.commands.setup._get_session", mock_get_session
+        ):
+            err = aws_credentials_error("us-east-1")
+
+        assert err is not None
+        assert err.is_auth is True
+
+    @patch("lablink_cli.commands.utils._get_session", create=True)
+    def test_does_not_print(self, mock_get_session, capsys):
+        """Unlike setup.check_credentials, the probe must stay quiet.
+
+        status/logs render their own message; a red wall printed from
+        inside the probe would duplicate it (and corrupt doctor-style
+        tables).
+        """
+        mock_sts = MagicMock()
+        mock_get_session.return_value.client.return_value = mock_sts
+        mock_sts.get_caller_identity.side_effect = NoCredentialsError()
+
+        with patch(
+            "lablink_cli.commands.setup._get_session", mock_get_session
+        ):
+            aws_credentials_error("us-east-1")
+
+        assert capsys.readouterr().out == ""
 
 
 # ------------------------------------------------------------------

--- a/packages/cli/tests/test_utils.py
+++ b/packages/cli/tests/test_utils.py
@@ -20,6 +20,7 @@ from lablink_cli.commands.utils import (
     _parse_instances,
     aws_credentials_error,
     get_terraform_outputs,
+    print_aws_error,
     query_ec2_instances,
     get_allocator_vm,
     get_client_vms,
@@ -233,9 +234,6 @@ class TestClassifyAwsError:
         "code",
         [
             "AuthFailure",
-            "UnauthorizedOperation",
-            "AccessDenied",
-            "AccessDeniedException",
             "ExpiredToken",
             "ExpiredTokenException",
             "RequestExpired",
@@ -244,19 +242,75 @@ class TestClassifyAwsError:
             "UnrecognizedClientException",
         ],
     )
-    def test_auth_client_error_codes(self, code):
+    def test_authentication_codes(self, code):
+        """Identity could not be established — new credentials fix it."""
         err = _classify_aws_error(_client_error(code))
         assert err.is_auth is True, code
+        assert err.is_permission is False, code
         assert code in str(err)
 
-    def test_unrelated_client_error_is_not_auth(self):
+    @pytest.mark.parametrize(
+        "code",
+        ["AccessDenied", "AccessDeniedException", "UnauthorizedOperation"],
+    )
+    def test_authorization_codes(self, code):
+        """Identity is fine but lacks permission — only IAM fixes it, so
+        these must not be lumped in with 'go re-authenticate'."""
+        err = _classify_aws_error(_client_error(code))
+        assert err.is_permission is True, code
+        assert err.is_auth is False, code
+        assert code in str(err)
+
+    def test_unrelated_client_error_is_neither(self):
         err = _classify_aws_error(_client_error("InvalidParameterValue"))
         assert err.is_auth is False
+        assert err.is_permission is False
 
-    def test_arbitrary_exception_is_not_auth(self):
+    def test_arbitrary_exception_is_neither(self):
         err = _classify_aws_error(RuntimeError("boom"))
         assert err.is_auth is False
+        assert err.is_permission is False
         assert "boom" in str(err)
+
+
+# ------------------------------------------------------------------
+# print_aws_error — the remedy must match the failure
+# ------------------------------------------------------------------
+class TestPrintAwsError:
+    def test_authentication_gets_credential_steps(self, capsys):
+        print_aws_error(AwsQueryError("expired", is_auth=True))
+        out = capsys.readouterr().out
+        assert "aws configure" in out
+        assert "lack permission" not in out
+
+    def test_authorization_gets_iam_guidance_not_credential_steps(
+        self, capsys
+    ):
+        """Telling someone to run 'aws configure' cannot fix a missing IAM
+        permission — their credentials are already valid."""
+        print_aws_error(
+            AwsQueryError(
+                "AWS denied the request: UnauthorizedOperation — "
+                "not authorized to perform ec2:DescribeInstances",
+                is_permission=True,
+            )
+        )
+        out = capsys.readouterr().out
+        assert "aws configure" not in out
+        assert "aws sso login" not in out
+        assert "lack permission" in out
+        assert "ec2:DescribeInstances" in out
+
+    def test_other_errors_get_no_remedy(self, capsys):
+        print_aws_error(AwsQueryError("ThrottlingException: slow down"))
+        out = capsys.readouterr().out
+        assert "ThrottlingException" in out
+        assert "aws configure" not in out
+        assert "lack permission" not in out
+
+    def test_prefix_is_used_when_given(self, capsys):
+        print_aws_error(AwsQueryError("boom"), prefix="Could not query EC2")
+        assert "Could not query EC2: boom" in capsys.readouterr().out
 
 
 # ------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `lablink status` reported **"No client VMs found"** plus a full cost table when the actual problem was an unauthenticated caller — a silent wrong answer, not an error.
- The same bug class made a rejected admin login surface as a bare **"HTTP 401"** in `status` (manual provider), `stats`, and `export-metrics`.
- Root cause in both: helpers collapsing *"the query failed"* into *"nothing exists"*.

This was found from a real report, and the reporter's machine turned out to have genuinely invalid AWS credentials (`InvalidClientTokenId`) — `aws sts get-caller-identity` said so plainly while `lablink status` hid it entirely.

## Changes Made

### AWS credential failures (`utils.py`, `status.py`, `logs.py`)

- `AwsQueryError` carrying `is_auth`, so credential/permission problems get remediation steps while throttling and endpoint errors are reported verbatim.
- `_classify_aws_error()` maps `NoCredentialsError`, `PartialCredentialsError`, SSO token errors (`TokenRetrievalError`, `UnauthorizedSSOTokenError`, `SSOTokenLoadError`), `ProfileNotFound`, and the auth-flavored `ClientError` codes (`AuthFailure`, `UnauthorizedOperation`, `AccessDenied*`, `ExpiredToken*`, `RequestExpired`, `InvalidClientTokenId`, `SignatureDoesNotMatch`, `UnrecognizedClientException`).
- `aws_credentials_error()` — a **quiet** STS probe. Deliberately not reusing `setup.check_credentials`, which prints a red wall and `SystemExit`s; that's why `doctor._check_aws_credentials` has to catch `SystemExit`.
- **`query_ec2_instances` now raises** instead of returning `[]`. An empty list means the query succeeded and matched nothing.
- `status` probes credentials up front and prints one banner (reason, remediation, region/profile) instead of three misleading empty sections. DNS/HTTP/SSL checks still run — they need no AWS. Costs render marked as fallback and skip Pricing API calls that can only fail.
- `_render_client_vms` also catches `AwsQueryError` directly, which covers valid-credentials-but-missing-`ec2:DescribeInstances` — something the upfront probe cannot see.
- `logs` catches `AwsQueryError` and exits 1 instead of tracebacking (required: `list_all_vms` can now raise).

### Rejected admin logins (`status.py`, `stats.py`, `export_metrics.py`)

Each now names the rejected admin user and where its credentials come from, via a shared `print_admin_credentials_hint()`. Non-401 codes keep their previous generic wording, since credential guidance would be actively misleading there.

`stats.py` also needed its handlers reordered: it caught `(HTTPError, URLError)` in one clause, and since `HTTPError` subclasses `URLError`, a 401 branch added there would have been unreachable.

## Testing

- **630 CLI tests pass** (1 integration deselected), `ruff check` clean across all three packages. Every new line is covered; remaining gaps in the touched files are all pre-existing.
- Written test-first — each new test was confirmed failing against the old code (e.g. `assert 'admin' in 'HTTP 401: Unauthorized\n'`).
- Updated the two existing `test_*_returns_empty` cases in `test_utils.py`, which encoded the old swallow-and-return-`[]` contract.
- Manual verification of the AWS path: bogus credentials, genuinely absent credentials, an exported-but-empty `AWS_PROFILE`, and `lablink logs` (exit 1, no traceback).
- Confirmed against the allocator that `/api/session-metrics/summary`, `/api/export-metrics`, and `/api/v1/clients` all answer **401** for *both* missing and wrong-password Basic auth (two were already pinned by existing allocator tests; the third I verified with a throwaway test).
- Confirmed via a real local socket that `urllib` surfaces flask_httpauth's 401 — including its `WWW-Authenticate: Basic realm=...` header — as `HTTPError.code == 401`, and that the `Authorization` header **survives a 302**. That last check matters: had it been dropped, a Funnel-fronted `http://` allocator would 401 with *correct* credentials and this message would send people to edit config files that were fine.

## Design Decisions

- **Raise rather than return a tuple.** Only two production call sites exist (`status.py`, `logs.py`), so raising keeps the honest signal without back-compat wrappers whose whole job is to re-hide the error.
- **One upfront probe rather than three per-section errors.** Terraform state, VM inventory, and pricing all degrade to empty on a credential failure; reporting once at the top and labelling the affected sections reads better than the same error three times. Costs one extra STS call per `status` run.
- **Costs stay visible under dead credentials,** marked as fallback, rather than being hidden — the static estimate is still useful.
- **Hints are pre-split into short lines.** Rich wraps at console width without carrying the indent onto continuation lines; the first attempt rendered raggedly, which is why the output was eyeballed rather than assumed.
- **`is_auth` gates remediation** so `aws configure` is never suggested over a throttling error.

## Not included

- `get_terraform_outputs` still discards Terraform's stderr — parsing that is a separate job; the new banner already explains the empty state.
- `doctor._check_aws_credentials` could now drop its `except SystemExit` hack and call `aws_credentials_error`; left alone to keep this diff scoped.
- `logs.py:64` already had a 401 branch. It's terser than the new wording, but it returns an error dict into the TUI rather than printing, so the multi-line hint would need that panel reworked.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)