### PR TITLE
refactor(allocator): split database.py into a db/ package

### DIFF
--- a/.github/workflows/lablink-images.yml
+++ b/.github/workflows/lablink-images.yml
@@ -271,8 +271,16 @@ jobs:
           print(\"Importing allocator packages:\")
           from lablink_allocator_service.main import main
           print(\"  - main.main imported\")
-          from lablink_allocator_service.database import PostgresqlDatabase
-          print(\"  - database.PostgresqlDatabase imported\")
+          from lablink_allocator_service.db.pool import PooledCursor, make_pool
+          print(\"  - db.pool imported\")
+          from lablink_allocator_service.db.vms import VmDatabase
+          print(\"  - db.vms.VmDatabase imported\")
+          from lablink_allocator_service.db.schedules import ScheduleDatabase
+          print(\"  - db.schedules.ScheduleDatabase imported\")
+          from lablink_allocator_service.db.metrics import MetricsDatabase
+          print(\"  - db.metrics.MetricsDatabase imported\")
+          from lablink_allocator_service.db.operations import OperationsDatabase
+          print(\"  - db.operations.OperationsDatabase imported\")
           from lablink_allocator_service.get_config import get_config
           print(\"  - get_config.get_config imported\")
           print(\"Allocator imports verified\")

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -78,11 +78,32 @@ Before implementing changes, present a plan and get user approval. Do not start 
 
 ## Quick Reference
 
+### Environment setup
+
+This repo is a **uv workspace** — the root `pyproject.toml` declares
+`[tool.uv.workspace]` with `packages/allocator`, `packages/client`, and
+`packages/cli` as members. There is ONE venv, at the repo root, shared by all
+three packages. Always sync from the repo root:
+
+```bash
+uv sync --all-packages --extra dev
+```
+
+Both flags matter. Without `--all-packages` you get only the docs-only root
+project — no pytest, and the member packages are *uninstalled* from the venv,
+which breaks entry-point tests like
+`tests/providers/test_registry.py::test_aws_entry_point_is_registered`.
+Without `--extra dev` you get no pytest/ruff. Running a bare `uv sync` from
+inside `packages/<name>` does not fix this; it re-resolves the same root venv.
+
+**In a fresh git worktree you must run this before anything else** — a new
+worktree has no venv, and the first `uv run` will create a wrong one.
+
 ```bash
 # Run tests
-cd packages/allocator && PYTHONPATH=. pytest
-cd packages/client && PYTHONPATH=. pytest
-cd packages/cli && PYTHONPATH=src pytest  # integration tests: pytest -m integration
+cd packages/allocator && PYTHONPATH=src uv run pytest --ignore=tests/terraform
+cd packages/client    && PYTHONPATH=src uv run pytest
+cd packages/cli       && PYTHONPATH=src uv run pytest  # integration: pytest -m integration
 
 # Lint
 ruff check packages/allocator packages/client packages/cli
@@ -90,6 +111,16 @@ ruff check packages/allocator packages/client packages/cli
 # Build Docker (dev)
 docker build -t lablink-allocator:dev -f packages/allocator/Dockerfile.dev .
 ```
+
+Two things about the allocator test command:
+
+- **`PYTHONPATH=src`, never `PYTHONPATH=.`** — inside a worktree, `.` can
+  resolve to the *other* checkout's code, so you silently test the wrong tree.
+- **`--ignore=tests/terraform`** — those tests shell out to the `terraform`
+  binary and need AWS credentials, so they fail locally (3 failures + 8 errors)
+  regardless of your changes. They are not a regression signal. CI runs the
+  full `tests` directory, so the 90% coverage gate is CI-only; a local run with
+  this flag caps around 86%.
 
 ## CLI Architecture
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -134,7 +134,7 @@ PR opened → ci.yml triggered
      ├─ Entry points importable: main(), generate_init_sql.main() ✓
      ├─ Console scripts: lablink-allocator, generate-init-sql ✓
      ├─ Dev dependencies: pytest 8.4.2, ruff, coverage 7.10.7 ✓
-     ├─ Package imports: main.main, database.PostgresqlDatabase, get_config ✓
+     ├─ Package imports: main.main, db.* classes, get_config ✓
      └─ Installation: Package installed via uv sync ✓
 ```
 
@@ -639,7 +639,7 @@ Runs after successful build, pulls and tests the allocator image:
 - **Virtual Environment**: Activates venv at `/app/.venv`
 - **Entry Points**: Verifies `main()` and `generate_init_sql.main()` are importable and callable
 - **Console Scripts**: Verifies `lablink-allocator` and `generate-init-sql` exist and execute
-- **Package Imports**: Tests importing `main`, `database.PostgresqlDatabase`, `get_config`
+- **Package Imports**: Tests importing `main`, every `db/` module (`db.pool`, `db.vms.VmDatabase`, `db.schedules.ScheduleDatabase`, `db.metrics.MetricsDatabase`, `db.operations.OperationsDatabase`), and `get_config`. Importing each `db/` submodule explicitly is what catches a subpackage that failed to ship in the wheel
 - **Dev Dependencies** (dev images only): Verifies pytest, ruff with versions
 
 #### 3. Verify Client Job
@@ -667,7 +667,7 @@ PR opened → lablink-images.yml triggered
      ├─ Venv activated: /app/.venv ✓
      ├─ Entry points callable: main(), generate_init_sql.main() ✓
      ├─ Console scripts: lablink-allocator, generate-init-sql ✓
-     ├─ Imports: main.main, database.PostgresqlDatabase, get_config ✓
+     ├─ Imports: main.main, db.* classes, get_config ✓
      └─ Dev deps: pytest 8.4.2, ruff ✓
   └─ Verify Client Job
      ├─ Pull ghcr.io/.../lablink-client-base-image:linux-amd64-abc1234-test

--- a/openspec/project.md
+++ b/openspec/project.md
@@ -70,7 +70,7 @@ packages/
 ├── allocator/           # Allocator service package
 │   ├── src/lablink_allocator_service/
 │   │   ├── main.py      # Flask application
-│   │   ├── database.py  # Database operations
+│   │   ├── db/          # Database layer (see below)
 │   │   ├── get_config.py # Config loader
 │   │   ├── validate_config.py # Config validation CLI
 │   │   ├── scheduler.py # Task scheduling
@@ -93,6 +93,35 @@ packages/
     ├── Dockerfile        # Production image (from PyPI)
     └── Dockerfile.dev    # Development image (local code)
 ```
+
+#### Allocator Database Layer
+
+All allocator persistence lives in `src/lablink_allocator_service/db/`. Each
+class owns one concern and they share a single connection pool rather than each
+opening their own — `POOL_MAX_SIZE` is tuned for the service's total connection
+budget, so a second pool would silently double it.
+
+```
+db/
+├── __init__.py     # Deliberately EMPTY — read its docstring before adding re-exports
+├── pool.py         # PooledCursor, make_pool, validate_pool_sizes, POOL_* sizing
+├── vms.py          # VmDatabase — VM rows, registration/auth, seats, logs, health
+├── schedules.py    # ScheduleDatabase — scheduled_destructions table
+├── metrics.py      # MetricsDatabase — session-metrics columns on the VM table
+└── operations.py   # OperationsDatabase — operations table (async apply/destroy jobs)
+```
+
+Two conventions worth knowing before changing anything here:
+
+- **`db/__init__.py` stays empty.** Re-exporting the classes would mean importing
+  any submodule executes `db/vms.py` and its top-level `import psycopg2`, which
+  couples every consumer to the heaviest module in the package.
+- **A class that constructs a pool must do so in its own module.** `VmDatabase`
+  builds its pool inline rather than calling `make_pool`, so that its own
+  `import psycopg2` binding is the one used. `make_pool` is for callers that need
+  only a bare pool (e.g. the APScheduler job in `scheduler.py`). `VmDatabase` also
+  accepts an injected `pool=` and tracks ownership, so it will not close a pool
+  it was handed.
 
 #### Configuration Management
 - **Hydra-based** structured configs (`conf/structured_config.py`)

--- a/packages/allocator/src/lablink_allocator_service/admin_session_expiry.py
+++ b/packages/allocator/src/lablink_allocator_service/admin_session_expiry.py
@@ -16,7 +16,7 @@ from threading import Event, Thread
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
-    from lablink_allocator_service.database import PostgresqlDatabase
+    from lablink_allocator_service.db.vms import VmDatabase
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class AdminSessionExpiryService:
     """Background service that releases expired admin VM reservations.
 
     Args:
-        database: PostgresqlDatabase instance for querying/updating VM state.
+        database: VmDatabase instance for querying/updating VM state.
         timeout_minutes: Age, in minutes, past which a reservation is
             considered expired and force-released.
         check_interval_seconds: How often to sweep for expired reservations.
@@ -33,7 +33,7 @@ class AdminSessionExpiryService:
 
     def __init__(
         self,
-        database: PostgresqlDatabase,
+        database: VmDatabase,
         timeout_minutes: int = 30,
         check_interval_seconds: int = 300,
     ):

--- a/packages/allocator/src/lablink_allocator_service/db/__init__.py
+++ b/packages/allocator/src/lablink_allocator_service/db/__init__.py
@@ -1,0 +1,13 @@
+"""Database access layer for the allocator service.
+
+Deliberately empty: do NOT re-export the classes from the submodules here.
+
+Every submodule is imported directly (``from ...db.vms import VmDatabase``).
+A module-level ``import psycopg2`` binds the module object at import time, so
+whichever module performs pool construction is the one whose binding of
+psycopg2 actually gets used. If this file re-exported the submodules,
+importing *any one* of them — including the dependency-free ``db.pool`` —
+would eagerly execute ``db/vms.py`` and its top-level ``import psycopg2`` as
+a side effect. Keeping this file empty keeps ``import db.pool`` (or any other
+submodule) from dragging in ``db.vms`` it has no need of.
+"""

--- a/packages/allocator/src/lablink_allocator_service/db/metrics.py
+++ b/packages/allocator/src/lablink_allocator_service/db/metrics.py
@@ -1,0 +1,213 @@
+"""Persistence for the Tier-1 session-metrics columns.
+
+A column-family split, not a table split: the SessionMetrics* / Seconds* /
+Gpu* columns live on the VM table itself, which is why this class needs
+table_name where OperationsDatabase needs only a pool. Nothing outside this
+module reads or writes those columns, with one soft exception —
+VmDatabase.get_all_vms_for_export does SELECT * via get_column_names()
+and therefore returns them too. That is a schema-shape dependency, not a code
+one.
+"""
+from __future__ import annotations
+
+from psycopg2.extras import Json
+
+from lablink_allocator_service.db.pool import PooledCursor
+
+
+def _median(values: list):
+    """Median of a list, ignoring None. Returns None when the list is empty.
+
+    Uses floor division for the even-length case because every column
+    fed in here is INTEGER in the schema; `960` reads more cleanly in
+    the rendered admin tile than `960.0`. If a future caller passes a
+    DOUBLE PRECISION column, switch this site to true division.
+    """
+    values = sorted(v for v in values if v is not None)
+    if not values:
+        return None
+    n = len(values)
+    mid = n // 2
+    if n % 2 == 1:
+        return values[mid]
+    return (values[mid - 1] + values[mid]) // 2
+
+
+# Named-key contract for rows returned by get_session_metrics_summary's
+# SELECT. The SELECT statement MUST emit these columns in this order;
+# both sides reference this tuple so column renames/reorderings stay
+# in lockstep. Reordering the SELECT without updating this list is the
+# kind of silent-wrong-numbers bug an earlier review flagged.
+_SUMMARY_COLUMNS = (
+    "host_name",
+    "session_metrics_started_at",
+    "seconds_to_first_sleap_label",
+    "seconds_to_first_sleap_train",
+    "seconds_to_first_sleap_track",
+    "seconds_in_subject_software",
+    "gpu_active_seconds",
+    "max_labeled_frames",
+    "training_epochs_completed",
+)
+
+
+def _build_summary(rows: list) -> dict:
+    """Build the session-metrics cohort summary from a row iterable.
+
+    Rows are positional tuples from psycopg2; we zip them against
+    `_SUMMARY_COLUMNS` so the rest of this function reads by name.
+    Test fixtures that pass fewer trailing fields produce dicts with
+    those keys missing — `.get(...)` returns None for those, which is
+    the same behavior callers see for a NULL column.
+    """
+    keyed = [dict(zip(_SUMMARY_COLUMNS, r)) for r in rows]
+    total = len(keyed)
+    started = sum(1 for r in keyed if r.get("session_metrics_started_at") is not None)
+    labeled = sum(1 for r in keyed if r.get("seconds_to_first_sleap_label") is not None)
+    trained = sum(1 for r in keyed if r.get("seconds_to_first_sleap_train") is not None)
+    tracked = sum(1 for r in keyed if r.get("seconds_to_first_sleap_track") is not None)
+    secs_in_subject = [r.get("seconds_in_subject_software") for r in keyed]
+    first_train = [r.get("seconds_to_first_sleap_train") for r in keyed]
+    frames = [r.get("max_labeled_frames") for r in keyed]
+    epochs = [r.get("training_epochs_completed") for r in keyed]
+    pct_train = (trained / total * 100.0) if total else 0.0
+    return {
+        "total_vms": total,
+        "funnel": {
+            "started": started,
+            "labeled": labeled,
+            "trained": trained,
+            "tracked": tracked,
+        },
+        "pct_reached_training": pct_train,
+        "median_seconds_in_subject_software": _median(secs_in_subject),
+        "median_seconds_to_first_train": _median(first_train),
+        "median_labeled_frames": _median(frames),
+        "median_epochs_completed": _median(epochs),
+    }
+
+
+class MetricsDatabase:
+    """Persistence for session-metrics columns on the VM table.
+
+    Args:
+        pool: A psycopg2 connection pool, shared with the other db classes.
+        table_name: The VM table name, from cfg.db.table_name.
+    """
+
+    def __init__(self, pool, table_name: str):
+        self._pool = pool
+        self.table_name = table_name
+
+    @property
+    def _cursor(self):
+        """Return a context manager that checks out a pooled connection
+        and yields a cursor. See db.pool.PooledCursor."""
+        return PooledCursor(self._pool)
+
+    def update_session_metrics(self, hostname: str, payload: dict) -> None:
+        """Last-write-wins UPDATE of session-metrics columns.
+
+        Atomic with respect to seal: the sealed-row check is folded into
+        the UPDATE's WHERE clause, so a concurrent ``bulk_seal_session_metrics``
+        cannot land between a separate SELECT and a separate UPDATE.
+        When the UPDATE affects zero rows, a follow-up existence SELECT
+        classifies the failure as ``LookupError`` (no such row) or
+        ``ValueError`` (row exists but is sealed).
+
+        Raises:
+            LookupError: if hostname unknown.
+            ValueError: if the row is already sealed.
+        """
+        counters = payload.get("counters", {})
+        with self._cursor as cursor:
+            cursor.execute(
+                f"""
+                UPDATE {self.table_name} SET
+                  SessionMetricsStartedAt      = COALESCE(SessionMetricsStartedAt, %s),
+                  SessionMetricsLastReportedAt = NOW(),
+                  SecondsInSubjectSoftware     = %s,
+                  SecondsInTerminal            = %s,
+                  SecondsInBrowser             = %s,
+                  SecondsInOther               = %s,
+                  GpuActiveSeconds             = %s,
+                  GpuUtilPeak                  = %s,
+                  VramUsedPeakMb               = %s,
+                  SecondsToFirstSleapLabel     = %s,
+                  SecondsToFirstSleapTrain     = %s,
+                  SecondsToFirstSleapTrack     = %s,
+                  MaxLabeledFrames             = %s,
+                  TrainingEpochsCompleted      = %s,
+                  TrainingFinalLoss            = %s,
+                  SessionMetricsRaw            = %s
+                WHERE HostName = %s AND SessionMetricsSealedAt IS NULL
+                """,
+                (
+                    payload.get("session_started_at"),
+                    counters.get("seconds_in_subject_software"),
+                    counters.get("seconds_in_terminal"),
+                    counters.get("seconds_in_browser"),
+                    counters.get("seconds_in_other"),
+                    counters.get("gpu_active_seconds"),
+                    counters.get("gpu_util_peak"),
+                    counters.get("vram_used_peak_mb"),
+                    counters.get("seconds_to_first_sleap_label"),
+                    counters.get("seconds_to_first_sleap_train"),
+                    counters.get("seconds_to_first_sleap_track"),
+                    counters.get("max_labeled_frames"),
+                    counters.get("training_epochs_completed"),
+                    counters.get("training_final_loss"),
+                    Json(counters),
+                    hostname,
+                ),
+            )
+            if cursor.rowcount >= 1:
+                return
+
+            # UPDATE matched zero rows — classify so the route can return
+            # 404 vs 409. HostName is PRIMARY KEY on vms, so this SELECT
+            # can return at most one row.
+            cursor.execute(
+                f"SELECT 1 FROM {self.table_name} WHERE HostName = %s",
+                (hostname,),
+            )
+            if cursor.fetchone() is None:
+                raise LookupError(f"VM {hostname} not found")
+            raise ValueError(f"VM {hostname} session is sealed")
+
+    def bulk_seal_session_metrics(self) -> int:
+        """Seal every unsealed VM (called from the destroy paths).
+
+        Returns:
+            int: number of rows sealed.
+        """
+        with self._cursor as cursor:
+            cursor.execute(
+                f"UPDATE {self.table_name} SET SessionMetricsSealedAt = NOW() "
+                "WHERE SessionMetricsSealedAt IS NULL"
+            )
+            return cursor.rowcount or 0
+
+    def get_session_metrics_summary(self) -> dict:
+        """Aggregate the cohort summary for the admin page.
+
+        The SELECT column order MUST match `_SUMMARY_COLUMNS` at module
+        top — `_build_summary` zips them together to access rows by name.
+        """
+        with self._cursor as cursor:
+            cursor.execute(
+                f"""
+                SELECT HostName,
+                       SessionMetricsStartedAt,
+                       SecondsToFirstSleapLabel,
+                       SecondsToFirstSleapTrain,
+                       SecondsToFirstSleapTrack,
+                       SecondsInSubjectSoftware,
+                       GpuActiveSeconds,
+                       MaxLabeledFrames,
+                       TrainingEpochsCompleted
+                FROM {self.table_name}
+                """
+            )
+            rows = cursor.fetchall()
+        return _build_summary(rows)

--- a/packages/allocator/src/lablink_allocator_service/db/operations.py
+++ b/packages/allocator/src/lablink_allocator_service/db/operations.py
@@ -1,13 +1,13 @@
 """Persistence for the operations table (on-demand apply/destroy jobs).
 
-A standalone class rather than more methods on PostgresqlDatabase: the
+A standalone class rather than more methods on VmDatabase: the
 operations table has no foreign-key or column coupling to the vms table
-(unlike scheduled_destructions or the AdminReservedAt admin-reservation
-columns, which reach directly into VM rows), so there's no reason for it
-to share PostgresqlDatabase's god-class surface. It shares the same
-connection pool (see PostgresqlDatabase.pool) rather than opening a
-second one, since POOL_MAX_SIZE is already tuned for this allocator's
-total connection budget.
+(unlike the AdminReservedAt admin-reservation columns, which reach
+directly into VM rows), so there's no reason for it to share
+VmDatabase's god-class surface. It shares the same connection
+pool (see VmDatabase.pool) rather than opening a second one,
+since POOL_MAX_SIZE is already tuned for this allocator's total
+connection budget.
 """
 from __future__ import annotations
 
@@ -15,6 +15,8 @@ import logging
 from typing import List, Optional
 
 import psycopg2
+
+from lablink_allocator_service.db.pool import PooledCursor
 
 logger = logging.getLogger(__name__)
 
@@ -53,8 +55,8 @@ class OperationsDatabase:
     """Persistence for the operations table.
 
     Args:
-        pool: A psycopg2 connection pool, shared with PostgresqlDatabase
-            (see PostgresqlDatabase.pool) rather than owned here.
+        pool: A psycopg2 connection pool, shared with VmDatabase
+            (see VmDatabase.pool) rather than owned here.
     """
 
     def __init__(self, pool):
@@ -63,22 +65,8 @@ class OperationsDatabase:
     @property
     def _cursor(self):
         """Return a context manager that checks out a pooled connection
-        and yields a cursor. See database._PooledCursor.
-
-        Imported lazily (not at module level): database.py does a real,
-        unmocked `import psycopg2` at its own top level, and several test
-        files (test_database.py, test_reboot.py) guard against that by
-        patching sys.modules before their own first import of database.py.
-        An eager module-level import here would race those files during
-        pytest collection — whichever import runs first wins, and a real
-        psycopg2 import poisons the cached database module for every test
-        file collected afterward. Deferring the import to first use (well
-        after collection, when those guards have already run) avoids the
-        race entirely.
-        """
-        from lablink_allocator_service.database import _PooledCursor
-
-        return _PooledCursor(self._pool)
+        and yields a cursor. See db.pool.PooledCursor."""
+        return PooledCursor(self._pool)
 
     def create_operation(
         self,

--- a/packages/allocator/src/lablink_allocator_service/db/pool.py
+++ b/packages/allocator/src/lablink_allocator_service/db/pool.py
@@ -1,0 +1,132 @@
+"""Connection-pool primitives shared by every class in this package.
+
+Kept separate from the persistence classes so that importing pool
+machinery never pulls in a module that opens connections or defines
+table-specific SQL.
+"""
+from __future__ import annotations
+
+import logging
+import os
+
+import psycopg2
+import psycopg2.pool
+
+logger = logging.getLogger(__name__)
+
+
+def _pool_max_size_from_env(default: int) -> int:
+    """LABLINK_DB_POOL_MAX_SIZE override, clamped to >= POOL_MIN_SIZE.
+    Invalid/missing values fall through to the default."""
+    raw = os.environ.get("LABLINK_DB_POOL_MAX_SIZE")
+    if not raw:
+        return default
+    try:
+        parsed = int(raw)
+    except ValueError:
+        logger.warning(
+            "Ignoring invalid LABLINK_DB_POOL_MAX_SIZE=%r; using %d", raw, default
+        )
+        return default
+    if parsed < 1:
+        logger.warning(
+            "Ignoring LABLINK_DB_POOL_MAX_SIZE=%d (<1); using %d", parsed, default
+        )
+        return default
+    return parsed
+
+
+# Pool sizing. Default sized for ~100 client VMs polling concurrently
+# plus the admin UI; start.sh raises Postgres max_connections in lockstep.
+# Override at deploy time with LABLINK_DB_POOL_MAX_SIZE without rebuilding
+# the image (keep it below max_connections minus autovacuum/admin headroom).
+POOL_MIN_SIZE = 2
+POOL_MAX_SIZE = _pool_max_size_from_env(default=200)
+
+
+class PooledCursor:
+    """Checks out an autocommit connection from the pool, opens a cursor,
+    and returns both to the pool/closes on exit. Preserves the per-call
+    context-manager API previously provided by _LockedCursor.
+    """
+
+    def __init__(self, pool):
+        self._pool = pool
+        self._conn = None
+        self._cur = None
+
+    def __enter__(self):
+        self._conn = self._pool.getconn()
+        try:
+            # Mirror pre-refactor behavior: every connection runs in
+            # autocommit. Applied per checkout — cheap, and defensive
+            # against anything that ever flips isolation levels on a
+            # pooled conn.
+            self._conn.set_isolation_level(
+                psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
+            )
+            self._cur = self._conn.cursor()
+            return self._cur
+        except Exception:
+            self._pool.putconn(self._conn)
+            self._conn = None
+            raise
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        try:
+            if self._cur is not None:
+                self._cur.close()
+        finally:
+            if self._conn is not None:
+                # On exception, discard the conn so a bad connection doesn't
+                # re-enter the pool. Happy path: return it for reuse.
+                self._pool.putconn(
+                    self._conn, close=(exc_type is not None)
+                )
+        return False  # don't swallow exceptions
+
+
+def validate_pool_sizes(pool_min_size: int, pool_max_size: int) -> None:
+    """Reject invalid pool sizing. Pure — deliberately touches no psycopg2.
+
+    Callers that build their own pool (VmDatabase.__init__) use this instead
+    of make_pool, so that pool CONSTRUCTION stays inside the caller's module.
+    A module-level `import psycopg2` binds the module object at import time,
+    so whichever module actually builds the pool is the one whose binding of
+    psycopg2 gets exercised. Keeping construction in VmDatabase rather than
+    delegating it to a helper here keeps that binding local to VmDatabase —
+    and therefore substitutable per-instance, e.g. by dependency-injecting a
+    pre-built pool via the `pool` constructor argument instead of needing to
+    intercept psycopg2 itself.
+
+    Raises:
+        ValueError: If pool sizing is invalid.
+    """
+    if pool_min_size < 1 or pool_max_size < pool_min_size:
+        raise ValueError(
+            f"Invalid pool sizes: min={pool_min_size}, max={pool_max_size}"
+        )
+
+
+def make_pool(cfg_db, *, pool_min_size=POOL_MIN_SIZE, pool_max_size=POOL_MAX_SIZE):
+    """Build a ThreadedConnectionPool from a `cfg.db`-shaped object.
+
+    For callers that need ONLY a pool and no persistence class — e.g. the
+    APScheduler job in scheduler.py, which shares one pool across several
+    handles. The pool is built with THIS module's psycopg2 binding; a caller
+    that needs the binding to be its own (see validate_pool_sizes) should
+    construct the pool itself rather than calling this.
+
+    Raises:
+        ValueError: If pool sizing is invalid.
+    """
+    validate_pool_sizes(pool_min_size, pool_max_size)
+    return psycopg2.pool.ThreadedConnectionPool(
+        minconn=pool_min_size,
+        maxconn=pool_max_size,
+        dbname=cfg_db.dbname,
+        user=cfg_db.user,
+        password=cfg_db.password,
+        host=cfg_db.host,
+        port=cfg_db.port,
+    )

--- a/packages/allocator/src/lablink_allocator_service/db/schedules.py
+++ b/packages/allocator/src/lablink_allocator_service/db/schedules.py
@@ -1,0 +1,203 @@
+"""Persistence for the scheduled_destructions table.
+
+A standalone table: no foreign key to, and no shared columns with, the VM
+table. The scheduled *job* clears VM rows (see scheduler.py), but that is
+job behavior, not schema coupling — this class touches only its own table.
+
+Shares the connection pool with the other classes in this package (see
+db.pool.make_pool) rather than opening a second one, since POOL_MAX_SIZE is
+tuned for the allocator's total connection budget.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+import logging
+from typing import List, Optional
+
+import psycopg2
+
+from lablink_allocator_service.db.pool import PooledCursor
+
+logger = logging.getLogger(__name__)
+
+# Named-key contract for rows returned by the SELECT * queries below. Every
+# query in this class must emit columns in this order (matches the
+# CREATE TABLE column order in generate_init_sql.py).
+_SCHEDULE_COLUMNS = (
+    "id",
+    "schedule_name",
+    "destruction_time",
+    "recurrence_rule",
+    "created_by",
+    "status",
+    "execution_count",
+    "last_execution_time",
+    "last_execution_result",
+    "notification_enabled",
+    "notification_hours_before",
+    "created_at",
+    "updated_at",
+)
+
+
+def _naive_utc(dt: datetime) -> datetime:
+    """Convert a datetime to naive UTC.
+
+    A private copy of the same helper in db/vms.py — six lines is not worth
+    a shared-utils module, and the two callers are on opposite sides of a
+    deliberate module boundary.
+    """
+    if dt.tzinfo is not None:
+        return dt.astimezone(timezone.utc).replace(tzinfo=None)
+    return dt
+
+
+class ScheduleDatabase:
+    """Persistence for the scheduled_destructions table.
+
+    Args:
+        pool: A psycopg2 connection pool, shared with the other db classes.
+    """
+
+    def __init__(self, pool):
+        self._pool = pool
+
+    @property
+    def _cursor(self):
+        """Return a context manager that checks out a pooled connection
+        and yields a cursor. See db.pool.PooledCursor."""
+        return PooledCursor(self._pool)
+
+    def create_scheduled_destruction(
+        self,
+        schedule_name: str,
+        destruction_time: datetime,
+        recurrence_rule: str = None,
+        created_by: str = None,
+        notification_enabled: bool = True,
+        notification_hours_before: int = 1,
+    ) -> int:
+        """Create a scheduled destruction entry and return its ID.
+
+        Raises:
+            ValueError: If a schedule with the same name already exists
+            RuntimeError: If database operation fails
+        """
+        query = """
+            INSERT INTO scheduled_destructions
+            (schedule_name, destruction_time, recurrence_rule, created_by,
+            notification_enabled, notification_hours_before, status)
+            VALUES (%s, %s, %s, %s, %s, %s, 'scheduled')
+            RETURNING id;
+        """
+        with self._cursor as cursor:
+            try:
+                cursor.execute(
+                    query,
+                    (
+                        schedule_name,
+                        _naive_utc(destruction_time),
+                        recurrence_rule,
+                        created_by,
+                        notification_enabled,
+                        notification_hours_before,
+                    ),
+                )
+                destruction_id = cursor.fetchone()[0]
+                logger.info(
+                    f"Created scheduled destruction "
+                    f"'{schedule_name}' "
+                    f"(ID: {destruction_id})"
+                )
+                return destruction_id
+
+            except psycopg2.IntegrityError as e:
+                if (
+                    'schedule_name' in str(e)
+                    or 'unique constraint' in str(e).lower()
+                ):
+                    error_msg = (
+                        f"Schedule '{schedule_name}' already exists"
+                    )
+                    logger.warning(error_msg)
+                    raise ValueError(error_msg) from e
+                else:
+                    logger.error(
+                        f"Database integrity error "
+                        f"creating schedule: {e}"
+                    )
+                    raise RuntimeError(
+                        f"Database integrity error: {e}"
+                    ) from e
+
+            except Exception as e:
+                logger.error(
+                    f"Failed to create scheduled destruction "
+                    f"'{schedule_name}': {e}"
+                )
+                raise RuntimeError(
+                    f"Failed to create scheduled destruction: {e}"
+                ) from e
+
+    def get_scheduled_destruction(self, schedule_id: int) -> Optional[dict]:
+        """Get scheduled destruction by ID."""
+        query = "SELECT * FROM scheduled_destructions WHERE id = %s;"
+        with self._cursor as cursor:
+            cursor.execute(query, (schedule_id,))
+            row = cursor.fetchone()
+        if row:
+            return dict(zip(_SCHEDULE_COLUMNS, row))
+        return None
+
+    def get_all_scheduled_destructions(
+        self, status: Optional[str] = None
+    ) -> List[dict]:
+        """Get all scheduled destructions, optionally filtered by status."""
+        with self._cursor as cursor:
+            if status:
+                query = (
+                    "SELECT * FROM scheduled_destructions "
+                    "WHERE status = %s "
+                    "ORDER BY destruction_time;"
+                )
+                cursor.execute(query, (status,))
+            else:
+                query = (
+                    "SELECT * FROM scheduled_destructions "
+                    "ORDER BY destruction_time;"
+                )
+                cursor.execute(query)
+
+            return [
+                dict(zip(_SCHEDULE_COLUMNS, row))
+                for row in cursor.fetchall()
+            ]
+
+    def update_scheduled_destruction_status(
+        self,
+        schedule_id: int,
+        status: str,
+        execution_result: Optional[str] = None,
+    ) -> None:
+        """Update destruction execution status."""
+        query = """
+            UPDATE scheduled_destructions
+            SET status = %s,
+                execution_count = execution_count + 1,
+                last_execution_time = NOW(),
+                last_execution_result = %s
+            WHERE id = %s;
+        """
+        with self._cursor as cursor:
+            cursor.execute(
+                query, (status, execution_result, schedule_id)
+            )
+
+    def cancel_scheduled_destruction(self, schedule_id: int) -> None:
+        """Cancel a scheduled destruction."""
+        query = (
+            "UPDATE scheduled_destructions "
+            "SET status = 'cancelled' WHERE id = %s;"
+        )
+        with self._cursor as cursor:
+            cursor.execute(query, (schedule_id,))

--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -1,279 +1,32 @@
-from collections import OrderedDict
+from __future__ import annotations
+
 from datetime import datetime, timezone
 import json
 import logging
-import os
-import threading
-import time
 from typing import List, Optional
 from urllib.parse import urlsplit
 
 import psycopg2
 import psycopg2.pool
 
-from lablink_allocator_service.secret_hash import invalidate_verify
+from lablink_allocator_service.db.pool import (
+    POOL_MAX_SIZE,
+    POOL_MIN_SIZE,
+    PooledCursor,
+    validate_pool_sizes,
+)
+from lablink_allocator_service.secret_hash import SecretHashCache, invalidate_verify
 
 # Set up logging
 logger = logging.getLogger(__name__)
 
 
-def _pool_max_size_from_env(default: int) -> int:
-    """LABLINK_DB_POOL_MAX_SIZE override, clamped to >= POOL_MIN_SIZE.
-    Invalid/missing values fall through to the default."""
-    raw = os.environ.get("LABLINK_DB_POOL_MAX_SIZE")
-    if not raw:
-        return default
-    try:
-        parsed = int(raw)
-    except ValueError:
-        logger.warning(
-            "Ignoring invalid LABLINK_DB_POOL_MAX_SIZE=%r; using %d", raw, default
-        )
-        return default
-    if parsed < 1:
-        logger.warning(
-            "Ignoring LABLINK_DB_POOL_MAX_SIZE=%d (<1); using %d", parsed, default
-        )
-        return default
-    return parsed
+class VmDatabase:
+    """Persistence for the VM table: rows, client registration and auth,
+    seat assignment, logs, health and heartbeat, and the settings table.
 
-
-# Pool sizing. Default sized for ~100 client VMs polling concurrently
-# plus the admin UI; start.sh raises Postgres max_connections in lockstep.
-# Override at deploy time with LABLINK_DB_POOL_MAX_SIZE without rebuilding
-# the image (keep it below max_connections minus autovacuum/admin headroom).
-POOL_MIN_SIZE = 2
-POOL_MAX_SIZE = _pool_max_size_from_env(default=200)
-
-
-# Secret-hash cache sizing. Every authed allocator endpoint reads the
-# argon2 hash before letting the request through. With ~30 client VMs
-# polling on tight loops the lookup alone can starve the pool during
-# bursts. The cache is invalidated by register_client and
-# unregister_client; TTLs are a safety net for any unexpected writer.
-# Positive TTL is short (60 s) so that any path that updates the hash
-# without going through invalidate (e.g. direct SQL, future code) only
-# leaves stale auth state for ~1 minute. With ~30 VMs polling at ~1 Hz
-# this still cuts steady-state DB load by ~60×.
-_SECRET_HASH_POSITIVE_TTL_S = 60.0
-_SECRET_HASH_NEGATIVE_TTL_S = 30.0
-# Working set is the number of registered VMs (tens). Cap well above
-# that so legitimate workloads never evict; the cap bounds memory under
-# unique-key floods.
-_SECRET_HASH_CACHE_MAX_SIZE = 1024
-
-
-class _SecretHashCache:
-    """Thread-safe per-hostname TTL+LRU cache for client_secret_hash.
-
-    Caches both real hashes (positive_ttl) and absent-hostname None
-    results (negative_ttl). The shorter negative TTL keeps freshly
-    registered hosts auth-able within seconds without a register-time
-    invalidate, and limits how long a repeatedly probed unknown
-    hostname sits in memory.
-
-    Race-against-rotation: ``get`` returns a per-hostname version token
-    that ``put`` re-checks under lock. If ``invalidate`` ran between
-    ``get`` and ``put`` — i.e. a concurrent ``register_client`` rotated
-    the secret while a stale SELECT was in flight — the version
-    mismatch rejects the stale write, so the next call re-queries the
-    DB and picks up the new hash.
-
-    Bounded size: the underlying store is an ``OrderedDict`` with LRU
-    eviction on insert beyond ``max_size``. Both ``get`` and ``put``
-    move the entry to the most-recently-used end. This bounds memory
-    even if a misbehaving caller iterates through unique fake
-    hostnames.
-    """
-
-    def __init__(
-        self,
-        *,
-        positive_ttl_seconds: float = _SECRET_HASH_POSITIVE_TTL_S,
-        negative_ttl_seconds: float = _SECRET_HASH_NEGATIVE_TTL_S,
-        max_size: int = _SECRET_HASH_CACHE_MAX_SIZE,
-    ):
-        if max_size < 1:
-            raise ValueError(f"Invalid cache max_size: {max_size}")
-        self._positive_ttl = positive_ttl_seconds
-        self._negative_ttl = negative_ttl_seconds
-        self._max_size = max_size
-        self._lock = threading.RLock()
-        # hostname -> (value, expires_at)
-        self._entries: OrderedDict = OrderedDict()
-        # hostname -> int. Bumped only by invalidate(); never reset by
-        # TTL expiry or LRU eviction (those aren't "the hash changed"
-        # events). put() rejects stores whose observed version is stale.
-        self._versions: dict = {}
-
-    def get(self, hostname: str):
-        """Return ``(hit, value, version)``.
-
-        ``hit=False`` means the caller must query the DB; pass
-        ``version`` back to :meth:`put` so a concurrent invalidate
-        between get and put rejects the stale write.
-        """
-        with self._lock:
-            version = self._versions.get(hostname, 0)
-            entry = self._entries.get(hostname)
-            if entry is None:
-                return False, None, version
-            value, expires_at = entry
-            if time.monotonic() >= expires_at:
-                del self._entries[hostname]
-                return False, None, version
-            # LRU touch
-            self._entries.move_to_end(hostname)
-            return True, value, version
-
-    def put(self, hostname: str, value, expected_version: int) -> bool:
-        """Store ``value`` for ``hostname`` if no invalidate raced.
-
-        Returns ``True`` if the entry was written, ``False`` if a
-        concurrent ``invalidate`` bumped the version between the
-        caller's ``get`` and this ``put``.
-        """
-        ttl = self._positive_ttl if value is not None else self._negative_ttl
-        with self._lock:
-            if self._versions.get(hostname, 0) != expected_version:
-                return False
-            self._entries[hostname] = (value, time.monotonic() + ttl)
-            self._entries.move_to_end(hostname)
-            # Evict LRU entries beyond cap. Bound is a soft DoS guard,
-            # not a working-set sizing knob.
-            while len(self._entries) > self._max_size:
-                self._entries.popitem(last=False)
-            return True
-
-    def invalidate(self, hostname: str) -> None:
-        with self._lock:
-            self._versions[hostname] = self._versions.get(hostname, 0) + 1
-            self._entries.pop(hostname, None)
-
-    def clear(self) -> None:
-        with self._lock:
-            self._entries.clear()
-            self._versions.clear()
-
-
-class _PooledCursor:
-    """Checks out an autocommit connection from the pool, opens a cursor,
-    and returns both to the pool/closes on exit. Preserves the per-call
-    context-manager API previously provided by _LockedCursor.
-    """
-
-    def __init__(self, pool):
-        self._pool = pool
-        self._conn = None
-        self._cur = None
-
-    def __enter__(self):
-        self._conn = self._pool.getconn()
-        try:
-            # Mirror pre-refactor behavior: every connection runs in
-            # autocommit. Applied per checkout — cheap, and defensive
-            # against anything that ever flips isolation levels on a
-            # pooled conn.
-            self._conn.set_isolation_level(
-                psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
-            )
-            self._cur = self._conn.cursor()
-            return self._cur
-        except Exception:
-            self._pool.putconn(self._conn)
-            self._conn = None
-            raise
-
-    def __exit__(self, exc_type, exc_val, exc_tb):
-        try:
-            if self._cur is not None:
-                self._cur.close()
-        finally:
-            if self._conn is not None:
-                # On exception, discard the conn so a bad connection doesn't
-                # re-enter the pool. Happy path: return it for reuse.
-                self._pool.putconn(
-                    self._conn, close=(exc_type is not None)
-                )
-        return False  # don't swallow exceptions
-
-
-def _median(values: list):
-    """Median of a list, ignoring None. Returns None when the list is empty.
-
-    Uses floor division for the even-length case because every column
-    fed in here is INTEGER in the schema; `960` reads more cleanly in
-    the rendered admin tile than `960.0`. If a future caller passes a
-    DOUBLE PRECISION column, switch this site to true division.
-    """
-    values = sorted(v for v in values if v is not None)
-    if not values:
-        return None
-    n = len(values)
-    mid = n // 2
-    if n % 2 == 1:
-        return values[mid]
-    return (values[mid - 1] + values[mid]) // 2
-
-
-# Named-key contract for rows returned by get_session_metrics_summary's
-# SELECT. The SELECT statement MUST emit these columns in this order;
-# both sides reference this tuple so column renames/reorderings stay
-# in lockstep. Reordering the SELECT without updating this list is the
-# kind of silent-wrong-numbers bug an earlier review flagged.
-_SUMMARY_COLUMNS = (
-    "host_name",
-    "session_metrics_started_at",
-    "seconds_to_first_sleap_label",
-    "seconds_to_first_sleap_train",
-    "seconds_to_first_sleap_track",
-    "seconds_in_subject_software",
-    "gpu_active_seconds",
-    "max_labeled_frames",
-    "training_epochs_completed",
-)
-
-
-def _build_summary(rows: list) -> dict:
-    """Build the session-metrics cohort summary from a row iterable.
-
-    Rows are positional tuples from psycopg2; we zip them against
-    `_SUMMARY_COLUMNS` so the rest of this function reads by name.
-    Test fixtures that pass fewer trailing fields produce dicts with
-    those keys missing — `.get(...)` returns None for those, which is
-    the same behavior callers see for a NULL column.
-    """
-    keyed = [dict(zip(_SUMMARY_COLUMNS, r)) for r in rows]
-    total = len(keyed)
-    started = sum(1 for r in keyed if r.get("session_metrics_started_at") is not None)
-    labeled = sum(1 for r in keyed if r.get("seconds_to_first_sleap_label") is not None)
-    trained = sum(1 for r in keyed if r.get("seconds_to_first_sleap_train") is not None)
-    tracked = sum(1 for r in keyed if r.get("seconds_to_first_sleap_track") is not None)
-    secs_in_subject = [r.get("seconds_in_subject_software") for r in keyed]
-    first_train = [r.get("seconds_to_first_sleap_train") for r in keyed]
-    frames = [r.get("max_labeled_frames") for r in keyed]
-    epochs = [r.get("training_epochs_completed") for r in keyed]
-    pct_train = (trained / total * 100.0) if total else 0.0
-    return {
-        "total_vms": total,
-        "funnel": {
-            "started": started,
-            "labeled": labeled,
-            "trained": trained,
-            "tracked": tracked,
-        },
-        "pct_reached_training": pct_train,
-        "median_seconds_in_subject_software": _median(secs_in_subject),
-        "median_seconds_to_first_train": _median(first_train),
-        "median_labeled_frames": _median(frames),
-        "median_epochs_completed": _median(epochs),
-    }
-
-
-class PostgresqlDatabase:
-    """Class to interact with a PostgreSQL database.
-    This class provides methods to connect to the database, insert data,
-    retrieve data, and listen for notifications.
+    Shares its connection pool with the other classes in this package via
+    the `pool` property, rather than each opening its own.
     """
 
     def __init__(
@@ -286,6 +39,7 @@ class PostgresqlDatabase:
         table_name: str,
         pool_min_size: int = POOL_MIN_SIZE,
         pool_max_size: int = POOL_MAX_SIZE,
+        pool=None,
     ):
         """Initialize the database connection pool.
 
@@ -297,19 +51,30 @@ class PostgresqlDatabase:
             port (int): The port number for the database connection.
             table_name (str): The name of the table to interact with.
             pool_min_size (int): Minimum pooled connections. Defaults to
-                POOL_MIN_SIZE. Override in tests only.
+                POOL_MIN_SIZE. Ignored when `pool` is provided.
             pool_max_size (int): Maximum pooled connections. Defaults to
                 POOL_MAX_SIZE (which honors LABLINK_DB_POOL_MAX_SIZE).
-                Override in tests only.
+                Ignored when `pool` is provided.
+            pool: A pre-built connection pool to use instead of
+                constructing a new `ThreadedConnectionPool`. Callers that
+                need only a pool-shaped object — tests supplying a
+                `MagicMock`, or code sharing an existing pool — pass this
+                instead of `pool_min_size`/`pool_max_size`. When provided,
+                no psycopg2 connection is attempted here and pool sizing
+                is not validated (the caller already built the pool).
+                Ownership contract: this instance does NOT take ownership
+                of an injected pool. `__del__` only calls `closeall()` on
+                a pool this `__init__` constructed itself; a pool you pass
+                in remains yours to close (e.g. once every handle sharing
+                it is done). This matters for callers like `make_pool`
+                consumers that share one pool across several instances —
+                without this, garbage-collecting any one of them would
+                close the pool out from under the others.
 
         Raises:
-            ValueError: If pool sizing is invalid.
+            ValueError: If pool sizing is invalid and `pool` was not
+                provided.
         """
-        if pool_min_size < 1 or pool_max_size < pool_min_size:
-            raise ValueError(
-                f"Invalid pool sizes: min={pool_min_size}, max={pool_max_size}"
-            )
-
         self.dbname = dbname
         self.user = user
         self.password = password
@@ -317,16 +82,22 @@ class PostgresqlDatabase:
         self.port = port
         self.table_name = table_name
 
-        self._pool = psycopg2.pool.ThreadedConnectionPool(
-            minconn=pool_min_size,
-            maxconn=pool_max_size,
-            dbname=dbname,
-            user=user,
-            password=password,
-            host=host,
-            port=port,
-        )
-        self._secret_hash_cache = _SecretHashCache()
+        if pool is not None:
+            self._pool = pool
+            self._owns_pool = False
+        else:
+            validate_pool_sizes(pool_min_size, pool_max_size)
+            self._pool = psycopg2.pool.ThreadedConnectionPool(
+                minconn=pool_min_size,
+                maxconn=pool_max_size,
+                dbname=dbname,
+                user=user,
+                password=password,
+                host=host,
+                port=port,
+            )
+            self._owns_pool = True
+        self._secret_hash_cache = SecretHashCache()
 
     @property
     def _cursor(self):
@@ -337,7 +108,7 @@ class PostgresqlDatabase:
             with self._cursor as cursor:
                 cursor.execute(...)
         """
-        return _PooledCursor(self._pool)
+        return PooledCursor(self._pool)
 
     @property
     def pool(self):
@@ -419,55 +190,10 @@ class PostgresqlDatabase:
             )
             return [row[0] for row in cursor.fetchall()]
 
-    def insert_vm(self, hostname) -> None:
-        """Insert a new row into the table.
-
-        Args:
-            hostname (str): The hostname of the VM.
-        """
-        column_names = self.get_column_names()
-
-        values = []
-
-        for col in column_names:
-            # Find the column that corresponds to the hostname and set its value
-            if col == "hostname":
-                values.append(hostname)
-            elif col == "inuse":
-                values.append(False)
-            else:
-                values.append(None)
-
-        # Construct the SQL query
-        columns = ", ".join(column_names)
-        placeholders = ", ".join(["%s" for _ in column_names])
-
-        with self._cursor as cursor:
-            try:
-                sql = (
-                    f"INSERT INTO {self.table_name} "
-                    f"({columns}) VALUES ({placeholders});"
-                )
-                cursor.execute(sql, values)
-            except Exception as e:
-                logger.error(f"Failed to insert VM '{hostname}': {e}")
-                raise
-
-    def get_vm_by_machine_identity(self, machine_identity: str):
-        """Return the hostname of the row with this machine_identity, or None."""
-        with self._cursor as cursor:
-            cursor.execute(
-                f"SELECT hostname FROM {self.table_name} "
-                f"WHERE machine_identity = %s;",
-                (machine_identity,),
-            )
-            row = cursor.fetchone()
-        return row[0] if row else None
-
     def get_client_secret_hash(self, hostname: str):
         """Return the argon2 client_secret_hash for a hostname, or None.
 
-        Cached per-hostname (see ``_SecretHashCache``). The version token
+        Cached per-hostname (see ``SecretHashCache``). The version token
         captured before the SELECT is re-checked on put — a concurrent
         ``register_client`` or ``unregister_client`` that bumps the
         version mid-flight rejects the stale write, so the next call
@@ -931,32 +657,6 @@ class PostgresqlDatabase:
                 )
                 raise
 
-    def get_gpu_health(self, hostname: str) -> str:
-        """Get the GPU health status of a VM.
-
-        Args:
-            hostname (str): The hostname of the VM.
-
-        Returns:
-            str: The health status of the GPU for the specified VM
-                or None if not found.
-        """
-        query = (
-            f"SELECT healthy FROM {self.table_name} "
-            f"WHERE hostname = %s;"
-        )
-        try:
-            with self._cursor as cursor:
-                cursor.execute(query, (hostname,))
-                result = cursor.fetchone()
-            return result[0] if result else None
-        except Exception as e:
-            logger.error(
-                f"Failed to retrieve GPU health "
-                f"for VM '{hostname}': {e}"
-            )
-            return None
-
     def get_status_by_hostname(self, hostname: str) -> str:
         """Get the status of a VM by its hostname.
 
@@ -1028,34 +728,6 @@ class PostgresqlDatabase:
                 f"for VM '{hostname}': {e}"
             )
             return None
-
-    def save_logs_by_hostname(
-        self, hostname: str, logs: str, log_type: str = "cloud_init"
-    ) -> None:
-        """Save logs for a VM by its hostname.
-
-        Args:
-            hostname (str): The hostname of the VM.
-            logs (str): The logs to save for the VM.
-            log_type (str): "cloud_init" or "docker".
-        """
-        column = (
-            "cloudinitlogs" if log_type == "cloud_init"
-            else "dockerlogs"
-        )
-        query = (
-            f"UPDATE {self.table_name} "
-            f"SET {column} = %s WHERE hostname = %s;"
-        )
-        with self._cursor as cursor:
-            try:
-                cursor.execute(query, (logs, hostname))
-            except Exception as e:
-                logger.error(
-                    f"Failed to save {log_type} logs "
-                    f"for VM '{hostname}': {e}"
-                )
-                raise
 
     def append_logs_by_hostname(
         self,
@@ -1166,34 +838,6 @@ class PostgresqlDatabase:
                     f"Failed to update status "
                     f"for VM '{hostname}': {e}"
                 )
-
-    @classmethod
-    def load_database(
-        cls,
-        dbname,
-        user,
-        password,
-        host,
-        port,
-        table_name,
-        pool_min_size: int = POOL_MIN_SIZE,
-        pool_max_size: int = POOL_MAX_SIZE,
-    ) -> "PostgresqlDatabase":
-        """Loads an existing database from PostgreSQL.
-
-        Args match __init__. Provided for callers that prefer the
-        classmethod style.
-        """
-        return cls(
-            dbname,
-            user,
-            password,
-            host,
-            port,
-            table_name,
-            pool_min_size=pool_min_size,
-            pool_max_size=pool_max_size,
-        )
 
     @staticmethod
     def _naive_utc(dt: datetime) -> datetime:
@@ -1335,171 +979,6 @@ class PostgresqlDatabase:
                     f"Failed to update metrics for VM '{hostname}': {e}"
                 )
                 raise
-
-    def create_scheduled_destruction(
-        self,
-        schedule_name: str,
-        destruction_time: datetime,
-        recurrence_rule: str = None,
-        created_by: str = None,
-        notification_enabled: bool = True,
-        notification_hours_before: int = 1,
-    ) -> int:
-        """Create a scheduled destruction entry and return its ID.
-
-        Raises:
-            ValueError: If a schedule with the same name already exists
-            RuntimeError: If database operation fails
-        """
-        query = """
-            INSERT INTO scheduled_destructions
-            (schedule_name, destruction_time, recurrence_rule, created_by,
-            notification_enabled, notification_hours_before, status)
-            VALUES (%s, %s, %s, %s, %s, %s, 'scheduled')
-            RETURNING id;
-        """
-        with self._cursor as cursor:
-            try:
-                cursor.execute(
-                    query,
-                    (
-                        schedule_name,
-                        self._naive_utc(destruction_time),
-                        recurrence_rule,
-                        created_by,
-                        notification_enabled,
-                        notification_hours_before,
-                    ),
-                )
-                destruction_id = cursor.fetchone()[0]
-                logger.info(
-                    f"Created scheduled destruction "
-                    f"'{schedule_name}' "
-                    f"(ID: {destruction_id})"
-                )
-                return destruction_id
-
-            except psycopg2.IntegrityError as e:
-                if (
-                    'schedule_name' in str(e)
-                    or 'unique constraint' in str(e).lower()
-                ):
-                    error_msg = (
-                        f"Schedule '{schedule_name}' already exists"
-                    )
-                    logger.warning(error_msg)
-                    raise ValueError(error_msg) from e
-                else:
-                    logger.error(
-                        f"Database integrity error "
-                        f"creating schedule: {e}"
-                    )
-                    raise RuntimeError(
-                        f"Database integrity error: {e}"
-                    ) from e
-
-            except Exception as e:
-                logger.error(
-                    f"Failed to create scheduled destruction "
-                    f"'{schedule_name}': {e}"
-                )
-                raise RuntimeError(
-                    f"Failed to create scheduled destruction: {e}"
-                ) from e
-
-    def get_scheduled_destruction(self, schedule_id: int) -> Optional[dict]:
-        """Get scheduled destruction by ID."""
-        query = "SELECT * FROM scheduled_destructions WHERE id = %s;"
-        with self._cursor as cursor:
-            cursor.execute(query, (schedule_id,))
-            row = cursor.fetchone()
-        if row:
-            columns = [
-                "id",
-                "schedule_name",
-                "destruction_time",
-                "recurrence_rule",
-                "created_by",
-                "status",
-                "execution_count",
-                "last_execution_time",
-                "last_execution_result",
-                "notification_enabled",
-                "notification_hours_before",
-                "created_at",
-                "updated_at",
-            ]
-            return dict(zip(columns, row))
-        return None
-
-    def get_all_scheduled_destructions(
-        self, status: Optional[str] = None
-    ) -> List[dict]:
-        """Get all scheduled destructions, optionally filtered by status."""
-        columns = [
-            "id",
-            "schedule_name",
-            "destruction_time",
-            "recurrence_rule",
-            "created_by",
-            "status",
-            "execution_count",
-            "last_execution_time",
-            "last_execution_result",
-            "notification_enabled",
-            "notification_hours_before",
-            "created_at",
-            "updated_at",
-        ]
-
-        with self._cursor as cursor:
-            if status:
-                query = (
-                    "SELECT * FROM scheduled_destructions "
-                    "WHERE status = %s "
-                    "ORDER BY destruction_time;"
-                )
-                cursor.execute(query, (status,))
-            else:
-                query = (
-                    "SELECT * FROM scheduled_destructions "
-                    "ORDER BY destruction_time;"
-                )
-                cursor.execute(query)
-
-            return [
-                dict(zip(columns, row))
-                for row in cursor.fetchall()
-            ]
-
-    def update_scheduled_destruction_status(
-        self,
-        schedule_id: int,
-        status: str,
-        execution_result: Optional[str] = None,
-    ) -> None:
-        """Update destruction execution status."""
-        query = """
-            UPDATE scheduled_destructions
-            SET status = %s,
-                execution_count = execution_count + 1,
-                last_execution_time = NOW(),
-                last_execution_result = %s
-            WHERE id = %s;
-        """
-        with self._cursor as cursor:
-            cursor.execute(
-                query, (status, execution_result, schedule_id)
-            )
-
-    def cancel_scheduled_destruction(self, schedule_id: int) -> None:
-        """Cancel a scheduled destruction."""
-        query = (
-            "UPDATE scheduled_destructions "
-            "SET status = 'cancelled' WHERE id = %s;"
-        )
-        with self._cursor as cursor:
-            cursor.execute(query, (schedule_id,))
 
     def ensure_reboot_columns(self) -> None:
         """Add reboot tracking columns to vm_table if they don't exist."""
@@ -1761,130 +1240,17 @@ class PostgresqlDatabase:
                 )
                 raise
 
-    def update_session_metrics(self, hostname: str, payload: dict) -> None:
-        """Last-write-wins UPDATE of session-metrics columns.
-
-        Atomic with respect to seal: the sealed-row check is folded into
-        the UPDATE's WHERE clause, so a concurrent ``bulk_seal_session_metrics``
-        cannot land between a separate SELECT and a separate UPDATE.
-        When the UPDATE affects zero rows, a follow-up existence SELECT
-        classifies the failure as ``LookupError`` (no such row) or
-        ``ValueError`` (row exists but is sealed).
-
-        Raises:
-            LookupError: if hostname unknown.
-            ValueError: if the row is already sealed.
-        """
-        # Lazy import: the legacy test_database.py module-level mock of
-        # sys.modules does not stub psycopg2.extras, so importing Json
-        # at module scope would break that suite.
-        from psycopg2.extras import Json
-
-        counters = payload.get("counters", {})
-        with self._cursor as cursor:
-            cursor.execute(
-                f"""
-                UPDATE {self.table_name} SET
-                  SessionMetricsStartedAt      = COALESCE(SessionMetricsStartedAt, %s),
-                  SessionMetricsLastReportedAt = NOW(),
-                  SecondsInSubjectSoftware     = %s,
-                  SecondsInTerminal            = %s,
-                  SecondsInBrowser             = %s,
-                  SecondsInOther               = %s,
-                  GpuActiveSeconds             = %s,
-                  GpuUtilPeak                  = %s,
-                  VramUsedPeakMb               = %s,
-                  SecondsToFirstSleapLabel     = %s,
-                  SecondsToFirstSleapTrain     = %s,
-                  SecondsToFirstSleapTrack     = %s,
-                  MaxLabeledFrames             = %s,
-                  TrainingEpochsCompleted      = %s,
-                  TrainingFinalLoss            = %s,
-                  SessionMetricsRaw            = %s
-                WHERE HostName = %s AND SessionMetricsSealedAt IS NULL
-                """,
-                (
-                    payload.get("session_started_at"),
-                    counters.get("seconds_in_subject_software"),
-                    counters.get("seconds_in_terminal"),
-                    counters.get("seconds_in_browser"),
-                    counters.get("seconds_in_other"),
-                    counters.get("gpu_active_seconds"),
-                    counters.get("gpu_util_peak"),
-                    counters.get("vram_used_peak_mb"),
-                    counters.get("seconds_to_first_sleap_label"),
-                    counters.get("seconds_to_first_sleap_train"),
-                    counters.get("seconds_to_first_sleap_track"),
-                    counters.get("max_labeled_frames"),
-                    counters.get("training_epochs_completed"),
-                    counters.get("training_final_loss"),
-                    Json(counters),
-                    hostname,
-                ),
-            )
-            if cursor.rowcount >= 1:
-                return
-
-            # UPDATE matched zero rows — classify so the route can return
-            # 404 vs 409. HostName is PRIMARY KEY on vms, so this SELECT
-            # can return at most one row.
-            cursor.execute(
-                f"SELECT 1 FROM {self.table_name} WHERE HostName = %s",
-                (hostname,),
-            )
-            if cursor.fetchone() is None:
-                raise LookupError(f"VM {hostname} not found")
-            raise ValueError(f"VM {hostname} session is sealed")
-
-    def seal_session_metrics(self, hostname: str) -> None:
-        """Mark a single VM's session-metrics row as sealed (final)."""
-        with self._cursor as cursor:
-            cursor.execute(
-                f"UPDATE {self.table_name} SET SessionMetricsSealedAt = NOW() "
-                "WHERE HostName = %s AND SessionMetricsSealedAt IS NULL",
-                (hostname,),
-            )
-
-    def bulk_seal_session_metrics(self) -> int:
-        """Seal every unsealed VM (called from the destroy paths).
-
-        Returns:
-            int: number of rows sealed.
-        """
-        with self._cursor as cursor:
-            cursor.execute(
-                f"UPDATE {self.table_name} SET SessionMetricsSealedAt = NOW() "
-                "WHERE SessionMetricsSealedAt IS NULL"
-            )
-            return cursor.rowcount or 0
-
-    def get_session_metrics_summary(self) -> dict:
-        """Aggregate the cohort summary for the admin page.
-
-        The SELECT column order MUST match `_SUMMARY_COLUMNS` at module
-        top — `_build_summary` zips them together to access rows by name.
-        """
-        with self._cursor as cursor:
-            cursor.execute(
-                f"""
-                SELECT HostName,
-                       SessionMetricsStartedAt,
-                       SecondsToFirstSleapLabel,
-                       SecondsToFirstSleapTrain,
-                       SecondsToFirstSleapTrack,
-                       SecondsInSubjectSoftware,
-                       GpuActiveSeconds,
-                       MaxLabeledFrames,
-                       TrainingEpochsCompleted
-                FROM {self.table_name}
-                """
-            )
-            rows = cursor.fetchall()
-        return _build_summary(rows)
-
     def __del__(self):
-        """Close all pooled connections when the object is deleted."""
-        if hasattr(self, "_pool") and self._pool is not None:
+        """Close all pooled connections when the object is deleted.
+
+        Only closes a pool this instance built itself (see `__init__`'s
+        `pool` parameter). An injected pool is owned by whoever built it
+        and stays open — it may still be in use by other holders.
+        """
+        if (
+            getattr(self, "_owns_pool", False)
+            and getattr(self, "_pool", None) is not None
+        ):
             try:
                 self._pool.closeall()
             except Exception:

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -28,7 +28,9 @@ import psycopg2
 
 from lablink_allocator_service.get_config import get_config
 from lablink_allocator_service.conf.structured_config import MISSING_SECRET
-from lablink_allocator_service.database import PostgresqlDatabase
+from lablink_allocator_service.db.vms import VmDatabase
+from lablink_allocator_service.db.schedules import ScheduleDatabase
+from lablink_allocator_service.db.metrics import MetricsDatabase
 from lablink_allocator_service.utils.config_helpers import (
     get_allocator_url,
     is_self_signed_ssl,
@@ -39,7 +41,7 @@ from lablink_allocator_service.scheduler import ScheduledDestructionService
 from lablink_allocator_service.reboot import AutoRebootService
 from lablink_allocator_service.admin_session_expiry import AdminSessionExpiryService
 from lablink_allocator_service.operations import OperationsWorker
-from lablink_allocator_service.operations_db import (
+from lablink_allocator_service.db.operations import (
     OperationInProgress,
     OperationsDatabase,
 )
@@ -146,6 +148,12 @@ AGENT_TOKEN = secrets.token_urlsafe(32)
 # Initialize the database connection
 database = None
 
+# Scheduled-destructions query layer (initialized in init_database()).
+schedule_db = None
+
+# Session-metrics query layer (initialized in init_database()).
+metrics_db = None
+
 # Scheduler service (initialized in main())
 scheduler_service = None
 
@@ -176,7 +184,7 @@ _startup_time: float | None = None
 def init_database():
     """Initialize the database connection."""
     global database
-    database = PostgresqlDatabase(
+    database = VmDatabase(
         dbname=cfg.db.dbname,
         user=cfg.db.user,
         password=cfg.db.password,
@@ -184,9 +192,13 @@ def init_database():
         port=cfg.db.port,
         table_name=cfg.db.table_name,
     )
+    global schedule_db
+    schedule_db = ScheduleDatabase(pool=database.pool)
+    global metrics_db
+    metrics_db = MetricsDatabase(pool=database.pool, table_name=cfg.db.table_name)
     # Expose the underlying psycopg2 pool to blueprints (e.g. /desktop,
     # /internal/proxy_auth) that need a raw connection for the signed-cookie
-    # helpers, without coupling them to the PostgresqlDatabase wrapper.
+    # helpers, without coupling them to the VmDatabase wrapper.
     app.config["DB_POOL"] = database._pool
     app.config["VM_TABLE_NAME"] = cfg.db.table_name
     # Persist the deployment register-token as an argon2 hash at rest
@@ -737,7 +749,7 @@ def destroy():
         # about to be killed. Best-effort: never block destroy on a seal
         # failure.
         try:
-            sealed = database.bulk_seal_session_metrics()
+            sealed = metrics_db.bulk_seal_session_metrics()
             logger.info("Sealed %d session-metrics rows before destroy", sealed)
         except Exception as e:
             logger.warning("Could not bulk-seal session metrics: %s", e)
@@ -1016,7 +1028,7 @@ def post_session_metrics(hostname):
         data = request.get_json(silent=True) or {}
         if "counters" not in data:
             return jsonify({"error": "Missing 'counters' in payload."}), 400
-        database.update_session_metrics(hostname=hostname, payload=data)
+        metrics_db.update_session_metrics(hostname=hostname, payload=data)
         return jsonify({"message": "Session metrics updated."}), 200
     except LookupError:
         return jsonify({"error": "VM not found."}), 404
@@ -1052,7 +1064,7 @@ def _session_metrics_view_model() -> dict:
         or "subject"
     )
     summary = (
-        database.get_session_metrics_summary() if monitoring_enabled else None
+        metrics_db.get_session_metrics_summary() if monitoring_enabled else None
     )
     return {
         "enabled": monitoring_enabled,
@@ -1234,7 +1246,7 @@ def create_scheduled_destruction() -> Response | tuple[Response, int]:
 def get_scheduled_destruction(schedule_id: int):
     """Get details of a scheduled destruction."""
 
-    schedule = database.get_scheduled_destruction(schedule_id)
+    schedule = schedule_db.get_scheduled_destruction(schedule_id)
 
     if not schedule:
         return jsonify({"success": False, "message": "Schedule not found"}), 404
@@ -1269,7 +1281,7 @@ def list_scheduled_destructions() -> Response | tuple[Response, int]:
             {"success": False, "message": f"Invalid status filter: {status_filter}"}
         ), 400
 
-    schedules = database.get_all_scheduled_destructions(status=status_filter)
+    schedules = schedule_db.get_all_scheduled_destructions(status=status_filter)
 
     return jsonify({"success": True, "schedules": schedules, "count": len(schedules)})
 
@@ -1280,7 +1292,7 @@ def cancel_scheduled_destruction(schedule_id: int):
     """Cancel a scheduled destruction."""
 
     # Check if schedule exists
-    schedule = database.get_scheduled_destruction(schedule_id)
+    schedule = schedule_db.get_scheduled_destruction(schedule_id)
     if not schedule:
         return jsonify({"success": False, "message": "Schedule not found"}), 404
 
@@ -1357,7 +1369,7 @@ def main():
             f"@{cfg.db.host}:{cfg.db.port}/{cfg.db.dbname}"
         )
         scheduler_service = ScheduledDestructionService(
-            database=database,
+            schedule_db=schedule_db,
             db_url=db_url,
         )
         scheduler_service.start()

--- a/packages/allocator/src/lablink_allocator_service/operations.py
+++ b/packages/allocator/src/lablink_allocator_service/operations.py
@@ -11,7 +11,7 @@ from threading import Thread
 from typing import TYPE_CHECKING, Callable, Optional
 
 if TYPE_CHECKING:
-    from lablink_allocator_service.operations_db import OperationsDatabase
+    from lablink_allocator_service.db.operations import OperationsDatabase
 
 logger = logging.getLogger(__name__)
 

--- a/packages/allocator/src/lablink_allocator_service/reboot.py
+++ b/packages/allocator/src/lablink_allocator_service/reboot.py
@@ -16,7 +16,7 @@ import subprocess
 from datetime import datetime, timezone
 from threading import Thread, Event
 
-from lablink_allocator_service.database import PostgresqlDatabase
+from lablink_allocator_service.db.vms import VmDatabase
 
 logger = logging.getLogger(__name__)
 
@@ -25,7 +25,7 @@ class AutoRebootService:
     """Background service that monitors for failed VMs and reboots them.
 
     Args:
-        database: PostgresqlDatabase instance for querying/updating VM state.
+        database: VmDatabase instance for querying/updating VM state.
         region: AWS region where VMs are deployed.
         terraform_dir: Path to the Terraform directory (for SSH key retrieval).
         max_attempts: Maximum reboot attempts per VM before giving up.
@@ -35,7 +35,7 @@ class AutoRebootService:
 
     def __init__(
         self,
-        database: PostgresqlDatabase,
+        database: VmDatabase,
         region: str = "us-west-2",
         terraform_dir: str = "",
         max_attempts: int = 3,

--- a/packages/allocator/src/lablink_allocator_service/scheduler.py
+++ b/packages/allocator/src/lablink_allocator_service/scheduler.py
@@ -10,15 +10,16 @@ from apscheduler.triggers.date import DateTrigger
 from apscheduler.triggers.cron import CronTrigger
 from dateutil import rrule
 
-from lablink_allocator_service.database import PostgresqlDatabase
+from lablink_allocator_service.db.schedules import ScheduleDatabase
+from lablink_allocator_service.db.metrics import MetricsDatabase
 
 logger = logging.getLogger(__name__)
 
 
-def run_scheduled_destroy(handles: list, database, provider) -> None:
+def run_scheduled_destroy(handles: list, metrics_db, provider) -> None:
     """Seal session-metrics rows, then tear down the VMs."""
     logger.info("Bulk-sealing session metrics before destroy")
-    sealed = database.bulk_seal_session_metrics()
+    sealed = metrics_db.bulk_seal_session_metrics()
     logger.info("Sealed %d session-metrics rows", sealed)
     logger.info("Running provider.destroy_hosts via scheduled job")
     result = provider.destroy_hosts(handles)
@@ -47,49 +48,60 @@ def execute_scheduled_destruction_job(
         schedule_id: ID of the scheduled destruction
         terraform_dir: Path to Terraform directory
     """
-    from lablink_allocator_service.database import PostgresqlDatabase
+    from lablink_allocator_service.db.pool import make_pool
+    from lablink_allocator_service.db.vms import VmDatabase
     from lablink_allocator_service.get_config import get_config
     from lablink_allocator_service.providers.registry import get_provider
 
     # Load config at runtime to get credentials (avoids storing passwords in job store)
     cfg = get_config()
 
-    # Create a fresh database connection for this job
-    database = PostgresqlDatabase(
-        dbname=cfg.db.dbname,
-        user=cfg.db.user,
-        password=cfg.db.password,
-        host=cfg.db.host,
-        port=cfg.db.port,
-        table_name=cfg.db.table_name,
-    )
-
-    # Instantiate the provider from config (same as main.py at startup)
-    provider = get_provider(
-        cfg.provider,
-        region=cfg.app.region,
-        terraform_dir=terraform_dir,
-    )
-
-    logger.info(f"Executing scheduled destruction ID: {schedule_id}")
+    # Build a single pool for the whole job and derive every handle from
+    # it — including the VmDatabase kept around for
+    # clear_database() at the end of the job — instead of opening a
+    # second pool internally. VmDatabase does not take ownership
+    # of an injected pool (see its __init__ docstring), so `pool` remains
+    # the sole owner and `finally` below is the only place that closes it.
+    pool = make_pool(cfg.db)
 
     try:
+        schedule_db = ScheduleDatabase(pool=pool)
+        metrics_db = MetricsDatabase(pool=pool, table_name=cfg.db.table_name)
+        database = VmDatabase(
+            dbname=cfg.db.dbname,
+            user=cfg.db.user,
+            password=cfg.db.password,
+            host=cfg.db.host,
+            port=cfg.db.port,
+            table_name=cfg.db.table_name,
+            pool=pool,
+        )
+
+        # Instantiate the provider from config (same as main.py at startup)
+        provider = get_provider(
+            cfg.provider,
+            region=cfg.app.region,
+            terraform_dir=terraform_dir,
+        )
+
+        logger.info(f"Executing scheduled destruction ID: {schedule_id}")
+
         # Mark as executing
-        database.update_scheduled_destruction_status(
+        schedule_db.update_scheduled_destruction_status(
             schedule_id=schedule_id,
             status="executing",
         )
 
-        from lablink_allocator_service.operations_db import OperationsDatabase
+        from lablink_allocator_service.db.operations import OperationsDatabase
 
-        operations_db = OperationsDatabase(pool=database.pool)
+        operations_db = OperationsDatabase(pool=pool)
         if operations_db.get_in_progress_operation() is not None:
             logger.info(
                 "Scheduled destruction %s skipped — an on-demand operation "
                 "is in progress",
                 schedule_id,
             )
-            database.update_scheduled_destruction_status(
+            schedule_db.update_scheduled_destruction_status(
                 schedule_id=schedule_id,
                 status="failed",
                 execution_result=(
@@ -108,14 +120,14 @@ def execute_scheduled_destruction_job(
             # by way of run_scheduled_destroy, which also seals any open
             # session-metrics rows so they don't survive the tear-down.
             handles = provider.list_hosts()
-            run_scheduled_destroy(handles, database, provider)
+            run_scheduled_destroy(handles, metrics_db, provider)
 
         # Clear database
         logger.info("Clearing all VMs from database")
         database.clear_database()
 
         # Mark as completed
-        database.update_scheduled_destruction_status(
+        schedule_db.update_scheduled_destruction_status(
             schedule_id=schedule_id,
             status="completed",
             execution_result="All VMs destroyed successfully",
@@ -127,7 +139,7 @@ def execute_scheduled_destruction_job(
         error_msg = f"Terraform destroy failed: {e.stderr}"
         logger.error(error_msg)
 
-        database.update_scheduled_destruction_status(
+        schedule_db.update_scheduled_destruction_status(
             schedule_id=schedule_id,
             status="failed",
             execution_result=error_msg,
@@ -137,36 +149,32 @@ def execute_scheduled_destruction_job(
         error_msg = f"Destruction failed: {str(e)}"
         logger.error(error_msg)
 
-        database.update_scheduled_destruction_status(
+        schedule_db.update_scheduled_destruction_status(
             schedule_id=schedule_id,
             status="failed",
             execution_result=error_msg,
         )
 
     finally:
-        # Close the database connection manually
-        if hasattr(database, "cursor") and database.cursor:
-            database.cursor.close()
-        if hasattr(database, "conn") and database.conn:
-            database.conn.close()
-        logger.debug("Database connection closed.")
+        pool.closeall()
+        logger.debug("Scheduled-job connection pool closed.")
 
 
 class ScheduledDestructionService:
     def __init__(
         self,
-        database: PostgresqlDatabase,
+        schedule_db: ScheduleDatabase,
         db_url: str,
         terraform_dir: Optional[str] = None,
     ):
         """Initialize the scheduler service.
 
         Args:
-            database: PostgresqlDatabase instance
+            schedule_db: ScheduleDatabase instance
             db_url: PostgreSQL connection URL for APScheduler job store
             terraform_dir: Path to Terraform directory (optional, auto-detected if None)
         """
-        self.database: PostgresqlDatabase = database
+        self.schedule_db: ScheduleDatabase = schedule_db
         self.db_url = db_url
 
         self.terraform_dir = terraform_dir or os.path.join(
@@ -229,7 +237,7 @@ class ScheduledDestructionService:
         # Create database record
         # This will raise ValueError for duplicate names or RuntimeError for
         # other DB errors
-        schedule_id = self.database.create_scheduled_destruction(
+        schedule_id = self.schedule_db.create_scheduled_destruction(
             schedule_name=schedule_name,
             destruction_time=destruction_time,
             recurrence_rule=recurrence_rule,
@@ -260,7 +268,7 @@ class ScheduledDestructionService:
             self.scheduler.remove_job(job_id)
 
         # Update database
-        self.database.cancel_scheduled_destruction(schedule_id)
+        self.schedule_db.cancel_scheduled_destruction(schedule_id)
 
         logger.info(f"Cancelled scheduled destruction ID: {schedule_id}")
 
@@ -352,7 +360,7 @@ class ScheduledDestructionService:
     def _load_scheduled_destructions(self) -> None:
         """Load existing scheduled destructions from database on startup."""
 
-        pending_schedules = self.database.get_all_scheduled_destructions(
+        pending_schedules = self.schedule_db.get_all_scheduled_destructions(
             status="scheduled"
         )
 

--- a/packages/allocator/src/lablink_allocator_service/secret_hash.py
+++ b/packages/allocator/src/lablink_allocator_service/secret_hash.py
@@ -55,6 +55,116 @@ def _token_fingerprint(plaintext: str) -> str:
     return hashlib.sha256(plaintext.encode("utf-8")).hexdigest()
 
 
+# Secret-hash cache sizing. Every authed allocator endpoint reads the
+# argon2 hash before letting the request through. With ~30 client VMs
+# polling on tight loops the lookup alone can starve the pool during
+# bursts. The cache is invalidated by register_client and
+# unregister_client; TTLs are a safety net for any unexpected writer.
+# Positive TTL is short (60 s) so that any path that updates the hash
+# without going through invalidate (e.g. direct SQL, future code) only
+# leaves stale auth state for ~1 minute. With ~30 VMs polling at ~1 Hz
+# this still cuts steady-state DB load by ~60×.
+_SECRET_HASH_POSITIVE_TTL_S = 60.0
+_SECRET_HASH_NEGATIVE_TTL_S = 30.0
+# Working set is the number of registered VMs (tens). Cap well above
+# that so legitimate workloads never evict; the cap bounds memory under
+# unique-key floods.
+_SECRET_HASH_CACHE_MAX_SIZE = 1024
+
+
+class SecretHashCache:
+    """Thread-safe per-hostname TTL+LRU cache for client_secret_hash.
+
+    Caches both real hashes (positive_ttl) and absent-hostname None
+    results (negative_ttl). The shorter negative TTL keeps freshly
+    registered hosts auth-able within seconds without a register-time
+    invalidate, and limits how long a repeatedly probed unknown
+    hostname sits in memory.
+
+    Race-against-rotation: ``get`` returns a per-hostname version token
+    that ``put`` re-checks under lock. If ``invalidate`` ran between
+    ``get`` and ``put`` — i.e. a concurrent ``register_client`` rotated
+    the secret while a stale SELECT was in flight — the version
+    mismatch rejects the stale write, so the next call re-queries the
+    DB and picks up the new hash.
+
+    Bounded size: the underlying store is an ``OrderedDict`` with LRU
+    eviction on insert beyond ``max_size``. Both ``get`` and ``put``
+    move the entry to the most-recently-used end. This bounds memory
+    even if a misbehaving caller iterates through unique fake
+    hostnames.
+    """
+
+    def __init__(
+        self,
+        *,
+        positive_ttl_seconds: float = _SECRET_HASH_POSITIVE_TTL_S,
+        negative_ttl_seconds: float = _SECRET_HASH_NEGATIVE_TTL_S,
+        max_size: int = _SECRET_HASH_CACHE_MAX_SIZE,
+    ):
+        if max_size < 1:
+            raise ValueError(f"Invalid cache max_size: {max_size}")
+        self._positive_ttl = positive_ttl_seconds
+        self._negative_ttl = negative_ttl_seconds
+        self._max_size = max_size
+        self._lock = threading.RLock()
+        # hostname -> (value, expires_at)
+        self._entries: OrderedDict = OrderedDict()
+        # hostname -> int. Bumped only by invalidate(); never reset by
+        # TTL expiry or LRU eviction (those aren't "the hash changed"
+        # events). put() rejects stores whose observed version is stale.
+        self._versions: dict = {}
+
+    def get(self, hostname: str):
+        """Return ``(hit, value, version)``.
+
+        ``hit=False`` means the caller must query the DB; pass
+        ``version`` back to :meth:`put` so a concurrent invalidate
+        between get and put rejects the stale write.
+        """
+        with self._lock:
+            version = self._versions.get(hostname, 0)
+            entry = self._entries.get(hostname)
+            if entry is None:
+                return False, None, version
+            value, expires_at = entry
+            if time.monotonic() >= expires_at:
+                del self._entries[hostname]
+                return False, None, version
+            # LRU touch
+            self._entries.move_to_end(hostname)
+            return True, value, version
+
+    def put(self, hostname: str, value, expected_version: int) -> bool:
+        """Store ``value`` for ``hostname`` if no invalidate raced.
+
+        Returns ``True`` if the entry was written, ``False`` if a
+        concurrent ``invalidate`` bumped the version between the
+        caller's ``get`` and this ``put``.
+        """
+        ttl = self._positive_ttl if value is not None else self._negative_ttl
+        with self._lock:
+            if self._versions.get(hostname, 0) != expected_version:
+                return False
+            self._entries[hostname] = (value, time.monotonic() + ttl)
+            self._entries.move_to_end(hostname)
+            # Evict LRU entries beyond cap. Bound is a soft DoS guard,
+            # not a working-set sizing knob.
+            while len(self._entries) > self._max_size:
+                self._entries.popitem(last=False)
+            return True
+
+    def invalidate(self, hostname: str) -> None:
+        with self._lock:
+            self._versions[hostname] = self._versions.get(hostname, 0) + 1
+            self._entries.pop(hostname, None)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._entries.clear()
+            self._versions.clear()
+
+
 class _VerifyResultCache:
     """Thread-safe per-(subject, token-fingerprint) TTL+LRU cache for
     successful argon2 verifies.
@@ -65,7 +175,7 @@ class _VerifyResultCache:
 
     Invalidation: ``invalidate(subject)`` drops every entry for that
     subject. Called from the registration paths that rotate or remove a
-    stored hash (the same hook ``_SecretHashCache`` uses), so a rotated
+    stored hash (the same hook ``SecretHashCache`` uses), so a rotated
     secret doesn't keep accepting old tokens up to the TTL.
 
     Bounded size: OrderedDict with LRU eviction on insert beyond

--- a/packages/allocator/tests/conftest.py
+++ b/packages/allocator/tests/conftest.py
@@ -315,7 +315,7 @@ def write_config_file(tmp_path):
 
 @pytest.fixture
 def real_db():
-    """Yield a PostgresqlDatabase connected to a real Postgres.
+    """Yield a VmDatabase connected to a real Postgres.
 
     Used by the concurrency test that asserts pool checkouts actually
     overlap in wall-clock time. If Postgres is unreachable (typical for
@@ -332,7 +332,7 @@ def real_db():
     except ImportError:
         pytest.skip("psycopg2 not installed")
 
-    from lablink_allocator_service.database import PostgresqlDatabase
+    from lablink_allocator_service.db.vms import VmDatabase
 
     host = os.getenv("POSTGRES_HOST", "localhost")
     port = int(os.getenv("POSTGRES_PORT", "5432"))
@@ -364,7 +364,7 @@ def real_db():
         )
     setup.close()
 
-    db = PostgresqlDatabase(
+    db = VmDatabase(
         dbname=dbname,
         user=user,
         password=password,

--- a/packages/allocator/tests/db/conftest.py
+++ b/packages/allocator/tests/db/conftest.py
@@ -1,0 +1,77 @@
+"""Shared fixtures for tests/db/*.
+
+`mock_db_connection`/`db_instance` build a `VmDatabase` wired to a
+mocked pool via dependency injection (`VmDatabase(..., pool=...)`),
+not by mocking `psycopg2` in `sys.modules`. That used to be necessary
+because `__init__` called `psycopg2.pool.ThreadedConnectionPool(...)`
+directly, so tests had to intercept it. Now that construction is skippable
+via `pool=`, no interception is needed, `db.vms`/`db.pool` import normally
+(once, real-bound, like any other module), and correctness no longer
+depends on collection order or which module's `import psycopg2` a given
+test happened to capture — the two-instances-of-db.pool bug this replaced
+is structurally impossible once no test needs the module-level psycopg2
+mock for construction.
+
+`VmDatabase` is a plain, ordinary import here (no `sys.modules`
+patching), since nothing needs psycopg2 mocked anymore.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+from lablink_allocator_service.db.vms import VmDatabase
+from lablink_allocator_service.db.schedules import ScheduleDatabase
+
+
+@pytest.fixture
+def mock_db_connection():
+    """Fixture returning (mock_conn, mock_cursor, mock_pool).
+
+    - mock_pool.getconn() returns mock_conn.
+    - mock_conn.cursor() returns mock_cursor directly.
+
+    Tests that previously reassigned db.conn and db.cursor after
+    instantiation continue to work via the convenience aliases set in
+    db_instance below.
+    """
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+
+    # conn.cursor() returns the cursor directly (real psycopg2 behavior).
+    # PooledCursor calls conn.cursor() and uses the result as the cursor.
+    mock_conn.cursor.return_value = mock_cursor
+
+    mock_pool = MagicMock()
+    mock_pool.getconn.return_value = mock_conn
+
+    return mock_conn, mock_cursor, mock_pool
+
+
+@pytest.fixture
+def db_instance(mock_db_connection):
+    """Fixture returning a VmDatabase wired to a mocked pool."""
+    mock_conn, mock_cursor, mock_pool = mock_db_connection
+    db = VmDatabase(
+        dbname="testdb",
+        user="testuser",
+        password="testpassword",
+        host="localhost",
+        port=5432,
+        table_name="vms",
+        pool=mock_pool,
+    )
+    # Convenience aliases so test bodies can keep using db_instance.cursor
+    # and db_instance.conn without knowing about pool internals.
+    db.conn = mock_conn
+    db.cursor = mock_cursor
+    return db
+
+
+@pytest.fixture
+def schedule_db_instance(mock_db_connection):
+    """A ScheduleDatabase over the same mocked pool as db_instance."""
+    mock_conn, mock_cursor, mock_pool = mock_db_connection
+    db = ScheduleDatabase(pool=mock_pool)
+    # The relocated tests read db.cursor directly, matching db_instance.
+    db.cursor = mock_cursor
+    return db

--- a/packages/allocator/tests/db/test_metrics.py
+++ b/packages/allocator/tests/db/test_metrics.py
@@ -7,20 +7,20 @@ import pytest
 
 @pytest.fixture
 def fake_db():
-    """Return a PostgresqlDatabase instance with mocked cursor."""
-    from lablink_allocator_service.database import PostgresqlDatabase
+    """Return a MetricsDatabase instance with a mocked cursor."""
+    from lablink_allocator_service.db.metrics import MetricsDatabase
 
-    db = PostgresqlDatabase.__new__(PostgresqlDatabase)
+    db = MetricsDatabase.__new__(MetricsDatabase)
     db.table_name = "vms"
     db._cursor_mock = MagicMock()
     cursor_ctx = MagicMock(
         __enter__=MagicMock(return_value=db._cursor_mock),
         __exit__=MagicMock(return_value=False),
     )
-    # _cursor is a property on PostgresqlDatabase; override it at the
-    # class level for the duration of each test.
+    # _cursor is a property on MetricsDatabase; override it at the class
+    # level for the duration of each test.
     patcher = patch.object(
-        PostgresqlDatabase,
+        MetricsDatabase,
         "_cursor",
         new_callable=PropertyMock,
         return_value=cursor_ctx,
@@ -78,13 +78,6 @@ def test_update_session_metrics_lookup_error_when_host_unknown(fake_db):
     payload = {"session_started_at": "x", "counters": {}}
     with pytest.raises(LookupError, match="not found"):
         fake_db.update_session_metrics("vm-missing", payload)
-
-
-def test_seal_session_metrics_sets_sealed_at(fake_db):
-    fake_db.seal_session_metrics("vm-1")
-    sql = fake_db._cursor_mock.execute.call_args.args[0]
-    assert "SessionMetricsSealedAt" in sql
-    assert "vm-1" in str(fake_db._cursor_mock.execute.call_args.args[1])
 
 
 def test_bulk_seal_session_metrics_targets_all_unsealed(fake_db):

--- a/packages/allocator/tests/db/test_operations.py
+++ b/packages/allocator/tests/db/test_operations.py
@@ -13,7 +13,7 @@ from unittest.mock import MagicMock
 import psycopg2
 import pytest
 
-from lablink_allocator_service.operations_db import (
+from lablink_allocator_service.db.operations import (
     OperationInProgress,
     OperationsDatabase,
 )

--- a/packages/allocator/tests/db/test_pool.py
+++ b/packages/allocator/tests/db/test_pool.py
@@ -1,0 +1,175 @@
+import psycopg2
+import pytest
+from unittest.mock import patch
+
+from lablink_allocator_service.db.vms import VmDatabase
+
+
+class _Cfg:
+    """Stand-in for cfg.db — only the attributes make_pool reads."""
+
+    dbname = "testdb"
+    user = "testuser"
+    password = "testpass"
+    host = "localhost"
+    port = 5432
+
+
+def test_make_pool_passes_connection_params():
+    with patch("psycopg2.pool.ThreadedConnectionPool") as mock_pool:
+        from lablink_allocator_service.db.pool import make_pool
+
+        make_pool(_Cfg(), pool_min_size=2, pool_max_size=10)
+
+    mock_pool.assert_called_once_with(
+        minconn=2,
+        maxconn=10,
+        dbname="testdb",
+        user="testuser",
+        password="testpass",
+        host="localhost",
+        port=5432,
+    )
+
+
+def test_make_pool_rejects_min_below_one():
+    from lablink_allocator_service.db.pool import make_pool
+
+    with pytest.raises(ValueError, match="Invalid pool sizes"):
+        make_pool(_Cfg(), pool_min_size=0, pool_max_size=10)
+
+
+def test_make_pool_rejects_max_below_min():
+    from lablink_allocator_service.db.pool import make_pool
+
+    with pytest.raises(ValueError, match="Invalid pool sizes"):
+        make_pool(_Cfg(), pool_min_size=5, pool_max_size=2)
+
+
+def test_validate_pool_sizes_accepts_valid_sizes():
+    """No exception, no return value, for well-formed sizes. Also confirms
+    validate_pool_sizes touches no psycopg2 — no mock is patched here."""
+    from lablink_allocator_service.db.pool import validate_pool_sizes
+
+    assert validate_pool_sizes(2, 200) is None
+    assert validate_pool_sizes(1, 1) is None
+
+
+def test_validate_pool_sizes_rejects_min_below_one():
+    from lablink_allocator_service.db.pool import validate_pool_sizes
+
+    with pytest.raises(ValueError, match="Invalid pool sizes"):
+        validate_pool_sizes(0, 10)
+
+
+def test_validate_pool_sizes_rejects_max_below_min():
+    from lablink_allocator_service.db.pool import validate_pool_sizes
+
+    with pytest.raises(ValueError, match="Invalid pool sizes"):
+        validate_pool_sizes(5, 2)
+
+
+def test_pool_size_validation_rejects_min_zero():
+    """pool_min_size must be >= 1."""
+    with pytest.raises(ValueError, match="Invalid pool sizes"):
+        VmDatabase(
+            dbname="testdb",
+            user="testuser",
+            password="testpassword",
+            host="localhost",
+            port=5432,
+            table_name="vms",
+            pool_min_size=0,
+            pool_max_size=5,
+        )
+
+
+def test_pool_size_validation_rejects_max_below_min():
+    """pool_max_size must be >= pool_min_size."""
+    with pytest.raises(ValueError, match="Invalid pool sizes"):
+        VmDatabase(
+            dbname="testdb",
+            user="testuser",
+            password="testpassword",
+            host="localhost",
+            port=5432,
+            table_name="vms",
+            pool_min_size=5,
+            pool_max_size=2,
+        )
+
+
+def test_pool_max_size_env_override_parses_int(monkeypatch):
+    from lablink_allocator_service.db.pool import _pool_max_size_from_env
+
+    monkeypatch.setenv("LABLINK_DB_POOL_MAX_SIZE", "120")
+    assert _pool_max_size_from_env(default=60) == 120
+
+
+def test_pool_max_size_env_override_unset_returns_default(monkeypatch):
+    from lablink_allocator_service.db.pool import _pool_max_size_from_env
+
+    monkeypatch.delenv("LABLINK_DB_POOL_MAX_SIZE", raising=False)
+    assert _pool_max_size_from_env(default=60) == 60
+
+
+def test_pool_max_size_env_override_invalid_falls_back(monkeypatch, caplog):
+    from lablink_allocator_service.db.pool import _pool_max_size_from_env
+
+    monkeypatch.setenv("LABLINK_DB_POOL_MAX_SIZE", "not-a-number")
+    with caplog.at_level("WARNING"):
+        assert _pool_max_size_from_env(default=60) == 60
+    assert "Ignoring invalid LABLINK_DB_POOL_MAX_SIZE" in caplog.text
+
+
+def test_pool_max_size_env_override_nonpositive_falls_back(monkeypatch, caplog):
+    from lablink_allocator_service.db.pool import _pool_max_size_from_env
+
+    monkeypatch.setenv("LABLINK_DB_POOL_MAX_SIZE", "0")
+    with caplog.at_level("WARNING"):
+        assert _pool_max_size_from_env(default=60) == 60
+    assert "Ignoring LABLINK_DB_POOL_MAX_SIZE=0" in caplog.text
+
+
+def test_cursor_returns_connection_on_success(db_instance):
+    """After a successful `with self._cursor` block, the pool's
+    putconn is called once with close=False."""
+    mock_pool = db_instance._pool
+    with db_instance._cursor as cur:
+        cur.execute("SELECT 1;")
+    mock_pool.putconn.assert_called_once()
+    # close defaults to False on success; verify via kwargs or positional
+    _, kwargs = mock_pool.putconn.call_args
+    assert kwargs.get("close", False) is False
+
+
+def test_cursor_discards_connection_on_exception(db_instance):
+    """If a query raises, putconn is called with close=True so the bad
+    connection is evicted from the pool."""
+    mock_pool = db_instance._pool
+    db_instance.cursor.execute.side_effect = RuntimeError("boom")
+    with pytest.raises(RuntimeError):
+        with db_instance._cursor as cur:
+            cur.execute("SELECT 1;")
+    mock_pool.putconn.assert_called_once()
+    _, kwargs = mock_pool.putconn.call_args
+    assert kwargs.get("close") is True
+
+
+def test_cursor_sets_autocommit_per_checkout(db_instance):
+    """Every checkout applies ISOLATION_LEVEL_AUTOCOMMIT, preserving
+    the pre-refactor per-statement-transaction behavior.
+
+    psycopg2 is not mocked anywhere in this test suite anymore (db_instance
+    injects a MagicMock pool via VmDatabase(..., pool=...)), so
+    this asserts against the real psycopg2.extensions constant — the same
+    module-level `psycopg2` that db/pool.py's PooledCursor itself uses,
+    since there is now exactly one db.pool module for the whole session.
+    """
+    mock_conn = db_instance.conn
+    mock_conn.set_isolation_level.reset_mock()
+    with db_instance._cursor:
+        pass
+    mock_conn.set_isolation_level.assert_called_once_with(
+        psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
+    )

--- a/packages/allocator/tests/db/test_schedules.py
+++ b/packages/allocator/tests/db/test_schedules.py
@@ -1,0 +1,262 @@
+"""Tests for ScheduleDatabase (persistence for the scheduled_destructions
+table).
+
+`schedule_db_instance`/`mock_db_connection` fixtures live in
+tests/db/conftest.py — the same mocked-pool pattern as db_instance in
+test_vms.py, just wired to ScheduleDatabase instead of VmDatabase.
+"""
+
+
+def test_create_scheduled_destruction(schedule_db_instance):
+    """Test creating a new scheduled destruction."""
+    from datetime import datetime, timezone
+
+    schedule_name = "Friday Tutorial End"
+    destruction_time = datetime(2025, 12, 5, 17, 30, 0, tzinfo=timezone.utc)
+    recurrence_rule = "FREQ=WEEKLY;BYDAY=FR"
+    created_by = "admin@example.com"
+
+    schedule_db_instance.cursor.fetchone.return_value = (1,)
+
+    schedule_id = schedule_db_instance.create_scheduled_destruction(
+        schedule_name=schedule_name,
+        destruction_time=destruction_time,
+        recurrence_rule=recurrence_rule,
+        created_by=created_by,
+        notification_enabled=True,
+        notification_hours_before=1,
+    )
+
+    expected_query = """
+            INSERT INTO scheduled_destructions
+            (schedule_name, destruction_time, recurrence_rule, created_by,
+            notification_enabled, notification_hours_before, status)
+            VALUES (%s, %s, %s, %s, %s, %s, 'scheduled')
+            RETURNING id;
+        """
+
+    # Convert to naive UTC for comparison
+    naive_destruction_time = destruction_time.replace(tzinfo=None)
+
+    schedule_db_instance.cursor.execute.assert_called_once()
+    args = schedule_db_instance.cursor.execute.call_args[0]
+    assert "".join(args[0].split()) == "".join(expected_query.split())
+    assert args[1] == (
+        schedule_name,
+        naive_destruction_time,
+        recurrence_rule,
+        created_by,
+        True,
+        1,
+    )
+    assert schedule_id == 1
+
+
+def test_create_scheduled_destruction_one_time(schedule_db_instance):
+    """Test creating a one-time scheduled destruction (no recurrence)."""
+    from datetime import datetime, timezone
+
+    schedule_name = "One-Time Cleanup"
+    destruction_time = datetime(2025, 12, 6, 18, 0, 0, tzinfo=timezone.utc)
+
+    schedule_db_instance.cursor.fetchone.return_value = (2,)
+
+    schedule_id = schedule_db_instance.create_scheduled_destruction(
+        schedule_name=schedule_name,
+        destruction_time=destruction_time,
+        recurrence_rule=None,
+        created_by=None,
+        notification_enabled=False,
+        notification_hours_before=0,
+    )
+
+    naive_destruction_time = destruction_time.replace(tzinfo=None)
+
+    schedule_db_instance.cursor.execute.assert_called_once()
+    args = schedule_db_instance.cursor.execute.call_args[0]
+    assert args[1] == (
+        schedule_name,
+        naive_destruction_time,
+        None,
+        None,
+        False,
+        0,
+    )
+    assert schedule_id == 2
+
+
+def test_create_scheduled_destruction_error(schedule_db_instance, caplog):
+    """Test error handling in create_scheduled_destruction."""
+    from datetime import datetime, timezone
+    import pytest
+
+    schedule_db_instance.cursor.execute.side_effect = Exception("DB error")
+
+    # Should raise RuntimeError instead of returning None
+    with pytest.raises(RuntimeError, match="Failed to create scheduled destruction"):
+        schedule_db_instance.create_scheduled_destruction(
+            schedule_name="Test",
+            destruction_time=datetime.now(timezone.utc),
+        )
+
+    assert "Failed to create scheduled destruction" in caplog.text
+
+
+def test_get_scheduled_destruction(schedule_db_instance):
+    """Test getting a scheduled destruction by ID."""
+    schedule_id = 1
+
+    # Mock cursor.fetchone to return a tuple (as real PostgreSQL cursor does)
+    # Column order matches: id, schedule_name, destruction_time, recurrence_rule,
+    # created_by, status, execution_count, last_execution_time, last_execution_result,
+    # notification_enabled, notification_hours_before, created_at, updated_at
+    schedule_tuple = (
+        1,  # id
+        "Friday Tutorial End",  # schedule_name
+        "2025-12-05 17:30:00",  # destruction_time
+        "FREQ=WEEKLY;BYDAY=FR",  # recurrence_rule
+        "admin@example.com",  # created_by
+        "scheduled",  # status
+        0,  # execution_count
+        None,  # last_execution_time
+        None,  # last_execution_result
+        True,  # notification_enabled
+        1,  # notification_hours_before
+        None,  # created_at
+        None,  # updated_at
+    )
+
+    schedule_db_instance.cursor.fetchone.return_value = schedule_tuple
+
+    result = schedule_db_instance.get_scheduled_destruction(schedule_id)
+
+    schedule_db_instance.cursor.execute.assert_called_with(
+        "SELECT * FROM scheduled_destructions WHERE id = %s;", (schedule_id,)
+    )
+
+    # Verify the result is a dict with expected values
+    assert result["id"] == 1
+    assert result["schedule_name"] == "Friday Tutorial End"
+    assert result["destruction_time"] == "2025-12-05 17:30:00"
+    assert result["recurrence_rule"] == "FREQ=WEEKLY;BYDAY=FR"
+    assert result["created_by"] == "admin@example.com"
+    assert result["status"] == "scheduled"
+    assert result["execution_count"] == 0
+
+
+def test_get_scheduled_destruction_not_found(schedule_db_instance):
+    """Test getting a scheduled destruction that doesn't exist."""
+    schedule_id = 999
+    schedule_db_instance.cursor.fetchone.return_value = None
+
+    result = schedule_db_instance.get_scheduled_destruction(schedule_id)
+
+    assert result is None
+
+
+def test_get_all_scheduled_destructions(schedule_db_instance):
+    """Test getting all scheduled destructions."""
+    # Mock cursor.fetchall to return tuples (as real PostgreSQL cursor does)
+    schedules_tuples = [
+        (1, "Schedule 1", None, None, None, "scheduled", 0, None, None, True, 1, None, None),
+        (2, "Schedule 2", None, None, None, "completed", 0, None, None, True, 1, None, None),
+        (3, "Schedule 3", None, None, None, "scheduled", 0, None, None, True, 1, None, None),
+    ]
+
+    schedule_db_instance.cursor.fetchall.return_value = schedules_tuples
+
+    result = schedule_db_instance.get_all_scheduled_destructions()
+
+    schedule_db_instance.cursor.execute.assert_called_with(
+        "SELECT * FROM scheduled_destructions ORDER BY destruction_time;"
+    )
+    assert len(result) == 3
+    assert result[0]["id"] == 1
+    assert result[0]["schedule_name"] == "Schedule 1"
+    assert result[0]["status"] == "scheduled"
+    assert result[1]["id"] == 2
+    assert result[1]["schedule_name"] == "Schedule 2"
+    assert result[1]["status"] == "completed"
+    assert result[2]["id"] == 3
+    assert result[2]["schedule_name"] == "Schedule 3"
+    assert result[2]["status"] == "scheduled"
+
+
+def test_get_all_scheduled_destructions_with_status_filter(schedule_db_instance):
+    """Test getting scheduled destructions filtered by status."""
+    # Mock cursor.fetchall to return tuples (as real PostgreSQL cursor does)
+    scheduled_tuples = [
+        (1, "Schedule 1", None, None, None, "scheduled", 0, None, None, True, 1, None, None),
+        (3, "Schedule 3", None, None, None, "scheduled", 0, None, None, True, 1, None, None),
+    ]
+
+    schedule_db_instance.cursor.fetchall.return_value = scheduled_tuples
+
+    result = schedule_db_instance.get_all_scheduled_destructions(status="scheduled")
+
+    schedule_db_instance.cursor.execute.assert_called_with(
+        "SELECT * FROM scheduled_destructions WHERE status = %s ORDER BY destruction_time;",
+        ("scheduled",),
+    )
+    assert len(result) == 2
+    assert result[0]["id"] == 1
+    assert result[0]["schedule_name"] == "Schedule 1"
+    assert result[0]["status"] == "scheduled"
+    assert result[1]["id"] == 3
+    assert result[1]["schedule_name"] == "Schedule 3"
+    assert result[1]["status"] == "scheduled"
+
+
+def test_update_scheduled_destruction_status(schedule_db_instance):
+    """Test updating the status of a scheduled destruction."""
+    schedule_id = 1
+    status = "completed"
+    execution_result = "All VMs destroyed successfully"
+
+    schedule_db_instance.update_scheduled_destruction_status(
+        schedule_id=schedule_id,
+        status=status,
+        execution_result=execution_result,
+    )
+
+    expected_query = """
+            UPDATE scheduled_destructions
+            SET status = %s,
+                execution_count = execution_count + 1,
+                last_execution_time = NOW(),
+                last_execution_result = %s
+            WHERE id = %s;
+        """
+
+    schedule_db_instance.cursor.execute.assert_called_once()
+    args = schedule_db_instance.cursor.execute.call_args[0]
+    assert "".join(args[0].split()) == "".join(expected_query.split())
+    assert args[1] == (status, execution_result, schedule_id)
+
+
+def test_update_scheduled_destruction_status_failed(schedule_db_instance):
+    """Test updating status to failed with error message."""
+    schedule_id = 2
+    status = "failed"
+    execution_result = "Terraform destroy failed: timeout"
+
+    schedule_db_instance.update_scheduled_destruction_status(
+        schedule_id=schedule_id,
+        status=status,
+        execution_result=execution_result,
+    )
+
+    args = schedule_db_instance.cursor.execute.call_args[0]
+    assert args[1] == (status, execution_result, schedule_id)
+
+
+def test_cancel_scheduled_destruction(schedule_db_instance):
+    """Test cancelling a scheduled destruction."""
+    schedule_id = 1
+
+    schedule_db_instance.cancel_scheduled_destruction(schedule_id)
+
+    schedule_db_instance.cursor.execute.assert_called_with(
+        "UPDATE scheduled_destructions SET status = 'cancelled' WHERE id = %s;",
+        (schedule_id,),
+    )

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1,79 +1,12 @@
 import pytest
 from unittest.mock import MagicMock, patch, ANY
 
-# Mock psycopg2 before importing the database module
-# This allows us to avoid the real psycopg2 import raising an error if it's not installed
-# in the test environment, and to control its behavior for all tests in this file.
-mock_psycopg2 = MagicMock()
-
-# Create proper exception classes for psycopg2
-class MockIntegrityError(Exception):
-    """Mock psycopg2.IntegrityError for testing."""
-    pass
-
-mock_psycopg2.IntegrityError = MockIntegrityError
-
-with patch.dict(
-    "sys.modules",
-    {
-        "psycopg2": mock_psycopg2,
-        "psycopg2.extensions": MagicMock(),
-        "psycopg2.pool": mock_psycopg2.pool,
-    },
-):
-    from lablink_allocator_service.database import PostgresqlDatabase
-
-
-@pytest.fixture
-def mock_db_connection():
-    """Fixture returning (mock_conn, mock_cursor, mock_pool).
-
-    The connection-pool mock is wired so that:
-      - PostgresqlDatabase.__init__ receives a mock pool (via the patched
-        psycopg2.pool.ThreadedConnectionPool factory) instead of opening
-        a real pool.
-      - mock_pool.getconn() returns mock_conn.
-      - mock_conn.cursor() returns mock_cursor directly.
-
-    Tests that previously reassigned db.conn and db.cursor after
-    instantiation continue to work via the convenience aliases set in
-    db_instance below.
-    """
-    mock_conn = MagicMock()
-    mock_cursor = MagicMock()
-
-    # conn.cursor() returns the cursor directly (real psycopg2 behavior).
-    # _PooledCursor calls conn.cursor() and uses the result as the cursor.
-    mock_conn.cursor.return_value = mock_cursor
-
-    mock_pool = MagicMock()
-    mock_pool.getconn.return_value = mock_conn
-
-    # PostgresqlDatabase.__init__ calls psycopg2.pool.ThreadedConnectionPool(...).
-    # Route that through the mock so no real connection is attempted.
-    mock_psycopg2.pool.ThreadedConnectionPool.return_value = mock_pool
-
-    return mock_conn, mock_cursor, mock_pool
-
-
-@pytest.fixture
-def db_instance(mock_db_connection):
-    """Fixture returning a PostgresqlDatabase wired to a mocked pool."""
-    mock_conn, mock_cursor, mock_pool = mock_db_connection
-    db = PostgresqlDatabase(
-        dbname="testdb",
-        user="testuser",
-        password="testpassword",
-        host="localhost",
-        port=5432,
-        table_name="vms",
-    )
-    # Convenience aliases so test bodies can keep using db_instance.cursor
-    # and db_instance.conn without knowing about pool internals.
-    db.conn = mock_conn
-    db.cursor = mock_cursor
-    db._pool = mock_pool
-    return db
+# mock_db_connection/db_instance fixtures live in tests/db/conftest.py —
+# both this module and test_pool.py need them. VmDatabase no longer
+# needs any psycopg2 mocking to construct (db_instance injects a mock pool
+# via VmDatabase(..., pool=...)), so this is a plain, ordinary
+# import — no sys.modules patching, no collection-order sensitivity.
+from lablink_allocator_service.db.vms import VmDatabase
 
 
 def test_get_row_count(db_instance):
@@ -104,31 +37,6 @@ def test_get_column_names(db_instance):
         ("vms",),
     )
     assert columns == expected_columns
-
-
-def test_insert_vm(db_instance):
-    """Test inserting a new VM into the database."""
-    hostname = "test-vm-01"
-    # Mock the get_column_names method to return a specific set of columns
-    db_instance.get_column_names = MagicMock(
-        return_value=[
-            "hostname",
-            "inuse",
-            "status",
-            "email",
-            "pin",
-            "crdcommand",
-            "healthy",
-            "cloudinitlogs",
-            "dockerlogs",
-        ]
-    )
-    db_instance.insert_vm(hostname)
-
-    expected_sql = "INSERT INTO vms (hostname, inuse, status, email, pin, crdcommand, healthy, cloudinitlogs, dockerlogs) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s);"
-    # The values should correspond to the mocked column names
-    expected_values = [hostname, False, None, None, None, None, None, None, None]
-    db_instance.cursor.execute.assert_called_with(expected_sql, expected_values)
 
 
 def test_get_unassigned_vms(db_instance):
@@ -214,20 +122,6 @@ def test_update_health(db_instance):
     )
 
 
-def test_get_gpu_health(db_instance):
-    """Test getting the GPU health of a VM."""
-    hostname = "gpu-vm-01"
-    health_status = "fail"
-    db_instance.cursor.fetchone.return_value = (health_status,)
-
-    result = db_instance.get_gpu_health(hostname)
-
-    db_instance.cursor.execute.assert_called_with(
-        "SELECT healthy FROM vms WHERE hostname = %s;", (hostname,)
-    )
-    assert result == health_status
-
-
 def test_get_status_by_hostname(db_instance):
     """Test getting the status of a VM by its hostname."""
     hostname = "status-vm-01"
@@ -278,26 +172,6 @@ def test_get_vm_logs_by_type(db_instance):
         "SELECT dockerlogs FROM vms WHERE hostname = %s;", (hostname,)
     )
     assert result == {"docker_logs": "docker data"}
-
-
-def test_save_logs_by_hostname(db_instance):
-    """Test saving cloud_init logs for a specific VM."""
-    hostname = "log-vm-02"
-    logs = "new log data to save"
-    db_instance.save_logs_by_hostname(hostname, logs, log_type="cloud_init")
-    db_instance.cursor.execute.assert_called_with(
-        "UPDATE vms SET cloudinitlogs = %s WHERE hostname = %s;", (logs, hostname)
-    )
-
-
-def test_save_docker_logs_by_hostname(db_instance):
-    """Test saving docker logs for a specific VM."""
-    hostname = "log-vm-03"
-    logs = "docker log data"
-    db_instance.save_logs_by_hostname(hostname, logs, log_type="docker")
-    db_instance.cursor.execute.assert_called_with(
-        "UPDATE vms SET dockerlogs = %s WHERE hostname = %s;", (logs, hostname)
-    )
 
 
 def test_append_logs_by_hostname(db_instance):
@@ -357,7 +231,7 @@ def test_old_read_modify_write_race_condition():
     The old code did:
         1. existing = db.get_vm_logs(hostname)  # READ
         2. vm_log = existing + new_logs          # MODIFY
-        3. db.save_logs_by_hostname(vm_log)      # WRITE
+        3. db.<the old whole-column write>(vm_log)   # WRITE
 
     With concurrent requests for the same VM, two requests could read
     the same snapshot, append their own data, and overwrite each other:
@@ -570,42 +444,18 @@ def test_update_vm_status_invalid(db_instance, caplog):
     assert "Invalid VM status 'invalid_status'" in caplog.text
 
 
-def test_load_database():
-    """Test the class method for loading a database instance.
-
-    Derives the expected pool sizes from the module constants so this
-    test doesn't lock in a specific default (the max is also configurable
-    via LABLINK_DB_POOL_MAX_SIZE — see _pool_max_size_from_env)."""
-    from lablink_allocator_service.database import (
-        POOL_MAX_SIZE,
-        POOL_MIN_SIZE,
-    )
-
-    with patch.object(
-        PostgresqlDatabase,
-        "__init__",
-        return_value=None,
-    ) as mock_init:
-        inst = PostgresqlDatabase.load_database(
-            "db", "user", "pass", "host", 5432, "table"
-        )
-
-    mock_init.assert_called_once_with(
-        "db", "user", "pass", "host", 5432, "table",
-        pool_min_size=POOL_MIN_SIZE, pool_max_size=POOL_MAX_SIZE,
-    )
-
-    assert isinstance(inst, PostgresqlDatabase)
-
-
 def test_del(db_instance):
-    """Test that the destructor closes all pooled connections."""
+    """db_instance injects its pool (pool=mock_pool, not owned/constructed
+    by this instance), so __del__ must NOT close it — closing a pool you
+    don't own could yank it out from under other holders. See
+    test_del_closes_pool (owned pool -> closed) and
+    test_del_does_not_close_injected_pool for the full picture."""
     pool = db_instance._pool
 
     # Call __del__ directly for predictable testing, as garbage collection is not guaranteed
     db_instance.__del__()
 
-    pool.closeall.assert_called_once()
+    pool.closeall.assert_not_called()
 
 
 def test_get_unassigned_vms_error(db_instance, caplog):
@@ -622,14 +472,6 @@ def test_assign_vm_db_error(db_instance, caplog):
     with pytest.raises(Exception, match="DB error"):
         db_instance.assign_vm("user@example.com")
     assert "Failed to assign VM" in caplog.text
-
-
-def test_get_gpu_health_not_found(db_instance):
-    """Test getting GPU health for a non-existent VM."""
-    hostname = "non-existent-vm"
-    db_instance.cursor.fetchone.return_value = None
-    result = db_instance.get_gpu_health(hostname)
-    assert result is None
 
 
 def test_get_status_by_hostname_not_found(db_instance):
@@ -832,13 +674,13 @@ def test_naive_utc():
 
     # Test with timezone-aware datetime
     aware_dt = datetime(2023, 1, 1, 12, 0, 0, tzinfo=timezone(timedelta(hours=-5)))
-    naive_utc_dt = PostgresqlDatabase._naive_utc(aware_dt)
+    naive_utc_dt = VmDatabase._naive_utc(aware_dt)
     assert naive_utc_dt.tzinfo is None
     assert naive_utc_dt == datetime(2023, 1, 1, 17, 0, 0)
 
     # Test with naive datetime
     naive_dt = datetime(2023, 1, 1, 12, 0, 0)
-    naive_utc_dt = PostgresqlDatabase._naive_utc(naive_dt)
+    naive_utc_dt = VmDatabase._naive_utc(naive_dt)
     assert naive_utc_dt.tzinfo is None
     assert naive_utc_dt == naive_dt
 
@@ -898,261 +740,6 @@ def test_update_vm_metrics_atomic_container_only(db_instance):
     assert values == (1609459300, 1609459360, 60.0, 60.0, hostname)
 
 
-def test_create_scheduled_destruction(db_instance):
-    """Test creating a new scheduled destruction."""
-    from datetime import datetime, timezone
-
-    schedule_name = "Friday Tutorial End"
-    destruction_time = datetime(2025, 12, 5, 17, 30, 0, tzinfo=timezone.utc)
-    recurrence_rule = "FREQ=WEEKLY;BYDAY=FR"
-    created_by = "admin@example.com"
-
-    db_instance.cursor.fetchone.return_value = (1,)
-
-    schedule_id = db_instance.create_scheduled_destruction(
-        schedule_name=schedule_name,
-        destruction_time=destruction_time,
-        recurrence_rule=recurrence_rule,
-        created_by=created_by,
-        notification_enabled=True,
-        notification_hours_before=1,
-    )
-
-    expected_query = """
-            INSERT INTO scheduled_destructions
-            (schedule_name, destruction_time, recurrence_rule, created_by,
-            notification_enabled, notification_hours_before, status)
-            VALUES (%s, %s, %s, %s, %s, %s, 'scheduled')
-            RETURNING id;
-        """
-
-    # Convert to naive UTC for comparison
-    naive_destruction_time = destruction_time.replace(tzinfo=None)
-
-    db_instance.cursor.execute.assert_called_once()
-    args = db_instance.cursor.execute.call_args[0]
-    assert "".join(args[0].split()) == "".join(expected_query.split())
-    assert args[1] == (
-        schedule_name,
-        naive_destruction_time,
-        recurrence_rule,
-        created_by,
-        True,
-        1,
-    )
-    assert schedule_id == 1
-
-
-def test_create_scheduled_destruction_one_time(db_instance):
-    """Test creating a one-time scheduled destruction (no recurrence)."""
-    from datetime import datetime, timezone
-
-    schedule_name = "One-Time Cleanup"
-    destruction_time = datetime(2025, 12, 6, 18, 0, 0, tzinfo=timezone.utc)
-
-    db_instance.cursor.fetchone.return_value = (2,)
-
-    schedule_id = db_instance.create_scheduled_destruction(
-        schedule_name=schedule_name,
-        destruction_time=destruction_time,
-        recurrence_rule=None,
-        created_by=None,
-        notification_enabled=False,
-        notification_hours_before=0,
-    )
-
-    naive_destruction_time = destruction_time.replace(tzinfo=None)
-
-    db_instance.cursor.execute.assert_called_once()
-    args = db_instance.cursor.execute.call_args[0]
-    assert args[1] == (
-        schedule_name,
-        naive_destruction_time,
-        None,
-        None,
-        False,
-        0,
-    )
-    assert schedule_id == 2
-
-
-def test_create_scheduled_destruction_error(db_instance, caplog):
-    """Test error handling in create_scheduled_destruction."""
-    from datetime import datetime, timezone
-    import pytest
-
-    db_instance.cursor.execute.side_effect = Exception("DB error")
-
-    # Should raise RuntimeError instead of returning None
-    with pytest.raises(RuntimeError, match="Failed to create scheduled destruction"):
-        db_instance.create_scheduled_destruction(
-            schedule_name="Test",
-            destruction_time=datetime.now(timezone.utc),
-        )
-
-    assert "Failed to create scheduled destruction" in caplog.text
-
-
-def test_get_scheduled_destruction(db_instance):
-    """Test getting a scheduled destruction by ID."""
-    schedule_id = 1
-
-    # Mock cursor.fetchone to return a tuple (as real PostgreSQL cursor does)
-    # Column order matches: id, schedule_name, destruction_time, recurrence_rule,
-    # created_by, status, execution_count, last_execution_time, last_execution_result,
-    # notification_enabled, notification_hours_before, created_at, updated_at
-    schedule_tuple = (
-        1,  # id
-        "Friday Tutorial End",  # schedule_name
-        "2025-12-05 17:30:00",  # destruction_time
-        "FREQ=WEEKLY;BYDAY=FR",  # recurrence_rule
-        "admin@example.com",  # created_by
-        "scheduled",  # status
-        0,  # execution_count
-        None,  # last_execution_time
-        None,  # last_execution_result
-        True,  # notification_enabled
-        1,  # notification_hours_before
-        None,  # created_at
-        None,  # updated_at
-    )
-
-    db_instance.cursor.fetchone.return_value = schedule_tuple
-
-    result = db_instance.get_scheduled_destruction(schedule_id)
-
-    db_instance.cursor.execute.assert_called_with(
-        "SELECT * FROM scheduled_destructions WHERE id = %s;", (schedule_id,)
-    )
-
-    # Verify the result is a dict with expected values
-    assert result["id"] == 1
-    assert result["schedule_name"] == "Friday Tutorial End"
-    assert result["destruction_time"] == "2025-12-05 17:30:00"
-    assert result["recurrence_rule"] == "FREQ=WEEKLY;BYDAY=FR"
-    assert result["created_by"] == "admin@example.com"
-    assert result["status"] == "scheduled"
-    assert result["execution_count"] == 0
-
-
-def test_get_scheduled_destruction_not_found(db_instance):
-    """Test getting a scheduled destruction that doesn't exist."""
-    schedule_id = 999
-    db_instance.cursor.fetchone.return_value = None
-
-    result = db_instance.get_scheduled_destruction(schedule_id)
-
-    assert result is None
-
-
-def test_get_all_scheduled_destructions(db_instance):
-    """Test getting all scheduled destructions."""
-    # Mock cursor.fetchall to return tuples (as real PostgreSQL cursor does)
-    schedules_tuples = [
-        (1, "Schedule 1", None, None, None, "scheduled", 0, None, None, True, 1, None, None),
-        (2, "Schedule 2", None, None, None, "completed", 0, None, None, True, 1, None, None),
-        (3, "Schedule 3", None, None, None, "scheduled", 0, None, None, True, 1, None, None),
-    ]
-
-    db_instance.cursor.fetchall.return_value = schedules_tuples
-
-    result = db_instance.get_all_scheduled_destructions()
-
-    db_instance.cursor.execute.assert_called_with(
-        "SELECT * FROM scheduled_destructions ORDER BY destruction_time;"
-    )
-    assert len(result) == 3
-    assert result[0]["id"] == 1
-    assert result[0]["schedule_name"] == "Schedule 1"
-    assert result[0]["status"] == "scheduled"
-    assert result[1]["id"] == 2
-    assert result[1]["schedule_name"] == "Schedule 2"
-    assert result[1]["status"] == "completed"
-    assert result[2]["id"] == 3
-    assert result[2]["schedule_name"] == "Schedule 3"
-    assert result[2]["status"] == "scheduled"
-
-
-def test_get_all_scheduled_destructions_with_status_filter(db_instance):
-    """Test getting scheduled destructions filtered by status."""
-    # Mock cursor.fetchall to return tuples (as real PostgreSQL cursor does)
-    scheduled_tuples = [
-        (1, "Schedule 1", None, None, None, "scheduled", 0, None, None, True, 1, None, None),
-        (3, "Schedule 3", None, None, None, "scheduled", 0, None, None, True, 1, None, None),
-    ]
-
-    db_instance.cursor.fetchall.return_value = scheduled_tuples
-
-    result = db_instance.get_all_scheduled_destructions(status="scheduled")
-
-    db_instance.cursor.execute.assert_called_with(
-        "SELECT * FROM scheduled_destructions WHERE status = %s ORDER BY destruction_time;",
-        ("scheduled",),
-    )
-    assert len(result) == 2
-    assert result[0]["id"] == 1
-    assert result[0]["schedule_name"] == "Schedule 1"
-    assert result[0]["status"] == "scheduled"
-    assert result[1]["id"] == 3
-    assert result[1]["schedule_name"] == "Schedule 3"
-    assert result[1]["status"] == "scheduled"
-
-
-def test_update_scheduled_destruction_status(db_instance):
-    """Test updating the status of a scheduled destruction."""
-    schedule_id = 1
-    status = "completed"
-    execution_result = "All VMs destroyed successfully"
-
-    db_instance.update_scheduled_destruction_status(
-        schedule_id=schedule_id,
-        status=status,
-        execution_result=execution_result,
-    )
-
-    expected_query = """
-            UPDATE scheduled_destructions
-            SET status = %s,
-                execution_count = execution_count + 1,
-                last_execution_time = NOW(),
-                last_execution_result = %s
-            WHERE id = %s;
-        """
-
-    db_instance.cursor.execute.assert_called_once()
-    args = db_instance.cursor.execute.call_args[0]
-    assert "".join(args[0].split()) == "".join(expected_query.split())
-    assert args[1] == (status, execution_result, schedule_id)
-
-
-def test_update_scheduled_destruction_status_failed(db_instance):
-    """Test updating status to failed with error message."""
-    schedule_id = 2
-    status = "failed"
-    execution_result = "Terraform destroy failed: timeout"
-
-    db_instance.update_scheduled_destruction_status(
-        schedule_id=schedule_id,
-        status=status,
-        execution_result=execution_result,
-    )
-
-    args = db_instance.cursor.execute.call_args[0]
-    assert args[1] == (status, execution_result, schedule_id)
-
-
-def test_cancel_scheduled_destruction(db_instance):
-    """Test cancelling a scheduled destruction."""
-    schedule_id = 1
-
-    db_instance.cancel_scheduled_destruction(schedule_id)
-
-    db_instance.cursor.execute.assert_called_with(
-        "UPDATE scheduled_destructions SET status = 'cancelled' WHERE id = %s;",
-        (schedule_id,),
-    )
-
-
 def test_get_assigned_vm_for_email_found(db_instance):
     """Test looking up an email that already owns a VM."""
     db_instance.cursor.fetchone.return_value = ("vm-7", "running", 0)
@@ -1193,121 +780,47 @@ def test_get_assigned_vm_for_email_error(db_instance, caplog):
     assert "Failed to look up assigned VM" in caplog.text
 
 
-def test_pool_size_validation_rejects_min_zero():
-    """pool_min_size must be >= 1."""
-    with pytest.raises(ValueError, match="Invalid pool sizes"):
-        PostgresqlDatabase(
-            dbname="testdb",
-            user="testuser",
-            password="testpassword",
-            host="localhost",
-            port=5432,
-            table_name="vms",
-            pool_min_size=0,
-            pool_max_size=5,
-        )
-
-
-def test_pool_size_validation_rejects_max_below_min():
-    """pool_max_size must be >= pool_min_size."""
-    with pytest.raises(ValueError, match="Invalid pool sizes"):
-        PostgresqlDatabase(
-            dbname="testdb",
-            user="testuser",
-            password="testpassword",
-            host="localhost",
-            port=5432,
-            table_name="vms",
-            pool_min_size=5,
-            pool_max_size=2,
-        )
-
-
-def test_pool_max_size_env_override_parses_int(monkeypatch):
-    from lablink_allocator_service.database import _pool_max_size_from_env
-
-    monkeypatch.setenv("LABLINK_DB_POOL_MAX_SIZE", "120")
-    assert _pool_max_size_from_env(default=60) == 120
-
-
-def test_pool_max_size_env_override_unset_returns_default(monkeypatch):
-    from lablink_allocator_service.database import _pool_max_size_from_env
-
-    monkeypatch.delenv("LABLINK_DB_POOL_MAX_SIZE", raising=False)
-    assert _pool_max_size_from_env(default=60) == 60
-
-
-def test_pool_max_size_env_override_invalid_falls_back(monkeypatch, caplog):
-    from lablink_allocator_service.database import _pool_max_size_from_env
-
-    monkeypatch.setenv("LABLINK_DB_POOL_MAX_SIZE", "not-a-number")
-    with caplog.at_level("WARNING"):
-        assert _pool_max_size_from_env(default=60) == 60
-    assert "Ignoring invalid LABLINK_DB_POOL_MAX_SIZE" in caplog.text
-
-
-def test_pool_max_size_env_override_nonpositive_falls_back(monkeypatch, caplog):
-    from lablink_allocator_service.database import _pool_max_size_from_env
-
-    monkeypatch.setenv("LABLINK_DB_POOL_MAX_SIZE", "0")
-    with caplog.at_level("WARNING"):
-        assert _pool_max_size_from_env(default=60) == 60
-    assert "Ignoring LABLINK_DB_POOL_MAX_SIZE=0" in caplog.text
-
-
-def test_cursor_returns_connection_on_success(db_instance):
-    """After a successful `with self._cursor` block, the pool's
-    putconn is called once with close=False."""
-    mock_pool = db_instance._pool
-    with db_instance._cursor as cur:
-        cur.execute("SELECT 1;")
-    mock_pool.putconn.assert_called_once()
-    # close defaults to False on success; verify via kwargs or positional
-    _, kwargs = mock_pool.putconn.call_args
-    assert kwargs.get("close", False) is False
-
-
-def test_cursor_discards_connection_on_exception(db_instance):
-    """If a query raises, putconn is called with close=True so the bad
-    connection is evicted from the pool."""
-    mock_pool = db_instance._pool
-    db_instance.cursor.execute.side_effect = RuntimeError("boom")
-    with pytest.raises(RuntimeError):
-        with db_instance._cursor as cur:
-            cur.execute("SELECT 1;")
-    mock_pool.putconn.assert_called_once()
-    _, kwargs = mock_pool.putconn.call_args
-    assert kwargs.get("close") is True
-
-
-def test_cursor_sets_autocommit_per_checkout(db_instance):
-    """Every checkout applies ISOLATION_LEVEL_AUTOCOMMIT, preserving
-    the pre-refactor per-statement-transaction behavior."""
-    # mock_psycopg2 is the module-level mock installed in sys.modules before
-    # database.py was imported; the production code's psycopg2.extensions
-    # resolves to mock_psycopg2.extensions, so reference the same sentinel here.
-    mock_conn = db_instance.conn
-    mock_conn.set_isolation_level.reset_mock()
-    with db_instance._cursor:
-        pass
-    mock_conn.set_isolation_level.assert_called_once_with(
-        mock_psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
-    )
-
-
 def test_del_closes_pool(mock_db_connection):
-    """__del__ closes the pool (releases all connections)."""
+    """__del__ closes the pool it built itself (owned pool, no `pool=`
+    kwarg — the default construction path). Patches
+    psycopg2.pool.ThreadedConnectionPool locally (scoped to this test
+    only, not a session-wide mock) so no real connection is attempted."""
     mock_conn, mock_cursor, mock_pool = mock_db_connection
-    db = PostgresqlDatabase(
+    with patch(
+        "psycopg2.pool.ThreadedConnectionPool", return_value=mock_pool
+    ):
+        db = VmDatabase(
+            dbname="testdb",
+            user="testuser",
+            password="testpassword",
+            host="localhost",
+            port=5432,
+            table_name="vms",
+        )
+    db.__del__()
+    mock_pool.closeall.assert_called_once()
+
+
+def test_del_does_not_close_injected_pool(mock_db_connection):
+    """__del__ must NOT close a pool the caller injected via `pool=` —
+    that pool may be shared with other holders (e.g. an OperationsDatabase
+    using the same pool, or multiple VmDatabase handles sharing one
+    pool via make_pool), and only the pool's own builder is responsible for
+    closing it. This is the regression case for the ownership-tracking fix:
+    before it, __del__ closed *any* pool unconditionally, which would have
+    closed this injected pool out from under other holders."""
+    mock_conn, mock_cursor, mock_pool = mock_db_connection
+    db = VmDatabase(
         dbname="testdb",
         user="testuser",
         password="testpassword",
         host="localhost",
         port=5432,
         table_name="vms",
+        pool=mock_pool,
     )
     db.__del__()
-    mock_pool.closeall.assert_called_once()
+    mock_pool.closeall.assert_not_called()
 
 
 def test_concurrent_queries_do_not_serialize(real_db):
@@ -1636,21 +1149,6 @@ def test_get_setting_missing_returns_none(db_instance, mock_db_connection):
     assert db_instance.get_setting("nope") is None
 
 
-def test_get_vm_by_machine_identity_found(db_instance, mock_db_connection):
-    _, mock_cursor, _ = mock_db_connection
-    mock_cursor.fetchone.return_value = ("vm-1",)
-    assert db_instance.get_vm_by_machine_identity("i-abc") == "vm-1"
-    sql = mock_cursor.execute.call_args[0][0]
-    assert "WHERE machine_identity = %s" in sql
-    assert mock_cursor.execute.call_args[0][1] == ("i-abc",)
-
-
-def test_get_vm_by_machine_identity_missing(db_instance, mock_db_connection):
-    _, mock_cursor, _ = mock_db_connection
-    mock_cursor.fetchone.return_value = None
-    assert db_instance.get_vm_by_machine_identity("i-none") is None
-
-
 def test_get_client_secret_hash(db_instance, mock_db_connection):
     _, mock_cursor, _ = mock_db_connection
     mock_cursor.fetchone.return_value = ("$argon2id$h",)
@@ -1788,135 +1286,6 @@ def test_unregister_client_noop_does_not_invalidate(
     # Cache still serves the original value.
     assert db_instance.get_client_secret_hash("vm-1") == "$h"
     assert mock_cursor.execute.call_count == 2  # 1 seed + 1 unregister
-
-
-def test_secret_hash_cache_ttl_expiry_re_queries():
-    """Direct test of the cache primitive: after expiry, the next get is
-    a miss and the caller must re-query."""
-    from lablink_allocator_service.database import _SecretHashCache
-
-    cache = _SecretHashCache(
-        positive_ttl_seconds=0.05, negative_ttl_seconds=0.05
-    )
-    assert cache.put("vm-1", "$h", expected_version=0) is True
-    hit, val, _ = cache.get("vm-1")
-    assert hit is True and val == "$h"
-
-    import time as _time
-    _time.sleep(0.08)
-
-    hit, val, _ = cache.get("vm-1")
-    assert hit is False and val is None
-
-
-def test_secret_hash_cache_negative_entry_returns_hit_with_none():
-    """A cached None must read back as (hit=True, value=None) so the
-    caller short-circuits the DB query."""
-    from lablink_allocator_service.database import _SecretHashCache
-
-    cache = _SecretHashCache()
-    assert cache.put("nope", None, expected_version=0) is True
-    hit, val, _ = cache.get("nope")
-    assert hit is True and val is None
-
-
-def test_secret_hash_cache_invalidate_clears_entry():
-    from lablink_allocator_service.database import _SecretHashCache
-
-    cache = _SecretHashCache()
-    cache.put("vm-1", "$h", expected_version=0)
-    cache.invalidate("vm-1")
-    hit, val, _ = cache.get("vm-1")
-    assert hit is False and val is None
-
-
-def test_secret_hash_cache_put_rejected_when_invalidate_races():
-    """Simulate the rotate-race: reader gets a version, mid-flight
-    invalidate (concurrent re-register) bumps it, reader's put must
-    not commit the stale value."""
-    from lablink_allocator_service.database import _SecretHashCache
-
-    cache = _SecretHashCache()
-    # Reader observes the version before the DB SELECT.
-    hit, _, version = cache.get("vm-1")
-    assert hit is False
-
-    # Concurrent register_client rotates the secret and invalidates.
-    cache.invalidate("vm-1")
-
-    # Reader's SELECT returned the now-stale hash; put must be rejected.
-    accepted = cache.put("vm-1", "$stale", expected_version=version)
-    assert accepted is False
-
-    # Cache stays empty so the next caller re-fetches and gets the
-    # rotated value from the DB.
-    hit, val, _ = cache.get("vm-1")
-    assert hit is False and val is None
-
-
-def test_secret_hash_cache_put_accepted_when_no_race():
-    """Sanity check: with no intervening invalidate, put commits."""
-    from lablink_allocator_service.database import _SecretHashCache
-
-    cache = _SecretHashCache()
-    hit, _, version = cache.get("vm-1")
-    assert hit is False
-    assert cache.put("vm-1", "$h", expected_version=version) is True
-    hit, val, _ = cache.get("vm-1")
-    assert hit is True and val == "$h"
-
-
-def test_secret_hash_cache_version_bumped_per_hostname_only():
-    """Invalidating vm-1 must not affect vm-2's version: a concurrent
-    put for vm-2 must still succeed."""
-    from lablink_allocator_service.database import _SecretHashCache
-
-    cache = _SecretHashCache()
-    _, _, v1 = cache.get("vm-1")
-    _, _, v2 = cache.get("vm-2")
-    cache.invalidate("vm-1")
-    assert cache.put("vm-2", "$h2", expected_version=v2) is True
-    assert cache.put("vm-1", "$h1", expected_version=v1) is False
-
-
-def test_secret_hash_cache_lru_eviction_at_max_size():
-    """When the cache is full, inserting a new entry evicts the LRU
-    one. Bounds memory under unique-key floods."""
-    from lablink_allocator_service.database import _SecretHashCache
-
-    cache = _SecretHashCache(max_size=2)
-    assert cache.put("a", "$a", expected_version=0) is True
-    assert cache.put("b", "$b", expected_version=0) is True
-    # Touch "a" so "b" becomes LRU.
-    hit, _, _ = cache.get("a")
-    assert hit is True
-    # Inserting "c" should evict "b", not "a".
-    assert cache.put("c", "$c", expected_version=0) is True
-    assert cache.get("a")[0] is True
-    assert cache.get("b")[0] is False
-    assert cache.get("c")[0] is True
-
-
-def test_secret_hash_cache_rejects_invalid_max_size():
-    from lablink_allocator_service.database import _SecretHashCache
-
-    with pytest.raises(ValueError, match="Invalid cache max_size"):
-        _SecretHashCache(max_size=0)
-
-
-def test_secret_hash_cache_clear_resets_versions():
-    """clear() wipes entries and versions so a subsequent put against
-    the old version is still accepted (no zombie versions)."""
-    from lablink_allocator_service.database import _SecretHashCache
-
-    cache = _SecretHashCache()
-    cache.put("vm-1", "$h", expected_version=0)
-    cache.invalidate("vm-1")  # bumps version to 1
-    cache.clear()
-    # After clear, version is back to 0 for any hostname.
-    _, _, version = cache.get("vm-1")
-    assert version == 0
-    assert cache.put("vm-1", "$h2", expected_version=0) is True
 
 
 def test_register_client_upsert_returns_hostname(db_instance, mock_db_connection):

--- a/packages/allocator/tests/test_api_calls.py
+++ b/packages/allocator/tests/test_api_calls.py
@@ -1148,7 +1148,7 @@ def test_get_scheduled_destruction_success(client, admin_headers, monkeypatch):
     }
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
 
     resp = client.get(f"{SCHEDULE_DESTRUCTION_ENDPOINT}/123", headers=admin_headers)
@@ -1168,7 +1168,7 @@ def test_get_scheduled_destruction_not_found(client, admin_headers, monkeypatch)
     fake_db.get_scheduled_destruction.return_value = None
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
 
     resp = client.get(f"{SCHEDULE_DESTRUCTION_ENDPOINT}/999", headers=admin_headers)
@@ -1183,7 +1183,7 @@ def test_get_scheduled_destruction_requires_auth(client, monkeypatch):
     fake_db = MagicMock()
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
 
     resp = client.get(f"{SCHEDULE_DESTRUCTION_ENDPOINT}/123")
@@ -1209,7 +1209,7 @@ def test_list_scheduled_destructions_success(client, admin_headers, monkeypatch)
     ]
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
 
     resp = client.get(SCHEDULE_DESTRUCTION_ENDPOINT, headers=admin_headers)
@@ -1234,7 +1234,7 @@ def test_list_scheduled_destructions_with_filter(client, admin_headers, monkeypa
     ]
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
 
     resp = client.get(
@@ -1254,7 +1254,7 @@ def test_list_scheduled_destructions_invalid_status(client, admin_headers, monke
     fake_db = MagicMock()
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
 
     resp = client.get(
@@ -1272,7 +1272,7 @@ def test_list_scheduled_destructions_requires_auth(client, monkeypatch):
     fake_db = MagicMock()
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
 
     resp = client.get(SCHEDULE_DESTRUCTION_ENDPOINT)
@@ -1293,7 +1293,7 @@ def test_cancel_scheduled_destruction_success(client, admin_headers, monkeypatch
     fake_scheduler = MagicMock()
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
     monkeypatch.setattr(
         "lablink_allocator_service.main.scheduler_service",
@@ -1316,7 +1316,7 @@ def test_cancel_scheduled_destruction_not_found(client, admin_headers, monkeypat
     fake_db.get_scheduled_destruction.return_value = None
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
 
     resp = client.delete(f"{SCHEDULE_DESTRUCTION_ENDPOINT}/999", headers=admin_headers)
@@ -1340,7 +1340,7 @@ def test_cancel_scheduled_destruction_already_completed(
     fake_scheduler = MagicMock()
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
     monkeypatch.setattr(
         "lablink_allocator_service.main.scheduler_service",
@@ -1370,7 +1370,7 @@ def test_cancel_scheduled_destruction_already_cancelled(
     fake_scheduler = MagicMock()
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
     monkeypatch.setattr(
         "lablink_allocator_service.main.scheduler_service",
@@ -1398,7 +1398,7 @@ def test_cancel_scheduled_destruction_scheduler_unavailable(
     }
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
     monkeypatch.setattr(
         "lablink_allocator_service.main.scheduler_service", None, raising=False
@@ -1428,7 +1428,7 @@ def test_cancel_scheduled_destruction_scheduler_error(
     )
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
     monkeypatch.setattr(
         "lablink_allocator_service.main.scheduler_service",
@@ -1450,7 +1450,7 @@ def test_cancel_scheduled_destruction_requires_auth(client, monkeypatch):
     fake_scheduler = MagicMock()
 
     monkeypatch.setattr(
-        "lablink_allocator_service.main.database", fake_db, raising=False
+        "lablink_allocator_service.main.schedule_db", fake_db, raising=False
     )
     monkeypatch.setattr(
         "lablink_allocator_service.main.scheduler_service",

--- a/packages/allocator/tests/test_desktop_route.py
+++ b/packages/allocator/tests/test_desktop_route.py
@@ -39,7 +39,7 @@ def _ensure_session_columns(real_db):
 
 @pytest.fixture
 def client_with_db(real_db, monkeypatch):
-    """A Flask test client where `database` is the real_db PostgresqlDatabase
+    """A Flask test client where `database` is the real_db VmDatabase
     and `app.config['DB_POOL']` points at its pool, so the desktop route can
     read the signing secret."""
     _ensure_session_columns(real_db)

--- a/packages/allocator/tests/test_destroy_route_baseline.py
+++ b/packages/allocator/tests/test_destroy_route_baseline.py
@@ -66,10 +66,16 @@ def destroy_setup(app, monkeypatch, tmp_path):
 
     fake_db = MagicMock()
     fake_db.clear_database = MagicMock()
-    fake_db.bulk_seal_session_metrics = MagicMock(return_value=0)
     monkeypatch.setattr(main, "database", fake_db, raising=False)
 
-    return {"tmp_path": tmp_path, "database": fake_db}
+    # bulk_seal_session_metrics lives on metrics_db, not database. Use a
+    # separate MagicMock so an assertion here can't pass because a call
+    # actually landed on `fake_db` instead.
+    fake_metrics_db = MagicMock()
+    fake_metrics_db.bulk_seal_session_metrics = MagicMock(return_value=0)
+    monkeypatch.setattr(main, "metrics_db", fake_metrics_db, raising=False)
+
+    return {"tmp_path": tmp_path, "database": fake_db, "metrics_db": fake_metrics_db}
 
 
 def _capture_closure(client, admin_headers, mock_worker):
@@ -199,8 +205,11 @@ def test_destroy_closure_fails_when_no_runtime_tfvars(
     provider = AWSProvider(region="us-west-2", terraform_dir=str(tmp_path))
     monkeypatch.setitem(main.app.config, "LABLINK_PROVIDER", provider)
     fake_db = MagicMock()
-    fake_db.bulk_seal_session_metrics = MagicMock(return_value=0)
     monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    fake_metrics_db = MagicMock()
+    fake_metrics_db.bulk_seal_session_metrics = MagicMock(return_value=0)
+    monkeypatch.setattr(main, "metrics_db", fake_metrics_db, raising=False)
 
     with patch("lablink_allocator_service.providers.aws.get_instance_ids",
                return_value=[]), \
@@ -237,7 +246,7 @@ def test_destroy_closure_wraps_terraform_failure(
 
 
 def test_destroy_returns_409_when_operation_in_progress(client, admin_headers):
-    from lablink_allocator_service.operations_db import OperationInProgress
+    from lablink_allocator_service.db.operations import OperationInProgress
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.side_effect = OperationInProgress(job_id=4)
@@ -297,7 +306,7 @@ def test_destroy_redirects_with_error_code_when_operation_in_progress(
     client, admin_headers,
 ):
     from unittest.mock import patch
-    from lablink_allocator_service.operations_db import OperationInProgress
+    from lablink_allocator_service.db.operations import OperationInProgress
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.side_effect = OperationInProgress(job_id=4)

--- a/packages/allocator/tests/test_internal_proxy_auth.py
+++ b/packages/allocator/tests/test_internal_proxy_auth.py
@@ -38,7 +38,7 @@ def _ensure_session_columns(real_db):
 
 @pytest.fixture
 def client_with_db(real_db, monkeypatch):
-    """Flask test client wired to the real_db PostgresqlDatabase."""
+    """Flask test client wired to the real_db VmDatabase."""
     _ensure_session_columns(real_db)
     import lablink_allocator_service.main as main_module
     monkeypatch.setattr(main_module, "database", real_db, raising=True)

--- a/packages/allocator/tests/test_launch_route_baseline.py
+++ b/packages/allocator/tests/test_launch_route_baseline.py
@@ -391,7 +391,7 @@ def test_launch_returns_409_when_operation_in_progress(
     launch_setup, client, admin_headers,
 ):
     from unittest.mock import patch
-    from lablink_allocator_service.operations_db import OperationInProgress
+    from lablink_allocator_service.db.operations import OperationInProgress
 
     with patch(
         "lablink_allocator_service.main.operations_worker"
@@ -462,7 +462,7 @@ def test_launch_redirects_with_error_code_when_operation_in_progress(
     """A browser (non-JSON) submit that races an in-progress operation must
     get a plain redirect (no status-code override) so a real browser
     actually follows it — not a 409 inline-rendered error page."""
-    from lablink_allocator_service.operations_db import OperationInProgress
+    from lablink_allocator_service.db.operations import OperationInProgress
 
     with patch(
         "lablink_allocator_service.main.operations_worker"

--- a/packages/allocator/tests/test_operations.py
+++ b/packages/allocator/tests/test_operations.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from lablink_allocator_service.operations import OperationsWorker
-from lablink_allocator_service.operations_db import OperationInProgress
+from lablink_allocator_service.db.operations import OperationInProgress
 
 
 @pytest.fixture

--- a/packages/allocator/tests/test_reboot.py
+++ b/packages/allocator/tests/test_reboot.py
@@ -1,24 +1,17 @@
 """Tests for the automated VM reboot system."""
 
+import psycopg2
 import pytest
 from unittest.mock import MagicMock, patch, ANY
 from datetime import datetime, timezone, timedelta
 
-# Mock psycopg2 before importing modules
-mock_psycopg2 = MagicMock()
-mock_psycopg2.IntegrityError = type("IntegrityError", (Exception,), {})
-
-with patch.dict(
-    "sys.modules",
-    {
-        "psycopg2": mock_psycopg2,
-        "psycopg2.extensions": MagicMock(),
-        "psycopg2.pool": mock_psycopg2.pool,
-    },
-):
-    from lablink_allocator_service.database import PostgresqlDatabase
-    import lablink_allocator_service.reboot as reboot_mod
-    AutoRebootService = reboot_mod.AutoRebootService
+# No psycopg2 mocking: VmDatabase(..., pool=...) lets db_instance
+# inject a MagicMock pool directly, so db.vms/db.pool import normally, once,
+# real-bound, like any other module. See db_instance below and its
+# regression-test neighbor for why this replaced a sys.modules-based mock.
+from lablink_allocator_service.db.vms import VmDatabase
+import lablink_allocator_service.reboot as reboot_mod
+AutoRebootService = reboot_mod.AutoRebootService
 
 
 @pytest.fixture
@@ -31,27 +24,59 @@ def mock_db_connection():
 
     mock_pool = MagicMock()
     mock_pool.getconn.return_value = mock_conn
-    mock_psycopg2.pool.ThreadedConnectionPool.return_value = mock_pool
 
     return mock_conn, mock_cursor, mock_pool
 
 
 @pytest.fixture
 def db_instance(mock_db_connection):
-    """Fixture returning a PostgresqlDatabase wired to a mocked pool."""
+    """Fixture returning a VmDatabase wired to a mocked pool."""
     mock_conn, mock_cursor, mock_pool = mock_db_connection
-    db = PostgresqlDatabase(
+    db = VmDatabase(
         dbname="testdb",
         user="testuser",
         password="testpassword",
         host="localhost",
         port=5432,
         table_name="vms",
+        pool=mock_pool,
     )
     db.conn = mock_conn
     db.cursor = mock_cursor
-    db._pool = mock_pool
     return db
+
+
+def test_cursor_sets_autocommit_using_real_psycopg2_constant(db_instance):
+    """REGRESSION (two-db.pool-instances bug): PooledCursor.__enter__ must
+    apply the *same* ISOLATION_LEVEL_AUTOCOMMIT constant that db.vms's own
+    PooledCursor actually reads — not a stale value captured by some other
+    module's now-orphaned copy of db.pool.
+
+    Before dependency injection, this file mocked `sys.modules["psycopg2"]`
+    and relied on db.vms's own `import psycopg2` capturing that mock —
+    but VmDatabase._cursor's PooledCursor came from db.pool, a
+    *different* module, whose own psycopg2 binding depended on which test
+    file happened to import it first (tests/db/test_operations.py's real,
+    unmocked psycopg2 import, if collected first, would "win", poisoning
+    db.pool for every consumer collected afterward — including this file).
+    Every other test in this file drove _cursor without ever checking
+    which constant was actually used, so that divergence passed unnoticed.
+
+    Now that construction is injected (no psycopg2 mocking anywhere in
+    this file), db.vms/db.pool import normally exactly once, real-bound,
+    for the whole session — so this asserts against the real
+    psycopg2.extensions constant, and passes regardless of collection
+    order. Confirmed this fails on the pre-fix code (mocked sys.modules +
+    real db.pool.ThreadedConnectionPool construction) when run as
+    `pytest tests/db/test_operations.py tests/test_reboot.py -q`.
+    """
+    mock_conn = db_instance.conn
+    mock_conn.set_isolation_level.reset_mock()
+    with db_instance._cursor:
+        pass
+    mock_conn.set_isolation_level.assert_called_once_with(
+        psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT
+    )
 
 
 # --- Database method tests ---

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -19,7 +19,7 @@ def test_init_database_upserts_register_token_hash(monkeypatch, omega_config):
 
     fake_db = MagicMock()
     monkeypatch.setattr(
-        "lablink_allocator_service.main.PostgresqlDatabase",
+        "lablink_allocator_service.main.VmDatabase",
         lambda **kw: fake_db, raising=True,
     )
     main.init_database()

--- a/packages/allocator/tests/test_scheduler.py
+++ b/packages/allocator/tests/test_scheduler.py
@@ -46,8 +46,8 @@ from lablink_allocator_service.scheduler import ScheduledDestructionService  # n
 
 
 @pytest.fixture
-def mock_database():
-    """Fixture to create a mock database instance."""
+def mock_schedule_db():
+    """Fixture to create a mock schedule_db instance."""
     return MagicMock()
 
 
@@ -60,13 +60,13 @@ def mock_scheduler():
 
 
 @pytest.fixture
-def scheduler_service(mock_database, mock_scheduler):
+def scheduler_service(mock_schedule_db, mock_scheduler):
     """Fixture to create a ScheduledDestructionService instance."""
     db_url = "postgresql://user:pass@localhost:5432/lablink"
     terraform_dir = "/tmp/terraform"
 
     service = ScheduledDestructionService(
-        database=mock_database,
+        schedule_db=mock_schedule_db,
         db_url=db_url,
         terraform_dir=terraform_dir,
     )
@@ -77,17 +77,17 @@ def scheduler_service(mock_database, mock_scheduler):
     return service
 
 
-def test_init_creates_scheduler(mock_database):
+def test_init_creates_scheduler(mock_schedule_db):
     """Test that __init__ properly configures the APScheduler."""
     db_url = "postgresql://user:pass@localhost:5432/lablink"
 
     service = ScheduledDestructionService(
-        database=mock_database,
+        schedule_db=mock_schedule_db,
         db_url=db_url,
     )
 
     # Verify the service was created with correct attributes
-    assert service.database == mock_database
+    assert service.schedule_db == mock_schedule_db
     assert service.scheduler is not None
 
     # Only check mocks if they were actually used (when APScheduler wasn't pre-imported)
@@ -100,13 +100,13 @@ def test_init_creates_scheduler(mock_database):
         mock_background_scheduler.assert_called()
 
 
-def test_init_custom_terraform_dir(mock_database):
+def test_init_custom_terraform_dir(mock_schedule_db):
     """Test that custom terraform_dir is used when provided."""
     db_url = "postgresql://user:pass@localhost:5432/lablink"
     custom_dir = "/custom/terraform/path"
 
     service = ScheduledDestructionService(
-        database=mock_database,
+        schedule_db=mock_schedule_db,
         db_url=db_url,
         terraform_dir=custom_dir,
     )
@@ -114,9 +114,9 @@ def test_init_custom_terraform_dir(mock_database):
     assert service.terraform_dir == custom_dir
 
 
-def test_start_loads_scheduled_destructions(scheduler_service, mock_database):
+def test_start_loads_scheduled_destructions(scheduler_service, mock_schedule_db):
     """Test that start() initializes scheduler and loads existing schedules."""
-    mock_database.get_all_scheduled_destructions.return_value = [
+    mock_schedule_db.get_all_scheduled_destructions.return_value = [
         {
             "id": 1,
             "destruction_time": datetime(2025, 12, 6, 18, 0, 0),
@@ -135,7 +135,7 @@ def test_start_loads_scheduled_destructions(scheduler_service, mock_database):
     scheduler_service.scheduler.start.assert_called_once()
 
     # Verify schedules were loaded from database
-    mock_database.get_all_scheduled_destructions.assert_called_once_with(
+    mock_schedule_db.get_all_scheduled_destructions.assert_called_once_with(
         status="scheduled"
     )
 
@@ -143,13 +143,13 @@ def test_start_loads_scheduled_destructions(scheduler_service, mock_database):
     assert scheduler_service.scheduler.add_job.call_count == 2
 
 
-def test_schedule_destruction_one_time(scheduler_service, mock_database):
+def test_schedule_destruction_one_time(scheduler_service, mock_schedule_db):
     """Test scheduling a one-time destruction."""
     schedule_name = "End of Tutorial"
     destruction_time = datetime(2025, 12, 6, 18, 0, 0, tzinfo=timezone.utc)
     created_by = "admin@example.com"
 
-    mock_database.create_scheduled_destruction.return_value = 42
+    mock_schedule_db.create_scheduled_destruction.return_value = 42
 
     schedule_id = scheduler_service.schedule_destruction(
         schedule_name=schedule_name,
@@ -161,7 +161,7 @@ def test_schedule_destruction_one_time(scheduler_service, mock_database):
     )
 
     # Verify database record was created
-    mock_database.create_scheduled_destruction.assert_called_once_with(
+    mock_schedule_db.create_scheduled_destruction.assert_called_once_with(
         schedule_name=schedule_name,
         destruction_time=destruction_time,
         recurrence_rule=None,
@@ -181,13 +181,13 @@ def test_schedule_destruction_one_time(scheduler_service, mock_database):
     assert schedule_id == 42
 
 
-def test_schedule_destruction_recurring(scheduler_service, mock_database):
+def test_schedule_destruction_recurring(scheduler_service, mock_schedule_db):
     """Test scheduling a recurring destruction."""
     schedule_name = "Weekly Cleanup"
     destruction_time = datetime(2025, 12, 6, 17, 30, 0, tzinfo=timezone.utc)
     recurrence_rule = "FREQ=WEEKLY;BYDAY=FR"
 
-    mock_database.create_scheduled_destruction.return_value = 99
+    mock_schedule_db.create_scheduled_destruction.return_value = 99
 
     schedule_id = scheduler_service.schedule_destruction(
         schedule_name=schedule_name,
@@ -199,8 +199,8 @@ def test_schedule_destruction_recurring(scheduler_service, mock_database):
     )
 
     # Verify database record was created with recurrence
-    mock_database.create_scheduled_destruction.assert_called_once()
-    call_args = mock_database.create_scheduled_destruction.call_args[1]
+    mock_schedule_db.create_scheduled_destruction.assert_called_once()
+    call_args = mock_schedule_db.create_scheduled_destruction.call_args[1]
     assert call_args["recurrence_rule"] == recurrence_rule
 
     # Verify job was added to scheduler
@@ -208,7 +208,7 @@ def test_schedule_destruction_recurring(scheduler_service, mock_database):
     assert schedule_id == 99
 
 
-def test_cancel_scheduled_destruction(scheduler_service, mock_database):
+def test_cancel_scheduled_destruction(scheduler_service, mock_schedule_db):
     """Test cancelling a scheduled destruction."""
     schedule_id = 42
     mock_job = MagicMock()
@@ -221,10 +221,10 @@ def test_cancel_scheduled_destruction(scheduler_service, mock_database):
     scheduler_service.scheduler.remove_job.assert_called_once_with("destruction_42")
 
     # Verify database was updated
-    mock_database.cancel_scheduled_destruction.assert_called_once_with(schedule_id)
+    mock_schedule_db.cancel_scheduled_destruction.assert_called_once_with(schedule_id)
 
 
-def test_cancel_scheduled_destruction_job_not_found(scheduler_service, mock_database):
+def test_cancel_scheduled_destruction_job_not_found(scheduler_service, mock_schedule_db):
     """Test cancelling when job doesn't exist in scheduler."""
     schedule_id = 42
     scheduler_service.scheduler.get_job.return_value = None
@@ -235,7 +235,7 @@ def test_cancel_scheduled_destruction_job_not_found(scheduler_service, mock_data
     scheduler_service.scheduler.remove_job.assert_not_called()
 
     # Should still update database
-    mock_database.cancel_scheduled_destruction.assert_called_once_with(schedule_id)
+    mock_schedule_db.cancel_scheduled_destruction.assert_called_once_with(schedule_id)
 
 
 def test_parse_rrule_to_cron_weekly(scheduler_service):
@@ -295,7 +295,7 @@ def _make_mock_config(provider_name="aws"):
 
 
 def test_execute_scheduled_destruction_success(
-    scheduler_service, mock_database, tmp_path
+    scheduler_service, mock_schedule_db, tmp_path
 ):
     """Test successful execution of scheduled destruction via standalone function.
 
@@ -315,10 +315,20 @@ def test_execute_scheduled_destruction_success(
 
     fake_operations_db = MagicMock()
     fake_operations_db.get_in_progress_operation.return_value = None
+    fake_pool = MagicMock()
+    fake_vm_db = MagicMock()
 
+    # The standalone job builds one pool (make_pool) and derives its
+    # VmDatabase and ScheduleDatabase from it. Patch each database class to
+    # its own distinct double — fake_vm_db for VmDatabase, mock_schedule_db
+    # for ScheduleDatabase — so an assertion against the wrong owner (e.g.
+    # a regression that calls update_scheduled_destruction_status on the VM
+    # database) would fail loudly instead of silently passing.
     with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
-         patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
-         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+         patch("lablink_allocator_service.db.pool.make_pool", return_value=fake_pool), \
+         patch("lablink_allocator_service.db.vms.VmDatabase", return_value=fake_vm_db), \
+         patch("lablink_allocator_service.scheduler.ScheduleDatabase", return_value=mock_schedule_db), \
+         patch("lablink_allocator_service.db.operations.OperationsDatabase",
                return_value=fake_operations_db), \
          patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
 
@@ -329,9 +339,12 @@ def test_execute_scheduled_destruction_success(
             terraform_dir=terraform_dir,
         )
 
+    # Verify the job's pool was closed exactly once, in the finally block
+    fake_pool.closeall.assert_called_once()
+
     # Verify status updated to executing first
-    assert mock_database.update_scheduled_destruction_status.call_count >= 2
-    first_call = mock_database.update_scheduled_destruction_status.call_args_list[0]
+    assert mock_schedule_db.update_scheduled_destruction_status.call_count >= 2
+    first_call = mock_schedule_db.update_scheduled_destruction_status.call_args_list[0]
     assert first_call[1]["schedule_id"] == schedule_id
     assert first_call[1]["status"] == "executing"
 
@@ -339,16 +352,16 @@ def test_execute_scheduled_destruction_success(
     fake_provider.destroy_hosts.assert_called_once()
 
     # Verify database was cleared
-    mock_database.clear_database.assert_called_once()
+    fake_vm_db.clear_database.assert_called_once()
 
     # Verify status updated to completed
-    last_call = mock_database.update_scheduled_destruction_status.call_args_list[-1]
+    last_call = mock_schedule_db.update_scheduled_destruction_status.call_args_list[-1]
     assert last_call[1]["status"] == "completed"
     assert "successfully" in last_call[1]["execution_result"]
 
 
 def test_execute_scheduled_destruction_provider_cannot_destroy(
-    scheduler_service, mock_database, tmp_path
+    scheduler_service, mock_schedule_db, tmp_path
 ):
     """Test that job skips destroy and still clears DB when provider lacks capability."""
     from lablink_allocator_service.scheduler import execute_scheduled_destruction_job
@@ -361,10 +374,13 @@ def test_execute_scheduled_destruction_provider_cannot_destroy(
 
     fake_operations_db = MagicMock()
     fake_operations_db.get_in_progress_operation.return_value = None
+    fake_vm_db = MagicMock()
 
     with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
-         patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
-         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+         patch("lablink_allocator_service.db.pool.make_pool", return_value=MagicMock()), \
+         patch("lablink_allocator_service.db.vms.VmDatabase", return_value=fake_vm_db), \
+         patch("lablink_allocator_service.scheduler.ScheduleDatabase", return_value=mock_schedule_db), \
+         patch("lablink_allocator_service.db.operations.OperationsDatabase",
                return_value=fake_operations_db), \
          patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
 
@@ -379,13 +395,13 @@ def test_execute_scheduled_destruction_provider_cannot_destroy(
     fake_provider.destroy_hosts.assert_not_called()
 
     # DB should still be cleared and status set to completed
-    mock_database.clear_database.assert_called_once()
-    last_call = mock_database.update_scheduled_destruction_status.call_args_list[-1]
+    fake_vm_db.clear_database.assert_called_once()
+    last_call = mock_schedule_db.update_scheduled_destruction_status.call_args_list[-1]
     assert last_call[1]["status"] == "completed"
 
 
 def test_execute_scheduled_destruction_destroy_failure(
-    scheduler_service, mock_database, tmp_path
+    scheduler_service, mock_schedule_db, tmp_path
 ):
     """Test handling of provider.destroy_hosts failure (CalledProcessError)."""
     from lablink_allocator_service.scheduler import execute_scheduled_destruction_job
@@ -404,10 +420,13 @@ def test_execute_scheduled_destruction_destroy_failure(
 
     fake_operations_db = MagicMock()
     fake_operations_db.get_in_progress_operation.return_value = None
+    fake_vm_db = MagicMock()
 
     with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
-         patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
-         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+         patch("lablink_allocator_service.db.pool.make_pool", return_value=MagicMock()), \
+         patch("lablink_allocator_service.db.vms.VmDatabase", return_value=fake_vm_db), \
+         patch("lablink_allocator_service.scheduler.ScheduleDatabase", return_value=mock_schedule_db), \
+         patch("lablink_allocator_service.db.operations.OperationsDatabase",
                return_value=fake_operations_db), \
          patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
 
@@ -419,17 +438,17 @@ def test_execute_scheduled_destruction_destroy_failure(
         )
 
     # Verify status was updated to failed
-    calls = mock_database.update_scheduled_destruction_status.call_args_list
+    calls = mock_schedule_db.update_scheduled_destruction_status.call_args_list
     failed_call = [c for c in calls if c[1].get("status") == "failed"][0]
     assert failed_call[1]["schedule_id"] == schedule_id
     assert "Terraform destroy failed" in failed_call[1]["execution_result"]
 
     # DB should NOT be cleared on failure
-    mock_database.clear_database.assert_not_called()
+    fake_vm_db.clear_database.assert_not_called()
 
 
 def test_execute_scheduled_destruction_skips_when_operation_in_progress(
-    scheduler_service, mock_database, tmp_path
+    scheduler_service, mock_schedule_db, tmp_path
 ):
     """A scheduled destruction must not run while an on-demand operation
     (submitted via /destroy or /api/launch) is queued/running — it would
@@ -446,10 +465,13 @@ def test_execute_scheduled_destruction_skips_when_operation_in_progress(
     fake_operations_db.get_in_progress_operation.return_value = {
         "id": 17, "op_type": "apply", "status": "running",
     }
+    fake_vm_db = MagicMock()
 
     with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
-         patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
-         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+         patch("lablink_allocator_service.db.pool.make_pool", return_value=MagicMock()), \
+         patch("lablink_allocator_service.db.vms.VmDatabase", return_value=fake_vm_db), \
+         patch("lablink_allocator_service.scheduler.ScheduleDatabase", return_value=mock_schedule_db), \
+         patch("lablink_allocator_service.db.operations.OperationsDatabase",
                return_value=fake_operations_db), \
          patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
 
@@ -465,16 +487,16 @@ def test_execute_scheduled_destruction_skips_when_operation_in_progress(
     fake_provider.destroy_hosts.assert_not_called()
 
     # DB must NOT be cleared either — nothing was actually destroyed.
-    mock_database.clear_database.assert_not_called()
+    fake_vm_db.clear_database.assert_not_called()
 
-    calls = mock_database.update_scheduled_destruction_status.call_args_list
+    calls = mock_schedule_db.update_scheduled_destruction_status.call_args_list
     failed_call = [c for c in calls if c[1].get("status") == "failed"][0]
     assert failed_call[1]["schedule_id"] == schedule_id
     assert "operation was in progress" in failed_call[1]["execution_result"]
 
 
 def test_execute_scheduled_destruction_proceeds_when_no_operation_in_progress(
-    scheduler_service, mock_database, tmp_path
+    scheduler_service, mock_schedule_db, tmp_path
 ):
     """Baseline unchanged: with no on-demand operation running, the
     scheduled destruction proceeds exactly as before."""
@@ -491,10 +513,13 @@ def test_execute_scheduled_destruction_proceeds_when_no_operation_in_progress(
 
     fake_operations_db = MagicMock()
     fake_operations_db.get_in_progress_operation.return_value = None
+    fake_vm_db = MagicMock()
 
     with patch("lablink_allocator_service.get_config.get_config") as mock_get_config, \
-         patch("lablink_allocator_service.database.PostgresqlDatabase", return_value=mock_database), \
-         patch("lablink_allocator_service.operations_db.OperationsDatabase",
+         patch("lablink_allocator_service.db.pool.make_pool", return_value=MagicMock()), \
+         patch("lablink_allocator_service.db.vms.VmDatabase", return_value=fake_vm_db), \
+         patch("lablink_allocator_service.scheduler.ScheduleDatabase", return_value=mock_schedule_db), \
+         patch("lablink_allocator_service.db.operations.OperationsDatabase",
                return_value=fake_operations_db), \
          patch("lablink_allocator_service.providers.registry.get_provider", return_value=fake_provider):
 
@@ -506,8 +531,8 @@ def test_execute_scheduled_destruction_proceeds_when_no_operation_in_progress(
         )
 
     fake_provider.destroy_hosts.assert_called_once()
-    mock_database.clear_database.assert_called_once()
-    last_call = mock_database.update_scheduled_destruction_status.call_args_list[-1]
+    fake_vm_db.clear_database.assert_called_once()
+    last_call = mock_schedule_db.update_scheduled_destruction_status.call_args_list[-1]
     assert last_call[1]["status"] == "completed"
 
 
@@ -515,7 +540,7 @@ def test_execute_scheduled_destruction_proceeds_when_no_operation_in_progress(
 # and would need to be implemented differently if needed in the future
 
 
-def test_load_scheduled_destructions(scheduler_service, mock_database):
+def test_load_scheduled_destructions(scheduler_service, mock_schedule_db):
     """Test loading schedules from database on startup."""
     mock_schedules = [
         {
@@ -535,12 +560,12 @@ def test_load_scheduled_destructions(scheduler_service, mock_database):
         },
     ]
 
-    mock_database.get_all_scheduled_destructions.return_value = mock_schedules
+    mock_schedule_db.get_all_scheduled_destructions.return_value = mock_schedules
 
     scheduler_service._load_scheduled_destructions()
 
     # Verify correct status filter was used
-    mock_database.get_all_scheduled_destructions.assert_called_once_with(
+    mock_schedule_db.get_all_scheduled_destructions.assert_called_once_with(
         status="scheduled"
     )
 
@@ -548,9 +573,9 @@ def test_load_scheduled_destructions(scheduler_service, mock_database):
     assert scheduler_service.scheduler.add_job.call_count == 3
 
 
-def test_load_scheduled_destructions_empty(scheduler_service, mock_database):
+def test_load_scheduled_destructions_empty(scheduler_service, mock_schedule_db):
     """Test loading when no schedules exist."""
-    mock_database.get_all_scheduled_destructions.return_value = []
+    mock_schedule_db.get_all_scheduled_destructions.return_value = []
 
     scheduler_service._load_scheduled_destructions()
 

--- a/packages/allocator/tests/test_secret_hash.py
+++ b/packages/allocator/tests/test_secret_hash.py
@@ -6,6 +6,7 @@ import pytest
 from lablink_allocator_service import secret_hash
 from lablink_allocator_service.secret_hash import (
     REGISTER_TOKEN_SUBJECT,
+    SecretHashCache,
     _VerifyResultCache,
     _token_fingerprint,
     clear_verify_cache,
@@ -249,3 +250,117 @@ def test_token_fingerprint_does_not_include_plaintext():
     depth against memory inspection of the cache's keys)."""
     fp = _token_fingerprint("totally_secret_token_value")
     assert "totally_secret_token_value" not in fp
+
+
+# ── SecretHashCache: TTL, invalidate-race, LRU ─────────────────────────
+
+
+def test_secret_hash_cache_ttl_expiry_re_queries():
+    """Direct test of the cache primitive: after expiry, the next get is
+    a miss and the caller must re-query."""
+    cache = SecretHashCache(
+        positive_ttl_seconds=0.05, negative_ttl_seconds=0.05
+    )
+    assert cache.put("vm-1", "$h", expected_version=0) is True
+    hit, val, _ = cache.get("vm-1")
+    assert hit is True and val == "$h"
+
+    import time as _time
+    _time.sleep(0.08)
+
+    hit, val, _ = cache.get("vm-1")
+    assert hit is False and val is None
+
+
+def test_secret_hash_cache_negative_entry_returns_hit_with_none():
+    """A cached None must read back as (hit=True, value=None) so the
+    caller short-circuits the DB query."""
+    cache = SecretHashCache()
+    assert cache.put("nope", None, expected_version=0) is True
+    hit, val, _ = cache.get("nope")
+    assert hit is True and val is None
+
+
+def test_secret_hash_cache_invalidate_clears_entry():
+    cache = SecretHashCache()
+    cache.put("vm-1", "$h", expected_version=0)
+    cache.invalidate("vm-1")
+    hit, val, _ = cache.get("vm-1")
+    assert hit is False and val is None
+
+
+def test_secret_hash_cache_put_rejected_when_invalidate_races():
+    """Simulate the rotate-race: reader gets a version, mid-flight
+    invalidate (concurrent re-register) bumps it, reader's put must
+    not commit the stale value."""
+    cache = SecretHashCache()
+    # Reader observes the version before the DB SELECT.
+    hit, _, version = cache.get("vm-1")
+    assert hit is False
+
+    # Concurrent register_client rotates the secret and invalidates.
+    cache.invalidate("vm-1")
+
+    # Reader's SELECT returned the now-stale hash; put must be rejected.
+    accepted = cache.put("vm-1", "$stale", expected_version=version)
+    assert accepted is False
+
+    # Cache stays empty so the next caller re-fetches and gets the
+    # rotated value from the DB.
+    hit, val, _ = cache.get("vm-1")
+    assert hit is False and val is None
+
+
+def test_secret_hash_cache_put_accepted_when_no_race():
+    """Sanity check: with no intervening invalidate, put commits."""
+    cache = SecretHashCache()
+    hit, _, version = cache.get("vm-1")
+    assert hit is False
+    assert cache.put("vm-1", "$h", expected_version=version) is True
+    hit, val, _ = cache.get("vm-1")
+    assert hit is True and val == "$h"
+
+
+def test_secret_hash_cache_version_bumped_per_hostname_only():
+    """Invalidating vm-1 must not affect vm-2's version: a concurrent
+    put for vm-2 must still succeed."""
+    cache = SecretHashCache()
+    _, _, v1 = cache.get("vm-1")
+    _, _, v2 = cache.get("vm-2")
+    cache.invalidate("vm-1")
+    assert cache.put("vm-2", "$h2", expected_version=v2) is True
+    assert cache.put("vm-1", "$h1", expected_version=v1) is False
+
+
+def test_secret_hash_cache_lru_eviction_at_max_size():
+    """When the cache is full, inserting a new entry evicts the LRU
+    one. Bounds memory under unique-key floods."""
+    cache = SecretHashCache(max_size=2)
+    assert cache.put("a", "$a", expected_version=0) is True
+    assert cache.put("b", "$b", expected_version=0) is True
+    # Touch "a" so "b" becomes LRU.
+    hit, _, _ = cache.get("a")
+    assert hit is True
+    # Inserting "c" should evict "b", not "a".
+    assert cache.put("c", "$c", expected_version=0) is True
+    assert cache.get("a")[0] is True
+    assert cache.get("b")[0] is False
+    assert cache.get("c")[0] is True
+
+
+def test_secret_hash_cache_rejects_invalid_max_size():
+    with pytest.raises(ValueError, match="Invalid cache max_size"):
+        SecretHashCache(max_size=0)
+
+
+def test_secret_hash_cache_clear_resets_versions():
+    """clear() wipes entries and versions so a subsequent put against
+    the old version is still accepted (no zombie versions)."""
+    cache = SecretHashCache()
+    cache.put("vm-1", "$h", expected_version=0)
+    cache.invalidate("vm-1")  # bumps version to 1
+    cache.clear()
+    # After clear, version is back to 0 for any hostname.
+    _, _, version = cache.get("vm-1")
+    assert version == 0
+    assert cache.put("vm-1", "$h2", expected_version=0) is True

--- a/packages/allocator/tests/test_session_metrics_admin_page.py
+++ b/packages/allocator/tests/test_session_metrics_admin_page.py
@@ -10,7 +10,11 @@ def app_with_summary(monkeypatch, app):
     from lablink_allocator_service import main
 
     fake_db = MagicMock()
-    fake_db.get_session_metrics_summary.return_value = {
+    # get_session_metrics_summary now lives on metrics_db, not database.
+    # Use a separate MagicMock so an assertion here can't pass because a
+    # call actually landed on `fake_db` instead.
+    fake_metrics_db = MagicMock()
+    fake_metrics_db.get_session_metrics_summary.return_value = {
         "total_vms": 3,
         "funnel": {"started": 3, "labeled": 3, "trained": 2, "tracked": 1},
         "pct_reached_training": 66.7,
@@ -19,6 +23,7 @@ def app_with_summary(monkeypatch, app):
         "median_labeled_frames": 320,
         "median_epochs_completed": 20,
     }
+    monkeypatch.setattr(main, "metrics_db", fake_metrics_db, raising=False)
     # Postgres folds unquoted identifiers to lowercase, so the dict that
     # psycopg2 hands back from get_all_vms_for_export() has lowercase keys
     # — mirror that here so the template's vm.hostname / vm.useremail

--- a/packages/allocator/tests/test_session_metrics_endpoint.py
+++ b/packages/allocator/tests/test_session_metrics_endpoint.py
@@ -15,8 +15,15 @@ def app(monkeypatch):
     # argon2 hash of "letmein" — matches the verify_secret() the decorator uses.
     fake_db.get_client_secret_hash.return_value = hash_secret("letmein")
     monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    # update_session_metrics now lives on metrics_db, not database. Use a
+    # separate MagicMock so an assertion here can't pass because a call
+    # actually landed on `fake_db` instead.
+    fake_metrics_db = MagicMock()
+    monkeypatch.setattr(main, "metrics_db", fake_metrics_db, raising=False)
+
     main.app.config["TESTING"] = True
-    yield main.app, fake_db
+    yield main.app, fake_metrics_db
 
 
 def _payload():

--- a/packages/allocator/tests/test_session_metrics_seal_on_destroy.py
+++ b/packages/allocator/tests/test_session_metrics_seal_on_destroy.py
@@ -41,14 +41,17 @@ def destroy_setup(app, monkeypatch, tmp_path):
     fake_db = MagicMock()
     monkeypatch.setattr(main, "database", fake_db, raising=False)
 
-    return {"tmp_path": tmp_path, "database": fake_db}
+    fake_metrics_db = MagicMock()
+    monkeypatch.setattr(main, "metrics_db", fake_metrics_db, raising=False)
+
+    return {"tmp_path": tmp_path, "database": fake_db, "metrics_db": fake_metrics_db}
 
 
 def test_scheduled_destroy_seals_before_destroy():
     """run_scheduled_destroy must call bulk_seal_session_metrics, then destroy_hosts."""
     from lablink_allocator_service.scheduler import run_scheduled_destroy
 
-    fake_db = MagicMock()
+    fake_metrics_db = MagicMock()
     fake_provider = MagicMock()
     call_order: list[str] = []
 
@@ -60,10 +63,10 @@ def test_scheduled_destroy_seals_before_destroy():
         call_order.append("destroy")
         return MagicMock(stdout="ok")
 
-    fake_db.bulk_seal_session_metrics.side_effect = _seal
+    fake_metrics_db.bulk_seal_session_metrics.side_effect = _seal
     fake_provider.destroy_hosts.side_effect = _destroy
 
-    run_scheduled_destroy(["h1", "h2", "h3"], fake_db, fake_provider)
+    run_scheduled_destroy(["h1", "h2", "h3"], fake_metrics_db, fake_provider)
 
     assert call_order == ["seal", "destroy"]
     fake_provider.destroy_hosts.assert_called_once_with(["h1", "h2", "h3"])
@@ -89,7 +92,7 @@ def test_admin_destroy_route_seals_before_destroy(
     on OperationsWorker's background thread, so we capture and invoke
     that closure directly.
     """
-    fake_db = destroy_setup["database"]
+    fake_metrics_db = destroy_setup["metrics_db"]
     call_order: list[str] = []
 
     def _seal():
@@ -109,7 +112,7 @@ def test_admin_destroy_route_seals_before_destroy(
         result.returncode = 0
         return result
 
-    fake_db.bulk_seal_session_metrics.side_effect = _seal
+    fake_metrics_db.bulk_seal_session_metrics.side_effect = _seal
     mock_run.side_effect = _run
     mock_popen.return_value = _FakeCompletedPopen(
         stdout_text="Destroy complete (mocked)\n", returncode=0,
@@ -127,7 +130,7 @@ def test_admin_destroy_route_seals_before_destroy(
         fn = mock_worker.submit.call_args.kwargs["fn"]
         fn()
 
-    fake_db.bulk_seal_session_metrics.assert_called_once()
+    fake_metrics_db.bulk_seal_session_metrics.assert_called_once()
     assert call_order == ["seal", "destroy"], (
         f"Expected seal before destroy, got {call_order}"
     )
@@ -159,8 +162,8 @@ def test_admin_destroy_route_continues_when_seal_fails(
     mock_popen.return_value = _FakeCompletedPopen(
         stdout_text="Destroy complete (mocked)\n", returncode=0,
     )
-    fake_db = destroy_setup["database"]
-    fake_db.bulk_seal_session_metrics.side_effect = RuntimeError("db blew up")
+    fake_metrics_db = destroy_setup["metrics_db"]
+    fake_metrics_db.bulk_seal_session_metrics.side_effect = RuntimeError("db blew up")
 
     with patch("lablink_allocator_service.main.operations_worker") as mock_worker:
         mock_worker.submit.return_value = 1
@@ -171,7 +174,7 @@ def test_admin_destroy_route_continues_when_seal_fails(
         fn = mock_worker.submit.call_args.kwargs["fn"]
         fn()
 
-    fake_db.bulk_seal_session_metrics.assert_called_once()
+    fake_metrics_db.bulk_seal_session_metrics.assert_called_once()
     # Destroy still ran despite the seal failure.
     assert mock_run.called
     assert mock_popen.called

--- a/packages/allocator/tests/test_session_metrics_summary_endpoint.py
+++ b/packages/allocator/tests/test_session_metrics_summary_endpoint.py
@@ -20,11 +20,19 @@ _FIXTURE_SUMMARY = {
 def app_with_metrics(monkeypatch, app):
     from lablink_allocator_service import main
 
+    # database is still used by /admin/session-metrics for
+    # get_all_vms_for_export; get_session_metrics_summary lives on
+    # metrics_db. Keep these as two distinct MagicMocks so a call landing
+    # on the wrong object would fail the test instead of passing silently.
     fake_db = MagicMock()
-    fake_db.get_session_metrics_summary.return_value = _FIXTURE_SUMMARY
     monkeypatch.setattr(main, "database", fake_db, raising=False)
+
+    fake_metrics_db = MagicMock()
+    fake_metrics_db.get_session_metrics_summary.return_value = _FIXTURE_SUMMARY
+    monkeypatch.setattr(main, "metrics_db", fake_metrics_db, raising=False)
+
     main.cfg.monitoring.enabled = True
-    return main.app, fake_db
+    return main.app, fake_metrics_db
 
 
 def test_returns_summary_when_enabled(app_with_metrics, client, admin_headers):
@@ -125,7 +133,7 @@ def test_zero_rows_returns_zeroed_summary(
 ):
     from lablink_allocator_service import main
 
-    main.database.get_session_metrics_summary.return_value = {
+    main.metrics_db.get_session_metrics_summary.return_value = {
         "total_vms": 0,
         "funnel": {"started": 0, "labeled": 0, "trained": 0, "tracked": 0},
         "pct_reached_training": 0.0,


### PR DESCRIPTION
## Summary

`packages/allocator/src/lablink_allocator_service/database.py` was 1892 lines holding a single `PostgresqlDatabase` god class — 54 public methods spanning seven unrelated concerns. Every consumer took a dependency on all of it to use any of it.

This splits it into a `db/` subpackage of focused classes sharing one connection pool, following the pattern `operations_db.py` already established, and deletes six dead methods.

| Module | Lines | Owns |
|---|---:|---|
| `db/__init__.py` | 12 | deliberately empty — see its docstring |
| `db/pool.py` | 125 | `PooledCursor`, `make_pool`, `validate_pool_sizes`, `POOL_*` sizing |
| `db/vms.py` | 1254 | `VmDatabase` — VM rows, registration/auth, seats, logs, health, settings |
| `db/schedules.py` | 203 | `ScheduleDatabase` — `scheduled_destructions` table |
| `db/metrics.py` | 220 | `MetricsDatabase` — session-metrics columns on the VM table |
| `db/operations.py` | 212 | `OperationsDatabase` — moved from `operations_db.py` |

No `db/` module imports another except `pool`, so the dependency graph is flat and each class is readable on its own. `PostgresqlDatabase` is renamed `VmDatabase` to match its three role-named siblings.

**No SQL, schema, or runtime behaviour changes.** 751 passed / 19 skipped, `ruff check src tests` clean.

## The bigger win: the psycopg2 `sys.modules` mocking is gone

`operations_db.py` carried a 15-line docstring explaining why it had to lazy-import `_PooledCursor`. The reason: the test suite mocked psycopg2 by *captured binding* — patching `sys.modules` around an import, so the module under test permanently held the mock. That made import order load-bearing across the whole suite, and moving pool construction between modules broke 24 tests mid-refactor.

Replaced with dependency injection. `VmDatabase` accepts an optional `pool=` and tracks ownership, so `__del__` never closes a pool it was handed. Tests inject a `MagicMock` pool instead. **No `sys.modules` psycopg2 mocking remains anywhere in the allocator suite**, and the lazy-import workaround is deleted.

This creates two conventions, both documented in the code and in `openspec/project.md`:

- **`db/__init__.py` stays empty.** Re-exporting would make importing *any* submodule — including the dependency-free `db.pool` — execute `db/vms.py`'s top-level `import psycopg2`.
- **A class that *constructs* a pool must do so in its own module**, so its own psycopg2 binding is used. `make_pool` is for callers needing only a bare pool (the APScheduler job).

## Dead code removed

Six methods reachable only from their own tests, plus the 9 tests covering them: `insert_vm`, `get_vm_by_machine_identity`, `get_gpu_health`, `save_logs_by_hostname`, `load_database`, `seal_session_metrics`. `bulk_seal_session_metrics` is live and retained.

## Other fixes surfaced along the way

- `execute_scheduled_destruction_job` built a whole `PostgresqlDatabase` just to reach `.pool`, and ended in a `finally` block testing `.cursor`/`.conn` — attributes that had not existed since an earlier pool refactor, making both branches permanently unreachable. It now shares one pool across all four handles with a genuinely reachable `closeall()`.
- The two duplicated 13-element `scheduled_destructions` column lists are collapsed into one `_SCHEDULE_COLUMNS` tuple.
- `operations_db.py`'s docstring claimed `scheduled_destructions` reaches directly into VM rows. It does not, at the schema level — that conflated the scheduled *job* calling `clear_database()` with schema coupling.
- Several test fixtures shared one `MagicMock` across two collaborators, so they no longer pinned *which* object a call landed on — a regression calling the wrong object would have passed the test while raising `AttributeError` in production. Split into distinct doubles.

## Review notes

- **Reviewing by module is easier than by diff.** Each `db/*.py` is self-contained; the diff is dominated by moves.
- **Not covered by tests:** `scheduler.py`'s construction-failure window. The refactor made `pool.closeall()` reachable if `get_provider` or a handle constructor raises, but no test exercises that path. Worth a follow-up.
- **Deferred, recorded but not done:** further splitting `db/vms.py` (registration/auth and seat-assignment are the natural next seams); shortening method names now that the classes supply context; consolidating `signed_cookie.py`'s inline `settings` SQL with `set_setting`/`get_setting` into a `db/settings.py`.

## Test plan

```bash
uv sync --all-packages --extra dev            # from repo root
cd packages/allocator
PYTHONPATH=src uv run pytest --ignore=tests/terraform    # 751 passed, 19 skipped
ruff check src tests
```

`tests/terraform` is excluded because it shells out to the `terraform` binary and needs AWS credentials; it fails identically on `main`.