### PR TITLE
fix(client): join the overlay before the startup script; retry lost 'initializing'

### DIFF
--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -23,10 +23,22 @@ echo "TUTORIAL_REPO_TO_CLONE: $TUTORIAL_REPO_TO_CLONE"
 echo "SUBJECT_SOFTWARE: $SUBJECT_SOFTWARE"
 echo "CLOUD_INIT_LOG_GROUP: $CLOUD_INIT_LOG_GROUP"
 
+# Touched once a status later than 'initializing' has been reported, so the
+# background retrier below stops instead of racing a newer state back to a
+# stale value.
+STATUS_SUPERSEDED_FILE="${STATUS_SUPERSEDED_FILE:-/tmp/lablink-status-superseded}"
+STATUS_RETRY_INTERVAL="${STATUS_RETRY_INTERVAL_SECONDS:-15}"
+STATUS_RETRY_MAX_ATTEMPTS="${STATUS_RETRY_MAX_ATTEMPTS:-40}"
+# Per-run state: clear any sentinel a previous run of this container left
+# behind. `docker restart` (or the `unless-stopped` policy after a crash)
+# re-runs this script against the SAME filesystem, so /tmp is not empty — and
+# a stale sentinel would make the retrier below exit immediately on every
+# subsequent boot, silently disabling it exactly where it is needed most.
+rm -f "$STATUS_SUPERSEDED_FILE"
+
 # Helper to POST VM status to the allocator. Mirrors the send_status
-# pattern in user_data.sh. Best-effort — a failed POST does not abort
-# the container, since the allocator's stale-initializing timer will
-# eventually trigger a reboot if we never reach "running".
+# pattern in user_data.sh. Returns curl's exit status so callers can react
+# to a permanent failure; it does not abort the container on its own.
 send_status() {
   local status="$1"
   echo ">> Reporting status='$status' to allocator..."
@@ -42,16 +54,68 @@ send_status() {
     -H "Authorization: Bearer $CLIENT_SECRET" \
     -H "Content-Type: application/json" \
     -d "{\"hostname\":\"$VM_NAME\",\"status\":\"$status\"}" \
-    --max-time 5 --retry 5 --retry-delay 2 --retry-all-errors \
-    || echo ">> WARNING: failed to report status=$status (continuing)"
+    --max-time 5 --retry 5 --retry-delay 2 --retry-all-errors
 }
 
-# Report 'initializing' as soon as the container's start.sh begins. On cold
+# Join the Tailscale overlay when this client was registered with an
+# overlay hostname (mesh-overlay connectivity — MeshOverlayClientConnectivity
+# on the allocator side). Gated purely on TAILSCALE_AUTHKEY's presence;
+# lan_direct/allocator_proxied clients never set it, so this is a no-op
+# for every existing deployment.
+#
+# This runs FIRST, ahead of every allocator call and ahead of the custom
+# startup script, because on a mesh-overlay deployment the tailnet may be
+# the only route to the allocator at all — every pre-join POST would fail
+# outright, not merely race. Joining first also costs far less than it
+# saves: a join is seconds, while the startup script can run for minutes
+# (and is retried), and a container killed mid-script previously never
+# joined the overlay at all.
+if [ -n "$TAILSCALE_AUTHKEY" ]; then
+  echo "Starting tailscaled..."
+  sudo tailscaled >/tmp/tailscaled.log 2>&1 &
+  # Wait for tailscaled's local socket to come up before calling `tailscale up` —
+  # `tailscale status` exits 0 once the daemon is reachable, whether or not
+  # it's logged in yet, so this loop is purely "wait for the socket", not
+  # "wait for join".
+  for i in $(seq 1 30); do
+    sudo tailscale status >/dev/null 2>&1 && break
+    sleep 0.5
+  done
+  echo "Joining Tailscale as $OVERLAY_HOSTNAME..."
+  sudo tailscale up --authkey="$TAILSCALE_AUTHKEY" --hostname="$OVERLAY_HOSTNAME"
+  if [ $? -ne 0 ]; then
+    echo "Failed to join Tailscale overlay" >&2
+    touch "$STATUS_SUPERSEDED_FILE"
+    send_status "error" || echo ">> WARNING: failed to report status=error"
+    exit 1
+  fi
+fi
+
+# Report 'initializing' as soon as the overlay (if any) is up. On cold
 # reboot this is redundant with user_data.sh's earlier post, but on warm
 # reboot user_data.sh's guard may exit before reaching its send_status —
 # this call guarantees the transition rebooting → initializing → running
 # regardless of which path brought the container up.
-send_status "initializing"
+#
+# If the immediate attempt exhausts its 10s budget, keep retrying in the
+# background rather than giving up: the container's outbound network can be
+# unusable for the first few seconds of its life (observed on Docker
+# Desktop/WSL2, where a freshly created container's first connects fail
+# while the host's NAT path settles). Without this, one lost 10s window
+# leaves the allocator staring at a stale status for the entire duration of
+# the custom startup script — which can run for minutes.
+if ! send_status "initializing"; then
+  echo ">> WARNING: failed to report status=initializing; retrying in background"
+  (
+    for _ in $(seq 1 "$STATUS_RETRY_MAX_ATTEMPTS"); do
+      sleep "$STATUS_RETRY_INTERVAL"
+      # A later status already won; anything we post now would be stale.
+      [ -f "$STATUS_SUPERSEDED_FILE" ] && exit 0
+      send_status "initializing" && exit 0
+    done
+    echo ">> WARNING: gave up reporting status=initializing"
+  ) &
+fi
 
 # Clone the tutorial repository if specified
 if [ -n "$TUTORIAL_REPO_TO_CLONE" ]; then
@@ -116,37 +180,13 @@ if [ -f "/docker_scripts/custom-startup.sh" ] && [ -s "/docker_scripts/custom-st
   if [ $rc -ne 0 ]; then
     echo "Warning: custom startup script did not succeed after $MAX_ATTEMPTS attempt(s) (exit $rc)"
     if [ "${STARTUP_ON_ERROR}" = "fail" ]; then
-      send_status "error"
+      touch "$STATUS_SUPERSEDED_FILE"
+      send_status "error" || echo ">> WARNING: failed to report status=error"
       exit $rc
     fi
   fi
 else
   echo "No custom startup script found. Skipping."
-fi
-
-# Join the Tailscale overlay when this client was registered with an
-# overlay hostname (mesh-overlay connectivity — MeshOverlayClientConnectivity
-# on the allocator side). Gated purely on TAILSCALE_AUTHKEY's presence;
-# lan_direct/allocator_proxied clients never set it, so this is a no-op
-# for every existing deployment.
-if [ -n "$TAILSCALE_AUTHKEY" ]; then
-  echo "Starting tailscaled..."
-  sudo tailscaled >/tmp/tailscaled.log 2>&1 &
-  # Wait for tailscaled's local socket to come up before calling `tailscale up` —
-  # `tailscale status` exits 0 once the daemon is reachable, whether or not
-  # it's logged in yet, so this loop is purely "wait for the socket", not
-  # "wait for join".
-  for i in $(seq 1 30); do
-    sudo tailscale status >/dev/null 2>&1 && break
-    sleep 0.5
-  done
-  echo "Joining Tailscale as $OVERLAY_HOSTNAME..."
-  sudo tailscale up --authkey="$TAILSCALE_AUTHKEY" --hostname="$OVERLAY_HOSTNAME"
-  if [ $? -ne 0 ]; then
-    echo "Failed to join Tailscale overlay" >&2
-    send_status "error"
-    exit 1
-  fi
 fi
 
 # kasmvncserver wraps xauth, which expects ~/.Xauthority to exist; missing
@@ -310,8 +350,11 @@ stdbuf -oL -eL env DISPLAY=:1 /home/client/.vnc/xstartup \
 # from the allocator. Bearer-authenticated via REGISTER_TOKEN env var.
 agent 2>&1 | sed -u 's/^/[agent] /' >&5 &
 
-# Flip VM status to 'running' now that client services are launching.
-send_status "running"
+# Flip VM status to 'running' now that client services are launching. Mark
+# 'initializing' superseded first so a background retrier that is still
+# mid-sleep exits instead of posting the older status after this one lands.
+touch "$STATUS_SUPERSEDED_FILE"
+send_status "running" || echo ">> WARNING: failed to report status=running (continuing)"
 
 # Existing health/heartbeat/in-use workers
 update_inuse_status \

--- a/packages/client/tests/test_start_sh_status.py
+++ b/packages/client/tests/test_start_sh_status.py
@@ -1,20 +1,20 @@
-"""Tests for start.sh's VM-status reporting and startup ordering.
+"""Structural tests for start.sh's startup ordering and status reporting.
 
-start.sh isn't sourceable as a whole (it `exec`s stdout through a tagger and
-launches long-running services), so these tests extract the two self-contained
-regions under test — the `send_status` helper and the `initializing` reporting
-block — straight out of the real file and run them under bash with a stubbed
-`curl`. Extraction is marker-based rather than line-based so it survives edits
-elsewhere in the script.
+start.sh isn't sourceable as a whole — it `exec`s stdout through a tagger and
+launches long-running services — so these assert against the script text
+rather than executing it. That keeps them instant and free of timing
+dependence; the runtime behaviour of the background status retrier was
+verified by hand instead.
 
-The ordering tests assert against the real file directly: the Tailscale join
-must precede every allocator call and the custom startup script, because on a
-mesh-overlay deployment the tailnet can be the only route to the allocator
-(so a pre-join POST fails outright, not merely races), and because a container
-killed mid-startup-script would otherwise never join the overlay at all.
+What they protect is the ordering, which is where the bug was: the Tailscale
+join must precede every allocator call and the custom startup script, because
+on a mesh-overlay deployment the tailnet can be the only route to the
+allocator (so a pre-join POST fails outright, not merely races), and because a
+container killed mid-startup-script would otherwise never join the overlay at
+all. Each assertion below was checked against reconstructed pre-fix code to
+confirm it actually fails on it.
 """
 
-import subprocess
 from pathlib import Path
 
 import pytest
@@ -38,185 +38,48 @@ def _extract(text: str, first_line_startswith: str, closer: str) -> str:
     return "\n".join(lines[start : end + 1])
 
 
-@pytest.fixture(scope="module")
-def status_block(script_text: str) -> str:
-    """The status vars + send_status() + the `initializing` reporting block."""
-    helper = _extract(script_text, "STATUS_SUPERSEDED_FILE=", "}")
-    reporter = _extract(script_text, 'if ! send_status "initializing"; then', "fi")
-    return f"{helper}\n\n{reporter}\n"
-
-
-def _run(status_block: str, tmp_path: Path, *, fail: bool, **env) -> dict:
-    """Run the extracted block with a stubbed curl. Returns paths + output."""
-    bin_dir = tmp_path / "bin"
-    bin_dir.mkdir()
-    calls = tmp_path / "calls"
-    calls.write_text("")
-    fail_flag = tmp_path / "fail"
-    if fail:
-        fail_flag.write_text("")
-
-    # Stub curl: fails while the flag file exists, then succeeds. It does not
-    # emulate curl's own --retry loop, so one invocation == one send_status.
-    (bin_dir / "curl").write_text(
-        "#!/bin/bash\n"
-        f'echo call >> "{calls}"\n'
-        f'if [ -f "{fail_flag}" ]; then\n'
-        '  echo "curl: (7) Couldn\'t connect to server" >&2\n'
-        "  exit 7\n"
-        "fi\n"
-        'echo \'{"message":"VM status updated successfully."}\'\n'
-    )
-    (bin_dir / "curl").chmod(0o755)
-
-    script = tmp_path / "under_test.sh"
-    script.write_text(status_block)
-    out = tmp_path / "out"
-
-    full_env = {
-        "PATH": f"{bin_dir}:/usr/bin:/bin",
-        "ALLOCATOR_URL": "http://allocator.invalid",
-        "CLIENT_SECRET": "secret",
-        "VM_NAME": "vm-1",
-        "STATUS_SUPERSEDED_FILE": str(tmp_path / "superseded"),
-        **env,
-    }
-    # Redirect to a real file, not a pipe: the background retrier outlives this
-    # call and would die on EPIPE if stdout were a closed pipe.
-    with out.open("w") as fh:
-        subprocess.run(
-            ["bash", str(script)], env=full_env, stdout=fh, stderr=fh, check=False
-        )
-    return {
-        "calls": calls,
-        "out": out,
-        "fail_flag": fail_flag,
-        "superseded": Path(full_env["STATUS_SUPERSEDED_FILE"]),
-    }
-
-
-def _n_calls(paths: dict) -> int:
-    return len([ln for ln in paths["calls"].read_text().splitlines() if ln])
-
-
-def test_successful_report_posts_once_and_spawns_no_retrier(status_block, tmp_path):
-    paths = _run(
-        status_block,
-        tmp_path,
-        fail=False,
-        STATUS_RETRY_INTERVAL_SECONDS="1",
-        STATUS_RETRY_MAX_ATTEMPTS="5",
-    )
-    assert _n_calls(paths) == 1
-    assert "retrying in background" not in paths["out"].read_text()
-    # Nothing further should arrive: a retrier would have fired by now.
-    subprocess.run(["sleep", "2"], check=True)
-    assert _n_calls(paths) == 1
-
-
-def test_failed_report_retries_in_background_until_it_lands(status_block, tmp_path):
-    paths = _run(
-        status_block,
-        tmp_path,
-        fail=True,
-        STATUS_RETRY_INTERVAL_SECONDS="1",
-        STATUS_RETRY_MAX_ATTEMPTS="20",
-    )
-    assert "retrying in background" in paths["out"].read_text()
-    assert _n_calls(paths) == 1
-
-    paths["fail_flag"].unlink()  # network comes back
-    subprocess.run(["sleep", "3"], check=True)
-    after = _n_calls(paths)
-    assert after > 1, "background retrier never re-attempted"
-    assert "VM status updated successfully" in paths["out"].read_text()
-
-    # Having succeeded, the retrier must stop rather than keep posting.
-    subprocess.run(["sleep", "2"], check=True)
-    assert _n_calls(paths) == after
-
-
-def test_superseded_sentinel_stops_retrier_without_posting_stale_status(
-    status_block, tmp_path
-):
-    paths = _run(
-        status_block,
-        tmp_path,
-        fail=True,
-        STATUS_RETRY_INTERVAL_SECONDS="1",
-        STATUS_RETRY_MAX_ATTEMPTS="20",
-    )
-    before = _n_calls(paths)
-    paths["superseded"].write_text("")  # a later status ('running') won
-    paths["fail_flag"].unlink()  # network is fine now
-    subprocess.run(["sleep", "3"], check=True)
-    assert _n_calls(paths) == before, "posted a stale 'initializing' after supersede"
-
-
-def test_retrier_gives_up_after_max_attempts(status_block, tmp_path):
-    paths = _run(
-        status_block,
-        tmp_path,
-        fail=True,  # never recovers
-        STATUS_RETRY_INTERVAL_SECONDS="1",
-        STATUS_RETRY_MAX_ATTEMPTS="3",
-    )
-    subprocess.run(["sleep", "5"], check=True)
-    assert "gave up reporting status=initializing" in paths["out"].read_text()
-    assert _n_calls(paths) == 4, "expected 1 inline attempt + 3 bounded retries"
-
-
-def test_stale_sentinel_from_a_previous_run_does_not_disable_retrier(
-    status_block, tmp_path
-):
-    """`docker restart` re-runs start.sh against the same filesystem, so a
-    sentinel written by the previous run is still on disk. If it were not
-    cleared, the retrier would exit on its first tick on every boot after the
-    first — disabling itself precisely on a crash-looping client."""
-    stale = tmp_path / "superseded"
-    stale.write_text("")  # left over from a previous run
-    paths = _run(
-        status_block,
-        tmp_path,
-        fail=True,
-        STATUS_SUPERSEDED_FILE=str(stale),
-        STATUS_RETRY_INTERVAL_SECONDS="1",
-        STATUS_RETRY_MAX_ATTEMPTS="20",
-    )
-    assert not stale.exists(), "start.sh must clear the sentinel at startup"
-    paths["fail_flag"].unlink()
-    subprocess.run(["sleep", "3"], check=True)
-    assert _n_calls(paths) > 1, "stale sentinel silenced the background retrier"
+def _line_of(text: str, needle: str) -> int:
+    for i, ln in enumerate(text.splitlines()):
+        if needle in ln:
+            return i
+    raise AssertionError(f"{needle!r} not found in start.sh")
 
 
 def test_send_status_returns_curl_exit_status(script_text):
     """The helper must not swallow failures with a trailing `|| echo`, or
-    callers can't tell a lost report from a delivered one."""
+    callers can't tell a lost report from a delivered one — which is what let
+    a failed 'initializing' pass silently."""
     helper = _extract(script_text, "STATUS_SUPERSEDED_FILE=", "}")
     assert "|| echo" not in helper
+
+
+def test_supersede_sentinel_is_cleared_at_startup(script_text):
+    """`docker restart` re-runs start.sh against the same filesystem, so /tmp
+    still holds a sentinel written by the previous run. Unless it is cleared
+    first, the retrier exits on its first tick on every boot after the first —
+    silently disabling itself on exactly the crash-looping client it exists
+    for. The clear must come before anything reads or writes the sentinel."""
+    clear = _line_of(script_text, 'rm -f "$STATUS_SUPERSEDED_FILE"')
+    first_read = _line_of(script_text, '[ -f "$STATUS_SUPERSEDED_FILE" ]')
+    first_touch = _line_of(script_text, 'touch "$STATUS_SUPERSEDED_FILE"')
+    assert clear < first_read
+    assert clear < first_touch
 
 
 class TestStartupOrdering:
     """Guards the ordering fix: overlay join, then status, then startup script."""
 
-    @staticmethod
-    def _line_of(text: str, needle: str) -> int:
-        for i, ln in enumerate(text.splitlines()):
-            if needle in ln:
-                return i
-        raise AssertionError(f"{needle!r} not found in start.sh")
-
     def test_tailscale_join_precedes_first_allocator_call(self, script_text):
-        join = self._line_of(script_text, "tailscale up --authkey=")
-        first_status = self._line_of(script_text, 'if ! send_status "initializing"')
+        join = _line_of(script_text, "tailscale up --authkey=")
+        first_status = _line_of(script_text, 'if ! send_status "initializing"')
         assert join < first_status, (
             "the overlay join must run before any allocator POST — on a "
             "mesh-overlay deployment the tailnet may be the only route"
         )
 
     def test_tailscale_join_precedes_custom_startup_script(self, script_text):
-        join = self._line_of(script_text, "tailscale up --authkey=")
-        startup = self._line_of(script_text, "Running custom startup script")
+        join = _line_of(script_text, "tailscale up --authkey=")
+        startup = _line_of(script_text, "Running custom startup script")
         assert join < startup, (
             "the overlay join must not sit behind the startup script: a "
             "container killed mid-script would never join the overlay"
@@ -226,13 +89,13 @@ class TestStartupOrdering:
         """`running` must mark the sentinel first, or an in-flight retrier can
         overwrite the newer status with the older one."""
         lines = script_text.splitlines()
-        running = self._line_of(script_text, 'send_status "running"')
+        running = _line_of(script_text, 'send_status "running"')
         touches = [
             i
             for i, ln in enumerate(lines)
             if 'touch "$STATUS_SUPERSEDED_FILE"' in ln and i < running
         ]
-        assert touches, "no supersede marker before send_status \"running\""
+        assert touches, 'no supersede marker before send_status "running"'
         assert running - max(touches) <= 2, (
             "the supersede marker should immediately precede the 'running' post"
         )
@@ -245,13 +108,13 @@ class TestStartupOrdering:
         every non-overlay client would newly pay a `tailscale up` failure
         before reporting any status at all."""
         lines = script_text.splitlines()
-        gate = self._line_of(script_text, 'if [ -n "$TAILSCALE_AUTHKEY" ]; then')
-        join = self._line_of(script_text, "tailscale up --authkey=")
-        daemon = self._line_of(script_text, "sudo tailscaled")
+        gate = _line_of(script_text, 'if [ -n "$TAILSCALE_AUTHKEY" ]; then')
+        join = _line_of(script_text, "tailscale up --authkey=")
+        daemon = _line_of(script_text, "sudo tailscaled")
         assert gate < daemon < join, "tailscaled/join escaped the authkey gate"
         # ...and the gate must close before the startup script runs.
         closing = next(i for i in range(join, len(lines)) if lines[i] == "fi")
-        assert closing < self._line_of(script_text, "Running custom startup script")
+        assert closing < _line_of(script_text, "Running custom startup script")
 
     def test_join_failure_reports_error_status(self, script_text):
         """A failed join must still try to tell the allocator before exiting."""

--- a/packages/client/tests/test_start_sh_status.py
+++ b/packages/client/tests/test_start_sh_status.py
@@ -1,0 +1,261 @@
+"""Tests for start.sh's VM-status reporting and startup ordering.
+
+start.sh isn't sourceable as a whole (it `exec`s stdout through a tagger and
+launches long-running services), so these tests extract the two self-contained
+regions under test — the `send_status` helper and the `initializing` reporting
+block — straight out of the real file and run them under bash with a stubbed
+`curl`. Extraction is marker-based rather than line-based so it survives edits
+elsewhere in the script.
+
+The ordering tests assert against the real file directly: the Tailscale join
+must precede every allocator call and the custom startup script, because on a
+mesh-overlay deployment the tailnet can be the only route to the allocator
+(so a pre-join POST fails outright, not merely races), and because a container
+killed mid-startup-script would otherwise never join the overlay at all.
+"""
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+START_SH = Path(__file__).resolve().parents[1] / "start.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return START_SH.read_text()
+
+
+def _extract(text: str, first_line_startswith: str, closer: str) -> str:
+    """Return lines from the first line starting with `first_line_startswith`
+    through the next line equal to `closer` (inclusive)."""
+    lines = text.splitlines()
+    start = next(
+        i for i, ln in enumerate(lines) if ln.startswith(first_line_startswith)
+    )
+    end = next(i for i in range(start, len(lines)) if lines[i] == closer)
+    return "\n".join(lines[start : end + 1])
+
+
+@pytest.fixture(scope="module")
+def status_block(script_text: str) -> str:
+    """The status vars + send_status() + the `initializing` reporting block."""
+    helper = _extract(script_text, "STATUS_SUPERSEDED_FILE=", "}")
+    reporter = _extract(script_text, 'if ! send_status "initializing"; then', "fi")
+    return f"{helper}\n\n{reporter}\n"
+
+
+def _run(status_block: str, tmp_path: Path, *, fail: bool, **env) -> dict:
+    """Run the extracted block with a stubbed curl. Returns paths + output."""
+    bin_dir = tmp_path / "bin"
+    bin_dir.mkdir()
+    calls = tmp_path / "calls"
+    calls.write_text("")
+    fail_flag = tmp_path / "fail"
+    if fail:
+        fail_flag.write_text("")
+
+    # Stub curl: fails while the flag file exists, then succeeds. It does not
+    # emulate curl's own --retry loop, so one invocation == one send_status.
+    (bin_dir / "curl").write_text(
+        "#!/bin/bash\n"
+        f'echo call >> "{calls}"\n'
+        f'if [ -f "{fail_flag}" ]; then\n'
+        '  echo "curl: (7) Couldn\'t connect to server" >&2\n'
+        "  exit 7\n"
+        "fi\n"
+        'echo \'{"message":"VM status updated successfully."}\'\n'
+    )
+    (bin_dir / "curl").chmod(0o755)
+
+    script = tmp_path / "under_test.sh"
+    script.write_text(status_block)
+    out = tmp_path / "out"
+
+    full_env = {
+        "PATH": f"{bin_dir}:/usr/bin:/bin",
+        "ALLOCATOR_URL": "http://allocator.invalid",
+        "CLIENT_SECRET": "secret",
+        "VM_NAME": "vm-1",
+        "STATUS_SUPERSEDED_FILE": str(tmp_path / "superseded"),
+        **env,
+    }
+    # Redirect to a real file, not a pipe: the background retrier outlives this
+    # call and would die on EPIPE if stdout were a closed pipe.
+    with out.open("w") as fh:
+        subprocess.run(
+            ["bash", str(script)], env=full_env, stdout=fh, stderr=fh, check=False
+        )
+    return {
+        "calls": calls,
+        "out": out,
+        "fail_flag": fail_flag,
+        "superseded": Path(full_env["STATUS_SUPERSEDED_FILE"]),
+    }
+
+
+def _n_calls(paths: dict) -> int:
+    return len([ln for ln in paths["calls"].read_text().splitlines() if ln])
+
+
+def test_successful_report_posts_once_and_spawns_no_retrier(status_block, tmp_path):
+    paths = _run(
+        status_block,
+        tmp_path,
+        fail=False,
+        STATUS_RETRY_INTERVAL_SECONDS="1",
+        STATUS_RETRY_MAX_ATTEMPTS="5",
+    )
+    assert _n_calls(paths) == 1
+    assert "retrying in background" not in paths["out"].read_text()
+    # Nothing further should arrive: a retrier would have fired by now.
+    subprocess.run(["sleep", "2"], check=True)
+    assert _n_calls(paths) == 1
+
+
+def test_failed_report_retries_in_background_until_it_lands(status_block, tmp_path):
+    paths = _run(
+        status_block,
+        tmp_path,
+        fail=True,
+        STATUS_RETRY_INTERVAL_SECONDS="1",
+        STATUS_RETRY_MAX_ATTEMPTS="20",
+    )
+    assert "retrying in background" in paths["out"].read_text()
+    assert _n_calls(paths) == 1
+
+    paths["fail_flag"].unlink()  # network comes back
+    subprocess.run(["sleep", "3"], check=True)
+    after = _n_calls(paths)
+    assert after > 1, "background retrier never re-attempted"
+    assert "VM status updated successfully" in paths["out"].read_text()
+
+    # Having succeeded, the retrier must stop rather than keep posting.
+    subprocess.run(["sleep", "2"], check=True)
+    assert _n_calls(paths) == after
+
+
+def test_superseded_sentinel_stops_retrier_without_posting_stale_status(
+    status_block, tmp_path
+):
+    paths = _run(
+        status_block,
+        tmp_path,
+        fail=True,
+        STATUS_RETRY_INTERVAL_SECONDS="1",
+        STATUS_RETRY_MAX_ATTEMPTS="20",
+    )
+    before = _n_calls(paths)
+    paths["superseded"].write_text("")  # a later status ('running') won
+    paths["fail_flag"].unlink()  # network is fine now
+    subprocess.run(["sleep", "3"], check=True)
+    assert _n_calls(paths) == before, "posted a stale 'initializing' after supersede"
+
+
+def test_retrier_gives_up_after_max_attempts(status_block, tmp_path):
+    paths = _run(
+        status_block,
+        tmp_path,
+        fail=True,  # never recovers
+        STATUS_RETRY_INTERVAL_SECONDS="1",
+        STATUS_RETRY_MAX_ATTEMPTS="3",
+    )
+    subprocess.run(["sleep", "5"], check=True)
+    assert "gave up reporting status=initializing" in paths["out"].read_text()
+    assert _n_calls(paths) == 4, "expected 1 inline attempt + 3 bounded retries"
+
+
+def test_stale_sentinel_from_a_previous_run_does_not_disable_retrier(
+    status_block, tmp_path
+):
+    """`docker restart` re-runs start.sh against the same filesystem, so a
+    sentinel written by the previous run is still on disk. If it were not
+    cleared, the retrier would exit on its first tick on every boot after the
+    first — disabling itself precisely on a crash-looping client."""
+    stale = tmp_path / "superseded"
+    stale.write_text("")  # left over from a previous run
+    paths = _run(
+        status_block,
+        tmp_path,
+        fail=True,
+        STATUS_SUPERSEDED_FILE=str(stale),
+        STATUS_RETRY_INTERVAL_SECONDS="1",
+        STATUS_RETRY_MAX_ATTEMPTS="20",
+    )
+    assert not stale.exists(), "start.sh must clear the sentinel at startup"
+    paths["fail_flag"].unlink()
+    subprocess.run(["sleep", "3"], check=True)
+    assert _n_calls(paths) > 1, "stale sentinel silenced the background retrier"
+
+
+def test_send_status_returns_curl_exit_status(script_text):
+    """The helper must not swallow failures with a trailing `|| echo`, or
+    callers can't tell a lost report from a delivered one."""
+    helper = _extract(script_text, "STATUS_SUPERSEDED_FILE=", "}")
+    assert "|| echo" not in helper
+
+
+class TestStartupOrdering:
+    """Guards the ordering fix: overlay join, then status, then startup script."""
+
+    @staticmethod
+    def _line_of(text: str, needle: str) -> int:
+        for i, ln in enumerate(text.splitlines()):
+            if needle in ln:
+                return i
+        raise AssertionError(f"{needle!r} not found in start.sh")
+
+    def test_tailscale_join_precedes_first_allocator_call(self, script_text):
+        join = self._line_of(script_text, "tailscale up --authkey=")
+        first_status = self._line_of(script_text, 'if ! send_status "initializing"')
+        assert join < first_status, (
+            "the overlay join must run before any allocator POST — on a "
+            "mesh-overlay deployment the tailnet may be the only route"
+        )
+
+    def test_tailscale_join_precedes_custom_startup_script(self, script_text):
+        join = self._line_of(script_text, "tailscale up --authkey=")
+        startup = self._line_of(script_text, "Running custom startup script")
+        assert join < startup, (
+            "the overlay join must not sit behind the startup script: a "
+            "container killed mid-script would never join the overlay"
+        )
+
+    def test_running_supersedes_initializing_before_posting(self, script_text):
+        """`running` must mark the sentinel first, or an in-flight retrier can
+        overwrite the newer status with the older one."""
+        lines = script_text.splitlines()
+        running = self._line_of(script_text, 'send_status "running"')
+        touches = [
+            i
+            for i, ln in enumerate(lines)
+            if 'touch "$STATUS_SUPERSEDED_FILE"' in ln and i < running
+        ]
+        assert touches, "no supersede marker before send_status \"running\""
+        assert running - max(touches) <= 2, (
+            "the supersede marker should immediately precede the 'running' post"
+        )
+
+    def test_join_block_stays_gated_on_authkey(self, script_text):
+        """Blast-radius guard for moving the join earlier. AWS
+        (allocator_proxied) and lan_direct clients never get TAILSCALE_AUTHKEY
+        — `lablink register` writes it only alongside OVERLAY_HOSTNAME — so the
+        whole block must remain inside that gate. Were it ever unconditional,
+        every non-overlay client would newly pay a `tailscale up` failure
+        before reporting any status at all."""
+        lines = script_text.splitlines()
+        gate = self._line_of(script_text, 'if [ -n "$TAILSCALE_AUTHKEY" ]; then')
+        join = self._line_of(script_text, "tailscale up --authkey=")
+        daemon = self._line_of(script_text, "sudo tailscaled")
+        assert gate < daemon < join, "tailscaled/join escaped the authkey gate"
+        # ...and the gate must close before the startup script runs.
+        closing = next(i for i in range(join, len(lines)) if lines[i] == "fi")
+        assert closing < self._line_of(script_text, "Running custom startup script")
+
+    def test_join_failure_reports_error_status(self, script_text):
+        """A failed join must still try to tell the allocator before exiting."""
+        block = script_text[script_text.index("tailscale up --authkey=") :]
+        block = block[: block.index("\nfi\n")]
+        assert 'send_status "error"' in block
+        assert "exit 1" in block


### PR DESCRIPTION
## Problem

`start.sh` joined the Tailscale overlay **after** the custom startup script, so a mesh-overlay client stayed invisible on the tailnet for as long as that script ran. Observed live: **4m49s** for a SLEAP install — and up to `STARTUP_MAX_ATTEMPTS` × that when it retries.

Worse, a container killed mid-script never joined at all. A client crash-looping on a laptop restarted three times in six minutes and only reached `tailscale up` on the run where the install was already cached:

| Container start | Died during |
|---|---|
| 17:42:32 | torch/CUDA wheel download (~2.5 GB) |
| 17:45:02 | `sleap --version` verification |
| 17:47:38 | survived (all cached) — joined at 17:47:59 |

The ordering was also **outright broken, not merely racy**, for any mesh-overlay deployment whose allocator is reachable only over the tailnet: `send_status "initializing"` ran before the join, so it could never succeed.

Separately, that first status report had a 10s budget (1 attempt + 5 retries) and swallowed failure with `|| echo`. One bad window left the allocator on a stale status for the entire startup script.

## Changes

- **Move the overlay join ahead of** both the first allocator POST and the custom startup script.
- **`send_status` returns curl's exit status** instead of always succeeding.
- **A failed `initializing` retries in the background** until it lands, a later status supersedes it, or the attempt budget runs out (`STATUS_RETRY_INTERVAL_SECONDS`, `STATUS_RETRY_MAX_ATTEMPTS`).
- **The supersede sentinel is cleared at startup.** `/tmp` survives `docker restart`, so a stale sentinel would silence the retrier on every boot after the first — precisely the crash-looping case it exists for.

## Blast radius

The join stays inside the `TAILSCALE_AUTHKEY` gate, and `register.py` writes that key **only** alongside `OVERLAY_HOSTNAME` — the same condition that grants `NET_ADMIN` + `/dev/net/tun`. AWS (`allocator_proxied`) and `lan_direct` clients never set it, so the block remains a no-op for them. Pinned by `test_join_block_stays_gated_on_authkey`.

Two behaviour changes, both confined to mesh-overlay:

1. A failed `tailscale up` now exits **before** running the startup script rather than after it. Tailscale is baked into the image (`Dockerfile:94`), so the join never depended on that script — this just avoids a 5-minute install on a box that cannot reach the allocator.
2. That path reports `error` without reporting `initializing` first.

## Testing

`packages/client/tests/test_start_sh_status.py` asserts against the script text: ordering, the authkey gate, the supersede marker, the sentinel clear, and `send_status` no longer swallowing failures. All seven were checked against **reconstructed broken code** to confirm none are vacuous.

These started out executing an extracted copy of the script under bash with a stubbed curl. That was dropped: it tested a *copy* rather than `start.sh` itself (so it could pass while the real script was broken), it was timing-dependent, and it cost a 60× suite slowdown — 0.33s → 19.92s, of which 19.13s was five sleep-driven tests. The one dynamic test that earned its keep, by catching a real stale-sentinel bug, became a static check of the property that was actually missing. The retrier's runtime behaviour was hand-verified instead.

```
client:  136 passed in 0.42s
ruff:    All checks passed
bash -n: OK
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)