### PR TITLE
fix(cli): persist the client's tailscaled state; add `client reset-overlay` (#404)

### DIFF
--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -512,6 +512,33 @@ def unregister(
     run_unregister(env_file=env_file, insecure=insecure, yes=yes)
 
 
+@client_app.command("reset-overlay")
+def reset_overlay(
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the confirmation prompt.",
+    ),
+) -> None:
+    """Discard this box's persisted mesh-overlay node identity.
+
+    Only relevant to a mesh-overlay client. `unregister` deliberately
+    keeps the identity so that re-registering lands back on the same
+    tailnet node under the same name; run this when you want the next
+    `register` to join as a brand-new node instead.
+
+    Note that this does not remove the old machine from your tailnet — it
+    goes offline still holding its name, so the new node is given a
+    numeric suffix until you delete the stale machine in the Tailscale
+    admin console. Requires the `lablink-client` container to be gone
+    already (docker will not remove an attached volume).
+    """
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    run_reset_overlay(yes=yes)
+
+
 @app.command("show-config", rich_help_panel="Maintenance")
 def show_config(
     config: str = typer.Option(

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -33,6 +33,16 @@ DEFAULT_ENV_FILE = Path.home() / ".lablink" / "client.env"
 # local override.
 DEFAULT_STARTUP_SCRIPT = Path.home() / ".lablink" / "client-custom-startup.sh"
 PID_FILE = Path.home() / ".lablink" / "log_shipper.pid"
+# tailscaled's node identity (its state dir). Persisted in a named volume so
+# recreating the container reuses the SAME tailnet node instead of minting a
+# new one — a new node cannot claim a MagicDNS name that an existing (even
+# offline) node still holds, so Tailscale appends a numeric suffix (-1, -2,
+# ...) and the allocator's recorded overlay hostname ends up pointing at the
+# dead node (lablink#404). The allocator's own sidecar has done this from the
+# start (the `tailscale_state` volume in docker-compose-mesh-overlay.yml);
+# the client side never got the equivalent. Fixed name, like the fixed
+# `--name lablink-client` below: one box runs one client container.
+TAILSCALE_STATE_VOLUME = "lablink-client-tailscale"
 
 
 def _detect_hostname(hostname: str | None, console: Console) -> str:
@@ -246,6 +256,20 @@ def run_register(
             if line.startswith("#"):
                 continue
             print(line)
+        # There is no docker run for us to add `-v` to on this path, so the
+        # operator has to arrange persistence themselves. Without it every
+        # workload restart joins the tailnet as a brand-new node and
+        # Tailscale suffixes the name (-1, -2, ...); the client reports its
+        # real name back regardless (see start.sh), so this is an
+        # optimization rather than a correctness requirement. See
+        # TAILSCALE_STATE_VOLUME for the run-locally equivalent.
+        console.print(
+            "\n[dim]Also give the workload persistent storage mounted at "
+            "/var/lib/tailscale. Without it, each restart rejoins the "
+            "tailnet as a new node and Tailscale appends a numeric suffix "
+            "to its name. The client reports its actual name back either "
+            "way, so this is an optimization, not a requirement.[/dim]"
+        )
         return
 
     # Step 6: GPU runtime pre-flight (only when --gpus all will be added)
@@ -456,6 +480,11 @@ def _build_docker_run(
             "--cap-add", "NET_ADMIN",
             "--cap-add", "NET_RAW",
             "--device", "/dev/net/tun",
+            # Persist the tailnet node identity; see TAILSCALE_STATE_VOLUME.
+            # Re-registering with a *different* --overlay-hostname is still
+            # fine: renaming a node you already own is allowed and yields the
+            # unsuffixed name, which is exactly what we want.
+            "-v", f"{TAILSCALE_STATE_VOLUME}:/var/lib/tailscale",
         ]
     # Mount path mirrors the AWS terraform/user_data mount so the client
     # start.sh finds the script at /docker_scripts/custom-startup.sh

--- a/packages/cli/src/lablink_cli/commands/reset_overlay.py
+++ b/packages/cli/src/lablink_cli/commands/reset_overlay.py
@@ -1,0 +1,129 @@
+"""`lablink client reset-overlay` — discard this box's persisted overlay
+node identity.
+
+Separate from `unregister` on purpose. `unregister` keeps the identity so
+that unregister/register lands back on the same tailnet node with the same
+MagicDNS name. Removing it is the opposite intent — "let this box join as a
+brand-new node next time" — and it has a consequence that has to be stated
+out loud rather than buried in a teardown path:
+
+Deleting the local state does NOT delete the machine from the tailnet. The
+coordination server keeps its own record, the machine simply goes offline,
+and it *keeps holding its MagicDNS name*. So the next `register` mints a new
+node which cannot claim that name and is handed a suffixed one
+(`...-gpu-1` -> `...-gpu-1-1`). Freeing the name requires deleting the stale
+node in the Tailscale admin console. This command therefore says so.
+
+The client reports whatever name it actually got back to the allocator (see
+client/start.sh), so a suffixed name is not broken — just untidy, and
+untidiness here is what made lablink#404 hard to read.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import typer
+from rich.console import Console
+
+from lablink_cli.commands.register import TAILSCALE_STATE_VOLUME
+from lablink_cli.log_shipper import CONTAINER_NAME, inspect_container
+
+TAILNET_ADMIN_URL = "https://login.tailscale.com/admin/machines"
+
+
+def run_reset_overlay(*, yes: bool) -> None:
+    """Remove the persisted tailscaled state volume for the BYO client."""
+    console = Console()
+
+    if shutil.which("docker") is None:
+        console.print(
+            "[red]docker is not on PATH.[/red] There is nothing for this "
+            "command to remove without it."
+        )
+        raise SystemExit(1)
+
+    status = inspect_container(CONTAINER_NAME)
+    if status == "daemon_error":
+        console.print(
+            "[red]Docker daemon is unreachable.[/red] Start Docker and "
+            "re-run."
+        )
+        raise SystemExit(1)
+    if status != "missing":
+        # Docker refuses to remove a volume that is still attached, and
+        # tearing the container down belongs to unregister — don't duplicate
+        # it here and half-succeed.
+        console.print(
+            f"[red]The {CONTAINER_NAME} container still exists "
+            f"(status: {status}).[/red]\n"
+            "Docker will not remove a volume that is still attached. Run "
+            "[bold]lablink client unregister[/bold] first (or "
+            f"`docker rm -f {CONTAINER_NAME}`), then re-run this command."
+        )
+        raise SystemExit(1)
+
+    if not _volume_exists():
+        console.print(
+            "Nothing to reset — no persisted overlay identity on this box."
+        )
+        return
+
+    if not yes:
+        confirmed = typer.confirm(
+            f"Remove the {TAILSCALE_STATE_VOLUME} volume? The next "
+            "`lablink client register` will join the tailnet as a new node.",
+            default=False,
+        )
+        if not confirmed:
+            console.print("Aborted.")
+            return
+
+    result = subprocess.run(
+        ["docker", "volume", "rm", TAILSCALE_STATE_VOLUME],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        console.print(
+            f"[red]Could not remove {TAILSCALE_STATE_VOLUME}: "
+            f"{stderr or '(no stderr)'}[/red]"
+        )
+        raise SystemExit(1)
+
+    console.print(
+        f"[green]Removed {TAILSCALE_STATE_VOLUME}.[/green] The next "
+        "`lablink client register` will join the tailnet as a new node."
+    )
+    # Said explicitly because it is the non-obvious half: the operator has
+    # just discarded the local identity, but the old machine is still in the
+    # tailnet holding the name, so the new node gets a numeric suffix until
+    # that machine is deleted. Silence here is what makes the suffix look
+    # like a typo rather than a rename (lablink#404).
+    console.print(
+        "\n[yellow]This does not remove the old machine from your "
+        "tailnet.[/yellow] It goes offline but keeps holding its MagicDNS "
+        "name, so the new node will be given a numeric suffix (e.g. "
+        "[dim]-gpu-1[/dim] -> [dim]-gpu-1-1[/dim]) until you delete the "
+        f"stale machine at:\n  {TAILNET_ADMIN_URL}\n"
+        "The client reports whichever name it actually receives, so a "
+        "suffixed name still works."
+    )
+
+
+def _volume_exists() -> bool:
+    """True if the tailscaled state volume is present.
+
+    `docker volume inspect` exits non-zero for an unknown volume, which is
+    the only signal needed — a `lan_direct` box never had one.
+    """
+    result = subprocess.run(
+        ["docker", "volume", "inspect", TAILSCALE_STATE_VOLUME],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0

--- a/packages/cli/src/lablink_cli/commands/unregister.py
+++ b/packages/cli/src/lablink_cli/commands/unregister.py
@@ -166,6 +166,14 @@ def _exec_docker_rm(console: Console) -> bool:
     `docker rm -f` exits 0 in both cases — the only non-zero exits
     are for daemon-level failures (docker daemon down, permissions,
     etc.), which we surface as a yellow warning and continue.
+
+    Deliberately leaves the TAILSCALE_STATE_VOLUME in place. Deleting it
+    would NOT remove the node from the tailnet (the coordination server
+    keeps its own record, and the offline machine goes on holding its
+    MagicDNS name), so the next `register` would mint a fresh node and get a
+    suffixed name — the exact lablink#404 failure. Preserving it means
+    unregister/register reuses the same node and keeps the unsuffixed name.
+    `lablink client reset-overlay` is the opt-in path for discarding it.
     """
     try:
         result = subprocess.run(

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -279,6 +279,11 @@ class TestOverlayHostnamePath:
         assert "TAILSCALE_AUTHKEY=tskey-abc" in out
         assert "CLIENT_SECRET=s" in out
 
+        # We cannot mount anything on this path, so the operator must be
+        # told to persist tailscaled's state themselves — otherwise every
+        # workload restart mints a new tailnet node (lablink#404).
+        assert "/var/lib/tailscale" in out
+
     @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
@@ -1559,3 +1564,37 @@ class TestWriteEnvFile:
 
         content = tmp_env_file.read_text()
         assert "ALLOCATOR_URL=https://lablink.example.com" in content
+
+
+def test_overlay_run_mounts_tailscale_state_volume():
+    """tailscaled's node identity lives in /var/lib/tailscale. Unmounted, it
+    is ephemeral, so every container recreate mints a NEW tailnet node and
+    Tailscale suffixes the MagicDNS name (-1, -2, ...), stranding the
+    allocator on the dead one (lablink#404). Mirrors the allocator's own
+    tailscale_state volume in docker-compose-mesh-overlay.yml."""
+    from pathlib import Path
+
+    from lablink_cli.commands.register import (
+        TAILSCALE_STATE_VOLUME,
+        _build_docker_run,
+    )
+
+    resp = {"client_id": "1", "client_image": "ghcr.io/talmolab/c:latest"}
+    cmd = _build_docker_run(
+        Path("/tmp/env"), resp, False, None, "classroom-gpu-3",
+    )
+
+    assert "-v" in cmd
+    assert f"{TAILSCALE_STATE_VOLUME}:/var/lib/tailscale" in cmd
+
+
+def test_non_overlay_run_has_no_tailscale_volume():
+    """lan_direct/AWS clients never run `tailscale up`; no volume for them."""
+    from pathlib import Path
+
+    from lablink_cli.commands.register import _build_docker_run
+
+    resp = {"client_id": "1", "client_image": "ghcr.io/talmolab/c:latest"}
+    cmd = _build_docker_run(Path("/tmp/env"), resp, False, None, None)
+
+    assert not any("/var/lib/tailscale" in part for part in cmd)

--- a/packages/cli/tests/test_reset_overlay.py
+++ b/packages/cli/tests/test_reset_overlay.py
@@ -1,0 +1,138 @@
+"""Tests for `lablink client reset-overlay`.
+
+Discarding the persisted overlay node identity is deliberately its own
+command rather than part of `unregister`: removing the volume does NOT
+remove the node from the tailnet (the coordination server keeps its record
+and the offline machine keeps holding its MagicDNS name), so it guarantees
+the next `register` is handed a suffixed name — the lablink#404 failure.
+That is occasionally what an operator wants, but it must be opt-in.
+"""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+
+def _completed(cmd, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
+
+
+def test_aborts_when_docker_missing(capsys):
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value=None):
+        with pytest.raises(SystemExit) as exc:
+            run_reset_overlay(yes=True)
+
+    assert exc.value.code == 1
+    assert "docker" in capsys.readouterr().out.lower()
+
+
+def test_refuses_while_container_still_exists(capsys):
+    """Docker will not remove a volume that is still attached, and tearing
+    the container down is unregister's job — so point there instead of
+    half-doing it."""
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="running"):
+        with pytest.raises(SystemExit) as exc:
+            run_reset_overlay(yes=True)
+
+    assert exc.value.code == 1
+    assert "unregister" in capsys.readouterr().out
+
+
+def test_noop_when_volume_absent(capsys):
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        # `docker volume inspect` fails => no such volume.
+        return _completed(cmd, returncode=1, stderr="no such volume")
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="missing"), \
+         patch("lablink_cli.commands.reset_overlay.subprocess.run",
+               side_effect=fake_run):
+        run_reset_overlay(yes=True)
+
+    assert not any("rm" in c for c in calls), (
+        f"must not attempt removal when the volume is absent; got {calls}"
+    )
+    assert "Nothing to reset" in capsys.readouterr().out
+
+
+def test_removes_volume_and_explains_the_stale_node(capsys):
+    """The name is only freed by deleting the node in the admin console, so
+    the output has to say so — otherwise the operator resets, re-registers,
+    gets a suffixed name anyway, and has no idea why."""
+    from lablink_cli.commands.register import TAILSCALE_STATE_VOLUME
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _completed(cmd, returncode=0)
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="missing"), \
+         patch("lablink_cli.commands.reset_overlay.subprocess.run",
+               side_effect=fake_run):
+        run_reset_overlay(yes=True)
+
+    assert ["docker", "volume", "rm", TAILSCALE_STATE_VOLUME] in calls
+    out = capsys.readouterr().out
+    assert "login.tailscale.com/admin/machines" in out
+
+
+def test_prompt_abort_leaves_volume_alone(monkeypatch, capsys):
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _completed(cmd, returncode=0)
+
+    monkeypatch.setattr("typer.confirm", lambda *a, **kw: False)
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="missing"), \
+         patch("lablink_cli.commands.reset_overlay.subprocess.run",
+               side_effect=fake_run):
+        run_reset_overlay(yes=False)
+
+    assert ["docker", "volume", "rm", TAILSCALE_STATE_VOLUME_NAME] not in calls
+    assert "Aborted" in capsys.readouterr().out
+
+
+TAILSCALE_STATE_VOLUME_NAME = "lablink-client-tailscale"
+
+
+def test_daemon_error_aborts(capsys):
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="daemon_error"):
+        with pytest.raises(SystemExit) as exc:
+            run_reset_overlay(yes=True)
+
+    assert exc.value.code == 1
+    assert "daemon" in capsys.readouterr().out.lower()

--- a/packages/cli/tests/test_unregister.py
+++ b/packages/cli/tests/test_unregister.py
@@ -129,3 +129,33 @@ def test_unregister_prompt_aborted(env_file, capsys, monkeypatch):
     assert env_file.exists()
     out = capsys.readouterr().out
     assert "Aborted" in out
+
+
+def test_unregister_preserves_tailscale_state_volume(monkeypatch):
+    """Unregister must NOT drop the overlay node identity.
+
+    Deleting the volume would not remove the node from the tailnet — the
+    coordination server keeps its record and the offline machine goes on
+    holding its MagicDNS name — so the next `register` would mint a fresh
+    node and be handed a suffixed name, which is the lablink#404 failure
+    itself. Preserving it keeps unregister/register on the same node.
+    `lablink client reset-overlay` is the opt-in way to discard it.
+    """
+    import subprocess
+
+    from lablink_cli.commands import unregister as unreg
+    from rich.console import Console
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(unreg.subprocess, "run", fake_run)
+    unreg._exec_docker_rm(Console())
+
+    assert ["docker", "rm", "-f", "lablink-client"] in calls
+    assert not any(
+        "volume" in c for c in calls
+    ), f"unregister must not touch docker volumes; got {calls}"


### PR DESCRIPTION
## Summary

- Mount a named volume at `/var/lib/tailscale` for mesh-overlay clients, so recreating the container reuses the **same** tailnet node instead of minting a new one and being handed a suffixed name.
- `unregister` deliberately **preserves** that volume; discarding the identity is opt-in via a new `lablink client reset-overlay`.
- **PR 2 of 3** for #404. Stacked on #412 — review that one first; this PR's diff is CLI-only.

## The bug

tailscaled's node identity lives in `/var/lib/tailscale`. The client's `docker run` mounted nothing there, so the state was ephemeral and every container recreate minted a brand-new tailnet node. A new node cannot claim a MagicDNS name that an existing (even offline) node still holds, so Tailscale appended a numeric suffix — and the allocator's recorded overlay hostname ended up pointing at the dead node.

The allocator's own sidecar has done this correctly from the start (the `tailscale_state` volume in `docker-compose-mesh-overlay.yml`). The client side never got the equivalent.

## Changes Made

- `register.py`: `TAILSCALE_STATE_VOLUME = "lablink-client-tailscale"`, mounted in `_build_docker_run` alongside the existing `NET_ADMIN`/`/dev/net/tun` grants — gated on `overlay_hostname`, so `lan_direct`/AWS clients are untouched.
- `commands/reset_overlay.py` + `app.py`: new `lablink client reset-overlay`.
- `unregister.py`: docstring now records *why* the volume is deliberately left behind.
- The `--no-run-locally` Run:AI printout now tells the operator to mount persistent storage themselves, since LabLink runs no `docker run` on that path.

## Design Decisions

**Why `unregister` must NOT delete the volume.** This was the important finding. `docker volume rm` deletes only the *local* `tailscaled.state`. Tailscale's coordination server keeps its own record: the machine stays in the Machines list, goes offline, and **keeps holding its MagicDNS name**. So deleting it would *guarantee* a suffixed name on the very next register — the exact bug this PR exists to prevent — and would orphan another name-holder on every teardown cycle. `tailscale logout` does not help either; a logged-out machine still occupies its name. Only deleting the machine in the admin console frees it.

**So why have `reset-overlay` at all?** "Let this box join as a brand-new node" is a legitimate occasional need. It just has to be opt-in, and it has to state the consequence out loud — silence there is what made the numeric suffix read as a typo rather than a rename.

**Why it refuses while the container exists.** Docker will not remove an attached volume, and tearing the container down is `unregister`'s job. Better to point there than to half-succeed.

**Naming.** `reset-overlay`, not `reset-tailscale` — named for the behavior, not the vendor, matching the `mesh_overlay` connectivity strategy.

**Volume-name collision check.** `lablink-client-tailscale` is distinct from the allocator sidecar's compose volumes (`<project>_tailscale_state`), so this cannot touch an allocator deployment's state.

## Testing

- 9 new tests: volume present for overlay / absent for `lan_direct`; `unregister` touches no volumes at all (so the counterproductive behavior can't creep back); 6 covering `reset-overlay` (docker missing, container present, daemon error, no-op, removal + guidance, prompt abort).
- CLI 674 passed; allocator 761 / client 137 unaffected; `ruff check` clean.
- **Verified live on a real docker daemon**, not just mocked: no-op path prints `Nothing to reset`; a real volume is removed with the full guidance; the container-present path refuses with a real exit code of 1; and the two existing allocator `*_tailscale_state` volumes were confirmed untouched throughout. Test container and volume were cleaned up.
- Generated `docker run` inspected directly to confirm `-v` placement and its absence for `lan_direct`.

## Note for the reviewer

`_exec_docker_rm` returns early on success, so an earlier draft that appended the volume removal at the end of that function would have been dead code in the normal path. That draft is gone — this PR removes nothing during unregister — but it is worth knowing why the docstring there is explicit.

## Related Issues

Refs #404

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)