### PR TITLE
fix(client+allocator): report the overlay hostname Tailscale actually assigned (#404)

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -251,6 +251,44 @@ class VmDatabase:
             return None
         return row[0]
 
+    def set_overlay_hostname(
+        self, *, hostname: str, overlay_hostname: str
+    ) -> bool:
+        """Reconcile a mesh-overlay client's recorded overlay hostname with
+        the name Tailscale actually assigned it.
+
+        `tailscale up --hostname=X` does NOT guarantee the node is named X:
+        if an earlier (possibly offline) node still holds X, Tailscale
+        appends a numeric suffix and still exits 0. The name we recorded at
+        registration is therefore only a *request*, and after any
+        re-registration it can point at a dead node — every allocator ->
+        client dial then black-holes (lablink#404). The client reports the
+        real name after joining; this persists it.
+
+        Guarded on the key already existing so this can only ever correct a
+        mesh-overlay client: a lan_direct or AWS client cannot have an
+        `overlay_hostname` injected into its provider_metadata. Returns True
+        when a row was updated, False for an unknown or non-overlay host.
+        """
+        query = (
+            f"UPDATE {self.table_name} "
+            f"SET provider_metadata = jsonb_set("
+            f"    COALESCE(provider_metadata, '{{}}'::jsonb), "
+            f"    '{{overlay_hostname}}', to_jsonb(%s::text), true) "
+            f"WHERE hostname = %s "
+            f"  AND provider_metadata ? 'overlay_hostname';"
+        )
+        with self._cursor as cursor:
+            try:
+                cursor.execute(query, (overlay_hostname, hostname))
+                return cursor.rowcount > 0
+            except Exception as e:
+                logger.error(
+                    f"Failed to set overlay hostname for VM "
+                    f"'{hostname}': {e}"
+                )
+                raise
+
     def list_hosts_by_provider(self, provider: str) -> list:
         with self._cursor as cursor:
             cursor.execute(

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -1,4 +1,6 @@
-"""POST /api/v1/clients/register and GET /api/v1/clients/<id>/status.
+"""POST /api/v1/clients/register, GET /api/v1/clients/<id>/status, and
+POST /api/overlay-hostname (a mesh-overlay client correcting the overlay
+hostname it was recorded under — see report_overlay_hostname).
 
 Lazy-imports `main` inside views to avoid the module-load import cycle
 (main imports this blueprint at startup). Mirrors the rationale behind
@@ -13,7 +15,7 @@ import secrets
 
 from flask import Blueprint, current_app, jsonify, request
 
-from lablink_allocator_service.auth import auth
+from lablink_allocator_service.auth import auth, require_client_secret
 from lablink_allocator_service.providers.registry import get_provider
 from lablink_allocator_service.secret_hash import (
     REGISTER_TOKEN_SUBJECT,
@@ -256,3 +258,59 @@ def list_clients():
             "last_seen_at": last_seen,
         })
     return jsonify(clients=clients), 200
+
+
+@bp.route("/api/overlay-hostname", methods=["POST"])
+@require_client_secret
+def report_overlay_hostname():
+    """Record the overlay hostname Tailscale actually assigned this client.
+
+    The name captured at registration is only what the client *asked* for.
+    ``tailscale up --hostname=X`` exits 0 even when an existing (possibly
+    offline) node already holds X, in which case Tailscale appends a numeric
+    suffix instead. The allocator dials the recorded name, so an
+    unreconciled rename sends every call to a dead node and the client is
+    marked Unhealthy forever (lablink#404).
+
+    Deliberately its own endpoint rather than a field on ``/api/vm-status``:
+    that handler and the client's ``send_status`` are shared with the AWS
+    path, where a lost status POST is unrecoverable (see start.sh's own
+    comment and assign_vm's status='running' requirement). Nothing here runs
+    for an AWS or lan_direct client — start.sh only calls it inside its
+    ``TAILSCALE_AUTHKEY`` gate.
+
+    Lives in this module rather than vm_telemetry because this is where the
+    ``overlay_hostname`` contract is already enforced (see register_client's
+    expects_overlay check). Flat ``/api/`` prefix to match the sibling
+    client-VM writes (``/api/vm-status``, ``/api/gpu_health``,
+    ``/api/heartbeat``) and to stay out of ``/api/v1/clients/<client_id>``'s
+    path space.
+    """
+    from lablink_allocator_service import main
+
+    body = request.get_json(silent=True) or {}
+    hostname = body.get("hostname")
+    overlay_hostname = body.get("overlay_hostname")
+    if not hostname or not overlay_hostname:
+        return jsonify({
+            "error": "hostname and overlay_hostname required."
+        }), 400
+
+    try:
+        updated = main.database.set_overlay_hostname(
+            hostname=hostname, overlay_hostname=overlay_hostname
+        )
+    except Exception:
+        current_app.logger.exception(
+            "Failed to record overlay hostname for '%s'", hostname
+        )
+        return jsonify({"error": "Failed to record overlay hostname."}), 500
+
+    if not updated:
+        return jsonify({"error": "Not a mesh-overlay client."}), 404
+
+    current_app.logger.info(
+        "Client '%s' reported overlay hostname '%s'",
+        hostname, overlay_hostname,
+    )
+    return jsonify({"ok": True}), 200

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1483,3 +1483,31 @@ def test_release_expired_admin_sessions_releases_old_and_keeps_recent(real_db):
 
 def test_pool_property_returns_underlying_pool(db_instance):
     assert db_instance.pool is db_instance._pool
+
+
+def test_set_overlay_hostname_updates_jsonb_key(db_instance):
+    """Writes through jsonb_set so the rest of provider_metadata survives."""
+    db_instance.cursor.rowcount = 1
+
+    assert db_instance.set_overlay_hostname(
+        hostname="LAPTOP-M8NLMMGL",
+        overlay_hostname="lablink-client-local-gpu-1-1",
+    ) is True
+
+    sql, params = db_instance.cursor.execute.call_args[0]
+    assert "jsonb_set" in sql
+    # to_jsonb(%s::text), never a hand-quoted JSON literal.
+    assert "to_jsonb" in sql
+    # Only mesh-overlay rows may be touched, so a lan_direct/AWS client
+    # can never have an overlay_hostname injected into its metadata.
+    assert "provider_metadata ? 'overlay_hostname'" in sql
+    assert params == ("lablink-client-local-gpu-1-1", "LAPTOP-M8NLMMGL")
+
+
+def test_set_overlay_hostname_false_when_no_row_matched(db_instance):
+    """Unknown host, or a client with no overlay_hostname key, is a no-op."""
+    db_instance.cursor.rowcount = 0
+
+    assert db_instance.set_overlay_hostname(
+        hostname="aws-vm-1", overlay_hostname="whatever",
+    ) is False

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -762,3 +762,75 @@ def test_list_clients_returns_safe_fields(reg_client, admin_headers):
         assert "machine_identity" not in c
         assert "cloudinitlogs" not in c
         assert "dockerlogs" not in c
+
+
+OVERLAY_HOSTNAME_ENDPOINT = "/api/overlay-hostname"
+_OVERLAY_SECRET = "overlay-client-secret"
+
+
+def _overlay_db(monkeypatch, *, updated=True):
+    from lablink_allocator_service import main
+    from lablink_allocator_service.secret_hash import hash_secret
+
+    fake_db = MagicMock()
+    fake_db.get_client_secret_hash.return_value = hash_secret(_OVERLAY_SECRET)
+    fake_db.set_overlay_hostname.return_value = updated
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+    return fake_db
+
+
+def test_overlay_hostname_persists_reported_name(client, monkeypatch):
+    """The client's reported name replaces the one it merely requested."""
+    fake_db = _overlay_db(monkeypatch)
+
+    resp = client.post(
+        OVERLAY_HOSTNAME_ENDPOINT,
+        json={
+            "hostname": "LAPTOP-M8NLMMGL",
+            "overlay_hostname": "lablink-client-local-gpu-1-1",
+        },
+        headers={"Authorization": f"Bearer {_OVERLAY_SECRET}"},
+    )
+
+    assert resp.status_code == 200
+    fake_db.set_overlay_hostname.assert_called_once_with(
+        hostname="LAPTOP-M8NLMMGL",
+        overlay_hostname="lablink-client-local-gpu-1-1",
+    )
+
+
+def test_overlay_hostname_requires_client_secret(client, monkeypatch):
+    _overlay_db(monkeypatch)
+
+    resp = client.post(
+        OVERLAY_HOSTNAME_ENDPOINT,
+        json={"hostname": "LAPTOP-M8NLMMGL", "overlay_hostname": "x-1"},
+    )
+
+    assert resp.status_code == 401
+
+
+def test_overlay_hostname_rejects_missing_field(client, monkeypatch):
+    fake_db = _overlay_db(monkeypatch)
+
+    resp = client.post(
+        OVERLAY_HOSTNAME_ENDPOINT,
+        json={"hostname": "LAPTOP-M8NLMMGL"},
+        headers={"Authorization": f"Bearer {_OVERLAY_SECRET}"},
+    )
+
+    assert resp.status_code == 400
+    fake_db.set_overlay_hostname.assert_not_called()
+
+
+def test_overlay_hostname_404_when_not_an_overlay_client(client, monkeypatch):
+    """A lan_direct/AWS row has no overlay_hostname key to correct."""
+    _overlay_db(monkeypatch, updated=False)
+
+    resp = client.post(
+        OVERLAY_HOSTNAME_ENDPOINT,
+        json={"hostname": "aws-vm-1", "overlay_hostname": "sneaky-1"},
+        headers={"Authorization": f"Bearer {_OVERLAY_SECRET}"},
+    )
+
+    assert resp.status_code == 404

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -89,6 +89,69 @@ if [ -n "$TAILSCALE_AUTHKEY" ]; then
     send_status "error" || echo ">> WARNING: failed to report status=error"
     exit 1
   fi
+
+  # Tailscale assigns the node's name and it is NOT necessarily the one we
+  # asked for: when an existing (possibly offline) node from a prior
+  # registration still holds "$OVERLAY_HOSTNAME", MagicDNS appends a numeric
+  # suffix -- lablink-client-local-gpu-1 becomes lablink-client-local-gpu-1-1
+  # -- and `tailscale up` STILL EXITS 0, so nothing above notices. The
+  # allocator dials the name it recorded at registration, so an unreconciled
+  # rename black-holes every allocator -> client call and the client is
+  # marked Unhealthy forever, while its own logs look perfectly healthy
+  # (lablink#404). Read the real name back from the daemon and report it.
+  # Same readback the allocator already does for its own node via
+  # `tailscale funnel status` (see the CLI's _funnel_status_url).
+  #
+  # python3 rather than jq: the venv sourced at the top of this script
+  # guarantees python3, jq is not installed in this image. DNSName is
+  # fully-qualified with a trailing dot ("name.tailnet.ts.net."), and the
+  # allocator stores the bare first label and appends the tailnet itself.
+  ACTUAL_OVERLAY_HOSTNAME=$(sudo tailscale status --json 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["Self"]["DNSName"].split(".")[0])' \
+    2>/dev/null)
+
+  if [ -z "$ACTUAL_OVERLAY_HOSTNAME" ]; then
+    echo ">> WARNING: could not read assigned Tailscale hostname back;" \
+         "allocator keeps the requested name '$OVERLAY_HOSTNAME'"
+  else
+    if [ "$ACTUAL_OVERLAY_HOSTNAME" != "$OVERLAY_HOSTNAME" ]; then
+      echo ">> NOTE: Tailscale renamed this node:" \
+           "requested '$OVERLAY_HOSTNAME', assigned" \
+           "'$ACTUAL_OVERLAY_HOSTNAME' (a prior node still holds the" \
+           "requested name). Reporting the assigned name to the allocator."
+    else
+      echo "Joined Tailscale as $ACTUAL_OVERLAY_HOSTNAME (name as requested)."
+    fi
+
+    # Reported unconditionally, not only on mismatch, so a row left stale by
+    # a previous life of this container is repaired too. Idempotent server-side.
+    report_overlay_hostname() {
+      curl -sS -X POST "$ALLOCATOR_URL/api/overlay-hostname" \
+        -H "Authorization: Bearer $CLIENT_SECRET" \
+        -H "Content-Type: application/json" \
+        -d "{\"hostname\":\"$VM_NAME\",\"overlay_hostname\":\"$ACTUAL_OVERLAY_HOSTNAME\"}" \
+        --max-time 5 --retry 5 --retry-delay 2 --retry-all-errors
+    }
+
+    # Keep retrying in the background if the immediate attempt's budget is
+    # exhausted. The tailnet route (especially over a DERP relay fallback)
+    # isn't reliably usable for a few seconds after `tailscale up` returns,
+    # and losing this report permanently strands the allocator on the old
+    # name -- the exact failure this whole block exists to prevent. Mirrors
+    # the status retrier below.
+    if ! report_overlay_hostname; then
+      echo ">> WARNING: failed to report overlay hostname; retrying in background"
+      (
+        for _ in $(seq 1 "$STATUS_RETRY_MAX_ATTEMPTS"); do
+          sleep "$STATUS_RETRY_INTERVAL"
+          report_overlay_hostname && exit 0
+        done
+        echo ">> WARNING: gave up reporting overlay hostname" \
+             "'$ACTUAL_OVERLAY_HOSTNAME'; the allocator may be dialing a" \
+             "dead node -- see lablink#404"
+      ) &
+    fi
+  fi
 fi
 
 # Report 'initializing' as soon as the overlay (if any) is up. On cold

--- a/packages/client/tests/test_start_sh_status.py
+++ b/packages/client/tests/test_start_sh_status.py
@@ -122,3 +122,44 @@ class TestStartupOrdering:
         block = block[: block.index("\nfi\n")]
         assert 'send_status "error"' in block
         assert "exit 1" in block
+
+
+def test_overlay_hostname_read_back_after_join(script_text):
+    """`tailscale up --hostname=X` exits 0 even when Tailscale renamed the
+    node to X-1, so the assigned name must be read back from the daemon,
+    not assumed (lablink#404)."""
+    assert "tailscale status --json" in script_text
+    assert "Self" in script_text and "DNSName" in script_text
+
+
+def test_overlay_hostname_reported_to_dedicated_endpoint(script_text):
+    """Must NOT ride on /api/vm-status — that endpoint and send_status are
+    shared with the AWS path, where a lost status POST is unrecoverable."""
+    assert "/api/overlay-hostname" in script_text
+    send_status_body = _extract(script_text, "send_status() {", "}")
+    # Comments are stripped first: send_status's own comment legitimately
+    # discusses mesh-overlay clients (it explains why it needs --retry).
+    # What must not appear is overlay *code* — a second endpoint or an
+    # extra payload field on the AWS-shared status POST.
+    code = "\n".join(
+        ln for ln in send_status_body.splitlines()
+        if not ln.strip().startswith("#")
+    )
+    assert "overlay" not in code.lower()
+
+
+def test_overlay_report_is_inside_the_tailscale_gate(script_text):
+    """All of it sits inside `if [ -n "$TAILSCALE_AUTHKEY" ]`, so an AWS or
+    lan_direct client executes none of it."""
+    gate = _line_of(script_text, 'if [ -n "$TAILSCALE_AUTHKEY" ]')
+    report = _line_of(script_text, "/api/overlay-hostname")
+    initializing = _line_of(script_text, 'send_status "initializing"')
+    assert gate < report < initializing
+
+
+def test_overlay_report_retries(script_text):
+    """A lost report strands the allocator on the old name, so the immediate
+    attempt must be retried rather than abandoned."""
+    report = _line_of(script_text, "/api/overlay-hostname")
+    window = "\n".join(script_text.splitlines()[report - 6 : report + 12])
+    assert "--retry" in window


### PR DESCRIPTION
## Summary

- A mesh-overlay client now reads its assigned Tailscale name back from the daemon after joining and reports it, so the allocator stops dialing a dead node.
- New `POST /api/overlay-hostname` (client-secret auth) persists the corrected name to `provider_metadata.overlay_hostname`.
- **PR 1 of 3** for #404. Stacked: this one first, then #B (client tailscaled state), then #C (unstick `Unhealthy`).

## The bug

`tailscale up --hostname=X` does **not** guarantee the node is named X. If an existing — possibly offline — node from a prior registration still holds X, Tailscale appends a numeric suffix and **still exits 0**. The client has no idea it was renamed.

The allocator stores the name the client *requested* and builds its address from it (`_resolve_overlay_host` → `f"{overlay_hostname}.{tailnet}"`), so after any re-registration that name resolves to the previous, dead node. Every allocator → client call black-holes, rotation times out, and the client is marked `Unhealthy` — while its own logs look perfectly healthy end to end, which is what made this hard to diagnose.

Confirmed live on `sleap-lablink` (tailnet `tail9f6f81.ts.net`), where three generations of the same logical client coexisted and the DB pointed at the offline one.

## Changes Made

- `db/vms.py`: `set_overlay_hostname()` — `jsonb_set` + `to_jsonb(%s::text)`, guarded on `provider_metadata ? 'overlay_hostname'` so only a mesh-overlay row can ever be touched. Returns `False` for unknown or non-overlay hosts.
- `routes/registration.py`: `POST /api/overlay-hostname`, `@require_client_secret`.
- `client/start.sh`: after a successful join, parse `.Self.DNSName` from `tailscale status --json`, log loudly on rename, and report — wrapped in the same background retrier already used for `initializing`, since a lost report re-stranded the allocator.

## Design Decisions

**Why a dedicated endpoint, not a field on `/api/vm-status`.** That handler and start.sh's `send_status` are shared with the **AWS path** — the same client container runs on AWS VMs via `terraform/user_data.sh:174` — and a lost status POST there is unrecoverable (`start.sh`'s own comment records this; `assign_vm` requires `status='running'`). The AWS path executes **zero** new instructions: everything is inside the existing `TAILSCALE_AUTHKEY` gate, and the AWS `docker run` passes neither `TAILSCALE_AUTHKEY` nor `OVERLAY_HOSTNAME` (`grep -rn "TAILSCALE\|OVERLAY"` over the terraform dir returns nothing).

**Why the flat `/api/` prefix.** It matches the sibling client-VM writes (`/api/vm-status`, `/api/gpu_health`, `/api/heartbeat`, `/api/update_inuse_status`) and avoids `/api/v1/clients/<client_id>`, which already claims that path space — a `POST /api/v1/clients/overlay-hostname` returns 405.

**Why report unconditionally rather than only on mismatch.** It also repairs a row left stale by a previous life of the container. Idempotent server-side.

**Why this ships first.** It is the only fix that covers the Run:AI hand-off path (`--no-run-locally`), where LabLink never runs `docker run` and therefore cannot persist tailscaled state.

**Precedent.** `_funnel_status_url()` already does this exact readback for the allocator's *own* node. The client side just never got the equivalent.

## Testing

- 6 new tests: 2 DB (jsonb write + non-overlay refusal), 4 route (persist, 401, 400, 404).
- 4 new structural `start.sh` tests: readback present, dedicated endpoint (asserts `send_status` gains no overlay *code* — comments stripped, since its existing comment legitimately discusses mesh-overlay), ordering inside the authkey gate, retry present.
- Allocator 761 passed / 19 skipped; client 137 passed; `ruff check` clean; `bash -n start.sh` clean.
- **Verified against a real Postgres 15**, not just mocked SQL: `set_overlay_hostname` corrected `…gpu-1` → `…gpu-1-1`, preserved sibling metadata keys, and returned `False` for a `lan_direct` row, a NULL-metadata row, and an unknown host; `get_overlay_hostname` read the corrected name back (full round-trip).
- **Verified the `DNSName` parse directly**: extracts the suffixed name correctly (including the tricky suffix-on-a-name-already-ending-in-`-1`), and every failure mode — MagicDNS disabled, tailscaled down, malformed JSON, missing `Self` — yields an empty string that falls into the warn-and-keep-requested-name branch rather than sending a wrong value.

## Not covered

No test here exercises a real tailnet rename. Live verification against a `mesh_overlay` deployment is still required before #404 is closed.

## Related Issues

Refs #404

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)