### PR TITLE
fix(allocator+cli): report the real public URL behind Tailscale Funnel (#396)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,8 +108,14 @@ cd packages/cli       && PYTHONPATH=src uv run pytest  # integration: pytest -m 
 # Lint
 ruff check packages/allocator packages/client packages/cli
 
-# Build Docker (dev)
-docker build -t lablink-allocator:dev -f packages/allocator/Dockerfile.dev .
+# Build Docker (dev) — context MUST be the package dir, not the repo root:
+# Dockerfile.dev's COPY paths (start.sh, lablink-nginx.conf, pg_hba.conf) are
+# relative to packages/allocator/, so building from the root fails with
+# `"/start.sh": not found`. On Apple Silicon --platform is required too: the
+# image pulls an amd64-only kasmvncserver .deb, which aborts a native arm64
+# build with apt exit code 100.
+cd packages/allocator && docker build --platform linux/amd64 \
+  -t lablink-allocator:dev -f Dockerfile.dev .
 ```
 
 Two things about the allocator test command:

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -33,6 +33,7 @@ from lablink_allocator_service.db.schedules import ScheduleDatabase
 from lablink_allocator_service.db.metrics import MetricsDatabase
 from lablink_allocator_service.utils.config_helpers import (
     get_allocator_url,
+    canonical_base_url,
     is_self_signed_ssl,
     should_use_https,
 )
@@ -381,7 +382,7 @@ def byo_onboarding():
     """
     return render_template(
         "byo-onboarding.html",
-        allocator_url=request.host_url.rstrip("/"),
+        allocator_url=canonical_base_url(request),
         register_token=REGISTER_TOKEN,
         show_insecure=is_self_signed_ssl(cfg),
     )

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -18,6 +18,7 @@ from lablink_allocator_service.secret_hash import (
     hash_secret,
     verify_secret_cached,
 )
+from lablink_allocator_service.utils.config_helpers import canonical_base_url
 
 bp = Blueprint("registration", __name__)
 
@@ -99,7 +100,7 @@ def register_client():
     if client_id is None:
         return jsonify({"error": "registration conflict"}), 409
 
-    allocator_url = request.host_url.rstrip("/")
+    allocator_url = canonical_base_url(request)
     # cfg.machine.repository is the tutorial-repo-to-clone URL (shipped to
     # the AWS path as spec["repository"] -> TUTORIAL_REPO_TO_CLONE in
     # client/start.sh) — unrelated to the docker image reference. The AWS

--- a/packages/allocator/src/lablink_allocator_service/utils/config_helpers.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/config_helpers.py
@@ -84,6 +84,55 @@ def should_use_https(cfg) -> bool:
     return hasattr(cfg, "ssl") and cfg.ssl.provider != "none"
 
 
+# Written by the CLI (`lablink deploy`) once it has confirmed the real public
+# URL via `tailscale funnel status`. Lives alongside config.yaml in the
+# allocator's mounted config dir; absent on every deployment that isn't
+# Funnel-exposed.
+CANONICAL_URL_FILENAME = "allocator-url"
+
+
+def canonical_base_url(request) -> str:
+    """Return the allocator's public base URL, without a trailing slash.
+
+    Prefers the operator-supplied canonical URL file over ``request.host_url``.
+    Behind Tailscale Funnel, ``host_url`` reports ``http://`` even for requests
+    that arrived over Funnel's HTTPS: manual-provider deployments only support
+    ``ssl.provider: none``, so :func:`should_use_https` is false and the
+    ``X-Forwarded-Proto`` gate stays shut — and Funnel does not inject that
+    header anyway, so there is no in-request signal to detect it. Clients that
+    take the resulting ``http://`` URL at face value only get a 302 from
+    Funnel, which downgrades their POSTs to GET and surfaces as 405s.
+
+    The file is read per request rather than cached, because the CLI writes it
+    *after* `docker compose up` (Funnel can only be enabled once the container
+    is running), and the allocator must pick it up without a restart.
+
+    Falls back to ``request.host_url`` when the file is missing, empty, or does
+    not contain an http(s) URL — so the AWS/nginx topology, where ProxyFix
+    already yields the right scheme, is completely unaffected.
+    """
+    config_dir = os.getenv("CONFIG_DIR", "/config")
+    path = os.path.join(config_dir, CANONICAL_URL_FILENAME)
+    try:
+        with open(path) as f:
+            candidate = f.read().strip()
+    except (FileNotFoundError, NotADirectoryError, IsADirectoryError, PermissionError):
+        candidate = ""
+    except OSError as exc:  # pragma: no cover - defensive
+        logger.warning("Could not read %s: %s", path, exc)
+        candidate = ""
+
+    if candidate.startswith(("http://", "https://")):
+        return candidate.rstrip("/")
+    if candidate:
+        logger.warning(
+            "Ignoring %s: %r is not an http(s) URL; falling back to request host",
+            path,
+            candidate,
+        )
+    return request.host_url.rstrip("/")
+
+
 def is_self_signed_ssl(cfg) -> bool:
     """Check if the deployment uses a self-signed TLS cert.
 

--- a/packages/allocator/tests/conftest.py
+++ b/packages/allocator/tests/conftest.py
@@ -140,6 +140,35 @@ def client(app):
 
 
 @pytest.fixture
+def reg_client(app, monkeypatch):
+    """Flask client wired for /api/v1/clients/register, with a stub provider,
+    a MagicMock database, and a known register token.
+
+    Returns (test_client, fake_db). Shared by test_registration_api.py and
+    test_canonical_url.py.
+    """
+    from unittest.mock import MagicMock
+
+    from lablink_allocator_service import main
+    from lablink_allocator_service.secret_hash import hash_secret
+    from lablink_allocator_service.providers.connectivity.allocator_proxied import (
+        AllocatorProxiedClientConnectivity,
+    )
+
+    class _StubProvider:
+        client_connectivity = AllocatorProxiedClientConnectivity()
+
+    app.config["LABLINK_PROVIDER"] = _StubProvider()
+
+    fake_db = MagicMock()
+    fake_db.register_client.return_value = "vm-1"
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+    monkeypatch.setattr(main, "REGISTER_TOKEN", "tk_test_register", raising=False)
+    fake_db.get_setting.return_value = hash_secret("tk_test_register")
+    return app.test_client(), fake_db
+
+
+@pytest.fixture
 def admin_headers(omega_config):
     """Convenience Basic-Auth header using cfg credentials."""
 

--- a/packages/allocator/tests/test_canonical_url.py
+++ b/packages/allocator/tests/test_canonical_url.py
@@ -1,0 +1,163 @@
+"""Tests for the canonical allocator-URL override (issue #396).
+
+Behind Tailscale Funnel the allocator cannot determine its own public URL from
+the request: manual deployments run ssl.provider='none', so the ProxyFix gate
+that would trust X-Forwarded-Proto stays shut — and Funnel injects no such
+header anyway. request.host_url therefore reports http://, and a client that
+believes it gets only a 302 from Funnel, which downgrades its POSTs to GET
+(surfacing as 405s on heartbeat/gpu_health).
+
+The fix is an out-of-band file, written by `lablink deploy` from
+`tailscale funnel status` and bind-mounted next to config.yaml. These tests
+cover the allocator half: preferring the file when it is usable, and falling
+back to request.host_url in every other case so the AWS/nginx topology is
+untouched.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from lablink_allocator_service.utils.config_helpers import (
+    CANONICAL_URL_FILENAME,
+    canonical_base_url,
+)
+
+
+@pytest.fixture
+def config_dir(tmp_path, monkeypatch):
+    monkeypatch.setenv("CONFIG_DIR", str(tmp_path))
+    return tmp_path
+
+
+def _request(host_url="http://10.0.0.5/"):
+    return SimpleNamespace(host_url=host_url)
+
+
+def _write(config_dir, content):
+    (config_dir / CANONICAL_URL_FILENAME).write_text(content)
+
+
+class TestCanonicalBaseUrl:
+    def test_prefers_file_over_request_host(self, config_dir):
+        _write(config_dir, "https://lablink-allocator-lab.tailnet.ts.net\n")
+        assert (
+            canonical_base_url(_request())
+            == "https://lablink-allocator-lab.tailnet.ts.net"
+        )
+
+    def test_strips_trailing_slash_and_whitespace(self, config_dir):
+        _write(config_dir, "  https://foo.tailnet.ts.net/  \n")
+        assert canonical_base_url(_request()) == "https://foo.tailnet.ts.net"
+
+    def test_accepts_http_scheme_too(self, config_dir):
+        """The file is the operator's declared public URL; it is not the
+        allocator's business to insist on https (a plain reverse proxy in front
+        is a legitimate topology)."""
+        _write(config_dir, "http://lablink.internal:8080")
+        assert canonical_base_url(_request()) == "http://lablink.internal:8080"
+
+    def test_falls_back_when_file_missing(self, config_dir):
+        assert canonical_base_url(_request("http://10.0.0.5/")) == "http://10.0.0.5"
+
+    def test_falls_back_when_file_empty(self, config_dir):
+        """The non-Funnel case: render_compose_dir always materializes the file
+        so the bind mount resolves, but leaves it empty."""
+        _write(config_dir, "")
+        assert canonical_base_url(_request("http://10.0.0.5/")) == "http://10.0.0.5"
+
+    def test_falls_back_when_file_is_whitespace_only(self, config_dir):
+        _write(config_dir, "\n\n  \n")
+        assert canonical_base_url(_request("http://10.0.0.5/")) == "http://10.0.0.5"
+
+    def test_falls_back_when_content_is_not_a_url(self, config_dir, caplog):
+        _write(config_dir, "lablink-allocator-lab.tailnet.ts.net")  # no scheme
+        assert canonical_base_url(_request("http://10.0.0.5/")) == "http://10.0.0.5"
+        assert "not an http(s) URL" in caplog.text
+
+    def test_falls_back_when_config_dir_does_not_exist(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("CONFIG_DIR", str(tmp_path / "nope"))
+        assert canonical_base_url(_request("http://10.0.0.5/")) == "http://10.0.0.5"
+
+    def test_reads_file_per_call_not_cached(self, config_dir):
+        """The CLI writes this file *after* `docker compose up` (Funnel can
+        only be enabled once the sidecar runs), so a value cached at import
+        would never be seen without restarting the allocator."""
+        assert canonical_base_url(_request("http://10.0.0.5/")) == "http://10.0.0.5"
+        _write(config_dir, "https://later.tailnet.ts.net")
+        assert canonical_base_url(_request()) == "https://later.tailnet.ts.net"
+
+    def test_rejects_scheme_lookalike(self, config_dir):
+        """Guards against a partial/garbled write being accepted as a URL."""
+        _write(config_dir, "https:/typo.tailnet.ts.net")
+        assert canonical_base_url(_request("http://10.0.0.5/")) == "http://10.0.0.5"
+
+
+class TestRegisterResponseUsesCanonicalUrl:
+    """The register response's allocator_url is what a BYO client writes into
+    client.env as ALLOCATOR_URL, so this is the value that has to be right."""
+
+    def test_register_response_prefers_canonical_url(self, reg_client, config_dir):
+        _write(config_dir, "https://lablink-allocator-lab.tailnet.ts.net")
+        client, _ = reg_client
+        r = client.post(
+            "/api/v1/clients/register",
+            json={"hostname": "vm-1", "machine_identity": "i-1"},
+            headers={"Authorization": "Bearer tk_test_register"},
+        )
+        assert r.status_code == 200
+        assert (
+            r.get_json()["allocator_url"]
+            == "https://lablink-allocator-lab.tailnet.ts.net"
+        )
+
+    def test_canonical_url_beats_spoofed_forwarded_headers(
+        self, reg_client, config_dir
+    ):
+        """The file is operator-supplied and local; a client-supplied
+        X-Forwarded-Host must not displace it."""
+        _write(config_dir, "https://real.tailnet.ts.net")
+        client, _ = reg_client
+        r = client.post(
+            "/api/v1/clients/register",
+            json={"hostname": "vm-1", "machine_identity": "i-1"},
+            headers={
+                "Authorization": "Bearer tk_test_register",
+                "X-Forwarded-Proto": "https",
+                "X-Forwarded-Host": "evil.example.com",
+            },
+        )
+        assert r.status_code == 200
+        body = r.get_json()
+        assert body["allocator_url"] == "https://real.tailnet.ts.net"
+        assert "evil.example.com" not in body["allocator_url"]
+
+    def test_register_falls_back_without_file(self, reg_client, config_dir):
+        """No file → unchanged pre-existing behaviour (the AWS/nginx path)."""
+        client, _ = reg_client
+        r = client.post(
+            "/api/v1/clients/register",
+            json={"hostname": "vm-1", "machine_identity": "i-1"},
+            headers={"Authorization": "Bearer tk_test_register"},
+        )
+        assert r.status_code == 200
+        assert r.get_json()["allocator_url"].startswith("http://")
+
+
+class TestByoOnboardingUsesCanonicalUrl:
+    """The worse of the two call sites: the admin copy-pastes this URL into
+    `lablink client register`, so a wrong scheme here breaks the registration
+    POST itself — the CLI-side ALLOCATOR_URL precedence fix can't rescue it,
+    because the broken URL *is* the caller's input."""
+
+    def test_page_renders_canonical_url(self, client, admin_headers, config_dir):
+        _write(config_dir, "https://lablink-allocator-lab.tailnet.ts.net")
+        response = client.get("/admin/byo-onboarding", headers=admin_headers)
+        assert response.status_code == 200
+        html = response.data.decode()
+        assert "https://lablink-allocator-lab.tailnet.ts.net" in html
+
+    def test_page_falls_back_without_file(self, client, admin_headers, config_dir):
+        response = client.get("/admin/byo-onboarding", headers=admin_headers)
+        assert response.status_code == 200
+        assert "--allocator-url" in response.data.decode()

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -1,5 +1,4 @@
 """Tests for the registration API + register-token at-rest hashing."""
-import pytest
 from unittest.mock import MagicMock
 
 
@@ -73,27 +72,6 @@ def test_require_client_secret_rejects_missing_header(monkeypatch):
 def test_require_client_secret_rejects_null_hash(monkeypatch):
     resp = _decorated(monkeypatch, None, "Bearer sek")
     assert resp[1] == 401
-
-
-@pytest.fixture
-def reg_client(app, monkeypatch):
-    from lablink_allocator_service import main
-    from lablink_allocator_service.secret_hash import hash_secret
-    from lablink_allocator_service.providers.connectivity.allocator_proxied import (
-        AllocatorProxiedClientConnectivity,
-    )
-
-    class _StubProvider:
-        client_connectivity = AllocatorProxiedClientConnectivity()
-
-    app.config["LABLINK_PROVIDER"] = _StubProvider()
-
-    fake_db = MagicMock()
-    fake_db.register_client.return_value = "vm-1"
-    monkeypatch.setattr(main, "database", fake_db, raising=False)
-    monkeypatch.setattr(main, "REGISTER_TOKEN", "tk_test_register", raising=False)
-    fake_db.get_setting.return_value = hash_secret("tk_test_register")
-    return app.test_client(), fake_db
 
 
 def test_register_rejects_bad_token(reg_client):

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -48,6 +48,13 @@ ALLOCATOR_INTERNAL_PORT = 5000
 FUNNEL_ACL_NOT_GRANTED_MARKER = "Funnel is not enabled on your tailnet"
 FUNNEL_ENABLE_MAX_ATTEMPTS = 5
 FUNNEL_ENABLE_RETRY_DELAY_SECONDS = 2
+# Name of the file carrying the allocator's real public URL, staged next to
+# config.yaml and bind-mounted to /config/<name>. Must stay in sync with
+# config_helpers.CANONICAL_URL_FILENAME in the allocator package — duplicated
+# rather than imported because each package's CI job installs only its own
+# dependencies, so a cross-package import would fail there. Guarded by
+# test_deploy_compose.py::TestCanonicalUrlFile::test_filename_matches_allocator.
+CANONICAL_URL_FILENAME = "allocator-url"
 
 console = Console()
 
@@ -185,6 +192,24 @@ def render_compose_dir(
     #    allocator's registration handler only forwards it to clients
     #    when cfg.startup_script.enabled is true AND the file is non-
     #    empty.
+    # 4b. Stage the canonical-URL file. Always materialized (empty when the
+    #     deployment isn't Funnel-exposed) so the compose bind mount resolves
+    #     on every deploy — same reason custom-startup.sh below always exists.
+    #     _enable_funnel fills it in after `compose up`, since Funnel can only
+    #     be turned on once the sidecar is running. An existing value is
+    #     preserved across a redeploy that stays Funnel-exposed, so the window
+    #     between container start and _enable_funnel doesn't fall back to
+    #     request.host_url; a deployment that turns exposure off is cleared,
+    #     which is what stops a stale public URL being handed to clients.
+    canonical_target = target / CANONICAL_URL_FILENAME
+    if cfg.manual.participant_exposure == "tailscale_funnel":
+        previous_url = (
+            canonical_target.read_text() if canonical_target.exists() else ""
+        )
+        canonical_target.write_text(previous_url)
+    else:
+        canonical_target.write_text("")
+
     startup_target = target / "custom-startup.sh"
     if cfg.startup_script.enabled and cfg.startup_script.path:
         user_script = Path.home() / ".lablink" / "custom-startup.sh"
@@ -390,6 +415,8 @@ def run_deploy_compose(
     funnel_url = None
     if cfg.manual.participant_exposure == "tailscale_funnel":
         funnel_ok, funnel_url = _enable_funnel()
+        if funnel_url:
+            _write_canonical_url(target, funnel_url)
     funnel_active = cfg.manual.participant_exposure == "tailscale_funnel" and funnel_ok
 
     _print_summary(cfg, funnel_active=funnel_active, funnel_url=funnel_url)
@@ -416,6 +443,28 @@ def _compose_up(target: Path) -> None:
     if result.returncode != 0:
         console.print("[red]docker compose up failed.[/red]")
         raise SystemExit(result.returncode or 1)
+
+
+def _write_canonical_url(target: Path, url: str) -> None:
+    """Publish the allocator's real public URL to the bind-mounted file the
+    allocator reads (see config_helpers.canonical_base_url).
+
+    Behind Funnel the allocator cannot work its own public URL out from the
+    request: Funnel injects no X-Forwarded-Proto, and manual deployments run
+    ssl.provider=none so the header-trust gate is shut anyway. It therefore
+    reports http://, which clients can only follow via a 302 that downgrades
+    their POSTs to GET. This file is the out-of-band channel that fixes that,
+    carrying the address `tailscale funnel status` actually reported — which
+    also picks up the numeric hostname suffixes (-2, -3, ...) that a name
+    collision with an offline node from a prior deploy produces.
+
+    Written IN PLACE, never via a temp file + rename: docker bind-mounts a
+    single file by inode, so a rename would leave the running container
+    reading the old file forever.
+    """
+    path = target / CANONICAL_URL_FILENAME
+    with path.open("w") as f:
+        f.write(f"{url.rstrip('/')}\n")
 
 
 FUNNEL_STATUS_URL_RE = re.compile(r"(https://\S+)\s*\(Funnel on\)")

--- a/packages/cli/src/lablink_cli/commands/status.py
+++ b/packages/cli/src/lablink_cli/commands/status.py
@@ -744,6 +744,26 @@ def _render_manual_clients_table(clients: list[dict]) -> None:
     console.print(table)
 
 
+def _public_url(workdir: Path) -> str | None:
+    """The participant-facing URL `lablink deploy` published for this stack.
+
+    Read from the canonical-URL file staged in the deployment dir (the same
+    file bind-mounted into the allocator, written from `tailscale funnel
+    status`). Empty on every deployment that isn't Funnel-exposed, in which
+    case there is no public URL to show and this returns None.
+    """
+    # Imported inside the function: deploy_compose imports
+    # check_health_endpoint from this module, so a module-level import here
+    # would close an import cycle.
+    from lablink_cli.commands.deploy_compose import CANONICAL_URL_FILENAME
+
+    try:
+        candidate = (workdir / CANONICAL_URL_FILENAME).read_text().strip()
+    except OSError:
+        return None
+    return candidate if candidate.startswith(("http://", "https://")) else None
+
+
 def _run_status_manual(cfg: Config) -> None:
     """Report compose stack health, allocator HTTP health, and BYO clients."""
     workdir = Path.home() / ".lablink" / "compose" / (
@@ -783,6 +803,28 @@ def _run_status_manual(cfg: Config) -> None:
             f"[yellow]Allocator not healthy at {base_url}/api/health[/yellow]"
         )
 
+    # localhost above is the local liveness probe; it is not the address
+    # participants (or BYO clients) use. When the stack is Funnel-exposed,
+    # surface the public URL too — and check it, since Funnel being off or
+    # the tailnet being down is invisible from a localhost probe.
+    public_url = _public_url(workdir)
+    if public_url:
+        label = (
+            "Tailscale Funnel"
+            if cfg.manual.participant_exposure == "tailscale_funnel"
+            else "public"
+        )
+        console.print(f"[bold]Public URL ({label}):[/bold] {public_url}")
+        public_health = check_health_endpoint(public_url)
+        if public_health.get("healthy"):
+            console.print(f"[green]Reachable at {public_url}/api/health[/green]")
+        else:
+            detail = public_health.get("detail") or public_health.get("status", "")
+            console.print(
+                f"[yellow]Not reachable at {public_url}/api/health"
+                f"{f' — {detail}' if detail else ''}[/yellow]"
+            )
+
     console.print()
     console.print("[bold]Registered Clients[/bold]")
     creds = _resolve_manual_admin_credentials(cfg, workdir)
@@ -790,7 +832,7 @@ def _run_status_manual(cfg: Config) -> None:
         console.print(
             "[yellow]Admin credentials not found in config — "
             "cannot list clients. Open the admin dashboard at "
-            f"{scheme}://localhost instead.[/yellow]"
+            f"{public_url or f'{scheme}://localhost'} instead.[/yellow]"
         )
         return
 

--- a/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
+++ b/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
@@ -37,6 +37,13 @@ services:
       # response — matching the AWS path where Terraform/user_data
       # delivers the same file to the client container.
       - ./custom-startup.sh:/config/custom-startup.sh:ro
+      # The allocator's real public URL, written by `lablink deploy` after it
+      # confirms Funnel is live. Behind Funnel the allocator can't derive this
+      # from the request (no X-Forwarded-Proto, and ssl.provider=none keeps the
+      # header-trust gate shut), so it would otherwise hand clients an http://
+      # URL that only 302-redirects. Always present, empty when not
+      # Funnel-exposed; the allocator falls back to the request host then.
+      - ./allocator-url:/config/allocator-url:ro
       - allocator_pgdata:/var/lib/postgresql
     ports:
       # The container's nginx listens on :5000 (see lablink-nginx.conf in

--- a/packages/cli/src/lablink_cli/templates/docker-compose.yml
+++ b/packages/cli/src/lablink_cli/templates/docker-compose.yml
@@ -33,6 +33,12 @@ services:
       # response — matching the AWS path where Terraform/user_data
       # delivers the same file to the client container.
       - ./custom-startup.sh:/config/custom-startup.sh:ro
+      # Always materialized by render_compose_dir, same as above. This variant
+      # of the stack has no Tailscale sidecar and so is never Funnel-exposed,
+      # leaving the file empty — the allocator then falls back to the request
+      # host, which is correct here. Mounted anyway so both templates present
+      # the allocator an identical /config layout.
+      - ./allocator-url:/config/allocator-url:ro
       - allocator_pgdata:/var/lib/postgresql
     ports:
       # The container's nginx listens on :5000 (see lablink-nginx.conf in

--- a/packages/cli/tests/conftest.py
+++ b/packages/cli/tests/conftest.py
@@ -2,9 +2,73 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+import subprocess
+from unittest.mock import MagicMock, patch
 
 import pytest
+
+
+@pytest.fixture(autouse=True)
+def no_real_docker(request):
+    """Stop tests from driving the developer's real Docker daemon.
+
+    The CLI shells out to `docker` against fixed container names —
+    `lablink-allocator-tailscale`, `lablink-client` — from deploy_compose,
+    register, log_shipper and the logs viewer. Several of those commands
+    mutate state: `_disable_funnel` runs `tailscale funnel --https=443 off`,
+    and register can `docker rm -f lablink-client`.
+
+    22 tests reach `run_deploy_compose` without mocking `_disable_funnel`, so
+    on a machine running a live LabLink stack a green test run silently turned
+    that deployment's Funnel off — the public URL simply stopped working, with
+    nothing in the test output to say so. Reproduced directly: Funnel on ->
+    `pytest tests/test_deploy_compose.py` (101 passed) -> "No serve config".
+
+    `docker volume inspect` leaked the other way: unmocked, it read the
+    developer's real volumes, so whether a test saw an existing
+    `<name>_tailscale_state` depended on what happened to be on their machine.
+
+    This guard answers every `docker` invocation with the not-found result a
+    machine with no such container or volume would give. That is the honest
+    model for a unit-test environment, and it is what the callers already
+    handle: `_disable_funnel` is documented best-effort and stays silent on
+    failure, `_tailscale_state_volume_exists` reports False. Tests that mean
+    to exercise a docker-invoking helper patch `subprocess.run` in their own
+    module, which takes precedence over this fixture and is restored after.
+
+    Non-docker subprocess calls pass straight through, and tests marked
+    ``integration`` opt out entirely — those are the ones that may legitimately
+    want a real daemon.
+    """
+    if request.node.get_closest_marker("integration"):
+        yield
+        return
+
+    real_run = subprocess.run
+
+    def guard(cmd, *args, **kwargs):
+        argv = cmd if isinstance(cmd, (list, tuple)) else [cmd]
+        if not argv or argv[0] != "docker":
+            return real_run(cmd, *args, **kwargs)
+        text_mode = bool(
+            kwargs.get("text")
+            or kwargs.get("universal_newlines")
+            or kwargs.get("encoding")
+        )
+        empty = "" if text_mode else b""
+        message = (
+            "Error response from daemon: No such container: "
+            "<docker disabled in tests>"
+        )
+        return subprocess.CompletedProcess(
+            args=list(argv),
+            returncode=1,
+            stdout=empty,
+            stderr=message if text_mode else message.encode(),
+        )
+
+    with patch.object(subprocess, "run", guard):
+        yield
 
 
 @pytest.fixture()

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -1743,3 +1743,264 @@ class TestExtractRegisterToken:
 
         mock_run.return_value = MagicMock(returncode=0, stdout="nothing relevant\n")
         assert _extract_register_token() is None
+
+
+class TestCanonicalUrlFile:
+    """The allocator-url file (issue #396): the out-of-band channel carrying
+    the allocator's real public URL, since behind Funnel it can't derive one
+    from the request (no X-Forwarded-Proto, and ssl.provider=none keeps the
+    header-trust gate shut), and would otherwise hand clients an http:// URL
+    that only 302-redirects — downgrading their POSTs to GET."""
+
+    def test_filename_matches_allocator_constant(self):
+        """The name is duplicated rather than imported, because each package's
+        CI job installs only its own dependencies. Parse the allocator source
+        with `ast` instead of importing it, so this check works in that
+        isolated env too."""
+        import ast
+
+        from lablink_cli.commands.deploy_compose import CANONICAL_URL_FILENAME
+
+        helpers = (
+            Path(__file__).resolve().parents[2]
+            / "allocator"
+            / "src"
+            / "lablink_allocator_service"
+            / "utils"
+            / "config_helpers.py"
+        )
+        assert helpers.exists(), helpers
+        tree = ast.parse(helpers.read_text())
+        found = {
+            t.id: node.value.value
+            for node in ast.walk(tree)
+            if isinstance(node, ast.Assign) and isinstance(node.value, ast.Constant)
+            for t in node.targets
+            if isinstance(t, ast.Name)
+        }
+        assert found.get("CANONICAL_URL_FILENAME") == CANONICAL_URL_FILENAME
+
+    def test_file_materialized_empty_when_exposure_off(self, tmp_path):
+        """Always created so the compose bind mount resolves; empty means the
+        allocator falls back to the request host, which is right here."""
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            render_compose_dir,
+        )
+
+        cfg = _manual_cfg(connectivity="lan_direct", participant_exposure="none")
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        path = target / CANONICAL_URL_FILENAME
+        assert path.exists()
+        assert path.read_text() == ""
+
+    def test_file_materialized_when_funnel_enabled(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            render_compose_dir,
+        )
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            participant_exposure="tailscale_funnel",
+            overlay_tailnet="example.ts.net",
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-abc")
+
+        assert (target / CANONICAL_URL_FILENAME).exists()
+
+    def test_redeploy_preserves_url_while_funnel_stays_on(self, tmp_path):
+        """Otherwise the window between container start and _enable_funnel
+        would serve a fallback http:// URL to any client registering then."""
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            _write_canonical_url,
+            render_compose_dir,
+        )
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            participant_exposure="tailscale_funnel",
+            overlay_tailnet="example.ts.net",
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-abc")
+        _write_canonical_url(target, "https://lablink-allocator-testlab.example.ts.net")
+
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-abc")
+        content = (target / CANONICAL_URL_FILENAME).read_text()
+        assert "https://lablink-allocator-testlab.example.ts.net" in content
+
+    def test_turning_exposure_off_clears_the_url(self, tmp_path):
+        """A stale public URL must not keep being handed to clients after the
+        operator sets participant_exposure back to none."""
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            _write_canonical_url,
+            render_compose_dir,
+        )
+
+        target = tmp_path / "compose"
+        funnel_cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            participant_exposure="tailscale_funnel",
+            overlay_tailnet="example.ts.net",
+        )
+        render_compose_dir(funnel_cfg, target, tailscale_authkey="tskey-abc")
+        _write_canonical_url(target, "https://old.example.ts.net")
+
+        off_cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            participant_exposure="none",
+            overlay_tailnet="example.ts.net",
+        )
+        render_compose_dir(off_cfg, target, tailscale_authkey="tskey-abc")
+        assert (target / CANONICAL_URL_FILENAME).read_text() == ""
+
+    def test_write_strips_trailing_slash(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            _write_canonical_url,
+        )
+
+        target = tmp_path / "compose"
+        target.mkdir()
+        _write_canonical_url(target, "https://foo.example.ts.net/")
+        assert (target / CANONICAL_URL_FILENAME).read_text() == (
+            "https://foo.example.ts.net\n"
+        )
+
+    def test_write_is_in_place_not_a_rename(self, tmp_path):
+        """docker bind-mounts a single file by inode: replacing the file via
+        temp+rename would leave the running container reading the old one
+        forever. Pin the inode so nobody 'improves' this into a rename."""
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            _write_canonical_url,
+        )
+
+        target = tmp_path / "compose"
+        target.mkdir()
+        path = target / CANONICAL_URL_FILENAME
+        path.write_text("")
+        before = path.stat().st_ino
+
+        _write_canonical_url(target, "https://foo.example.ts.net")
+        assert path.stat().st_ino == before
+
+    @pytest.mark.parametrize(
+        "connectivity,exposure",
+        [
+            ("lan_direct", "none"),
+            ("mesh_overlay", "none"),
+        ],
+    )
+    def test_every_non_funnel_topology_leaves_the_file_empty(
+        self, connectivity, exposure, tmp_path
+    ):
+        """Blast-radius guard. The valid deployment topologies are: aws (which
+        never renders a compose dir at all), manual+lan_direct+none,
+        manual+mesh_overlay+none, and manual+mesh_overlay+tailscale_funnel
+        (lan_direct+funnel is rejected by validate_config). Only the last one
+        may ever get a URL here — every other manual topology must leave the
+        file empty so the allocator falls back to request.host_url exactly as
+        it did before this feature existed."""
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            render_compose_dir,
+        )
+
+        cfg = _manual_cfg(
+            connectivity=connectivity,
+            participant_exposure=exposure,
+            overlay_tailnet="example.ts.net" if connectivity == "mesh_overlay" else "",
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-abc")
+        assert (target / CANONICAL_URL_FILENAME).read_text() == ""
+
+    @pytest.mark.parametrize(
+        "template", ["docker-compose.yml", "docker-compose-mesh-overlay.yml"]
+    )
+    def test_both_templates_mount_the_file(self, template):
+        """Both variants mount it so the allocator sees an identical /config
+        layout regardless of which stack is running."""
+        from importlib import resources
+
+        content = (
+            resources.files("lablink_cli.templates").joinpath(template).read_text()
+        )
+        assert "./allocator-url:/config/allocator-url:ro" in content
+
+    def test_rendered_compose_mount_resolves(self, tmp_path):
+        """The mount source must exist after render, or docker refuses the
+        run — the same trap custom-startup.sh's always-materialize avoids."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(connectivity="lan_direct", participant_exposure="none")
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        compose = (target / "docker-compose.yml").read_text()
+        assert "./allocator-url:/config/allocator-url:ro" in compose
+        assert (target / "allocator-url").exists()
+
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    @patch("lablink_cli.commands.deploy_compose._enable_funnel")
+    def test_deploy_writes_url_reported_by_funnel_status(
+        self, mock_funnel, mock_up, mock_poll, mock_summary, tmp_path
+    ):
+        """The written value comes from `tailscale funnel status`, not from the
+        configured hostname — that's what picks up the numeric suffixes (-2,
+        -3, ...) a name collision with an offline prior-deploy node produces."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        mock_funnel.return_value = (True, "https://lablink-allocator-testlab-3.example.ts.net")
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            participant_exposure="tailscale_funnel",
+            overlay_tailnet="example.ts.net",
+            admin_password="a-strong-enough-password",
+        )
+        run_deploy_compose(
+            cfg, yes=True, workdir_root=tmp_path, tailscale_authkey="tskey-abc"
+        )
+
+        written = (tmp_path / "testlab" / "allocator-url").read_text()
+        assert written == "https://lablink-allocator-testlab-3.example.ts.net\n"
+
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    @patch("lablink_cli.commands.deploy_compose._enable_funnel")
+    def test_deploy_leaves_file_alone_when_status_url_unknown(
+        self, mock_funnel, mock_up, mock_poll, mock_summary, tmp_path
+    ):
+        """Funnel enabled but the URL couldn't be parsed: keep the last known
+        value rather than clearing it, since an empty file falls back to the
+        known-broken http:// host URL."""
+        from lablink_cli.commands.deploy_compose import (
+            _write_canonical_url,
+            run_deploy_compose,
+        )
+
+        mock_funnel.return_value = (True, None)
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            participant_exposure="tailscale_funnel",
+            overlay_tailnet="example.ts.net",
+            admin_password="a-strong-enough-password",
+        )
+        target = tmp_path / "testlab"
+        target.mkdir(parents=True)
+        _write_canonical_url(target, "https://known.example.ts.net")
+
+        run_deploy_compose(
+            cfg, yes=True, workdir_root=tmp_path, tailscale_authkey="tskey-abc"
+        )
+        assert "https://known.example.ts.net" in (target / "allocator-url").read_text()

--- a/packages/cli/tests/test_docker_isolation.py
+++ b/packages/cli/tests/test_docker_isolation.py
@@ -1,0 +1,83 @@
+"""Regression tests for the `no_real_docker` autouse guard in conftest.
+
+The CLI drives `docker` against fixed container names, and some of those
+commands mutate state — `_disable_funnel` runs `tailscale funnel --https=443
+off` on `lablink-allocator-tailscale`, register can `docker rm -f
+lablink-client`. Without isolation, running the unit suite on a machine with a
+live LabLink stack silently broke that deployment: Funnel went off and the
+public URL stopped serving, while the test run reported 101 passed.
+
+These tests pin the guard so that protection cannot be quietly lost.
+"""
+
+import subprocess
+
+from unittest.mock import MagicMock, patch
+
+
+def test_docker_commands_never_reach_the_real_daemon():
+    result = subprocess.run(
+        ["docker", "ps"], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 1
+    assert "docker disabled in tests" in result.stderr
+
+
+def test_state_mutating_docker_commands_are_intercepted_too():
+    """The dangerous ones, named explicitly: turning off a live deployment's
+    Funnel, and force-removing a registered client's container."""
+    for argv in (
+        ["docker", "exec", "lablink-allocator-tailscale",
+         "tailscale", "funnel", "--https=443", "off"],
+        ["docker", "rm", "-f", "lablink-client"],
+        ["docker", "compose", "up", "-d"],
+    ):
+        result = subprocess.run(argv, capture_output=True, text=True, check=False)
+        assert result.returncode == 1, argv
+        assert "docker disabled in tests" in result.stderr, argv
+
+
+def test_guard_respects_bytes_mode():
+    """register.py calls `docker start` without text=True and decodes stderr
+    itself, so the guard must hand back bytes there."""
+    result = subprocess.run(["docker", "start", "x"], capture_output=True, check=False)
+    assert isinstance(result.stderr, bytes)
+    assert b"docker disabled in tests" in result.stderr
+
+
+def test_non_docker_commands_still_run():
+    result = subprocess.run(
+        ["echo", "hello"], capture_output=True, text=True, check=False
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "hello"
+
+
+def test_disable_funnel_is_a_silent_noop_under_the_guard():
+    """_disable_funnel is documented best-effort, so the not-found result the
+    guard returns must leave it silent rather than erroring."""
+    from lablink_cli.commands.deploy_compose import _disable_funnel
+
+    _disable_funnel()  # must not raise
+
+
+def test_tailscale_state_volume_lookup_is_deterministic(tmp_path):
+    """Unmocked, this read the developer's real volumes — so whether a test
+    saw an existing <name>_tailscale_state depended on their machine."""
+    from lablink_cli.commands.deploy_compose import _tailscale_state_volume_exists
+
+    assert _tailscale_state_volume_exists(tmp_path / "sleap-lablink") is False
+
+
+def test_explicit_patches_still_take_precedence():
+    """Tests that mean to exercise a docker-invoking helper patch
+    subprocess.run in their own module; that must win over the guard."""
+    from lablink_cli.commands import deploy_compose as dc
+
+    with patch.object(dc.subprocess, "run") as mock_run:
+        mock_run.return_value = MagicMock(returncode=0, stdout="", stderr="")
+        dc._disable_funnel()
+        assert mock_run.call_args[0][0] == [
+            "docker", "exec", "lablink-allocator-tailscale",
+            "tailscale", "funnel", "--https=443", "off",
+        ]

--- a/packages/cli/tests/test_status.py
+++ b/packages/cli/tests/test_status.py
@@ -556,3 +556,110 @@ class TestManualStatus:
         # Health URL should use https scheme for self_signed.
         called_url = mock_health.call_args[0][0]
         assert called_url.startswith("https://")
+
+
+class TestManualStatusPublicUrl:
+    """`lablink status` must surface the participant-facing URL, not just the
+    localhost liveness probe — on a Funnel deployment localhost is not an
+    address any participant or BYO client can use."""
+
+    @staticmethod
+    def _workdir(tmp_path, url=None):
+        wd = tmp_path / ".lablink" / "compose" / "testlab"
+        wd.mkdir(parents=True)
+        if url is not None:
+            (wd / "allocator-url").write_text(url)
+        return wd
+
+    @patch("lablink_cli.commands.status.subprocess.run")
+    @patch("lablink_cli.commands.status.check_health_endpoint")
+    def test_shows_funnel_url_and_checks_it(
+        self, mock_health, mock_subproc, capsys, mock_cfg, tmp_path,
+    ):
+        from lablink_cli.commands.status import run_status
+
+        mock_cfg.provider = "manual"
+        mock_cfg.deployment_name = "testlab"
+        mock_cfg.manual.participant_exposure = "tailscale_funnel"
+        self._workdir(tmp_path, "https://lablink-allocator-testlab.example.ts.net\n")
+        mock_subproc.return_value = MagicMock(returncode=0, stdout="")
+        mock_health.return_value = {"healthy": True, "detail": ""}
+
+        with patch("lablink_cli.commands.status.Path.home", return_value=tmp_path):
+            run_status(mock_cfg)
+
+        out = capsys.readouterr().out
+        assert "https://lablink-allocator-testlab.example.ts.net" in out
+        assert "Tailscale Funnel" in out
+        # Probed in addition to localhost, not instead of it.
+        probed = [c.args[0] for c in mock_health.call_args_list]
+        assert "https://lablink-allocator-testlab.example.ts.net" in probed
+        assert any("localhost" in p for p in probed)
+
+    @patch("lablink_cli.commands.status.subprocess.run")
+    @patch("lablink_cli.commands.status.check_health_endpoint")
+    def test_reports_unreachable_funnel_url(
+        self, mock_health, mock_subproc, capsys, mock_cfg, tmp_path,
+    ):
+        """A dead Funnel is invisible to a localhost probe — the whole reason
+        to check the public URL separately."""
+        from lablink_cli.commands.status import run_status
+
+        mock_cfg.provider = "manual"
+        mock_cfg.deployment_name = "testlab"
+        mock_cfg.manual.participant_exposure = "tailscale_funnel"
+        self._workdir(tmp_path, "https://lablink-allocator-testlab.example.ts.net")
+        mock_subproc.return_value = MagicMock(returncode=0, stdout="")
+        mock_health.side_effect = [
+            {"healthy": True, "detail": ""},                      # localhost
+            {"healthy": False, "detail": "connection refused"},   # funnel
+        ]
+
+        with patch("lablink_cli.commands.status.Path.home", return_value=tmp_path):
+            run_status(mock_cfg)
+
+        out = capsys.readouterr().out
+        assert "Not reachable" in out
+        assert "connection refused" in out
+
+    @patch("lablink_cli.commands.status.subprocess.run")
+    @patch("lablink_cli.commands.status.check_health_endpoint")
+    def test_no_public_url_line_when_not_exposed(
+        self, mock_health, mock_subproc, capsys, mock_cfg, tmp_path,
+    ):
+        """Non-Funnel deployments stage the file empty; nothing extra printed
+        and no second probe fired."""
+        from lablink_cli.commands.status import run_status
+
+        mock_cfg.provider = "manual"
+        mock_cfg.deployment_name = "testlab"
+        mock_cfg.manual.participant_exposure = "none"
+        self._workdir(tmp_path, "")
+        mock_subproc.return_value = MagicMock(returncode=0, stdout="")
+        mock_health.return_value = {"healthy": True, "detail": ""}
+
+        with patch("lablink_cli.commands.status.Path.home", return_value=tmp_path):
+            run_status(mock_cfg)
+
+        assert "Public URL" not in capsys.readouterr().out
+        assert mock_health.call_count == 1
+
+    @patch("lablink_cli.commands.status.subprocess.run")
+    @patch("lablink_cli.commands.status.check_health_endpoint")
+    def test_missing_file_is_not_an_error(
+        self, mock_health, mock_subproc, capsys, mock_cfg, tmp_path,
+    ):
+        """A deployment dir rendered by an older CLI has no such file."""
+        from lablink_cli.commands.status import run_status
+
+        mock_cfg.provider = "manual"
+        mock_cfg.deployment_name = "testlab"
+        mock_cfg.manual.participant_exposure = "none"
+        self._workdir(tmp_path, None)
+        mock_subproc.return_value = MagicMock(returncode=0, stdout="")
+        mock_health.return_value = {"healthy": True, "detail": ""}
+
+        with patch("lablink_cli.commands.status.Path.home", return_value=tmp_path):
+            run_status(mock_cfg)
+
+        assert "Public URL" not in capsys.readouterr().out


### PR DESCRIPTION
Fixes #396.

Three related commits: the #396 fix itself, surfacing the resulting URL in `lablink status`, and a test-isolation bug found while verifying both.

---

## 1. The #396 fix

Behind Tailscale Funnel the allocator cannot work out its own public URL from the request, so both call sites that echo one back reported `http://` even for requests that arrived over Funnel's HTTPS:

- **`routes/registration.py:102`** — the register response's `allocator_url`, which a BYO client writes straight into `client.env` as `ALLOCATOR_URL`.
- **`main.py:384`** (`byo_onboarding`) — the copy-pasteable `lablink client register` command on `/admin/byo-onboarding`. This one is worse: the CLI's `_write_env_file` precedence fix can't rescue it, because the broken URL *is* the admin's input.

**Root cause.** `ProxyFix` only trusts `X-Forwarded-Proto` when `should_use_https(cfg)` is true, and manual deployments only ever support `ssl.provider: none` (Funnel is a separate `participant_exposure` axis), so the gate stays shut. Funnel injects no `X-Forwarded-Proto` of its own either, so there is no in-request signal even if the gate were open.

Worth noting: on a Funnel deployment nothing listens on port 80, so an `http://` allocator URL does not merely 302 — it **refuses the connection**, surfacing as `curl: (7) Couldn't connect to server` in the client's `send_status`.

**Fix.** `lablink deploy` publishes the address `tailscale funnel status` actually reports to a file staged beside `config.yaml` and bind-mounted at `/config/allocator-url`. Both call sites prefer it via a new `config_helpers.canonical_base_url()`, falling back to `request.host_url` when it is missing, empty, or not an http(s) URL.

Using `funnel status` rather than deriving from config is what picks up the numeric hostname suffixes (`-2`, `-3`, …) a collision with an offline node from a prior deploy produces.

Two load-bearing details:

- **Read per request.** The CLI can only write the file *after* `docker compose up` — Funnel cannot be enabled until the sidecar runs — so the allocator must pick it up without a restart.
- **Written in place, never temp+rename.** Docker bind-mounts a single file by inode; a rename would leave the container reading the old file forever. `test_write_is_in_place_not_a_rename` pins the inode.

The filename constant is duplicated in the CLI rather than imported (each package's CI job installs only its own dependencies); `test_filename_matches_allocator_constant` AST-parses the allocator source to catch drift.

### Blast radius

| Topology | `allocator-url` | Resolves to |
|---|---|---|
| `aws` | absent (no compose dir — Terraform) | `request.host_url` — unchanged |
| `manual + lan_direct + none` | empty | `request.host_url` — unchanged |
| `manual + mesh_overlay + none` | empty | `request.host_url` — unchanged |
| `manual + mesh_overlay + tailscale_funnel` | the Funnel URL | **fixed** |

`lan_direct + tailscale_funnel` is unreachable — rejected by `validate_config` and `run_deploy_compose`'s preflight. Guarded by `test_every_non_funnel_topology_leaves_the_file_empty`.

---

## 2. `lablink status` shows the public URL

`status` only reported `http://localhost` — the local liveness probe, not an address any participant or BYO client can use. It now also prints the Funnel URL and probes it, reading from the same canonical file so status and the allocator share one source of truth. A dead Funnel is completely invisible to a localhost check.

```
Allocator healthy at http://localhost/api/health
Public URL (Tailscale Funnel): https://lablink-allocator-sleap-lablink.tail9f6f81.ts.net
Reachable at https://lablink-allocator-sleap-lablink.tail9f6f81.ts.net/api/health
```

Printed only when the file holds a URL, so non-Funnel deployments and dirs rendered by an older CLI are unchanged, and no second probe fires.

---

## 3. The test suite was turning off live Funnel deployments

Found while verifying the above. `_disable_funnel()` runs `docker exec lablink-allocator-tailscale tailscale funnel --https=443 off` against a **fixed container name**, and 22 tests reach `run_deploy_compose` without mocking it. On a machine running a live LabLink stack:

```
funnel before: on
pytest tests/test_deploy_compose.py  ->  101 passed
funnel after:  No serve config
```

A green test run, and the deployment's public link is dead. This is the likeliest explanation for a Funnel URL that "fails at some point and works again at another" — run tests, link dies; redeploy, link returns. `register.py` can also `docker rm -f lablink-client`, and `docker volume inspect` leaked the other way, making tests depend on the developer's real volumes.

An autouse fixture now answers every `docker` invocation with the not-found result a machine with no such container would give — the honest model for a unit-test environment, and what the callers already handle (`_disable_funnel` is best-effort and silent; `_tailscale_state_volume_exists` reports False). **No existing test needed changing.** Explicit `subprocess.run` patches still take precedence, and `integration`-marked tests opt out.

This bug predates both of my PRs — it came in with the participant-exposure work.

---

## Testing

Verified live against a real Funnel deployment — **same container, `RestartCount=0`**, both requests through the **public Funnel ingress** (`208.111.34.11`):

```
file emptied  -> http://lablink-allocator-sleap-lablink.tail9f6f81.ts.net   (reproduces the bug)
file present  -> https://lablink-allocator-sleap-lablink.tail9f6f81.ts.net
byo-onboarding: --allocator-url https://lablink-allocator-sleap-lablink.tail9f6f81.ts.net
```

Zero restarts is the evidence the per-request read works. And with the guard in place, the full suite leaves a live Funnel untouched (on → 662 passed → still on).

```
allocator:  766 passed, 19 skipped   (tests/terraform excluded — needs AWS creds)
cli:        662 passed, 1 deselected
ruff:       All checks passed
```

## Also

Corrects CLAUDE.md's allocator dev-build command: `Dockerfile.dev`'s `COPY` paths are relative to `packages/allocator/`, so building from the repo root fails with `"/start.sh": not found`, and `--platform linux/amd64` is required on Apple Silicon (amd64-only kasmvncserver `.deb`, apt exit 100 otherwise). Both hit while verifying this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)