### PR TITLE
fix(allocator): stop one rotation timeout from permanently wedging a client (#404)

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -251,6 +251,44 @@ class VmDatabase:
             return None
         return row[0]
 
+    def set_overlay_hostname(
+        self, *, hostname: str, overlay_hostname: str
+    ) -> bool:
+        """Reconcile a mesh-overlay client's recorded overlay hostname with
+        the name Tailscale actually assigned it.
+
+        `tailscale up --hostname=X` does NOT guarantee the node is named X:
+        if an earlier (possibly offline) node still holds X, Tailscale
+        appends a numeric suffix and still exits 0. The name we recorded at
+        registration is therefore only a *request*, and after any
+        re-registration it can point at a dead node — every allocator ->
+        client dial then black-holes (lablink#404). The client reports the
+        real name after joining; this persists it.
+
+        Guarded on the key already existing so this can only ever correct a
+        mesh-overlay client: a lan_direct or AWS client cannot have an
+        `overlay_hostname` injected into its provider_metadata. Returns True
+        when a row was updated, False for an unknown or non-overlay host.
+        """
+        query = (
+            f"UPDATE {self.table_name} "
+            f"SET provider_metadata = jsonb_set("
+            f"    COALESCE(provider_metadata, '{{}}'::jsonb), "
+            f"    '{{overlay_hostname}}', to_jsonb(%s::text), true) "
+            f"WHERE hostname = %s "
+            f"  AND provider_metadata ? 'overlay_hostname';"
+        )
+        with self._cursor as cursor:
+            try:
+                cursor.execute(query, (overlay_hostname, hostname))
+                return cursor.rowcount > 0
+            except Exception as e:
+                logger.error(
+                    f"Failed to set overlay hostname for VM "
+                    f"'{hostname}': {e}"
+                )
+                raise
+
     def list_hosts_by_provider(self, provider: str) -> list:
         with self._cursor as cursor:
             cursor.execute(

--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -695,6 +695,37 @@ class VmDatabase:
                 )
                 raise
 
+    def clear_unhealthy(self, *, hostname: str) -> None:
+        """Clear an allocator-set Unhealthy flag, returning the VM to the
+        assignable pool.
+
+        Sets NULL rather than 'Healthy': the allocator marks a client
+        Unhealthy when it cannot *reach* it, which says nothing about the
+        GPU, and 'N/A' (no nvidia-smi, the normal case on a BYO box) is a
+        legitimate client-reported value we must not overwrite with a lie.
+        assign_vm treats NULL as assignable ("healthy IS NULL OR healthy <>
+        'Unhealthy'").
+
+        Needed because the flag is otherwise permanent: check_gpu only POSTs
+        on *change*, and on a GPU-less box it reports 'N/A' once and exits
+        its loop entirely, so the client can never overwrite the allocator's
+        write. Before this, raw SQL was the only way out (lablink#404).
+        """
+        query = (
+            f"UPDATE {self.table_name} "
+            f"SET healthy = NULL "
+            f"WHERE hostname = %s AND healthy = 'Unhealthy';"
+        )
+        with self._cursor as cursor:
+            try:
+                cursor.execute(query, (hostname,))
+            except Exception as e:
+                logger.error(
+                    f"Failed to clear unhealthy flag "
+                    f"for VM '{hostname}': {e}"
+                )
+                raise
+
     def get_status_by_hostname(self, hostname: str) -> str:
         """Get the status of a VM by its hostname.
 

--- a/packages/allocator/src/lablink_allocator_service/routes/admin_sessions.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/admin_sessions.py
@@ -85,6 +85,19 @@ def admin_connect_vm(hostname):
                 logger.exception("Could not mark '%s' unhealthy", hostname)
             return redirect("/admin/instances?vnc_error=rotation_failed")
 
+        # Reaching here means the rotation POST to the client's agent
+        # succeeded, which proves allocator -> client reachability — the
+        # very direction whose failure set Unhealthy above. Clearing it here
+        # is what makes Admin Connect the recovery path for a client wedged
+        # out of the assignable pool by a transient timeout, instead of
+        # leaving raw SQL as the only way out (lablink#404).
+        try:
+            main.database.clear_unhealthy(hostname=hostname)
+        except Exception:
+            logger.exception(
+                "Could not clear unhealthy flag for '%s'", hostname
+            )
+
         return sign_session_cookie_and_redirect(
             session_id, suffix="admin_session"
         )
@@ -113,4 +126,25 @@ def admin_release_vm(hostname):
     from lablink_allocator_service import main
 
     main.database.release_seat(hostname=hostname)
+    return redirect("/admin/instances")
+
+
+@bp.route("/admin/instances/<hostname>/clear-unhealthy", methods=["POST"])
+@auth.login_required
+def admin_clear_unhealthy(hostname):
+    """Clear an allocator-set Unhealthy flag by hand.
+
+    A rotation timeout marks a client Unhealthy and assign_vm skips those
+    rows, so the pool can read as empty while the client is perfectly fine.
+    The client cannot clear it itself: check_gpu only reports on *change*,
+    and on a GPU-less box it posts 'N/A' once and then exits its loop
+    entirely. A successful Admin Connect clears it automatically (see
+    admin_connect_vm); this is the escape hatch for when the box is known
+    good but connecting to it isn't wanted. Before either existed, raw SQL
+    was the only way out (lablink#404).
+    """
+    from lablink_allocator_service import main
+
+    main.database.clear_unhealthy(hostname=hostname)
+    logger.info("Admin cleared the unhealthy flag for '%s'", hostname)
     return redirect("/admin/instances")

--- a/packages/allocator/src/lablink_allocator_service/routes/public.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/public.py
@@ -88,6 +88,18 @@ def submit_vm_details():
                 logger.exception("Could not mark '%s' unhealthy", hostname)
             return render_template("rotation_failed.html"), 503
 
+        # Rotation succeeded, so the client is reachable — clear any
+        # Unhealthy flag a previous transient failure left behind. Reachable
+        # here via the rejoin branch above, which matches on status='running'
+        # rather than going through assign_vm and so can land on a row still
+        # marked Unhealthy (lablink#404).
+        try:
+            main.database.clear_unhealthy(hostname=hostname)
+        except Exception:
+            logger.exception(
+                "Could not clear unhealthy flag for '%s'", hostname
+            )
+
         return sign_session_cookie_and_redirect(session_id)
 
     except Exception as e:

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -1,4 +1,6 @@
-"""POST /api/v1/clients/register and GET /api/v1/clients/<id>/status.
+"""POST /api/v1/clients/register, GET /api/v1/clients/<id>/status, and
+POST /api/overlay-hostname (a mesh-overlay client correcting the overlay
+hostname it was recorded under — see report_overlay_hostname).
 
 Lazy-imports `main` inside views to avoid the module-load import cycle
 (main imports this blueprint at startup). Mirrors the rationale behind
@@ -13,7 +15,7 @@ import secrets
 
 from flask import Blueprint, current_app, jsonify, request
 
-from lablink_allocator_service.auth import auth
+from lablink_allocator_service.auth import auth, require_client_secret
 from lablink_allocator_service.providers.registry import get_provider
 from lablink_allocator_service.secret_hash import (
     REGISTER_TOKEN_SUBJECT,
@@ -256,3 +258,59 @@ def list_clients():
             "last_seen_at": last_seen,
         })
     return jsonify(clients=clients), 200
+
+
+@bp.route("/api/overlay-hostname", methods=["POST"])
+@require_client_secret
+def report_overlay_hostname():
+    """Record the overlay hostname Tailscale actually assigned this client.
+
+    The name captured at registration is only what the client *asked* for.
+    ``tailscale up --hostname=X`` exits 0 even when an existing (possibly
+    offline) node already holds X, in which case Tailscale appends a numeric
+    suffix instead. The allocator dials the recorded name, so an
+    unreconciled rename sends every call to a dead node and the client is
+    marked Unhealthy forever (lablink#404).
+
+    Deliberately its own endpoint rather than a field on ``/api/vm-status``:
+    that handler and the client's ``send_status`` are shared with the AWS
+    path, where a lost status POST is unrecoverable (see start.sh's own
+    comment and assign_vm's status='running' requirement). Nothing here runs
+    for an AWS or lan_direct client — start.sh only calls it inside its
+    ``TAILSCALE_AUTHKEY`` gate.
+
+    Lives in this module rather than vm_telemetry because this is where the
+    ``overlay_hostname`` contract is already enforced (see register_client's
+    expects_overlay check). Flat ``/api/`` prefix to match the sibling
+    client-VM writes (``/api/vm-status``, ``/api/gpu_health``,
+    ``/api/heartbeat``) and to stay out of ``/api/v1/clients/<client_id>``'s
+    path space.
+    """
+    from lablink_allocator_service import main
+
+    body = request.get_json(silent=True) or {}
+    hostname = body.get("hostname")
+    overlay_hostname = body.get("overlay_hostname")
+    if not hostname or not overlay_hostname:
+        return jsonify({
+            "error": "hostname and overlay_hostname required."
+        }), 400
+
+    try:
+        updated = main.database.set_overlay_hostname(
+            hostname=hostname, overlay_hostname=overlay_hostname
+        )
+    except Exception:
+        current_app.logger.exception(
+            "Failed to record overlay hostname for '%s'", hostname
+        )
+        return jsonify({"error": "Failed to record overlay hostname."}), 500
+
+    if not updated:
+        return jsonify({"error": "Not a mesh-overlay client."}), 404
+
+    current_app.logger.info(
+        "Client '%s' reported overlay hostname '%s'",
+        hostname, overlay_hostname,
+    )
+    return jsonify({"ok": True}), 200

--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -368,6 +368,27 @@
     {% else %}
     <span class="admin-session-label">—</span>
     {% endif %}
+    {# Deliberately outside the chain above, not another elif: an Unhealthy
+       VM should still offer Connect, since a *successful* Admin Connect is
+       the automatic way the flag gets cleared. This is the manual escape
+       hatch for when the box is known good but connecting isn't wanted —
+       assign_vm skips Unhealthy rows and the client can't clear the flag
+       itself (check_gpu only reports on change), so without this raw SQL
+       was the only way out (lablink#404). #}
+    {% if vm.healthy == 'Unhealthy' %}
+    <form
+      method="POST"
+      action="/admin/instances/{{ vm.hostname }}/clear-unhealthy"
+    >
+      <button
+        type="submit"
+        class="btn-sm"
+        title="Return this VM to the assignable pool after a failed password rotation. Does not re-check the GPU."
+      >
+        Clear Unhealthy
+      </button>
+    </form>
+    {% endif %}
     {% endmacro %}
 
     {% macro vm_list_content(instances) %}

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1511,3 +1511,15 @@ def test_set_overlay_hostname_false_when_no_row_matched(db_instance):
     assert db_instance.set_overlay_hostname(
         hostname="aws-vm-1", overlay_hostname="whatever",
     ) is False
+
+
+def test_clear_unhealthy_only_clears_the_allocator_set_flag(db_instance):
+    """Resets to NULL (unknown), not 'Healthy' -- the allocator has no idea
+    what the GPU is doing, and 'N/A' (no nvidia-smi) is a legitimate
+    client-reported value we must not overwrite with a lie."""
+    db_instance.clear_unhealthy(hostname="LAPTOP-M8NLMMGL")
+
+    sql, params = db_instance.cursor.execute.call_args[0]
+    assert "healthy = NULL" in sql
+    assert "healthy = 'Unhealthy'" in sql  # the WHERE guard
+    assert params == ("LAPTOP-M8NLMMGL",)

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1483,3 +1483,31 @@ def test_release_expired_admin_sessions_releases_old_and_keeps_recent(real_db):
 
 def test_pool_property_returns_underlying_pool(db_instance):
     assert db_instance.pool is db_instance._pool
+
+
+def test_set_overlay_hostname_updates_jsonb_key(db_instance):
+    """Writes through jsonb_set so the rest of provider_metadata survives."""
+    db_instance.cursor.rowcount = 1
+
+    assert db_instance.set_overlay_hostname(
+        hostname="LAPTOP-M8NLMMGL",
+        overlay_hostname="lablink-client-local-gpu-1-1",
+    ) is True
+
+    sql, params = db_instance.cursor.execute.call_args[0]
+    assert "jsonb_set" in sql
+    # to_jsonb(%s::text), never a hand-quoted JSON literal.
+    assert "to_jsonb" in sql
+    # Only mesh-overlay rows may be touched, so a lan_direct/AWS client
+    # can never have an overlay_hostname injected into its metadata.
+    assert "provider_metadata ? 'overlay_hostname'" in sql
+    assert params == ("lablink-client-local-gpu-1-1", "LAPTOP-M8NLMMGL")
+
+
+def test_set_overlay_hostname_false_when_no_row_matched(db_instance):
+    """Unknown host, or a client with no overlay_hostname key, is a no-op."""
+    db_instance.cursor.rowcount = 0
+
+    assert db_instance.set_overlay_hostname(
+        hostname="aws-vm-1", overlay_hostname="whatever",
+    ) is False

--- a/packages/allocator/tests/test_admin_vnc_routes.py
+++ b/packages/allocator/tests/test_admin_vnc_routes.py
@@ -200,3 +200,99 @@ def test_release_clears_seat_and_redirects(client, admin_headers, monkeypatch):
     assert resp.status_code == 302
     assert resp.headers["Location"].endswith("/admin/instances")
     fake_db.release_seat.assert_called_once_with(hostname="host1")
+
+
+def test_admin_connect_success_clears_unhealthy(
+    client, admin_headers, monkeypatch
+):
+    """A successful rotation proves allocator -> client reachability -- the
+    exact direction whose failure set the flag -- so the client goes back in
+    the pool without an operator touching SQL (lablink#404)."""
+    fake_db = MagicMock()
+    fake_db.admin_reserve_vm.return_value = True
+    fake_conn = MagicMock()
+    fake_db._pool.getconn.return_value = fake_conn
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=True
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.providers.connectivity.allocator_proxied."
+        "prepare_browser_session",
+        lambda **kw: None,
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.routes.session_cookie."
+        "get_or_create_cookie_secret",
+        lambda conn: "test-secret",
+    )
+
+    resp = client.post(
+        "/admin/instances/host1/connect",
+        headers=admin_headers,
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 303
+    fake_db.clear_unhealthy.assert_called_once_with(hostname="host1")
+
+
+def test_admin_connect_rotation_failure_does_not_clear_unhealthy(
+    client, admin_headers, monkeypatch
+):
+    """The mirror image: a failed rotation must still mark the VM Unhealthy
+    and must NOT clear it -- otherwise the flag would be pointless."""
+    from lablink_allocator_service.client_session import RotationFailed
+
+    fake_db = MagicMock()
+    fake_db.admin_reserve_vm.return_value = True
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=True
+    )
+
+    def boom(**kw):
+        raise RotationFailed("connect timeout")
+
+    monkeypatch.setattr(
+        "lablink_allocator_service.providers.connectivity.allocator_proxied."
+        "prepare_browser_session",
+        boom,
+    )
+
+    resp = client.post(
+        "/admin/instances/host1/connect",
+        headers=admin_headers,
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    assert "vnc_error=rotation_failed" in resp.headers["Location"]
+    fake_db.update_health.assert_called_once_with(
+        hostname="host1", healthy="Unhealthy"
+    )
+    fake_db.clear_unhealthy.assert_not_called()
+
+
+def test_clear_unhealthy_route_clears_and_redirects(
+    client, admin_headers, monkeypatch
+):
+    """The only non-SQL escape when the box is known-good but Admin Connect
+    is not wanted (lablink#404)."""
+    fake_db = MagicMock()
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=True
+    )
+
+    resp = client.post(
+        "/admin/instances/host1/clear-unhealthy",
+        headers=admin_headers,
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/admin/instances")
+    fake_db.clear_unhealthy.assert_called_once_with(hostname="host1")
+
+
+def test_clear_unhealthy_requires_auth(client):
+    resp = client.post("/admin/instances/host1/clear-unhealthy")
+    assert resp.status_code == 401

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -416,3 +416,41 @@ def test_operations_history_escapes_user_supplied_text(mock_database, client, ad
     html = resp.data.decode()
     assert "${escapeHtml(op.error)}" in html
     assert "${escapeHtml(op.created_by" in html
+
+
+@patch("lablink_allocator_service.main.database")
+def test_instances_shows_clear_unhealthy_only_for_unhealthy_rows(
+    mock_database, client, admin_headers,
+):
+    """The escape hatch has to be visible exactly where it applies: an
+    Unhealthy row is skipped by assign_vm and the client cannot clear the
+    flag itself, so without this button raw SQL is the only way out
+    (lablink#404). Healthy/N-A rows must not show it."""
+    rows = [
+        SimpleNamespace(
+            hostname="vm-unhealthy", useremail=None, inuse=False,
+            healthy="Unhealthy", status="running", sessionid=None,
+            adminreservedat=None,
+        ),
+        SimpleNamespace(
+            hostname="vm-ok", useremail=None, inuse=False,
+            healthy="Healthy", status="running", sessionid=None,
+            adminreservedat=None,
+        ),
+        SimpleNamespace(
+            hostname="vm-na", useremail=None, inuse=False,
+            healthy="N/A", status="running", sessionid=None,
+            adminreservedat=None,
+        ),
+    ]
+    mock_database.get_all_vms.return_value = rows
+
+    resp = client.get("/admin/instances", headers=admin_headers)
+    html = resp.data.decode()
+
+    assert "/admin/instances/vm-unhealthy/clear-unhealthy" in html
+    assert "/admin/instances/vm-ok/clear-unhealthy" not in html
+    assert "/admin/instances/vm-na/clear-unhealthy" not in html
+    # Connect must still be offered on the unhealthy row — a successful
+    # Admin Connect is the other, automatic way the flag gets cleared.
+    assert "/admin/instances/vm-unhealthy/connect" in html

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -762,3 +762,75 @@ def test_list_clients_returns_safe_fields(reg_client, admin_headers):
         assert "machine_identity" not in c
         assert "cloudinitlogs" not in c
         assert "dockerlogs" not in c
+
+
+OVERLAY_HOSTNAME_ENDPOINT = "/api/overlay-hostname"
+_OVERLAY_SECRET = "overlay-client-secret"
+
+
+def _overlay_db(monkeypatch, *, updated=True):
+    from lablink_allocator_service import main
+    from lablink_allocator_service.secret_hash import hash_secret
+
+    fake_db = MagicMock()
+    fake_db.get_client_secret_hash.return_value = hash_secret(_OVERLAY_SECRET)
+    fake_db.set_overlay_hostname.return_value = updated
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+    return fake_db
+
+
+def test_overlay_hostname_persists_reported_name(client, monkeypatch):
+    """The client's reported name replaces the one it merely requested."""
+    fake_db = _overlay_db(monkeypatch)
+
+    resp = client.post(
+        OVERLAY_HOSTNAME_ENDPOINT,
+        json={
+            "hostname": "LAPTOP-M8NLMMGL",
+            "overlay_hostname": "lablink-client-local-gpu-1-1",
+        },
+        headers={"Authorization": f"Bearer {_OVERLAY_SECRET}"},
+    )
+
+    assert resp.status_code == 200
+    fake_db.set_overlay_hostname.assert_called_once_with(
+        hostname="LAPTOP-M8NLMMGL",
+        overlay_hostname="lablink-client-local-gpu-1-1",
+    )
+
+
+def test_overlay_hostname_requires_client_secret(client, monkeypatch):
+    _overlay_db(monkeypatch)
+
+    resp = client.post(
+        OVERLAY_HOSTNAME_ENDPOINT,
+        json={"hostname": "LAPTOP-M8NLMMGL", "overlay_hostname": "x-1"},
+    )
+
+    assert resp.status_code == 401
+
+
+def test_overlay_hostname_rejects_missing_field(client, monkeypatch):
+    fake_db = _overlay_db(monkeypatch)
+
+    resp = client.post(
+        OVERLAY_HOSTNAME_ENDPOINT,
+        json={"hostname": "LAPTOP-M8NLMMGL"},
+        headers={"Authorization": f"Bearer {_OVERLAY_SECRET}"},
+    )
+
+    assert resp.status_code == 400
+    fake_db.set_overlay_hostname.assert_not_called()
+
+
+def test_overlay_hostname_404_when_not_an_overlay_client(client, monkeypatch):
+    """A lan_direct/AWS row has no overlay_hostname key to correct."""
+    _overlay_db(monkeypatch, updated=False)
+
+    resp = client.post(
+        OVERLAY_HOSTNAME_ENDPOINT,
+        json={"hostname": "aws-vm-1", "overlay_hostname": "sneaky-1"},
+        headers={"Authorization": f"Bearer {_OVERLAY_SECRET}"},
+    )
+
+    assert resp.status_code == 404

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -512,6 +512,33 @@ def unregister(
     run_unregister(env_file=env_file, insecure=insecure, yes=yes)
 
 
+@client_app.command("reset-overlay")
+def reset_overlay(
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip the confirmation prompt.",
+    ),
+) -> None:
+    """Discard this box's persisted mesh-overlay node identity.
+
+    Only relevant to a mesh-overlay client. `unregister` deliberately
+    keeps the identity so that re-registering lands back on the same
+    tailnet node under the same name; run this when you want the next
+    `register` to join as a brand-new node instead.
+
+    Note that this does not remove the old machine from your tailnet — it
+    goes offline still holding its name, so the new node is given a
+    numeric suffix until you delete the stale machine in the Tailscale
+    admin console. Requires the `lablink-client` container to be gone
+    already (docker will not remove an attached volume).
+    """
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    run_reset_overlay(yes=yes)
+
+
 @app.command("show-config", rich_help_panel="Maintenance")
 def show_config(
     config: str = typer.Option(

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -33,6 +33,16 @@ DEFAULT_ENV_FILE = Path.home() / ".lablink" / "client.env"
 # local override.
 DEFAULT_STARTUP_SCRIPT = Path.home() / ".lablink" / "client-custom-startup.sh"
 PID_FILE = Path.home() / ".lablink" / "log_shipper.pid"
+# tailscaled's node identity (its state dir). Persisted in a named volume so
+# recreating the container reuses the SAME tailnet node instead of minting a
+# new one — a new node cannot claim a MagicDNS name that an existing (even
+# offline) node still holds, so Tailscale appends a numeric suffix (-1, -2,
+# ...) and the allocator's recorded overlay hostname ends up pointing at the
+# dead node (lablink#404). The allocator's own sidecar has done this from the
+# start (the `tailscale_state` volume in docker-compose-mesh-overlay.yml);
+# the client side never got the equivalent. Fixed name, like the fixed
+# `--name lablink-client` below: one box runs one client container.
+TAILSCALE_STATE_VOLUME = "lablink-client-tailscale"
 
 
 def _detect_hostname(hostname: str | None, console: Console) -> str:
@@ -246,6 +256,20 @@ def run_register(
             if line.startswith("#"):
                 continue
             print(line)
+        # There is no docker run for us to add `-v` to on this path, so the
+        # operator has to arrange persistence themselves. Without it every
+        # workload restart joins the tailnet as a brand-new node and
+        # Tailscale suffixes the name (-1, -2, ...); the client reports its
+        # real name back regardless (see start.sh), so this is an
+        # optimization rather than a correctness requirement. See
+        # TAILSCALE_STATE_VOLUME for the run-locally equivalent.
+        console.print(
+            "\n[dim]Also give the workload persistent storage mounted at "
+            "/var/lib/tailscale. Without it, each restart rejoins the "
+            "tailnet as a new node and Tailscale appends a numeric suffix "
+            "to its name. The client reports its actual name back either "
+            "way, so this is an optimization, not a requirement.[/dim]"
+        )
         return
 
     # Step 6: GPU runtime pre-flight (only when --gpus all will be added)
@@ -456,6 +480,11 @@ def _build_docker_run(
             "--cap-add", "NET_ADMIN",
             "--cap-add", "NET_RAW",
             "--device", "/dev/net/tun",
+            # Persist the tailnet node identity; see TAILSCALE_STATE_VOLUME.
+            # Re-registering with a *different* --overlay-hostname is still
+            # fine: renaming a node you already own is allowed and yields the
+            # unsuffixed name, which is exactly what we want.
+            "-v", f"{TAILSCALE_STATE_VOLUME}:/var/lib/tailscale",
         ]
     # Mount path mirrors the AWS terraform/user_data mount so the client
     # start.sh finds the script at /docker_scripts/custom-startup.sh

--- a/packages/cli/src/lablink_cli/commands/reset_overlay.py
+++ b/packages/cli/src/lablink_cli/commands/reset_overlay.py
@@ -1,0 +1,129 @@
+"""`lablink client reset-overlay` — discard this box's persisted overlay
+node identity.
+
+Separate from `unregister` on purpose. `unregister` keeps the identity so
+that unregister/register lands back on the same tailnet node with the same
+MagicDNS name. Removing it is the opposite intent — "let this box join as a
+brand-new node next time" — and it has a consequence that has to be stated
+out loud rather than buried in a teardown path:
+
+Deleting the local state does NOT delete the machine from the tailnet. The
+coordination server keeps its own record, the machine simply goes offline,
+and it *keeps holding its MagicDNS name*. So the next `register` mints a new
+node which cannot claim that name and is handed a suffixed one
+(`...-gpu-1` -> `...-gpu-1-1`). Freeing the name requires deleting the stale
+node in the Tailscale admin console. This command therefore says so.
+
+The client reports whatever name it actually got back to the allocator (see
+client/start.sh), so a suffixed name is not broken — just untidy, and
+untidiness here is what made lablink#404 hard to read.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+
+import typer
+from rich.console import Console
+
+from lablink_cli.commands.register import TAILSCALE_STATE_VOLUME
+from lablink_cli.log_shipper import CONTAINER_NAME, inspect_container
+
+TAILNET_ADMIN_URL = "https://login.tailscale.com/admin/machines"
+
+
+def run_reset_overlay(*, yes: bool) -> None:
+    """Remove the persisted tailscaled state volume for the BYO client."""
+    console = Console()
+
+    if shutil.which("docker") is None:
+        console.print(
+            "[red]docker is not on PATH.[/red] There is nothing for this "
+            "command to remove without it."
+        )
+        raise SystemExit(1)
+
+    status = inspect_container(CONTAINER_NAME)
+    if status == "daemon_error":
+        console.print(
+            "[red]Docker daemon is unreachable.[/red] Start Docker and "
+            "re-run."
+        )
+        raise SystemExit(1)
+    if status != "missing":
+        # Docker refuses to remove a volume that is still attached, and
+        # tearing the container down belongs to unregister — don't duplicate
+        # it here and half-succeed.
+        console.print(
+            f"[red]The {CONTAINER_NAME} container still exists "
+            f"(status: {status}).[/red]\n"
+            "Docker will not remove a volume that is still attached. Run "
+            "[bold]lablink client unregister[/bold] first (or "
+            f"`docker rm -f {CONTAINER_NAME}`), then re-run this command."
+        )
+        raise SystemExit(1)
+
+    if not _volume_exists():
+        console.print(
+            "Nothing to reset — no persisted overlay identity on this box."
+        )
+        return
+
+    if not yes:
+        confirmed = typer.confirm(
+            f"Remove the {TAILSCALE_STATE_VOLUME} volume? The next "
+            "`lablink client register` will join the tailnet as a new node.",
+            default=False,
+        )
+        if not confirmed:
+            console.print("Aborted.")
+            return
+
+    result = subprocess.run(
+        ["docker", "volume", "rm", TAILSCALE_STATE_VOLUME],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0:
+        stderr = (result.stderr or "").strip()
+        console.print(
+            f"[red]Could not remove {TAILSCALE_STATE_VOLUME}: "
+            f"{stderr or '(no stderr)'}[/red]"
+        )
+        raise SystemExit(1)
+
+    console.print(
+        f"[green]Removed {TAILSCALE_STATE_VOLUME}.[/green] The next "
+        "`lablink client register` will join the tailnet as a new node."
+    )
+    # Said explicitly because it is the non-obvious half: the operator has
+    # just discarded the local identity, but the old machine is still in the
+    # tailnet holding the name, so the new node gets a numeric suffix until
+    # that machine is deleted. Silence here is what makes the suffix look
+    # like a typo rather than a rename (lablink#404).
+    console.print(
+        "\n[yellow]This does not remove the old machine from your "
+        "tailnet.[/yellow] It goes offline but keeps holding its MagicDNS "
+        "name, so the new node will be given a numeric suffix (e.g. "
+        "[dim]-gpu-1[/dim] -> [dim]-gpu-1-1[/dim]) until you delete the "
+        f"stale machine at:\n  {TAILNET_ADMIN_URL}\n"
+        "The client reports whichever name it actually receives, so a "
+        "suffixed name still works."
+    )
+
+
+def _volume_exists() -> bool:
+    """True if the tailscaled state volume is present.
+
+    `docker volume inspect` exits non-zero for an unknown volume, which is
+    the only signal needed — a `lan_direct` box never had one.
+    """
+    result = subprocess.run(
+        ["docker", "volume", "inspect", TAILSCALE_STATE_VOLUME],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    return result.returncode == 0

--- a/packages/cli/src/lablink_cli/commands/unregister.py
+++ b/packages/cli/src/lablink_cli/commands/unregister.py
@@ -166,6 +166,14 @@ def _exec_docker_rm(console: Console) -> bool:
     `docker rm -f` exits 0 in both cases — the only non-zero exits
     are for daemon-level failures (docker daemon down, permissions,
     etc.), which we surface as a yellow warning and continue.
+
+    Deliberately leaves the TAILSCALE_STATE_VOLUME in place. Deleting it
+    would NOT remove the node from the tailnet (the coordination server
+    keeps its own record, and the offline machine goes on holding its
+    MagicDNS name), so the next `register` would mint a fresh node and get a
+    suffixed name — the exact lablink#404 failure. Preserving it means
+    unregister/register reuses the same node and keeps the unsuffixed name.
+    `lablink client reset-overlay` is the opt-in path for discarding it.
     """
     try:
         result = subprocess.run(

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -279,6 +279,11 @@ class TestOverlayHostnamePath:
         assert "TAILSCALE_AUTHKEY=tskey-abc" in out
         assert "CLIENT_SECRET=s" in out
 
+        # We cannot mount anything on this path, so the operator must be
+        # told to persist tailscaled's state themselves — otherwise every
+        # workload restart mints a new tailnet node (lablink#404).
+        assert "/var/lib/tailscale" in out
+
     @patch("lablink_cli.commands.register.subprocess.Popen")
     @patch("lablink_cli.commands.register.subprocess.run")
     @patch("lablink_cli.commands.register.shutil.which")
@@ -1559,3 +1564,37 @@ class TestWriteEnvFile:
 
         content = tmp_env_file.read_text()
         assert "ALLOCATOR_URL=https://lablink.example.com" in content
+
+
+def test_overlay_run_mounts_tailscale_state_volume():
+    """tailscaled's node identity lives in /var/lib/tailscale. Unmounted, it
+    is ephemeral, so every container recreate mints a NEW tailnet node and
+    Tailscale suffixes the MagicDNS name (-1, -2, ...), stranding the
+    allocator on the dead one (lablink#404). Mirrors the allocator's own
+    tailscale_state volume in docker-compose-mesh-overlay.yml."""
+    from pathlib import Path
+
+    from lablink_cli.commands.register import (
+        TAILSCALE_STATE_VOLUME,
+        _build_docker_run,
+    )
+
+    resp = {"client_id": "1", "client_image": "ghcr.io/talmolab/c:latest"}
+    cmd = _build_docker_run(
+        Path("/tmp/env"), resp, False, None, "classroom-gpu-3",
+    )
+
+    assert "-v" in cmd
+    assert f"{TAILSCALE_STATE_VOLUME}:/var/lib/tailscale" in cmd
+
+
+def test_non_overlay_run_has_no_tailscale_volume():
+    """lan_direct/AWS clients never run `tailscale up`; no volume for them."""
+    from pathlib import Path
+
+    from lablink_cli.commands.register import _build_docker_run
+
+    resp = {"client_id": "1", "client_image": "ghcr.io/talmolab/c:latest"}
+    cmd = _build_docker_run(Path("/tmp/env"), resp, False, None, None)
+
+    assert not any("/var/lib/tailscale" in part for part in cmd)

--- a/packages/cli/tests/test_reset_overlay.py
+++ b/packages/cli/tests/test_reset_overlay.py
@@ -1,0 +1,138 @@
+"""Tests for `lablink client reset-overlay`.
+
+Discarding the persisted overlay node identity is deliberately its own
+command rather than part of `unregister`: removing the volume does NOT
+remove the node from the tailnet (the coordination server keeps its record
+and the offline machine keeps holding its MagicDNS name), so it guarantees
+the next `register` is handed a suffixed name — the lablink#404 failure.
+That is occasionally what an operator wants, but it must be opt-in.
+"""
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+
+def _completed(cmd, returncode=0, stdout="", stderr=""):
+    return subprocess.CompletedProcess(cmd, returncode, stdout, stderr)
+
+
+def test_aborts_when_docker_missing(capsys):
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value=None):
+        with pytest.raises(SystemExit) as exc:
+            run_reset_overlay(yes=True)
+
+    assert exc.value.code == 1
+    assert "docker" in capsys.readouterr().out.lower()
+
+
+def test_refuses_while_container_still_exists(capsys):
+    """Docker will not remove a volume that is still attached, and tearing
+    the container down is unregister's job — so point there instead of
+    half-doing it."""
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="running"):
+        with pytest.raises(SystemExit) as exc:
+            run_reset_overlay(yes=True)
+
+    assert exc.value.code == 1
+    assert "unregister" in capsys.readouterr().out
+
+
+def test_noop_when_volume_absent(capsys):
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        # `docker volume inspect` fails => no such volume.
+        return _completed(cmd, returncode=1, stderr="no such volume")
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="missing"), \
+         patch("lablink_cli.commands.reset_overlay.subprocess.run",
+               side_effect=fake_run):
+        run_reset_overlay(yes=True)
+
+    assert not any("rm" in c for c in calls), (
+        f"must not attempt removal when the volume is absent; got {calls}"
+    )
+    assert "Nothing to reset" in capsys.readouterr().out
+
+
+def test_removes_volume_and_explains_the_stale_node(capsys):
+    """The name is only freed by deleting the node in the admin console, so
+    the output has to say so — otherwise the operator resets, re-registers,
+    gets a suffixed name anyway, and has no idea why."""
+    from lablink_cli.commands.register import TAILSCALE_STATE_VOLUME
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _completed(cmd, returncode=0)
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="missing"), \
+         patch("lablink_cli.commands.reset_overlay.subprocess.run",
+               side_effect=fake_run):
+        run_reset_overlay(yes=True)
+
+    assert ["docker", "volume", "rm", TAILSCALE_STATE_VOLUME] in calls
+    out = capsys.readouterr().out
+    assert "login.tailscale.com/admin/machines" in out
+
+
+def test_prompt_abort_leaves_volume_alone(monkeypatch, capsys):
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return _completed(cmd, returncode=0)
+
+    monkeypatch.setattr("typer.confirm", lambda *a, **kw: False)
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="missing"), \
+         patch("lablink_cli.commands.reset_overlay.subprocess.run",
+               side_effect=fake_run):
+        run_reset_overlay(yes=False)
+
+    assert ["docker", "volume", "rm", TAILSCALE_STATE_VOLUME_NAME] not in calls
+    assert "Aborted" in capsys.readouterr().out
+
+
+TAILSCALE_STATE_VOLUME_NAME = "lablink-client-tailscale"
+
+
+def test_daemon_error_aborts(capsys):
+    from lablink_cli.commands.reset_overlay import run_reset_overlay
+
+    with patch("lablink_cli.commands.reset_overlay.shutil.which",
+               return_value="/usr/bin/docker"), \
+         patch("lablink_cli.commands.reset_overlay.inspect_container",
+               return_value="daemon_error"):
+        with pytest.raises(SystemExit) as exc:
+            run_reset_overlay(yes=True)
+
+    assert exc.value.code == 1
+    assert "daemon" in capsys.readouterr().out.lower()

--- a/packages/cli/tests/test_unregister.py
+++ b/packages/cli/tests/test_unregister.py
@@ -129,3 +129,33 @@ def test_unregister_prompt_aborted(env_file, capsys, monkeypatch):
     assert env_file.exists()
     out = capsys.readouterr().out
     assert "Aborted" in out
+
+
+def test_unregister_preserves_tailscale_state_volume(monkeypatch):
+    """Unregister must NOT drop the overlay node identity.
+
+    Deleting the volume would not remove the node from the tailnet — the
+    coordination server keeps its record and the offline machine goes on
+    holding its MagicDNS name — so the next `register` would mint a fresh
+    node and be handed a suffixed name, which is the lablink#404 failure
+    itself. Preserving it keeps unregister/register on the same node.
+    `lablink client reset-overlay` is the opt-in way to discard it.
+    """
+    import subprocess
+
+    from lablink_cli.commands import unregister as unreg
+    from rich.console import Console
+
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, "", "")
+
+    monkeypatch.setattr(unreg.subprocess, "run", fake_run)
+    unreg._exec_docker_rm(Console())
+
+    assert ["docker", "rm", "-f", "lablink-client"] in calls
+    assert not any(
+        "volume" in c for c in calls
+    ), f"unregister must not touch docker volumes; got {calls}"

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -89,6 +89,69 @@ if [ -n "$TAILSCALE_AUTHKEY" ]; then
     send_status "error" || echo ">> WARNING: failed to report status=error"
     exit 1
   fi
+
+  # Tailscale assigns the node's name and it is NOT necessarily the one we
+  # asked for: when an existing (possibly offline) node from a prior
+  # registration still holds "$OVERLAY_HOSTNAME", MagicDNS appends a numeric
+  # suffix -- lablink-client-local-gpu-1 becomes lablink-client-local-gpu-1-1
+  # -- and `tailscale up` STILL EXITS 0, so nothing above notices. The
+  # allocator dials the name it recorded at registration, so an unreconciled
+  # rename black-holes every allocator -> client call and the client is
+  # marked Unhealthy forever, while its own logs look perfectly healthy
+  # (lablink#404). Read the real name back from the daemon and report it.
+  # Same readback the allocator already does for its own node via
+  # `tailscale funnel status` (see the CLI's _funnel_status_url).
+  #
+  # python3 rather than jq: the venv sourced at the top of this script
+  # guarantees python3, jq is not installed in this image. DNSName is
+  # fully-qualified with a trailing dot ("name.tailnet.ts.net."), and the
+  # allocator stores the bare first label and appends the tailnet itself.
+  ACTUAL_OVERLAY_HOSTNAME=$(sudo tailscale status --json 2>/dev/null \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["Self"]["DNSName"].split(".")[0])' \
+    2>/dev/null)
+
+  if [ -z "$ACTUAL_OVERLAY_HOSTNAME" ]; then
+    echo ">> WARNING: could not read assigned Tailscale hostname back;" \
+         "allocator keeps the requested name '$OVERLAY_HOSTNAME'"
+  else
+    if [ "$ACTUAL_OVERLAY_HOSTNAME" != "$OVERLAY_HOSTNAME" ]; then
+      echo ">> NOTE: Tailscale renamed this node:" \
+           "requested '$OVERLAY_HOSTNAME', assigned" \
+           "'$ACTUAL_OVERLAY_HOSTNAME' (a prior node still holds the" \
+           "requested name). Reporting the assigned name to the allocator."
+    else
+      echo "Joined Tailscale as $ACTUAL_OVERLAY_HOSTNAME (name as requested)."
+    fi
+
+    # Reported unconditionally, not only on mismatch, so a row left stale by
+    # a previous life of this container is repaired too. Idempotent server-side.
+    report_overlay_hostname() {
+      curl -sS -X POST "$ALLOCATOR_URL/api/overlay-hostname" \
+        -H "Authorization: Bearer $CLIENT_SECRET" \
+        -H "Content-Type: application/json" \
+        -d "{\"hostname\":\"$VM_NAME\",\"overlay_hostname\":\"$ACTUAL_OVERLAY_HOSTNAME\"}" \
+        --max-time 5 --retry 5 --retry-delay 2 --retry-all-errors
+    }
+
+    # Keep retrying in the background if the immediate attempt's budget is
+    # exhausted. The tailnet route (especially over a DERP relay fallback)
+    # isn't reliably usable for a few seconds after `tailscale up` returns,
+    # and losing this report permanently strands the allocator on the old
+    # name -- the exact failure this whole block exists to prevent. Mirrors
+    # the status retrier below.
+    if ! report_overlay_hostname; then
+      echo ">> WARNING: failed to report overlay hostname; retrying in background"
+      (
+        for _ in $(seq 1 "$STATUS_RETRY_MAX_ATTEMPTS"); do
+          sleep "$STATUS_RETRY_INTERVAL"
+          report_overlay_hostname && exit 0
+        done
+        echo ">> WARNING: gave up reporting overlay hostname" \
+             "'$ACTUAL_OVERLAY_HOSTNAME'; the allocator may be dialing a" \
+             "dead node -- see lablink#404"
+      ) &
+    fi
+  fi
 fi
 
 # Report 'initializing' as soon as the overlay (if any) is up. On cold

--- a/packages/client/tests/test_start_sh_status.py
+++ b/packages/client/tests/test_start_sh_status.py
@@ -122,3 +122,44 @@ class TestStartupOrdering:
         block = block[: block.index("\nfi\n")]
         assert 'send_status "error"' in block
         assert "exit 1" in block
+
+
+def test_overlay_hostname_read_back_after_join(script_text):
+    """`tailscale up --hostname=X` exits 0 even when Tailscale renamed the
+    node to X-1, so the assigned name must be read back from the daemon,
+    not assumed (lablink#404)."""
+    assert "tailscale status --json" in script_text
+    assert "Self" in script_text and "DNSName" in script_text
+
+
+def test_overlay_hostname_reported_to_dedicated_endpoint(script_text):
+    """Must NOT ride on /api/vm-status — that endpoint and send_status are
+    shared with the AWS path, where a lost status POST is unrecoverable."""
+    assert "/api/overlay-hostname" in script_text
+    send_status_body = _extract(script_text, "send_status() {", "}")
+    # Comments are stripped first: send_status's own comment legitimately
+    # discusses mesh-overlay clients (it explains why it needs --retry).
+    # What must not appear is overlay *code* — a second endpoint or an
+    # extra payload field on the AWS-shared status POST.
+    code = "\n".join(
+        ln for ln in send_status_body.splitlines()
+        if not ln.strip().startswith("#")
+    )
+    assert "overlay" not in code.lower()
+
+
+def test_overlay_report_is_inside_the_tailscale_gate(script_text):
+    """All of it sits inside `if [ -n "$TAILSCALE_AUTHKEY" ]`, so an AWS or
+    lan_direct client executes none of it."""
+    gate = _line_of(script_text, 'if [ -n "$TAILSCALE_AUTHKEY" ]')
+    report = _line_of(script_text, "/api/overlay-hostname")
+    initializing = _line_of(script_text, 'send_status "initializing"')
+    assert gate < report < initializing
+
+
+def test_overlay_report_retries(script_text):
+    """A lost report strands the allocator on the old name, so the immediate
+    attempt must be retried rather than abandoned."""
+    report = _line_of(script_text, "/api/overlay-hostname")
+    window = "\n".join(script_text.splitlines()[report - 6 : report + 12])
+    assert "--retry" in window


### PR DESCRIPTION
## Summary

- A **successful** password rotation now clears an allocator-set `Unhealthy` flag, making Admin Connect the automatic recovery path.
- Adds `POST /admin/instances/<hostname>/clear-unhealthy` and a "Clear Unhealthy" button as the manual escape hatch.
- **PR 3 of 3** for #404. Stacked on #413 — review #412 and #413 first; this PR's own diff is allocator-only.

## The bug

A failed rotation marks a client `Unhealthy`, and `assign_vm` skips those rows — so a single transient connect timeout empties the assignable pool permanently.

The client cannot undo it. `check_gpu.py` only POSTs on **change**, and on a GPU-less BYO box it reports `'N/A'` once with `break_now=True` and then **exits its loop entirely**, so the allocator's write can never be overwritten. The recovery sweep logs `provider manual cannot recover hosts`. Raw SQL was the only way out.

This is what turned a recoverable blip into a dead deployment in #404.

## Changes Made

- `db/vms.py`: `clear_unhealthy()`.
- `routes/admin_sessions.py`: clear on rotation success; new `clear-unhealthy` route.
- `routes/public.py`: clear on rotation success.
- `templates/instances.html`: "Clear Unhealthy" button, rendered only on `Unhealthy` rows.

## Design Decisions

**Why clearing on rotation *success* is safe.** Admin Connect already ignores `healthy` and targets one specific host, so it was the natural retry path. A successful `prepare_browser_session` means the rotation POST to the client's agent succeeded, which proves allocator → client reachability — the exact direction whose failure set the flag. No participant can ever be handed a client that was not just proven reachable, which is what the pool predicate protects. Also wired into the participant path's rejoin branch, which matches on `status='running'` rather than going through `assign_vm` and so can land on a row still marked `Unhealthy`.

**Why `NULL`, not `'Healthy'`.** The allocator marks a client `Unhealthy` when it cannot *reach* it, which says nothing about the GPU — and `'N/A'` (no nvidia-smi, normal on a BYO box) is a legitimate client-reported value we must not overwrite with a lie. `assign_vm`'s predicate is already `(healthy IS NULL OR healthy <> 'Unhealthy')`, so NULL is assignable. The `WHERE healthy = 'Unhealthy'` guard keeps it from touching anything else. The button is labelled "Clear Unhealthy" rather than "Mark healthy" for the same reason.

**Why the button sits outside the `vm_actions` if/elif chain.** That chain is mutually exclusive, so another `elif` would have *replaced* the Connect button on exactly the rows that need it most — and a successful Connect is the automatic clear.

**Alternative rejected: clear on heartbeat.** Fully automatic, but the heartbeat is client → allocator (outbound) and does not prove allocator → client reachability, the direction that actually failed. It would resurrect a genuinely unreachable client straight into the pool.

## Testing

- 6 new tests: DB (NULL + guard), admin connect success clears, rotation failure still marks and does **not** clear, route clears + redirects, route requires auth, template shows the button only on `Unhealthy` rows while still offering Connect.
- Allocator 767 passed / 19 skipped; CLI 674; client 137; `ruff check` clean.
- **Verified against a real Postgres 15**: `clear_unhealthy` nulled the `Unhealthy` row while leaving `'Healthy'` and `'N/A'` untouched, and the cleared row then satisfied `assign_vm`'s predicate — i.e. genuinely back in the pool.
- The `admin_connect_success_clears_unhealthy` test was written after its implementation, so rather than assume it was meaningful I temporarily disabled the `clear_unhealthy` call, confirmed the test fails, then restored and re-ran. That assertion is verified to have teeth.

## Related Issues

Refs #404 — closes item 3. Items 1 and 2 are #412 and #413; item 4 (MagicDNS resolution inside the Flask process) is deliberately deferred to its own issue, since pointing the allocator container's `dns:` at `100.100.100.100` would break all DNS in that container until the sidecar's tailscaled is up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)