### PR TITLE
fix(allocator+cli): clone the configured repository on BYO clients (#405)

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -147,10 +147,23 @@ def register_client():
         "push_interval_seconds": main.cfg.monitoring.push_interval_seconds,
     }
 
+    # cfg.machine settings the AWS path delivers as `docker run -e` flags
+    # in terraform/user_data.sh. The register response is the manual/BYO
+    # path's only equivalent channel, so ship them here and let the CLI
+    # write them into the client's env file under the same names
+    # client/start.sh already reads (lablink#405). `repository` is
+    # Optional and normalized to "" — a JSON null would round-trip through
+    # the CLI's env file as the literal string "None" and start.sh's `-n`
+    # check would pass, making it `git clone None`.
+    repository = main.cfg.machine.repository or ""
+    subject_software = main.cfg.machine.software or ""
+
     return jsonify(
         client_id=client_id,
         client_secret=client_secret,
         agent_token=main.AGENT_TOKEN,
+        repository=repository,
+        subject_software=subject_software,
         register_token=jm.register_token,
         allocator_url=jm.allocator_url,
         connectivity=jm.connectivity,

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -136,6 +136,45 @@ def test_register_client_image_is_machine_image_only(reg_client):
     assert r.get_json()["client_image"] == main.cfg.machine.image
 
 
+def test_register_ships_repository_and_subject_software(reg_client):
+    """The register response is the manual/BYO path's only channel for
+    cfg.machine settings that the AWS path delivers via user_data.sh's
+    `docker run -e` flags. Without `repository` here, the BYO client's
+    start.sh sees an unset TUTORIAL_REPO_TO_CLONE and logs "Skipping
+    clone step" (lablink#405); without `subject_software` it launches
+    update_inuse_status with an empty client.software, which matches no
+    process at all."""
+    client, _ = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": "vm-1", "machine_identity": "i-1"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    from lablink_allocator_service import main
+    body = r.get_json()
+    assert body["repository"] == main.cfg.machine.repository
+    assert body["subject_software"] == main.cfg.machine.software
+
+
+def test_register_repository_absent_returns_empty_string(reg_client, monkeypatch):
+    """cfg.machine.repository is Optional and defaults to None. jsonify
+    would emit a JSON null, which the CLI would then write into the env
+    file as the literal string "None" and start.sh would happily `git
+    clone None`. Normalize to "" so the CLI's falsy check skips the var
+    entirely."""
+    from lablink_allocator_service import main
+    monkeypatch.setattr(main.cfg.machine, "repository", None, raising=False)
+    client, _ = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": "vm-1", "machine_identity": "i-1"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    assert r.get_json()["repository"] == ""
+
+
 def test_status_requires_client_secret(reg_client):
     client, fake_db = reg_client
     fake_db.get_client_secret_hash.return_value = None

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -378,6 +378,20 @@ def _write_env_file(
         f"CLIENT_IMAGE={resp['client_image']}",
         f"REGISTER_RESPONSE={register_response_json}",
     ]
+    # cfg.machine.repository / cfg.machine.software, shipped by the
+    # allocator's register response. These reach an AWS client through
+    # user_data.sh's `docker run -e TUTORIAL_REPO_TO_CLONE=... -e
+    # SUBJECT_SOFTWARE=...`; on a BYO box this env file is the only
+    # channel, and without them start.sh logs "TUTORIAL_REPO_TO_CLONE not
+    # set. Skipping clone step." and launches update_inuse_status with an
+    # empty client.software (lablink#405). Omitted entirely when unset so
+    # the --no-run-locally paste-into-Run:AI printout stays clean; a bare
+    # `VAR=` would be equivalent to start.sh's `-n` check either way.
+    # Absent keys (older allocator, newer CLI) behave the same as unset.
+    if resp.get("repository"):
+        lines.append(f"TUTORIAL_REPO_TO_CLONE={resp['repository']}")
+    if resp.get("subject_software"):
+        lines.append(f"SUBJECT_SOFTWARE={resp['subject_software']}")
     if overlay_hostname is not None:
         # Written so a nested `docker run --env-file` (the run_locally
         # path) carries these into the container automatically —

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -361,6 +361,99 @@ class TestOverlayHostnamePath:
         assert not tmp_env_file.exists()
 
 
+class TestRepositoryAndSoftwareEnv:
+    """lablink#405 — the BYO client container never cloned the configured
+    repository because `~/.lablink/client.env` carried no
+    TUTORIAL_REPO_TO_CLONE. start.sh gates the clone on that var, and the
+    env file is the only way it reaches a manual/BYO box (the AWS path
+    uses user_data.sh's `docker run -e` flags instead)."""
+
+    @staticmethod
+    def _register(tmp_env_file, resp, mock_detect, mock_client_cls,
+                  mock_which, mock_subproc_run):
+        from lablink_cli.commands.register import run_register
+
+        mock_detect.detect_hostname.return_value = "byo-01"
+        mock_detect.detect_lan_ip.return_value = "192.168.1.42"
+        mock_detect.resolve_machine_identity.return_value = "mid-abc"
+        mock_detect.detect_gpu.return_value = (False, None)
+
+        mock_client = MagicMock()
+        mock_client.register.return_value = resp
+        mock_client_cls.return_value = mock_client
+        mock_which.return_value = "/usr/bin/docker"
+        mock_subproc_run.return_value = MagicMock(
+            returncode=0, stdout="cgroupfs\n"
+        )
+
+        run_register(**_kwargs(tmp_env_file))
+        return tmp_env_file.read_text()
+
+    @patch("lablink_cli.commands.register.subprocess.Popen")
+    @patch("lablink_cli.commands.register.subprocess.run")
+    @patch("lablink_cli.commands.register.shutil.which")
+    @patch("lablink_cli.commands.register.RegistrationClient")
+    @patch("lablink_cli.commands.register.byo_detect")
+    def test_env_file_carries_repository_and_software(
+        self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
+        mock_popen, tmp_env_file, successful_response,
+    ):
+        resp = dict(
+            successful_response,
+            repository="https://github.com/talmolab/sleap-tutorial-data.git",
+            subject_software="sleap",
+        )
+        content = self._register(
+            tmp_env_file, resp, mock_detect, mock_client_cls,
+            mock_which, mock_subproc_run,
+        )
+        assert (
+            "TUTORIAL_REPO_TO_CLONE="
+            "https://github.com/talmolab/sleap-tutorial-data.git"
+        ) in content
+        assert "SUBJECT_SOFTWARE=sleap" in content
+
+    @patch("lablink_cli.commands.register.subprocess.Popen")
+    @patch("lablink_cli.commands.register.subprocess.run")
+    @patch("lablink_cli.commands.register.shutil.which")
+    @patch("lablink_cli.commands.register.RegistrationClient")
+    @patch("lablink_cli.commands.register.byo_detect")
+    def test_env_file_omits_empty_repository_and_software(
+        self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
+        mock_popen, tmp_env_file, successful_response,
+    ):
+        """An unset cfg.machine.repository must leave the var out entirely
+        rather than emit a bare `TUTORIAL_REPO_TO_CLONE=`. Both are
+        equivalent to start.sh's `-n` check, but an absent line keeps the
+        --no-run-locally paste-into-Run:AI printout free of noise."""
+        resp = dict(successful_response, repository="", subject_software="")
+        content = self._register(
+            tmp_env_file, resp, mock_detect, mock_client_cls,
+            mock_which, mock_subproc_run,
+        )
+        assert "TUTORIAL_REPO_TO_CLONE" not in content
+        assert "SUBJECT_SOFTWARE" not in content
+
+    @patch("lablink_cli.commands.register.subprocess.Popen")
+    @patch("lablink_cli.commands.register.subprocess.run")
+    @patch("lablink_cli.commands.register.shutil.which")
+    @patch("lablink_cli.commands.register.RegistrationClient")
+    @patch("lablink_cli.commands.register.byo_detect")
+    def test_env_file_omits_vars_when_allocator_predates_fix(
+        self, mock_detect, mock_client_cls, mock_which, mock_subproc_run,
+        mock_popen, tmp_env_file, successful_response,
+    ):
+        """A newer CLI against an older allocator gets a response with
+        neither key. That must not raise — just fall back to today's
+        (repo-less) behaviour."""
+        content = self._register(
+            tmp_env_file, dict(successful_response), mock_detect,
+            mock_client_cls, mock_which, mock_subproc_run,
+        )
+        assert "TUTORIAL_REPO_TO_CLONE" not in content
+        assert "SUBJECT_SOFTWARE" not in content
+
+
 class TestSuccessFlow:
     @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")


### PR DESCRIPTION
## Summary

- BYO/manual clients never cloned `machine.repository` — `client/start.sh` gates its `git clone` on `$TUTORIAL_REPO_TO_CLONE`, and nothing on the manual path ever set it.
- Ships `repository` and `subject_software` in the register response, and writes them into the client's env file under the names `start.sh` already reads.
- No client-image change required.

## The bug

`client/start.sh:121`:

```bash
if [ -n "$TUTORIAL_REPO_TO_CLONE" ]; then ... else echo "TUTORIAL_REPO_TO_CLONE not set. Skipping clone step."
```

The AWS path sets it from `cfg.machine.repository` in `terraform/user_data.sh:178` (`-e TUTORIAL_REPO_TO_CLONE="${repository}"`). The manual/BYO path's **only** channel to the client container is the register handshake → `~/.lablink/client.env` → `docker run --env-file`, and neither end carried it:

- `routes/registration.py` returned `client_image`, `startup_script_b64`, `monitoring`, … but never `cfg.machine.repository`. It appeared only in the comment warning *not* to concatenate it onto `client_image`.
- `_write_env_file` wrote 11 vars, none of them `TUTORIAL_REPO_TO_CLONE`.

So BYO containers started, logged the "skipping clone step" line, and came up with nothing on the Desktop.

**`SUBJECT_SOFTWARE` was the same gap one line over** in `user_data.sh:180`. Without it, `start.sh:361` ran `update_inuse_status client.software=` — an empty `process_name`, matching no process — and `start.sh:398` left the monitoring config's `client_software` label blank on BYO clients.

## Changes Made

| File | Change |
|---|---|
| `allocator/routes/registration.py` | Register response ships `repository` + `subject_software` from `cfg.machine` |
| `cli/commands/register.py` (`_write_env_file`) | Writes `TUTORIAL_REPO_TO_CLONE=` / `SUBJECT_SOFTWARE=`, omitting each when unset |

The `--no-run-locally` mesh-overlay hand-off printout picks both up for free — it dumps the env file verbatim for pasting into a Run:AI workload.

## Design Decisions

- **Env vars over parsing `REGISTER_RESPONSE` in `start.sh`.** The full response JSON is already in the container, so `start.sh` could read `repository` from it — but that would mean editing and republishing the client image, and BYO boxes pull whatever `resp["client_image"]` points at. Reusing the var names the AWS path already sets keeps the client image untouched and makes both providers converge on one code path in `start.sh`.
- **`repository` normalized to `""` on the allocator side.** The field is `Optional[str]`. A JSON `null` would round-trip through the CLI's env file as the literal string `"None"`, pass `start.sh`'s `-n` check, and run `git clone None`.
- **Lines omitted rather than emitted empty.** `TUTORIAL_REPO_TO_CLONE=` and an absent line are equivalent to `start.sh`'s `-n` test, but omitting keeps the `--no-run-locally` paste-into-Run:AI output free of noise.
- **`resp.get()`, not `resp[...]`.** A newer CLI against an older allocator degrades to the previous repo-less behaviour instead of raising.

## Related Issues

Closes #405

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)