### PR TITLE
fix(allocator): stop one rotation timeout from permanently wedging a client (#404)

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -695,6 +695,37 @@ class VmDatabase:
                 )
                 raise
 
+    def clear_unhealthy(self, *, hostname: str) -> None:
+        """Clear an allocator-set Unhealthy flag, returning the VM to the
+        assignable pool.
+
+        Sets NULL rather than 'Healthy': the allocator marks a client
+        Unhealthy when it cannot *reach* it, which says nothing about the
+        GPU, and 'N/A' (no nvidia-smi, the normal case on a BYO box) is a
+        legitimate client-reported value we must not overwrite with a lie.
+        assign_vm treats NULL as assignable ("healthy IS NULL OR healthy <>
+        'Unhealthy'").
+
+        Needed because the flag is otherwise permanent: check_gpu only POSTs
+        on *change*, and on a GPU-less box it reports 'N/A' once and exits
+        its loop entirely, so the client can never overwrite the allocator's
+        write. Before this, raw SQL was the only way out (lablink#404).
+        """
+        query = (
+            f"UPDATE {self.table_name} "
+            f"SET healthy = NULL "
+            f"WHERE hostname = %s AND healthy = 'Unhealthy';"
+        )
+        with self._cursor as cursor:
+            try:
+                cursor.execute(query, (hostname,))
+            except Exception as e:
+                logger.error(
+                    f"Failed to clear unhealthy flag "
+                    f"for VM '{hostname}': {e}"
+                )
+                raise
+
     def get_status_by_hostname(self, hostname: str) -> str:
         """Get the status of a VM by its hostname.
 

--- a/packages/allocator/src/lablink_allocator_service/routes/admin_sessions.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/admin_sessions.py
@@ -85,6 +85,19 @@ def admin_connect_vm(hostname):
                 logger.exception("Could not mark '%s' unhealthy", hostname)
             return redirect("/admin/instances?vnc_error=rotation_failed")
 
+        # Reaching here means the rotation POST to the client's agent
+        # succeeded, which proves allocator -> client reachability — the
+        # very direction whose failure set Unhealthy above. Clearing it here
+        # is what makes Admin Connect the recovery path for a client wedged
+        # out of the assignable pool by a transient timeout, instead of
+        # leaving raw SQL as the only way out (lablink#404).
+        try:
+            main.database.clear_unhealthy(hostname=hostname)
+        except Exception:
+            logger.exception(
+                "Could not clear unhealthy flag for '%s'", hostname
+            )
+
         return sign_session_cookie_and_redirect(
             session_id, suffix="admin_session"
         )
@@ -113,4 +126,25 @@ def admin_release_vm(hostname):
     from lablink_allocator_service import main
 
     main.database.release_seat(hostname=hostname)
+    return redirect("/admin/instances")
+
+
+@bp.route("/admin/instances/<hostname>/clear-unhealthy", methods=["POST"])
+@auth.login_required
+def admin_clear_unhealthy(hostname):
+    """Clear an allocator-set Unhealthy flag by hand.
+
+    A rotation timeout marks a client Unhealthy and assign_vm skips those
+    rows, so the pool can read as empty while the client is perfectly fine.
+    The client cannot clear it itself: check_gpu only reports on *change*,
+    and on a GPU-less box it posts 'N/A' once and then exits its loop
+    entirely. A successful Admin Connect clears it automatically (see
+    admin_connect_vm); this is the escape hatch for when the box is known
+    good but connecting to it isn't wanted. Before either existed, raw SQL
+    was the only way out (lablink#404).
+    """
+    from lablink_allocator_service import main
+
+    main.database.clear_unhealthy(hostname=hostname)
+    logger.info("Admin cleared the unhealthy flag for '%s'", hostname)
     return redirect("/admin/instances")

--- a/packages/allocator/src/lablink_allocator_service/routes/public.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/public.py
@@ -88,6 +88,18 @@ def submit_vm_details():
                 logger.exception("Could not mark '%s' unhealthy", hostname)
             return render_template("rotation_failed.html"), 503
 
+        # Rotation succeeded, so the client is reachable — clear any
+        # Unhealthy flag a previous transient failure left behind. Reachable
+        # here via the rejoin branch above, which matches on status='running'
+        # rather than going through assign_vm and so can land on a row still
+        # marked Unhealthy (lablink#404).
+        try:
+            main.database.clear_unhealthy(hostname=hostname)
+        except Exception:
+            logger.exception(
+                "Could not clear unhealthy flag for '%s'", hostname
+            )
+
         return sign_session_cookie_and_redirect(session_id)
 
     except Exception as e:

--- a/packages/allocator/src/lablink_allocator_service/templates/instances.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instances.html
@@ -368,6 +368,27 @@
     {% else %}
     <span class="admin-session-label">—</span>
     {% endif %}
+    {# Deliberately outside the chain above, not another elif: an Unhealthy
+       VM should still offer Connect, since a *successful* Admin Connect is
+       the automatic way the flag gets cleared. This is the manual escape
+       hatch for when the box is known good but connecting isn't wanted —
+       assign_vm skips Unhealthy rows and the client can't clear the flag
+       itself (check_gpu only reports on change), so without this raw SQL
+       was the only way out (lablink#404). #}
+    {% if vm.healthy == 'Unhealthy' %}
+    <form
+      method="POST"
+      action="/admin/instances/{{ vm.hostname }}/clear-unhealthy"
+    >
+      <button
+        type="submit"
+        class="btn-sm"
+        title="Return this VM to the assignable pool after a failed password rotation. Does not re-check the GPU."
+      >
+        Clear Unhealthy
+      </button>
+    </form>
+    {% endif %}
     {% endmacro %}
 
     {% macro vm_list_content(instances) %}

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1511,3 +1511,15 @@ def test_set_overlay_hostname_false_when_no_row_matched(db_instance):
     assert db_instance.set_overlay_hostname(
         hostname="aws-vm-1", overlay_hostname="whatever",
     ) is False
+
+
+def test_clear_unhealthy_only_clears_the_allocator_set_flag(db_instance):
+    """Resets to NULL (unknown), not 'Healthy' -- the allocator has no idea
+    what the GPU is doing, and 'N/A' (no nvidia-smi) is a legitimate
+    client-reported value we must not overwrite with a lie."""
+    db_instance.clear_unhealthy(hostname="LAPTOP-M8NLMMGL")
+
+    sql, params = db_instance.cursor.execute.call_args[0]
+    assert "healthy = NULL" in sql
+    assert "healthy = 'Unhealthy'" in sql  # the WHERE guard
+    assert params == ("LAPTOP-M8NLMMGL",)

--- a/packages/allocator/tests/test_admin_vnc_routes.py
+++ b/packages/allocator/tests/test_admin_vnc_routes.py
@@ -200,3 +200,99 @@ def test_release_clears_seat_and_redirects(client, admin_headers, monkeypatch):
     assert resp.status_code == 302
     assert resp.headers["Location"].endswith("/admin/instances")
     fake_db.release_seat.assert_called_once_with(hostname="host1")
+
+
+def test_admin_connect_success_clears_unhealthy(
+    client, admin_headers, monkeypatch
+):
+    """A successful rotation proves allocator -> client reachability -- the
+    exact direction whose failure set the flag -- so the client goes back in
+    the pool without an operator touching SQL (lablink#404)."""
+    fake_db = MagicMock()
+    fake_db.admin_reserve_vm.return_value = True
+    fake_conn = MagicMock()
+    fake_db._pool.getconn.return_value = fake_conn
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=True
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.providers.connectivity.allocator_proxied."
+        "prepare_browser_session",
+        lambda **kw: None,
+    )
+    monkeypatch.setattr(
+        "lablink_allocator_service.routes.session_cookie."
+        "get_or_create_cookie_secret",
+        lambda conn: "test-secret",
+    )
+
+    resp = client.post(
+        "/admin/instances/host1/connect",
+        headers=admin_headers,
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 303
+    fake_db.clear_unhealthy.assert_called_once_with(hostname="host1")
+
+
+def test_admin_connect_rotation_failure_does_not_clear_unhealthy(
+    client, admin_headers, monkeypatch
+):
+    """The mirror image: a failed rotation must still mark the VM Unhealthy
+    and must NOT clear it -- otherwise the flag would be pointless."""
+    from lablink_allocator_service.client_session import RotationFailed
+
+    fake_db = MagicMock()
+    fake_db.admin_reserve_vm.return_value = True
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=True
+    )
+
+    def boom(**kw):
+        raise RotationFailed("connect timeout")
+
+    monkeypatch.setattr(
+        "lablink_allocator_service.providers.connectivity.allocator_proxied."
+        "prepare_browser_session",
+        boom,
+    )
+
+    resp = client.post(
+        "/admin/instances/host1/connect",
+        headers=admin_headers,
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    assert "vnc_error=rotation_failed" in resp.headers["Location"]
+    fake_db.update_health.assert_called_once_with(
+        hostname="host1", healthy="Unhealthy"
+    )
+    fake_db.clear_unhealthy.assert_not_called()
+
+
+def test_clear_unhealthy_route_clears_and_redirects(
+    client, admin_headers, monkeypatch
+):
+    """The only non-SQL escape when the box is known-good but Admin Connect
+    is not wanted (lablink#404)."""
+    fake_db = MagicMock()
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=True
+    )
+
+    resp = client.post(
+        "/admin/instances/host1/clear-unhealthy",
+        headers=admin_headers,
+        follow_redirects=False,
+    )
+
+    assert resp.status_code == 302
+    assert resp.headers["Location"].endswith("/admin/instances")
+    fake_db.clear_unhealthy.assert_called_once_with(hostname="host1")
+
+
+def test_clear_unhealthy_requires_auth(client):
+    resp = client.post("/admin/instances/host1/clear-unhealthy")
+    assert resp.status_code == 401

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -416,3 +416,41 @@ def test_operations_history_escapes_user_supplied_text(mock_database, client, ad
     html = resp.data.decode()
     assert "${escapeHtml(op.error)}" in html
     assert "${escapeHtml(op.created_by" in html
+
+
+@patch("lablink_allocator_service.main.database")
+def test_instances_shows_clear_unhealthy_only_for_unhealthy_rows(
+    mock_database, client, admin_headers,
+):
+    """The escape hatch has to be visible exactly where it applies: an
+    Unhealthy row is skipped by assign_vm and the client cannot clear the
+    flag itself, so without this button raw SQL is the only way out
+    (lablink#404). Healthy/N-A rows must not show it."""
+    rows = [
+        SimpleNamespace(
+            hostname="vm-unhealthy", useremail=None, inuse=False,
+            healthy="Unhealthy", status="running", sessionid=None,
+            adminreservedat=None,
+        ),
+        SimpleNamespace(
+            hostname="vm-ok", useremail=None, inuse=False,
+            healthy="Healthy", status="running", sessionid=None,
+            adminreservedat=None,
+        ),
+        SimpleNamespace(
+            hostname="vm-na", useremail=None, inuse=False,
+            healthy="N/A", status="running", sessionid=None,
+            adminreservedat=None,
+        ),
+    ]
+    mock_database.get_all_vms.return_value = rows
+
+    resp = client.get("/admin/instances", headers=admin_headers)
+    html = resp.data.decode()
+
+    assert "/admin/instances/vm-unhealthy/clear-unhealthy" in html
+    assert "/admin/instances/vm-ok/clear-unhealthy" not in html
+    assert "/admin/instances/vm-na/clear-unhealthy" not in html
+    # Connect must still be offered on the unhealthy row — a successful
+    # Admin Connect is the other, automatic way the flag gets cleared.
+    assert "/admin/instances/vm-unhealthy/connect" in html


### PR DESCRIPTION
> Supersedes #414, which GitHub auto-closed when its base branch (#413) was merged and deleted. Same commit, rebased onto `main`; unreviewed at the time of closure.

## Summary

- A **successful** password rotation now clears an allocator-set `Unhealthy` flag, making Admin Connect the automatic recovery path.
- Adds `POST /admin/instances/<hostname>/clear-unhealthy` and a "Clear Unhealthy" button as the manual escape hatch.
- **PR 3 of 3** for #404. #412 and #413 are merged; this now targets `main` directly.

## The bug

A failed rotation marks a client `Unhealthy`, and `assign_vm` skips those rows — so a single transient connect timeout empties the assignable pool permanently.

The client cannot undo it. `check_gpu.py` only POSTs on **change**, and on a GPU-less BYO box it reports `'N/A'` once with `break_now=True` and then **exits its loop entirely**, so the allocator's write can never be overwritten. The recovery sweep logs `provider manual cannot recover hosts`. Raw SQL was the only way out.

This is what turned a recoverable blip into a dead deployment in #404.

## Changes Made

- `db/vms.py`: `clear_unhealthy()`.
- `routes/admin_sessions.py`: clear on rotation success; new `clear-unhealthy` route.
- `routes/public.py`: clear on rotation success.
- `templates/instances.html`: "Clear Unhealthy" button, rendered only on `Unhealthy` rows.

## Design Decisions

**Why clearing on rotation *success* is safe.** Admin Connect already ignores `healthy` and targets one specific host, so it was the natural retry path. A successful `prepare_browser_session` means the rotation POST to the client's agent succeeded, which proves allocator → client reachability — the exact direction whose failure set the flag. No participant can ever be handed a client that was not just proven reachable, which is what the pool predicate protects. Also wired into the participant path's rejoin branch, which matches on `status='running'` rather than going through `assign_vm` and so can land on a row still marked `Unhealthy`.

**Why `NULL`, not `'Healthy'`.** The allocator marks a client `Unhealthy` when it cannot *reach* it, which says nothing about the GPU — and `'N/A'` (no nvidia-smi, normal on a BYO box) is a legitimate client-reported value we must not overwrite with a lie. `assign_vm`'s predicate is already `(healthy IS NULL OR healthy <> 'Unhealthy')`, so NULL is assignable. The `WHERE healthy = 'Unhealthy'` guard keeps it from touching anything else. The button is labelled "Clear Unhealthy" rather than "Mark healthy" for the same reason.

**Why the button sits outside the `vm_actions` if/elif chain.** That chain is mutually exclusive, so another `elif` would have *replaced* the Connect button on exactly the rows that need it most — and a successful Connect is the automatic clear.

**Alternative rejected: clear on heartbeat.** Fully automatic, but the heartbeat is client → allocator (outbound) and does not prove allocator → client reachability, the direction that actually failed. It would resurrect a genuinely unreachable client straight into the pool.

## Testing

- 6 new tests: DB (NULL + guard), admin connect success clears, rotation failure still marks and does **not** clear, route clears + redirects, route requires auth, template shows the button only on `Unhealthy` rows while still offering Connect.
- Allocator 767 passed / 19 skipped; CLI 674; client 137; `ruff check` clean.
- **Verified against a real Postgres 15**: `clear_unhealthy` nulled the `Unhealthy` row while leaving `'Healthy'` and `'N/A'` untouched, and the cleared row then satisfied `assign_vm`'s predicate — i.e. genuinely back in the pool.
- The `admin_connect_success_clears_unhealthy` test was written after its implementation, so rather than assume it was meaningful I temporarily disabled the `clear_unhealthy` call, confirmed the test fails, then restored and re-ran. That assertion is verified to have teeth.

## Related Issues

Refs #404 — closes item 3. Items 1 and 2 are #412 and #413; item 4 (MagicDNS resolution inside the Flask process) is deliberately deferred to its own issue, since pointing the allocator container's `dns:` at `100.100.100.100` would break all DNS in that container until the sidecar's tailscaled is up.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
