### PR TITLE
feat(allocator): add relay connectivity for off-LAN clients without Tailscale

### DIFF
--- a/packages/allocator/Dockerfile
+++ b/packages/allocator/Dockerfile
@@ -62,6 +62,20 @@ RUN for f in /usr/share/kasmvnc/www/assets/ui-*.js; do \
             || { echo "ERROR: sed did not remove the clobber from $f"; exit 1; }; \
     done
 
+# frp (Fast Reverse Proxy) -- relay connectivity's tunnel server (frps)
+# and the per-client frpc-visitor subprocess that pulls tunneled ports
+# down to loopback aliases nginx can dial. See the
+# relay-client-connectivity design spec. Harmless when unused --
+# lan_direct/mesh_overlay deployments never start frps (start.sh gates
+# it on FRPS_AUTH_TOKEN's presence).
+ARG FRP_VERSION=0.60.0
+RUN curl -L -o /tmp/frp.tar.gz \
+      "https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_amd64.tar.gz" && \
+    tar -xzf /tmp/frp.tar.gz -C /tmp && \
+    mv "/tmp/frp_${FRP_VERSION}_linux_amd64/frps" /usr/local/bin/frps && \
+    mv "/tmp/frp_${FRP_VERSION}_linux_amd64/frpc" /usr/local/bin/frpc && \
+    rm -rf /tmp/frp.tar.gz "/tmp/frp_${FRP_VERSION}_linux_amd64"
+
 COPY lablink-nginx.conf /etc/nginx/conf.d/lablink.conf
 
 # Disable nginx's default site so it doesn't compete with lablink-nginx.conf.

--- a/packages/allocator/Dockerfile.dev
+++ b/packages/allocator/Dockerfile.dev
@@ -58,6 +58,21 @@ RUN for f in /usr/share/kasmvnc/www/assets/ui-*.js; do \
             || { echo "ERROR: sed did not remove the clobber from $f"; exit 1; }; \
     done
 
+# frp (Fast Reverse Proxy) -- relay connectivity's tunnel server (frps)
+# and the per-client frpc-visitor subprocess that pulls tunneled ports
+# down to loopback aliases nginx can dial. Must stay in lockstep with the
+# identical block in Dockerfile: this is the image built from local source,
+# so it is the ONLY one that can exercise unreleased relay code (the prod
+# Dockerfile installs lablink-allocator-service from PyPI). Harmless when
+# unused -- start.sh gates frps on FRPS_AUTH_TOKEN's presence.
+ARG FRP_VERSION=0.60.0
+RUN curl -L -o /tmp/frp.tar.gz \
+      "https://github.com/fatedier/frp/releases/download/v${FRP_VERSION}/frp_${FRP_VERSION}_linux_amd64.tar.gz" && \
+    tar -xzf /tmp/frp.tar.gz -C /tmp && \
+    mv "/tmp/frp_${FRP_VERSION}_linux_amd64/frps" /usr/local/bin/frps && \
+    mv "/tmp/frp_${FRP_VERSION}_linux_amd64/frpc" /usr/local/bin/frpc && \
+    rm -rf /tmp/frp.tar.gz "/tmp/frp_${FRP_VERSION}_linux_amd64"
+
 COPY lablink-nginx.conf /etc/nginx/conf.d/lablink.conf
 
 # Disable nginx's default site so it doesn't compete with lablink-nginx.conf.

--- a/packages/allocator/src/lablink_allocator_service/conf/structured_config.py
+++ b/packages/allocator/src/lablink_allocator_service/conf/structured_config.py
@@ -192,6 +192,10 @@ class ManualConfig:
               path through its own nginx, same as the AWS path. For
               clients that aren't on the allocator's LAN (e.g. a
               Run:AI-hosted workload).
+            - "relay": the client dials out to the allocator through an
+              frp tunnel instead of joining any overlay. The fallback of
+              last resort when a client's network won't carry Tailscale
+              at all.
         overlay_tailnet (str): The Tailscale tailnet's MagicDNS domain
             suffix (e.g. "example.ts.net"), used to resolve a registered
             client's overlay hostname, and/or the allocator's own
@@ -207,11 +211,28 @@ class ManualConfig:
               public internet via the tailnet named by overlay_tailnet,
               using the same tailscale sidecar connectivity="mesh_overlay"
               already provisions (reused, not a second sidecar).
+        relay_server_addr (str): The host:port relay clients' `frpc` dial
+            to reach this allocator's `frps` (its control port). Required
+            when connectivity is "relay"; ignored otherwise. How this
+            address is made reachable from a relay client's network
+            (Tailscale Funnel, a public port-forward, etc.) is the
+            operator's choice, not automated by this config.
+        frps_bind_port (int): The local port `frps` binds on inside the
+            allocator's own container. Usually matches the port half of
+            relay_server_addr, but may differ if the operator's exposure
+            mechanism does port translation (e.g. Funnel).
+        frps_auth_token (str): Deployment-wide token protecting the
+            frpc<->frps control connection itself (frp's own `auth.token`
+            setting) -- distinct from the per-client STCP `secretKey`
+            minted at registration time for each relay client's tunnel.
     """
 
     connectivity: str = field(default="lan_direct")
     overlay_tailnet: str = field(default="")
     participant_exposure: str = field(default="none")
+    relay_server_addr: str = field(default="")
+    frps_bind_port: int = field(default=7000)
+    frps_auth_token: str = field(default="")
 
 
 @dataclass

--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -251,6 +251,49 @@ class VmDatabase:
             return None
         return row[0]
 
+    def get_relay_alias(self, hostname: str):
+        """Loopback alias octet for a relay client:
+        provider_metadata->>'relay_alias_octet'. None if absent.
+
+        Returned as an int (the column is JSONB text) so callers can
+        format it straight into an address without re-parsing."""
+        with self._cursor as cursor:
+            cursor.execute(
+                f"SELECT provider_metadata->>'relay_alias_octet' "
+                f"FROM {self.table_name} WHERE hostname = %s;",
+                (hostname,),
+            )
+            row = cursor.fetchone()
+        if not row or row[0] is None:
+            return None
+        return int(row[0])
+
+    # First octet handed out. Starts above 1 so a relay alias is never
+    # confused with plain 127.0.0.1 in logs or upstream strings.
+    _RELAY_ALIAS_BASE = 10
+
+    def allocate_relay_alias_octet(self) -> int:
+        """Return the next unused loopback-alias octet for a new relay
+        client. Never recycled -- see the design spec's Decision 11: the
+        thing that actually revokes a departed client's reachability is
+        killing its visitor subprocess, not reclaiming the integer, and a
+        dedicated allocation-pool table would need the DB migration
+        machinery this codebase deliberately avoids.
+
+        Only the final octet varies, so this tops out at ~245 concurrent
+        relay clients (base 10 through 254) -- far beyond any deployment
+        size this product targets, and deployments are ephemeral with a
+        fresh DB each time.
+        """
+        with self._cursor as cursor:
+            cursor.execute(
+                f"SELECT MAX((provider_metadata->>'relay_alias_octet')::int) "
+                f"FROM {self.table_name};"
+            )
+            row = cursor.fetchone()
+        highest = row[0] if row else None
+        return highest + 1 if highest is not None else self._RELAY_ALIAS_BASE
+
     def set_overlay_hostname(
         self, *, hostname: str, overlay_hostname: str
     ) -> bool:

--- a/packages/allocator/src/lablink_allocator_service/providers/connectivity/allocator_proxied.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/connectivity/allocator_proxied.py
@@ -37,6 +37,7 @@ def _aws_fallback_ip(hostname: str) -> str:
 class AllocatorProxiedClientConnectivity:
     name = "allocator_proxied"
     requires_tailscale_check = False
+    requires_frp_check = False
 
     def prepare_browser_session(self, **kwargs) -> BrowserSessionTarget:
         # Inject AWS EC2 fallback resolver so client_session.py remains

--- a/packages/allocator/src/lablink_allocator_service/providers/connectivity/lan_direct.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/connectivity/lan_direct.py
@@ -16,6 +16,7 @@ from lablink_allocator_service.providers.protocol import ClientJoinMaterial
 class LANDirectClientConnectivity:
     name = "lan_direct"
     requires_tailscale_check = False
+    requires_frp_check = False
 
     def make_join_material(
         self, *, allocator_url: str, client_image: str,

--- a/packages/allocator/src/lablink_allocator_service/providers/connectivity/mesh_overlay.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/connectivity/mesh_overlay.py
@@ -41,6 +41,7 @@ def _resolve_overlay_host(hostname: str) -> str:
 class MeshOverlayClientConnectivity:
     name = "mesh_overlay"
     requires_tailscale_check = True
+    requires_frp_check = False
 
     def prepare_browser_session(self, **kwargs) -> BrowserSessionTarget:
         kwargs.setdefault("fallback_fn", _resolve_overlay_host)

--- a/packages/allocator/src/lablink_allocator_service/providers/connectivity/relay.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/connectivity/relay.py
@@ -1,0 +1,61 @@
+"""Relay connectivity: browser -> allocator nginx proxy -> client KasmVNC,
+reached over an frp (Fast Reverse Proxy) tunnel the client dials out
+through, instead of a routable LAN/VPC address or a Tailscale overlay.
+The fallback of last resort when a client's network won't carry
+Tailscale at all -- see the relay-client-connectivity design spec.
+
+`frp` is an internal implementation detail; nothing in this module's
+public shape (class name, provider_metadata keys) names it."""
+from __future__ import annotations
+
+from lablink_allocator_service import relay_manager
+from lablink_allocator_service.client_session import (
+    BrowserSessionTarget,
+    RotationFailed,
+    prepare_browser_session,
+)
+from lablink_allocator_service.providers.protocol import ClientJoinMaterial
+
+
+def _db():
+    from lablink_allocator_service import main
+
+    return main.database
+
+
+def _resolve_relay_alias(hostname: str) -> str:
+    """Resolve *hostname*'s assigned loopback alias. Used as
+    ``prepare_browser_session``'s ``fallback_fn`` -- same extension point
+    ``MeshOverlayClientConnectivity``/``AllocatorProxiedClientConnectivity``
+    already use for their own resolvers, so ``client_session`` stays free
+    of any frp-specific import.
+
+    Returns a bare address with no port, so ``prepare_browser_session``'s
+    hardcoded ``:6080``/``:7070`` suffixes land on this client's own
+    visitor bindings."""
+    octet = _db().get_relay_alias(hostname)
+    if octet is None:
+        raise RotationFailed(f"no relay alias recorded for {hostname}")
+    return f"127.0.0.{octet}"
+
+
+class RelayClientConnectivity:
+    name = "relay"
+    requires_tailscale_check = False
+    requires_frp_check = True
+
+    def prepare_browser_session(self, **kwargs) -> BrowserSessionTarget:
+        kwargs.setdefault("fallback_fn", _resolve_relay_alias)
+        return prepare_browser_session(**kwargs)
+
+    def make_join_material(
+        self, *, allocator_url: str, client_image: str,
+        register_token: str, hostname_hint: str | None = None,
+    ) -> ClientJoinMaterial:
+        return ClientJoinMaterial(
+            register_token=register_token, allocator_url=allocator_url,
+            connectivity=self.name, client_image=client_image,
+        )
+
+    def cleanup_client_identity(self, *, hostname: str) -> None:
+        relay_manager.stop_visitor(hostname)

--- a/packages/allocator/src/lablink_allocator_service/providers/protocol.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/protocol.py
@@ -70,6 +70,7 @@ class ClientConnectivity(Protocol):
 
     name: str
     requires_tailscale_check: bool
+    requires_frp_check: bool
 
     def prepare_browser_session(self, **kwargs) -> BrowserSessionTarget: ...
 

--- a/packages/allocator/src/lablink_allocator_service/providers/registry.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/registry.py
@@ -14,6 +14,9 @@ from lablink_allocator_service.providers.connectivity.lan_direct import (
 from lablink_allocator_service.providers.connectivity.mesh_overlay import (
     MeshOverlayClientConnectivity,
 )
+from lablink_allocator_service.providers.connectivity.relay import (
+    RelayClientConnectivity,
+)
 from lablink_allocator_service.providers.protocol import ComputeProvider
 
 logger = logging.getLogger(__name__)
@@ -31,6 +34,7 @@ _BUILTIN: dict[str, type] = {"aws": AWSProvider, "manual": ManualProvider}
 _CONNECTIVITY_BUILTIN: dict[str, type] = {
     "lan_direct": LANDirectClientConnectivity,
     "mesh_overlay": MeshOverlayClientConnectivity,
+    "relay": RelayClientConnectivity,
 }
 
 

--- a/packages/allocator/src/lablink_allocator_service/relay_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/relay_manager.py
@@ -107,10 +107,19 @@ def start_visitor(
 ) -> None:
     """Spawn this client's dedicated frpc-visitor subprocess.
 
-    Idempotent for a *live* visitor: an already-running visitor for this
-    client_id is left alone (re-registration is expected to reuse the same
-    alias/secret rather than churn the subprocess). A tracked-but-dead
-    visitor is replaced.
+    Idempotent only for a live visitor whose rendered config is *identical*
+    to what this call wants. A live visitor with a different config is
+    replaced, because re-registration does NOT reuse the previous
+    alias/secret: `register_client` mints a fresh `secrets.token_urlsafe(24)`
+    and allocates a new alias octet every time. The earlier
+    leave-a-live-visitor-alone rule assumed otherwise, and stranded the old
+    pairing -- observed live 2026-07-30, where the DB recorded alias .11 /
+    secret 8pJLHl... while the running visitor still listened on .10 with
+    secret A3Oc9h..., so frps logged `visitor connection ... auth failed`
+    and nginx dialled an alias nothing was bound to. Every other signal
+    (frps logins, the client's "start proxy success", /api/health) reported
+    healthy, and the trigger was the most ordinary operator action there
+    is: retrying a failed registration.
 
     Raises ValueError for a client_id outside the hostname charset, before
     any filesystem or subprocess work happens.
@@ -119,9 +128,19 @@ def start_visitor(
         raise ValueError(
             f"unsafe client_id for a relay visitor config: {client_id!r}"
         )
+    desired = _visitor_config_toml(
+        client_id=client_id, alias_octet=alias_octet,
+        secret_key=secret_key, server_addr=server_addr,
+        server_port=server_port, auth_token=auth_token,
+    )
     running = _visitors.get(client_id)
     if running is not None and running.poll() is None:
-        return
+        config_path = _visitor_config_path(client_id)
+        if config_path.exists() and config_path.read_text() == desired:
+            return
+        # Config changed under a live visitor: tear it down so the write
+        # below and the fresh Popen carry the new pairing.
+        stop_visitor(client_id)
     VISITOR_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
     # mkdir(mode=) is masked by umask and is a no-op when the directory
     # already exists, so set the mode explicitly.

--- a/packages/allocator/src/lablink_allocator_service/relay_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/relay_manager.py
@@ -68,12 +68,20 @@ def _visitor_config_path(client_id: str) -> Path:
 
 def _visitor_config_toml(
     *, client_id: str, alias_octet: int, secret_key: str,
-    server_addr: str, server_port: int,
+    server_addr: str, server_port: int, auth_token: str,
 ) -> str:
     alias = f"127.0.0.{alias_octet}"
     return (
         f"serverAddr = {_toml_str(server_addr)}\n"
         f"serverPort = {int(server_port)}\n"
+        # The allocator's own visitor is an frpc client too, so it must
+        # present the deployment's control-plane token exactly like a relay
+        # client's proxy-side frpc does. Without it frps rejects the login
+        # ("token in login doesn't match token from configuration") and
+        # frpc exits immediately -- with loginFailExit on by default it
+        # does not even retry -- so every relay client is unreachable while
+        # registration still returns a healthy 200.
+        f"auth.token = {_toml_str(auth_token)}\n"
         "\n"
         "[[visitors]]\n"
         f"name = {_toml_str(f'{client_id}-kasmvnc-visitor')}\n"
@@ -95,7 +103,7 @@ def _visitor_config_toml(
 
 def start_visitor(
     *, client_id: str, alias_octet: int, secret_key: str,
-    server_addr: str, server_port: int,
+    server_addr: str, server_port: int, auth_token: str,
 ) -> None:
     """Spawn this client's dedicated frpc-visitor subprocess.
 
@@ -128,7 +136,7 @@ def start_visitor(
         handle.write(_visitor_config_toml(
             client_id=client_id, alias_octet=alias_octet,
             secret_key=secret_key, server_addr=server_addr,
-            server_port=server_port,
+            server_port=server_port, auth_token=auth_token,
         ))
     os.chmod(config_path, 0o600)
     _visitors[client_id] = subprocess.Popen(["frpc", "-c", str(config_path)])

--- a/packages/allocator/src/lablink_allocator_service/relay_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/relay_manager.py
@@ -1,0 +1,121 @@
+"""Process lifecycle for the relay connectivity's two frp roles.
+
+`frps` (the always-on tunnel server relay clients' `frpc` dial into) is
+started once by start.sh, not by this module -- this module only reports
+on its liveness (frp_status, for /api/health). What this module DOES own
+is the per-client `frpc`-visitor subprocess: each relay-connected client
+gets its own dedicated `frpc` process running purely in visitor mode,
+pulling that one client's two STCP proxies (KasmVNC :6080, agent :7070)
+down to its assigned loopback alias so nginx can dial them exactly like
+any other connectivity's "private IP" -- see the relay-client-connectivity
+design spec for the full rationale.
+
+One subprocess per client (rather than one shared frpc with N
+dynamically-reloaded [[visitors]] blocks) avoids relying on frp's
+config-reload command being race-free under concurrent registrations.
+
+No interface setup is needed for the loopback aliases: Linux binds the
+whole 127.0.0.0/8 to `lo`, so 127.0.0.<n> is already locally bindable
+without an `ip addr add`.
+"""
+from __future__ import annotations
+
+import socket
+import subprocess
+from pathlib import Path
+
+from lablink_allocator_service.get_config import get_config
+
+VISITOR_CONFIG_DIR = Path("/tmp/lablink-frp-visitors")
+
+# client_id -> subprocess.Popen, so a later stop_visitor() can find and
+# terminate the right process. Module-level: there is exactly one
+# allocator process per deployment, matching how other per-deployment
+# in-memory state (e.g. the secret-hash cache in secret_hash.py) is
+# already modeled.
+_visitors: dict[str, subprocess.Popen] = {}
+
+
+def _visitor_config_path(client_id: str) -> Path:
+    return VISITOR_CONFIG_DIR / f"{client_id}.toml"
+
+
+def _visitor_config_toml(
+    *, client_id: str, alias_octet: int, secret_key: str,
+    server_addr: str, server_port: int,
+) -> str:
+    alias = f"127.0.0.{alias_octet}"
+    return (
+        f'serverAddr = "{server_addr}"\n'
+        f"serverPort = {server_port}\n"
+        "\n"
+        "[[visitors]]\n"
+        f'name = "{client_id}-kasmvnc-visitor"\n'
+        'type = "stcp"\n'
+        f'serverName = "{client_id}-kasmvnc"\n'
+        f'secretKey = "{secret_key}"\n'
+        f'bindAddr = "{alias}"\n'
+        "bindPort = 6080\n"
+        "\n"
+        "[[visitors]]\n"
+        f'name = "{client_id}-agent-visitor"\n'
+        'type = "stcp"\n'
+        f'serverName = "{client_id}-agent"\n'
+        f'secretKey = "{secret_key}"\n'
+        f'bindAddr = "{alias}"\n'
+        "bindPort = 7070\n"
+    )
+
+
+def start_visitor(
+    *, client_id: str, alias_octet: int, secret_key: str,
+    server_addr: str, server_port: int,
+) -> None:
+    """Spawn this client's dedicated frpc-visitor subprocess.
+
+    Idempotent for a *live* visitor: an already-running visitor for this
+    client_id is left alone (re-registration is expected to reuse the same
+    alias/secret rather than churn the subprocess). A tracked-but-dead
+    visitor is replaced.
+    """
+    running = _visitors.get(client_id)
+    if running is not None and running.poll() is None:
+        return
+    VISITOR_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    config_path = _visitor_config_path(client_id)
+    config_path.write_text(_visitor_config_toml(
+        client_id=client_id, alias_octet=alias_octet, secret_key=secret_key,
+        server_addr=server_addr, server_port=server_port,
+    ))
+    _visitors[client_id] = subprocess.Popen(["frpc", "-c", str(config_path)])
+
+
+def stop_visitor(client_id: str) -> None:
+    """Terminate client_id's visitor subprocess and remove its config.
+
+    No-op if no visitor is tracked for this client_id (e.g. it was never
+    a relay client) -- cleanup_client_identity calls this unconditionally
+    on every unregister.
+    """
+    proc = _visitors.pop(client_id, None)
+    if proc is not None and proc.poll() is None:
+        proc.terminate()
+        proc.wait(timeout=5)
+    _visitor_config_path(client_id).unlink(missing_ok=True)
+
+
+def frp_status() -> str:
+    """"ok" iff the shared frps process (started by start.sh, not this
+    module) is reachable on its configured bind port; "not running"
+    otherwise.
+
+    frps ships no CLI-friendly "am I up" subcommand comparable to
+    `tailscale status`; a raw TCP connect to its own bind port is the
+    cheapest reliable signal available from inside this container.
+    """
+    port = get_config().manual.frps_bind_port
+    try:
+        with socket.create_connection(("127.0.0.1", port), timeout=2):
+            return "ok"
+    except OSError:
+        return "not running"

--- a/packages/allocator/src/lablink_allocator_service/relay_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/relay_manager.py
@@ -20,6 +20,9 @@ without an `ip addr add`.
 """
 from __future__ import annotations
 
+import json
+import os
+import re
 import socket
 import subprocess
 from pathlib import Path
@@ -27,6 +30,29 @@ from pathlib import Path
 from lablink_allocator_service.get_config import get_config
 
 VISITOR_CONFIG_DIR = Path("/tmp/lablink-frp-visitors")
+
+# client_id is a caller-supplied hostname that reaches BOTH a filesystem
+# path and the body of a config file, so it is constrained to a hostname-ish
+# charset here rather than trusted. Without this, "../../etc/foo" escapes
+# VISITOR_CONFIG_DIR (arbitrary write via start_visitor, arbitrary unlink
+# via stop_visitor) and a quote or newline breaks out of a TOML string.
+# routes/registration.py validates the same shape at the API boundary; this
+# is the defense-in-depth copy so the module is safe on its own.
+_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,252}$")
+
+
+def _is_safe_client_id(client_id: str) -> bool:
+    return bool(_CLIENT_ID_RE.fullmatch(client_id or ""))
+
+
+def _toml_str(value: str) -> str:
+    """Encode *value* as an escaped TOML basic string.
+
+    TOML basic strings share JSON's escape rules, so json.dumps is a
+    correct encoder and keeps a stray quote in operator-supplied config
+    (e.g. server_addr) from terminating the string and corrupting the
+    file."""
+    return json.dumps(value)
 
 # client_id -> subprocess.Popen, so a later stop_visitor() can find and
 # terminate the right process. Module-level: there is exactly one
@@ -46,23 +72,23 @@ def _visitor_config_toml(
 ) -> str:
     alias = f"127.0.0.{alias_octet}"
     return (
-        f'serverAddr = "{server_addr}"\n'
-        f"serverPort = {server_port}\n"
+        f"serverAddr = {_toml_str(server_addr)}\n"
+        f"serverPort = {int(server_port)}\n"
         "\n"
         "[[visitors]]\n"
-        f'name = "{client_id}-kasmvnc-visitor"\n'
+        f"name = {_toml_str(f'{client_id}-kasmvnc-visitor')}\n"
         'type = "stcp"\n'
-        f'serverName = "{client_id}-kasmvnc"\n'
-        f'secretKey = "{secret_key}"\n'
-        f'bindAddr = "{alias}"\n'
+        f"serverName = {_toml_str(f'{client_id}-kasmvnc')}\n"
+        f"secretKey = {_toml_str(secret_key)}\n"
+        f"bindAddr = {_toml_str(alias)}\n"
         "bindPort = 6080\n"
         "\n"
         "[[visitors]]\n"
-        f'name = "{client_id}-agent-visitor"\n'
+        f"name = {_toml_str(f'{client_id}-agent-visitor')}\n"
         'type = "stcp"\n'
-        f'serverName = "{client_id}-agent"\n'
-        f'secretKey = "{secret_key}"\n'
-        f'bindAddr = "{alias}"\n'
+        f"serverName = {_toml_str(f'{client_id}-agent')}\n"
+        f"secretKey = {_toml_str(secret_key)}\n"
+        f"bindAddr = {_toml_str(alias)}\n"
         "bindPort = 7070\n"
     )
 
@@ -77,16 +103,34 @@ def start_visitor(
     client_id is left alone (re-registration is expected to reuse the same
     alias/secret rather than churn the subprocess). A tracked-but-dead
     visitor is replaced.
+
+    Raises ValueError for a client_id outside the hostname charset, before
+    any filesystem or subprocess work happens.
     """
+    if not _is_safe_client_id(client_id):
+        raise ValueError(
+            f"unsafe client_id for a relay visitor config: {client_id!r}"
+        )
     running = _visitors.get(client_id)
     if running is not None and running.poll() is None:
         return
     VISITOR_CONFIG_DIR.mkdir(parents=True, exist_ok=True)
+    # mkdir(mode=) is masked by umask and is a no-op when the directory
+    # already exists, so set the mode explicitly.
+    VISITOR_CONFIG_DIR.chmod(0o700)
     config_path = _visitor_config_path(client_id)
-    config_path.write_text(_visitor_config_toml(
-        client_id=client_id, alias_octet=alias_octet, secret_key=secret_key,
-        server_addr=server_addr, server_port=server_port,
-    ))
+    # Create at 0600 up front rather than write-then-chmod, so the embedded
+    # per-client secretKey is never even briefly world-readable. The
+    # explicit chmod covers a pre-existing file, whose mode os.open leaves
+    # untouched.
+    fd = os.open(config_path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(_visitor_config_toml(
+            client_id=client_id, alias_octet=alias_octet,
+            secret_key=secret_key, server_addr=server_addr,
+            server_port=server_port,
+        ))
+    os.chmod(config_path, 0o600)
     _visitors[client_id] = subprocess.Popen(["frpc", "-c", str(config_path)])
 
 
@@ -96,7 +140,15 @@ def stop_visitor(client_id: str) -> None:
     No-op if no visitor is tracked for this client_id (e.g. it was never
     a relay client) -- cleanup_client_identity calls this unconditionally
     on every unregister.
+
+    An unsafe client_id is a silent no-op rather than a raise: this runs on
+    every unregister, so raising would turn a harmless request into a 500,
+    and start_visitor's own check means nothing can ever have been created
+    under such an id. Critically, it returns *before* deriving a path, so a
+    traversal id can never reach unlink().
     """
+    if not _is_safe_client_id(client_id):
+        return
     proc = _visitors.pop(client_id, None)
     if proc is not None and proc.poll() is None:
         proc.terminate()

--- a/packages/allocator/src/lablink_allocator_service/routes/health.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/health.py
@@ -43,6 +43,19 @@ def _tailscale_status() -> str:
     return "ok" if result.returncode == 0 and "inet " in result.stdout else "not joined"
 
 
+def _frp_status() -> str:
+    """Thin wrapper around relay_manager.frp_status(), kept as its own
+    module-level function (rather than calling relay_manager directly from
+    health_check) so tests can monkeypatch it the same way
+    _tailscale_status is monkeypatched.
+
+    Imported lazily to keep this blueprint importable without pulling in
+    get_config at module scope."""
+    from lablink_allocator_service import relay_manager
+
+    return relay_manager.frp_status()
+
+
 @bp.route("/api/health", methods=["GET"])
 def health_check():
     """Return structured readiness status."""
@@ -61,6 +74,10 @@ def health_check():
         "LABLINK_PROVIDER"
     ].client_connectivity.requires_tailscale_check:
         checks["tailscale"] = _tailscale_status()
+    if current_app.config[
+        "LABLINK_PROVIDER"
+    ].client_connectivity.requires_frp_check:
+        checks["frp"] = _frp_status()
 
     all_ready = all(v == "ok" for v in checks.values())
     status = "healthy" if all_ready else "starting"

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 from datetime import datetime
 import psycopg2
+import re
 import secrets
 
 from flask import Blueprint, current_app, jsonify, request
@@ -25,6 +26,14 @@ from lablink_allocator_service.secret_hash import (
 from lablink_allocator_service.utils.config_helpers import canonical_base_url
 
 bp = Blueprint("registration", __name__)
+
+# A registering client's self-declared hostname becomes its client_id, which
+# is the DB primary key AND (under relay connectivity) is interpolated into a
+# visitor config's filesystem path and TOML body. Constrain it to a
+# hostname-ish charset at the boundary so "../.." can't escape the config
+# directory and a quote/newline can't break out of a TOML string.
+# relay_manager re-checks the same shape as defense in depth.
+_VALID_HOSTNAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,252}$")
 
 
 @bp.route("/api/v1/clients/register", methods=["POST"])
@@ -47,6 +56,14 @@ def register_client():
     machine_identity = body.get("machine_identity")
     if not hostname or not machine_identity:
         return jsonify({"error": "hostname and machine_identity required."}), 400
+    if not _VALID_HOSTNAME.fullmatch(hostname):
+        return jsonify({
+            "error": (
+                "hostname must start with a letter or digit and contain only "
+                "letters, digits, dots, dashes and underscores (max 253 "
+                "characters)."
+            )
+        }), 400
 
     provider = body.get("provider", "aws")
     provider_metadata = body.get("provider_metadata") or {}

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -85,6 +85,40 @@ def register_client():
                     "here; omit it and let --lan-ip auto-detect."
                 )
             }), 400
+        expects_relay = prov.client_connectivity.name == "relay"
+        has_relay = provider_metadata.get("relay") is True
+        if expects_relay and not has_relay:
+            return jsonify({
+                "error": (
+                    "This allocator is configured for relay connectivity "
+                    "-- register with provider_metadata={'relay': True}."
+                )
+            }), 400
+        if not expects_relay and has_relay:
+            return jsonify({
+                "error": (
+                    "This allocator is not configured for relay "
+                    "connectivity -- provider_metadata['relay'] is not "
+                    "applicable here."
+                )
+            }), 400
+
+    # Relay clients need two allocator-owned values minted before the row
+    # is written: a loopback alias octet (the address nginx will dial) and
+    # the symmetric STCP secret both sides of the frp tunnel must present.
+    # The secret is stored in plaintext deliberately -- the allocator's own
+    # frpc visitor has to reproduce it verbatim, so a one-way hash would
+    # leave it unable to configure its own side (design spec Decision 9).
+    relay_secret_key = None
+    relay_alias_octet = None
+    if provider == "manual" and provider_metadata.get("relay") is True:
+        relay_alias_octet = main.database.allocate_relay_alias_octet()
+        relay_secret_key = secrets.token_urlsafe(24)
+        provider_metadata = {
+            **provider_metadata,
+            "relay_alias_octet": relay_alias_octet,
+            "relay_secret_key": relay_secret_key,
+        }
 
     client_secret = secrets.token_urlsafe(32)
 
@@ -103,6 +137,16 @@ def register_client():
         return jsonify({"error": "registration conflict"}), 409
     if client_id is None:
         return jsonify({"error": "registration conflict"}), 409
+
+    if relay_secret_key is not None:
+        from lablink_allocator_service import relay_manager
+
+        server_addr, _, server_port = main.cfg.manual.relay_server_addr.rpartition(":")
+        relay_manager.start_visitor(
+            client_id=client_id, alias_octet=relay_alias_octet,
+            secret_key=relay_secret_key,
+            server_addr=server_addr, server_port=int(server_port),
+        )
 
     allocator_url = canonical_base_url(request)
     # cfg.machine.repository is the tutorial-repo-to-clone URL (shipped to
@@ -162,7 +206,7 @@ def register_client():
     repository = main.cfg.machine.repository or ""
     subject_software = main.cfg.machine.software or ""
 
-    return jsonify(
+    response_body = dict(
         client_id=client_id,
         client_secret=client_secret,
         agent_token=main.AGENT_TOKEN,
@@ -184,7 +228,19 @@ def register_client():
             else ""
         ),
         monitoring=monitoring,
-    ), 200
+    )
+    # Relay's three allocator-owned values, returned once here so Plan 2's
+    # `--relay` can be a valueless flag (design spec Decision 6). Added
+    # conditionally so every non-relay deployment's response stays
+    # byte-identical. What returning frps_auth_token does and does not buy
+    # is Decision 12 -- it is a scanner filter, not an independent trust
+    # layer.
+    if relay_secret_key is not None:
+        response_body["relay_secret_key"] = relay_secret_key
+        response_body["relay_server_addr"] = main.cfg.manual.relay_server_addr
+        response_body["frps_auth_token"] = main.cfg.manual.frps_auth_token
+
+    return jsonify(**response_body), 200
 
 
 @bp.route("/api/v1/clients/<client_id>/status", methods=["GET"])
@@ -226,6 +282,14 @@ def unregister_client(client_id):
     deleted = main.database.unregister_client(client_id)
     if not deleted:
         return jsonify({"error": "Client not found."}), 404
+
+    # Optional, feature-detected hook: connectivity strategies that mint
+    # per-client server-side state (relay's frpc-visitor subprocess) tear
+    # it down here. lan_direct/mesh_overlay/allocator_proxied don't
+    # implement it and stay no-ops.
+    connectivity = current_app.config["LABLINK_PROVIDER"].client_connectivity
+    if hasattr(connectivity, "cleanup_client_identity"):
+        connectivity.cleanup_client_identity(hostname=client_id)
 
     return jsonify(client_id=client_id, status="unregistered"), 200
 

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -158,11 +158,22 @@ def register_client():
     if relay_secret_key is not None:
         from lablink_allocator_service import relay_manager
 
-        server_addr, _, server_port = main.cfg.manual.relay_server_addr.rpartition(":")
+        # Dial frps over loopback, NOT via manual.relay_server_addr. That
+        # config value is the address *clients* dial, so it has to be
+        # publicly reachable -- and using it here sent every byte of every
+        # desktop session out to that public address and back to a service
+        # running in this very container. Measured on a cross-LAN test
+        # (2026-07-30): 58-350ms per connect via the public address vs 4-5ms
+        # over loopback, which was ~90% of a 0.69-1.42s tunnel round trip.
+        # Assumes frps is the one start.sh launches in this container, the
+        # only shape supported today -- relay_manager.frp_status() probes
+        # 127.0.0.1 on the same assumption. Both must gain a config knob
+        # together if frps is ever allowed to run off-box.
         relay_manager.start_visitor(
             client_id=client_id, alias_octet=relay_alias_octet,
             secret_key=relay_secret_key,
-            server_addr=server_addr, server_port=int(server_port),
+            server_addr="127.0.0.1",
+            server_port=main.cfg.manual.frps_bind_port,
             auth_token=main.cfg.manual.frps_auth_token,
         )
 

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -163,6 +163,7 @@ def register_client():
             client_id=client_id, alias_octet=relay_alias_octet,
             secret_key=relay_secret_key,
             server_addr=server_addr, server_port=int(server_port),
+            auth_token=main.cfg.manual.frps_auth_token,
         )
 
     allocator_url = canonical_base_url(request)

--- a/packages/allocator/src/lablink_allocator_service/validate_config.py
+++ b/packages/allocator/src/lablink_allocator_service/validate_config.py
@@ -191,13 +191,29 @@ def get_config_errors(cfg) -> list:
         # int("") raises, turning a misconfiguration into a 500 on the
         # first client to register instead of a startup error message.
         if connectivity == "relay":
-            if not getattr(manual_cfg, "relay_server_addr", ""):
+            relay_addr = getattr(manual_cfg, "relay_server_addr", "")
+            if not relay_addr:
                 errors.append(
                     "manual.relay_server_addr is required when "
                     "manual.connectivity is 'relay' — relay clients' frpc "
                     "dial this host:port to reach the allocator's frps "
                     "(e.g. 'allocator.example.com:7000')"
                 )
+            else:
+                # Must be parseable by register_client's
+                # `relay_server_addr.rpartition(":")` + `int(port)`, or the
+                # first relay registration 500s instead of failing here.
+                # rpartition (not partition) is what makes bracketed IPv6
+                # like "[::1]:7000" split correctly.
+                host, sep, port = relay_addr.rpartition(":")
+                if not sep or not host or not port.isdigit() or not (
+                    1 <= int(port) <= 65535
+                ):
+                    errors.append(
+                        "manual.relay_server_addr must be 'host:port' with a "
+                        "numeric port in 1-65535 (e.g. "
+                        f"'allocator.example.com:7000'); got '{relay_addr}'"
+                    )
             if is_weak_frps_token(getattr(manual_cfg, "frps_auth_token", "")):
                 errors.append(
                     "manual.connectivity is 'relay' but "

--- a/packages/allocator/src/lablink_allocator_service/validate_config.py
+++ b/packages/allocator/src/lablink_allocator_service/validate_config.py
@@ -28,8 +28,10 @@ VALID_PROVIDERS = ("aws", "manual")
 
 # manual.connectivity — must stay in sync with the connectivity registry
 # (_CONNECTIVITY_BUILTIN in providers/registry.py). "mesh_overlay" reaches
-# clients that aren't on the allocator's own LAN over a Tailscale tailnet.
-VALID_CONNECTIVITY = ("lan_direct", "mesh_overlay")
+# clients that aren't on the allocator's own LAN over a Tailscale tailnet;
+# "relay" reaches them over an frp tunnel the client dials out through,
+# for networks that won't carry Tailscale at all.
+VALID_CONNECTIVITY = ("lan_direct", "mesh_overlay", "relay")
 
 # manual.participant_exposure — how participants (not clients) reach the
 # allocator when it isn't on their LAN. Independent of connectivity above;
@@ -62,6 +64,30 @@ def is_weak_admin_password(password: str) -> bool:
     if password.lower() in WEAK_ADMIN_PASSWORDS:
         return True
     return len(password) < MIN_ADMIN_PASSWORD_LENGTH
+
+
+# frps's control port is reachable from client networks by construction
+# (that is the whole point of relay connectivity), so it is exposed to the
+# same CT-log-driven scanning as a Funnel-published admin panel. The design
+# spec's Error Handling section is explicit: don't ship this with a weak
+# default. Kept separate from WEAK_ADMIN_PASSWORDS because an frp control
+# token is machine-generated and can afford a longer minimum than a
+# human-typed password.
+WEAK_FRPS_TOKENS = frozenset(
+    {"", "token", "secret", "changeme", "password", "frp", "frps", "lablink", "test"}
+)
+MIN_FRPS_TOKEN_LENGTH = 16
+
+
+def is_weak_frps_token(token: str) -> bool:
+    """True if *token* is empty, a known example/default value, or shorter
+    than the minimum length required of a token guarding a port that is
+    reachable from outside the allocator's own network."""
+    if not token:
+        return True
+    if token.lower() in WEAK_FRPS_TOKENS:
+        return True
+    return len(token) < MIN_FRPS_TOKEN_LENGTH
 
 
 def validate_domain_format(domain: str) -> Tuple[bool, str]:
@@ -158,6 +184,29 @@ def get_config_errors(cfg) -> list:
                 "is 'mesh_overlay' or manual.participant_exposure is "
                 "'tailscale_funnel' (e.g. 'example.ts.net')"
             )
+
+        # relay's two load-bearing config values. Checked at validation
+        # time rather than at first registration: without relay_server_addr,
+        # register_client's rpartition(":") yields an empty host and
+        # int("") raises, turning a misconfiguration into a 500 on the
+        # first client to register instead of a startup error message.
+        if connectivity == "relay":
+            if not getattr(manual_cfg, "relay_server_addr", ""):
+                errors.append(
+                    "manual.relay_server_addr is required when "
+                    "manual.connectivity is 'relay' — relay clients' frpc "
+                    "dial this host:port to reach the allocator's frps "
+                    "(e.g. 'allocator.example.com:7000')"
+                )
+            if is_weak_frps_token(getattr(manual_cfg, "frps_auth_token", "")):
+                errors.append(
+                    "manual.connectivity is 'relay' but "
+                    "manual.frps_auth_token is empty, a known example "
+                    "value, or shorter than "
+                    f"{MIN_FRPS_TOKEN_LENGTH} characters — frps's control "
+                    "port is reachable from client networks and is scanned "
+                    "by bots within minutes of exposure; set a strong token"
+                )
 
         if participant_exposure == "tailscale_funnel":
             admin_password = getattr(getattr(cfg, "app", None), "admin_password", "")

--- a/packages/allocator/start.sh
+++ b/packages/allocator/start.sh
@@ -70,10 +70,16 @@ echo "[allocator] Using config: $CONFIG_DIR/$CONFIG_NAME"
 # for them.
 if [ -n "$FRPS_AUTH_TOKEN" ]; then
   echo "Starting frps on :${FRPS_BIND_PORT:-7000}..."
-  cat > /tmp/frps.toml <<EOF
+  # Subshell + umask so the file is created 0600 from the outset -- it holds
+  # auth.token in plaintext -- and so the tightened umask doesn't leak into
+  # the Flask/nginx startup that follows.
+  (
+    umask 077
+    cat > /tmp/frps.toml <<EOF
 bindPort = ${FRPS_BIND_PORT:-7000}
 auth.token = "$FRPS_AUTH_TOKEN"
 EOF
+  )
   frps -c /tmp/frps.toml &
 fi
 

--- a/packages/allocator/start.sh
+++ b/packages/allocator/start.sh
@@ -63,6 +63,20 @@ fi
 
 echo "[allocator] Using config: $CONFIG_DIR/$CONFIG_NAME"
 
+# Start frps (relay connectivity's tunnel server) if this deployment is
+# configured for it. Gated purely on FRPS_AUTH_TOKEN's presence,
+# mirroring the client image's TAILSCALE_AUTHKEY gate -- lan_direct/
+# mesh_overlay deployments never set this env var, so this is a no-op
+# for them.
+if [ -n "$FRPS_AUTH_TOKEN" ]; then
+  echo "Starting frps on :${FRPS_BIND_PORT:-7000}..."
+  cat > /tmp/frps.toml <<EOF
+bindPort = ${FRPS_BIND_PORT:-7000}
+auth.token = "$FRPS_AUTH_TOKEN"
+EOF
+  frps -c /tmp/frps.toml &
+fi
+
 # Start Flask in the background (binds 127.0.0.1:8000).
 echo "Starting Flask app on 127.0.0.1:8000..."
 lablink-allocator &

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1388,6 +1388,53 @@ def test_get_overlay_hostname_none_when_row_absent(db_instance, mock_db_connecti
     assert db_instance.get_overlay_hostname("nope") is None
 
 
+def test_get_relay_alias_present(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = ("12",)
+    assert db_instance.get_relay_alias("vm-1") == 12
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "provider_metadata->>'relay_alias_octet'" in sql
+    assert "WHERE hostname = %s" in sql
+
+
+def test_get_relay_alias_none_when_absent(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = (None,)
+    assert db_instance.get_relay_alias("vm-1") is None
+
+
+def test_get_relay_alias_none_when_row_absent(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = None
+    assert db_instance.get_relay_alias("nope") is None
+
+
+def test_allocate_relay_alias_octet_starts_at_base_when_none_exist(
+    db_instance, mock_db_connection,
+):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = (None,)
+    assert db_instance.allocate_relay_alias_octet() == 10
+
+
+def test_allocate_relay_alias_octet_increments_past_highest(
+    db_instance, mock_db_connection,
+):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = (17,)
+    assert db_instance.allocate_relay_alias_octet() == 18
+
+
+def test_allocate_relay_alias_octet_starts_at_base_when_table_empty(
+    db_instance, mock_db_connection,
+):
+    """MAX() over zero rows returns a row containing NULL, not no row --
+    but guard the no-row shape too, since both mean "nothing allocated"."""
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = None
+    assert db_instance.allocate_relay_alias_octet() == 10
+
+
 def test_list_hosts_by_provider(db_instance, mock_db_connection):
     _, mock_cursor, _ = mock_db_connection
     mock_cursor.fetchall.return_value = [("vm-1",), ("vm-2",)]

--- a/packages/allocator/tests/providers/connectivity/test_lan_direct.py
+++ b/packages/allocator/tests/providers/connectivity/test_lan_direct.py
@@ -1,6 +1,22 @@
 import uuid
 
 
+def test_satisfies_protocol_and_name():
+    """lan_direct was the one registered connectivity with no protocol
+    conformance test, so a newly-required ClientConnectivity attribute
+    could be omitted here and only surface at runtime."""
+    from lablink_allocator_service.providers.protocol import ClientConnectivity
+    from lablink_allocator_service.providers.connectivity.lan_direct import (
+        LANDirectClientConnectivity,
+    )
+
+    conn = LANDirectClientConnectivity()
+    assert isinstance(conn, ClientConnectivity)
+    assert conn.name == "lan_direct"
+    assert conn.requires_tailscale_check is False
+    assert conn.requires_frp_check is False
+
+
 def test_make_join_material_lan_direct():
     from lablink_allocator_service.providers.connectivity.lan_direct import (
         LANDirectClientConnectivity,

--- a/packages/allocator/tests/providers/connectivity/test_relay.py
+++ b/packages/allocator/tests/providers/connectivity/test_relay.py
@@ -1,0 +1,111 @@
+import uuid
+from unittest.mock import patch
+
+from lablink_allocator_service.providers.protocol import (
+    ClientConnectivity,
+    BrowserSessionTarget,
+)
+
+
+def test_satisfies_protocol_and_name():
+    from lablink_allocator_service.providers.connectivity.relay import (
+        RelayClientConnectivity,
+    )
+
+    conn = RelayClientConnectivity()
+    assert isinstance(conn, ClientConnectivity)
+    assert conn.name == "relay"
+    assert conn.requires_tailscale_check is False
+    assert conn.requires_frp_check is True
+
+
+def test_delegates_to_client_session_with_relay_fallback():
+    from lablink_allocator_service.providers.connectivity.relay import (
+        RelayClientConnectivity,
+        _resolve_relay_alias,
+    )
+
+    sentinel = BrowserSessionTarget(ws_url="proxy/tok", browser_credential=None)
+    sid = uuid.uuid4()
+    with patch(
+        "lablink_allocator_service.providers.connectivity.relay."
+        "prepare_browser_session",
+        return_value=sentinel,
+    ) as m:
+        conn = RelayClientConnectivity()
+        out = conn.prepare_browser_session(
+            database="DB", hostname="vm-1", session_id=sid,
+            browser_token="tok", agent_token="api",
+        )
+    assert out is sentinel
+    m.assert_called_once_with(
+        database="DB", hostname="vm-1", session_id=sid,
+        browser_token="tok", agent_token="api",
+        fallback_fn=_resolve_relay_alias,
+    )
+
+
+def test_resolve_relay_alias_builds_loopback_address():
+    from lablink_allocator_service.providers.connectivity.relay import (
+        _resolve_relay_alias,
+    )
+
+    mock_db = type("DB", (), {"get_relay_alias": staticmethod(
+        lambda hostname: 12
+    )})()
+
+    with patch(
+        "lablink_allocator_service.providers.connectivity.relay._db",
+        return_value=mock_db,
+    ):
+        result = _resolve_relay_alias("vm-1")
+    assert result == "127.0.0.12"
+
+
+def test_resolve_relay_alias_raises_when_not_registered():
+    from lablink_allocator_service.client_session import RotationFailed
+    from lablink_allocator_service.providers.connectivity.relay import (
+        _resolve_relay_alias,
+    )
+
+    mock_db = type("DB", (), {"get_relay_alias": staticmethod(lambda hostname: None)})()
+
+    with patch(
+        "lablink_allocator_service.providers.connectivity.relay._db",
+        return_value=mock_db,
+    ):
+        try:
+            _resolve_relay_alias("vm-1")
+            assert False, "expected RotationFailed"
+        except RotationFailed as e:
+            assert "vm-1" in str(e)
+
+
+def test_make_join_material_returns_relay():
+    from lablink_allocator_service.providers.connectivity.relay import (
+        RelayClientConnectivity,
+    )
+    from lablink_allocator_service.providers.protocol import ClientJoinMaterial
+
+    c = RelayClientConnectivity()
+    m = c.make_join_material(
+        allocator_url="http://a:5000", client_image="img:1",
+        register_token="tk_1",
+    )
+    assert isinstance(m, ClientJoinMaterial)
+    assert m.connectivity == "relay"
+    assert m.allocator_url == "http://a:5000"
+    assert m.client_image == "img:1"
+    assert m.register_token == "tk_1"
+
+
+def test_cleanup_client_identity_stops_visitor():
+    from lablink_allocator_service.providers.connectivity.relay import (
+        RelayClientConnectivity,
+    )
+
+    with patch(
+        "lablink_allocator_service.providers.connectivity.relay.relay_manager"
+    ) as mock_manager:
+        RelayClientConnectivity().cleanup_client_identity(hostname="vm-1")
+    mock_manager.stop_visitor.assert_called_once_with("vm-1")

--- a/packages/allocator/tests/providers/test_protocol.py
+++ b/packages/allocator/tests/providers/test_protocol.py
@@ -28,6 +28,7 @@ def test_protocols_are_runtime_checkable():
     class GoodConn:
         name = "allocator_proxied"
         requires_tailscale_check = False
+        requires_frp_check = False
 
         def prepare_browser_session(self, **kwargs):
             return BrowserSessionTarget(ws_url="proxy/tok", browser_credential=None)
@@ -83,6 +84,7 @@ def test_client_connectivity_protocol_requires_make_join_material():
     class Complete:
         name = "x"
         requires_tailscale_check = False
+        requires_frp_check = False
 
         def prepare_browser_session(self, **kwargs):
             ...
@@ -92,3 +94,25 @@ def test_client_connectivity_protocol_requires_make_join_material():
 
     assert not isinstance(Missing(), ClientConnectivity)
     assert isinstance(Complete(), ClientConnectivity)
+
+
+def test_client_connectivity_protocol_requires_frp_check():
+    from lablink_allocator_service.providers.protocol import ClientConnectivity
+
+    class MissingFrpCheck:
+        name = "x"
+        requires_tailscale_check = False
+
+        def prepare_browser_session(self, **kwargs): ...
+        def make_join_material(self, **kwargs): ...
+
+    class CompleteWithFrpCheck:
+        name = "x"
+        requires_tailscale_check = False
+        requires_frp_check = False
+
+        def prepare_browser_session(self, **kwargs): ...
+        def make_join_material(self, **kwargs): ...
+
+    assert not isinstance(MissingFrpCheck(), ClientConnectivity)
+    assert isinstance(CompleteWithFrpCheck(), ClientConnectivity)

--- a/packages/allocator/tests/providers/test_registry.py
+++ b/packages/allocator/tests/providers/test_registry.py
@@ -74,6 +74,16 @@ def test_get_provider_manual_mesh_overlay_connectivity():
     assert isinstance(p.client_connectivity, MeshOverlayClientConnectivity)
 
 
+def test_get_provider_manual_relay_connectivity():
+    from lablink_allocator_service.providers.connectivity.relay import (
+        RelayClientConnectivity,
+    )
+    p = get_provider(
+        "manual", region=None, terraform_dir=None, connectivity="relay",
+    )
+    assert isinstance(p.client_connectivity, RelayClientConnectivity)
+
+
 def test_get_provider_manual_unknown_connectivity_raises():
     with pytest.raises(ValueError, match="unknown connectivity 'bogus'"):
         get_provider(

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -192,3 +192,74 @@ class TestHealthEndpoint:
         data = resp.get_json()
         assert data["status"] == "starting"
         assert data["checks"]["tailscale"] == "not joined"
+
+    def test_frp_check_absent_when_not_relay(self, client, monkeypatch):
+        """A connectivity strategy that doesn't require an frp check
+        (lan_direct/mesh_overlay/allocator_proxied) must not add an frp
+        key -- byte-identical health payload for every existing
+        deployment."""
+        import lablink_allocator_service.main as main_mod
+
+        monkeypatch.setattr(main_mod, "database", MagicMock())
+        monkeypatch.setattr(main_mod, "scheduler_service", MagicMock())
+        monkeypatch.setattr(main_mod, "reboot_service", MagicMock())
+        monkeypatch.setattr(
+            main_mod.app.config["LABLINK_PROVIDER"].client_connectivity,
+            "requires_frp_check",
+            False,
+        )
+
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        assert "frp" not in resp.get_json()["checks"]
+
+    def test_frp_check_ok_when_frps_running(self, client, monkeypatch):
+        import lablink_allocator_service.main as main_mod
+        import lablink_allocator_service.routes.health as health_mod
+
+        monkeypatch.setattr(main_mod, "database", MagicMock())
+        monkeypatch.setattr(main_mod, "scheduler_service", MagicMock())
+        monkeypatch.setattr(main_mod, "reboot_service", MagicMock())
+        monkeypatch.setattr(
+            main_mod.app.config["LABLINK_PROVIDER"].client_connectivity,
+            "requires_frp_check",
+            True,
+        )
+        monkeypatch.setattr(health_mod, "_frp_status", lambda: "ok")
+
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        assert resp.get_json()["checks"]["frp"] == "ok"
+
+    def test_frp_check_not_running_marks_unhealthy(self, client, monkeypatch):
+        import lablink_allocator_service.main as main_mod
+        import lablink_allocator_service.routes.health as health_mod
+
+        monkeypatch.setattr(main_mod, "database", MagicMock())
+        monkeypatch.setattr(main_mod, "scheduler_service", MagicMock())
+        monkeypatch.setattr(main_mod, "reboot_service", MagicMock())
+        monkeypatch.setattr(
+            main_mod.app.config["LABLINK_PROVIDER"].client_connectivity,
+            "requires_frp_check",
+            True,
+        )
+        monkeypatch.setattr(health_mod, "_frp_status", lambda: "not running")
+
+        resp = client.get("/api/health")
+        assert resp.status_code == 503
+        data = resp.get_json()
+        assert data["status"] == "starting"
+        assert data["checks"]["frp"] == "not running"
+
+
+class TestFrpStatus:
+    """_frp_status() is a thin delegation to relay_manager.frp_status(),
+    kept as its own module-level function so the endpoint tests can
+    monkeypatch it the way _tailscale_status is monkeypatched."""
+
+    def test_delegates_to_relay_manager(self, monkeypatch):
+        import lablink_allocator_service.routes.health as health_mod
+        from lablink_allocator_service import relay_manager
+
+        monkeypatch.setattr(relay_manager, "frp_status", lambda: "ok")
+        assert health_mod._frp_status() == "ok"

--- a/packages/allocator/tests/test_manual_config.py
+++ b/packages/allocator/tests/test_manual_config.py
@@ -17,6 +17,24 @@ class TestManualConfig:
         assert config.connectivity == "mesh_overlay"
         assert config.overlay_tailnet == "example.ts.net"
 
+    def test_manual_config_relay_defaults(self):
+        config = ManualConfig()
+        assert config.relay_server_addr == ""
+        assert config.frps_bind_port == 7000
+        assert config.frps_auth_token == ""
+
+    def test_manual_config_relay(self):
+        config = ManualConfig(
+            connectivity="relay",
+            relay_server_addr="allocator.example.com:7000",
+            frps_bind_port=7001,
+            frps_auth_token="tok123",
+        )
+        assert config.connectivity == "relay"
+        assert config.relay_server_addr == "allocator.example.com:7000"
+        assert config.frps_bind_port == 7001
+        assert config.frps_auth_token == "tok123"
+
     def test_config_has_manual_field(self):
         cfg = Config()
         assert isinstance(cfg.manual, ManualConfig)

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -544,6 +544,64 @@ def test_unregister_success(reg_client):
     fake_db.unregister_client.assert_called_once_with("vm-1")
 
 
+def test_unregister_calls_cleanup_client_identity_when_supported(reg_client):
+    from lablink_allocator_service.secret_hash import hash_secret
+
+    client, fake_db = reg_client
+    fake_db.get_client_secret_hash.return_value = hash_secret("sek")
+    fake_db.unregister_client.return_value = True
+
+    connectivity = client.application.config[
+        "LABLINK_PROVIDER"
+    ].client_connectivity
+    connectivity.cleanup_client_identity = MagicMock()
+
+    r = client.delete(
+        "/api/v1/clients/vm-1",
+        headers={"Authorization": "Bearer sek"},
+    )
+    assert r.status_code == 200
+    connectivity.cleanup_client_identity.assert_called_once_with(hostname="vm-1")
+
+
+def test_unregister_skips_cleanup_when_connectivity_lacks_hook(reg_client):
+    """AllocatorProxiedClientConnectivity (reg_client's default stub) has
+    no cleanup_client_identity method -- must not raise AttributeError."""
+    from lablink_allocator_service.secret_hash import hash_secret
+
+    client, fake_db = reg_client
+    fake_db.get_client_secret_hash.return_value = hash_secret("sek")
+    fake_db.unregister_client.return_value = True
+
+    r = client.delete(
+        "/api/v1/clients/vm-1",
+        headers={"Authorization": "Bearer sek"},
+    )
+    assert r.status_code == 200
+
+
+def test_unregister_skips_cleanup_when_delete_found_nothing(reg_client):
+    """cleanup must not run for a client that wasn't actually deleted --
+    it would tear down a live visitor on a 404."""
+    from lablink_allocator_service.secret_hash import hash_secret
+
+    client, fake_db = reg_client
+    fake_db.get_client_secret_hash.return_value = hash_secret("sek")
+    fake_db.unregister_client.return_value = False
+
+    connectivity = client.application.config[
+        "LABLINK_PROVIDER"
+    ].client_connectivity
+    connectivity.cleanup_client_identity = MagicMock()
+
+    r = client.delete(
+        "/api/v1/clients/vm-1",
+        headers={"Authorization": "Bearer sek"},
+    )
+    assert r.status_code == 404
+    connectivity.cleanup_client_identity.assert_not_called()
+
+
 # ---- GET /api/v1/clients (list endpoint) ---------------------------------
 
 def test_list_clients_rejects_missing_auth(reg_client):
@@ -714,6 +772,141 @@ def test_register_fallback_provider_construction_includes_connectivity(
     )
     assert r.status_code == 200
     fake_db.register_client.assert_called_once()
+
+
+def test_register_rejects_relay_sentinel_against_non_relay_allocator(reg_client):
+    client, fake_db = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual", "provider_metadata": {"relay": True},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 400
+    assert "relay" in r.get_json()["error"]
+    fake_db.register_client.assert_not_called()
+
+
+def test_register_rejects_missing_relay_sentinel_against_relay_allocator(reg_client):
+    from lablink_allocator_service.providers.connectivity.relay import (
+        RelayClientConnectivity,
+    )
+
+    client, fake_db = reg_client
+    client.application.config["LABLINK_PROVIDER"].client_connectivity = (
+        RelayClientConnectivity()
+    )
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual", "provider_metadata": {"lan_ip": "1.2.3.4"},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 400
+    assert "relay" in r.get_json()["error"]
+    fake_db.register_client.assert_not_called()
+
+
+def test_register_relay_allocates_alias_and_spawns_visitor(reg_client, monkeypatch):
+    from lablink_allocator_service.providers.connectivity.relay import (
+        RelayClientConnectivity,
+    )
+    from lablink_allocator_service import main
+
+    client, fake_db = reg_client
+    client.application.config["LABLINK_PROVIDER"].client_connectivity = (
+        RelayClientConnectivity()
+    )
+    fake_db.allocate_relay_alias_octet.return_value = 12
+    monkeypatch.setattr(
+        main.cfg.manual, "relay_server_addr", "allocator.example.com:7000",
+        raising=False,
+    )
+    monkeypatch.setattr(
+        main.cfg.manual, "frps_auth_token", "a-long-enough-frps-token",
+        raising=False,
+    )
+    mock_start_visitor = MagicMock()
+    monkeypatch.setattr(
+        "lablink_allocator_service.relay_manager.start_visitor",
+        mock_start_visitor,
+    )
+
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual", "provider_metadata": {"relay": True},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["relay_secret_key"]
+    assert body["relay_server_addr"] == "allocator.example.com:7000"
+    assert body["frps_auth_token"] == "a-long-enough-frps-token"
+
+    kw = fake_db.register_client.call_args.kwargs
+    assert kw["provider_metadata"]["relay_alias_octet"] == 12
+    assert kw["provider_metadata"]["relay_secret_key"] == body["relay_secret_key"]
+
+    mock_start_visitor.assert_called_once_with(
+        client_id="vm-1", alias_octet=12,
+        secret_key=body["relay_secret_key"],
+        server_addr="allocator.example.com", server_port=7000,
+    )
+
+
+def test_register_response_omits_relay_fields_when_not_relay(reg_client):
+    client, fake_db = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": "vm-1", "machine_identity": "i-1"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert "relay_secret_key" not in body
+    assert "relay_server_addr" not in body
+    assert "frps_auth_token" not in body
+
+
+def test_register_response_preserves_all_non_relay_fields(reg_client):
+    """Regression guard for the relay refactor of this response: the
+    Task 9 change rebuilds the jsonify() call as a dict, and an earlier
+    draft of this plan enumerated a stale 10-field subset that would have
+    silently dropped the five fields added after 2026-07-22. Pin the full
+    contract so any future rebuild of this response fails loudly."""
+    client, fake_db = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": "vm-1", "machine_identity": "i-1"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    for key in (
+        "client_id",
+        "client_secret",
+        "agent_token",
+        "repository",
+        "subject_software",
+        "register_token",
+        "allocator_url",
+        "connectivity",
+        "client_image",
+        "startup_script_b64",
+        "startup_on_error",
+        "startup_max_attempts",
+        "startup_base_delay_seconds",
+        "startup_success_check_b64",
+        "monitoring",
+    ):
+        assert key in body, f"register response lost the {key!r} field"
 
 
 def test_list_clients_returns_safe_fields(reg_client, admin_headers):

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -893,10 +893,13 @@ def test_register_relay_allocates_alias_and_spawns_visitor(reg_client, monkeypat
     assert kw["provider_metadata"]["relay_alias_octet"] == 12
     assert kw["provider_metadata"]["relay_secret_key"] == body["relay_secret_key"]
 
+    # auth_token is load-bearing: without it the spawned frpc is rejected by
+    # frps and exits immediately, so pin that the route passes it through.
     mock_start_visitor.assert_called_once_with(
         client_id="vm-1", alias_octet=12,
         secret_key=body["relay_secret_key"],
         server_addr="allocator.example.com", server_port=7000,
+        auth_token="a-long-enough-frps-token",
     )
 
 

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -774,6 +774,45 @@ def test_register_fallback_provider_construction_includes_connectivity(
     fake_db.register_client.assert_called_once()
 
 
+def test_register_rejects_hostname_outside_charset(reg_client):
+    """hostname is the client_id, and relay connectivity interpolates it
+    into a filesystem path and a TOML config. Constrain it at the API
+    boundary so traversal ('../..') and TOML-breaking characters (quote,
+    newline) can never reach relay_manager."""
+    client, fake_db = reg_client
+    for bad in (
+        "../../etc/passwd",
+        "a/b",
+        "/abs",
+        "..",
+        'x"y',
+        "x\ny",
+        "-leading-dash",
+        "has space",
+        "x" * 300,
+    ):
+        r = client.post(
+            "/api/v1/clients/register",
+            json={"hostname": bad, "machine_identity": "i-1"},
+            headers={"Authorization": "Bearer tk_test_register"},
+        )
+        assert r.status_code == 400, f"{bad!r} should have been rejected"
+        assert "hostname" in r.get_json()["error"]
+    fake_db.register_client.assert_not_called()
+
+
+def test_register_accepts_ordinary_hostnames(reg_client):
+    """The charset must not break the names real deployments already use."""
+    client, fake_db = reg_client
+    for good in ("vm-1", "classroom-gpu-3", "host.example.com", "A1_b-2", "byo1"):
+        r = client.post(
+            "/api/v1/clients/register",
+            json={"hostname": good, "machine_identity": "i-1"},
+            headers={"Authorization": "Bearer tk_test_register"},
+        )
+        assert r.status_code == 200, f"{good!r} should have been accepted"
+
+
 def test_register_rejects_relay_sentinel_against_non_relay_allocator(reg_client):
     client, fake_db = reg_client
     r = client.post(

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -869,6 +869,7 @@ def test_register_relay_allocates_alias_and_spawns_visitor(reg_client, monkeypat
         main.cfg.manual, "frps_auth_token", "a-long-enough-frps-token",
         raising=False,
     )
+    monkeypatch.setattr(main.cfg.manual, "frps_bind_port", 7000, raising=False)
     mock_start_visitor = MagicMock()
     monkeypatch.setattr(
         "lablink_allocator_service.relay_manager.start_visitor",
@@ -893,14 +894,21 @@ def test_register_relay_allocates_alias_and_spawns_visitor(reg_client, monkeypat
     assert kw["provider_metadata"]["relay_alias_octet"] == 12
     assert kw["provider_metadata"]["relay_secret_key"] == body["relay_secret_key"]
 
-    # auth_token is load-bearing: without it the spawned frpc is rejected by
-    # frps and exits immediately, so pin that the route passes it through.
+    # Two things pinned here:
+    # - auth_token is load-bearing: without it the spawned frpc is rejected
+    #   by frps and exits immediately.
+    # - the visitor dials frps over LOOPBACK, not the public
+    #   relay_server_addr clients use. Using the public address sent every
+    #   desktop byte out to the internet and back to a service in this same
+    #   container: measured 58-350ms vs 4-5ms, ~90% of the tunnel's latency.
     mock_start_visitor.assert_called_once_with(
         client_id="vm-1", alias_octet=12,
         secret_key=body["relay_secret_key"],
-        server_addr="allocator.example.com", server_port=7000,
+        server_addr="127.0.0.1", server_port=7000,
         auth_token="a-long-enough-frps-token",
     )
+    # The public address still goes to the CLIENT, which is what dials it.
+    assert body["relay_server_addr"] == "allocator.example.com:7000"
 
 
 def test_register_response_omits_relay_fields_when_not_relay(reg_client):

--- a/packages/allocator/tests/test_relay_manager.py
+++ b/packages/allocator/tests/test_relay_manager.py
@@ -20,6 +20,7 @@ def test_start_visitor_writes_config_and_spawns_frpc(tmp_path, monkeypatch):
         relay_manager.start_visitor(
             client_id="vm-1", alias_octet=12, secret_key="sek",
             server_addr="allocator.example.com", server_port=7000,
+            auth_token="ctl-token",
         )
 
     config_path = tmp_path / "vm-1.toml"
@@ -48,7 +49,7 @@ def test_start_visitor_is_idempotent_when_already_running(tmp_path, monkeypatch)
     ) as mock_popen:
         relay_manager.start_visitor(
             client_id="vm-1", alias_octet=12, secret_key="sek",
-            server_addr="a", server_port=7000,
+            server_addr="a", server_port=7000, auth_token="ctl-token",
         )
     mock_popen.assert_not_called()
 
@@ -72,7 +73,7 @@ def test_start_visitor_respawns_when_tracked_process_is_dead(tmp_path, monkeypat
     ) as mock_popen:
         relay_manager.start_visitor(
             client_id="vm-1", alias_octet=12, secret_key="sek",
-            server_addr="a", server_port=7000,
+            server_addr="a", server_port=7000, auth_token="ctl-token",
         )
     mock_popen.assert_called_once()
     assert relay_manager._visitors["vm-1"] is new_proc
@@ -159,7 +160,7 @@ def test_start_visitor_rejects_unsafe_client_id(bad, tmp_path, monkeypatch):
         with pytest.raises(ValueError):
             relay_manager.start_visitor(
                 client_id=bad, alias_octet=12, secret_key="sek",
-                server_addr="h", server_port=7000,
+                server_addr="h", server_port=7000, auth_token="ctl-token",
             )
     mock_popen.assert_not_called()
     assert list(tmp_path.iterdir()) == []
@@ -202,7 +203,7 @@ def test_start_visitor_config_is_owner_readable_only(tmp_path, monkeypatch):
     ):
         relay_manager.start_visitor(
             client_id="vm-1", alias_octet=12, secret_key="sek",
-            server_addr="h", server_port=7000,
+            server_addr="h", server_port=7000, auth_token="ctl-token",
         )
 
     assert (conf_dir / "vm-1.toml").stat().st_mode & 0o777 == 0o600
@@ -221,7 +222,7 @@ def test_visitor_config_escapes_string_values():
     injected = 'vm"\nbindPort = 22'
     toml = relay_manager._visitor_config_toml(
         client_id="vm-1", alias_octet=12, secret_key='se"k',
-        server_addr=injected, server_port=7000,
+        server_addr=injected, server_port=7000, auth_token="ctl-token",
     )
 
     # The quote is backslash-escaped, and the newline is the two-character
@@ -235,9 +236,9 @@ def test_visitor_config_escapes_string_values():
         line.strip().startswith("bindPort = 22") for line in toml.splitlines()
     )
 
-    # Structure is fixed regardless of input: 2 header lines + 2 blocks of
-    # 7 keys each, separated by blank lines.
-    assert len(toml.splitlines()) == 18
+    # Structure is fixed regardless of input: 3 header lines (serverAddr,
+    # serverPort, auth.token) + 2 blocks of 7 keys each, separated by blanks.
+    assert len(toml.splitlines()) == 19
 
 
 def test_visitor_config_shape_for_normal_input():
@@ -248,6 +249,7 @@ def test_visitor_config_shape_for_normal_input():
     toml = relay_manager._visitor_config_toml(
         client_id="classroom-gpu-3", alias_octet=10, secret_key="s3cret",
         server_addr="allocator.example.com", server_port=7000,
+            auth_token="ctl-token",
     )
 
     assert 'serverName = "classroom-gpu-3-kasmvnc"' in toml
@@ -259,3 +261,41 @@ def test_visitor_config_shape_for_normal_input():
 
     for line in (ln for ln in toml.splitlines() if ln.strip()):
         assert line == "[[visitors]]" or " = " in line, f"malformed line: {line!r}"
+
+
+def test_visitor_config_carries_the_control_plane_auth_token():
+    """Regression guard for a showstopper found only by hand-testing: the
+    allocator's own visitor is an frpc client, so it must present the
+    deployment's auth.token. Without it frps rejects the login with "token
+    in login doesn't match token from configuration" and frpc exits at
+    once (loginFailExit defaults on), leaving every relay client
+    unreachable while registration still returns a healthy 200. Mocked
+    Popen means no unit test can observe the exit -- so assert the config
+    key directly."""
+    from lablink_allocator_service import relay_manager
+
+    toml = relay_manager._visitor_config_toml(
+        client_id="vm-1", alias_octet=12, secret_key="sek",
+        server_addr="h", server_port=7000, auth_token="ctl-token",
+    )
+    assert 'auth.token = "ctl-token"' in toml
+
+
+def test_visitor_config_escapes_the_auth_token():
+    from lablink_allocator_service import relay_manager
+
+    toml = relay_manager._visitor_config_toml(
+        client_id="vm-1", alias_octet=12, secret_key="sek",
+        server_addr="h", server_port=7000, auth_token='tok"en',
+    )
+    assert 'auth.token = "tok\\"en"' in toml
+
+
+def test_start_visitor_requires_an_auth_token_argument():
+    """Keyword is required, not defaulted: a default would let a caller
+    silently omit it and reproduce the original outage."""
+    import inspect
+    from lablink_allocator_service import relay_manager
+
+    param = inspect.signature(relay_manager.start_visitor).parameters["auth_token"]
+    assert param.default is inspect.Parameter.empty

--- a/packages/allocator/tests/test_relay_manager.py
+++ b/packages/allocator/tests/test_relay_manager.py
@@ -1,6 +1,5 @@
 """Unit tests for relay_manager: per-client frpc-visitor subprocess
 lifecycle + frps liveness check."""
-import tomllib
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -211,30 +210,52 @@ def test_start_visitor_config_is_owner_readable_only(tmp_path, monkeypatch):
 
 
 def test_visitor_config_escapes_string_values():
-    """Every interpolated string must be emitted as a properly escaped
-    TOML basic string, so a stray quote in operator-supplied config can't
-    corrupt the file."""
+    """Every interpolated string must be emitted as an escaped TOML basic
+    string, so a stray quote or newline in operator-supplied config can't
+    terminate the string and inject a key.
+
+    Asserted on the rendered text rather than via a TOML parser: tomllib is
+    3.11+, and this package supports Python 3.10 (CI runs 3.10)."""
     from lablink_allocator_service import relay_manager
 
+    injected = 'vm"\nbindPort = 22'
     toml = relay_manager._visitor_config_toml(
         client_id="vm-1", alias_octet=12, secret_key='se"k',
-        server_addr='ho"st', server_port=7000,
+        server_addr=injected, server_port=7000,
     )
-    parsed = tomllib.loads(toml)
-    assert parsed["serverAddr"] == 'ho"st'
-    assert parsed["serverPort"] == 7000
-    assert parsed["visitors"][0]["secretKey"] == 'se"k'
-    assert parsed["visitors"][0]["bindAddr"] == "127.0.0.12"
-    assert [v["bindPort"] for v in parsed["visitors"]] == [6080, 7070]
+
+    # The quote is backslash-escaped, and the newline is the two-character
+    # escape rather than a real line break.
+    assert 'secretKey = "se\\"k"' in toml
+    assert "\\n" in toml
+    assert injected not in toml
+
+    # The decisive property: the injected text cannot become a key.
+    assert not any(
+        line.strip().startswith("bindPort = 22") for line in toml.splitlines()
+    )
+
+    # Structure is fixed regardless of input: 2 header lines + 2 blocks of
+    # 7 keys each, separated by blank lines.
+    assert len(toml.splitlines()) == 18
 
 
-def test_visitor_config_is_valid_toml_for_normal_input():
+def test_visitor_config_shape_for_normal_input():
+    """Structural check without a TOML parser (see the note above): every
+    non-blank line is either a table header or a single key = value."""
     from lablink_allocator_service import relay_manager
 
     toml = relay_manager._visitor_config_toml(
         client_id="classroom-gpu-3", alias_octet=10, secret_key="s3cret",
         server_addr="allocator.example.com", server_port=7000,
     )
-    parsed = tomllib.loads(toml)
-    assert parsed["visitors"][0]["serverName"] == "classroom-gpu-3-kasmvnc"
-    assert parsed["visitors"][1]["serverName"] == "classroom-gpu-3-agent"
+
+    assert 'serverName = "classroom-gpu-3-kasmvnc"' in toml
+    assert 'serverName = "classroom-gpu-3-agent"' in toml
+    assert 'serverAddr = "allocator.example.com"' in toml
+    assert "serverPort = 7000" in toml
+    assert 'bindAddr = "127.0.0.10"' in toml
+    assert toml.count("[[visitors]]") == 2
+
+    for line in (ln for ln in toml.splitlines() if ln.strip()):
+        assert line == "[[visitors]]" or " = " in line, f"malformed line: {line!r}"

--- a/packages/allocator/tests/test_relay_manager.py
+++ b/packages/allocator/tests/test_relay_manager.py
@@ -1,6 +1,9 @@
 """Unit tests for relay_manager: per-client frpc-visitor subprocess
 lifecycle + frps liveness check."""
+import tomllib
 from unittest.mock import MagicMock, patch
+
+import pytest
 
 
 def test_start_visitor_writes_config_and_spawns_frpc(tmp_path, monkeypatch):
@@ -125,3 +128,113 @@ def test_frp_status_not_running_when_connection_refused(monkeypatch):
         side_effect=OSError("refused"),
     ):
         assert relay_manager.frp_status() == "not running"
+
+
+# ---- hardening: client_id reaches a filesystem path and a config file ----
+
+UNSAFE_CLIENT_IDS = [
+    "../../etc/passwd",   # directory traversal
+    "..",                 # traversal via bare dotdot
+    "a/b",                # nested path
+    "/abs",               # absolute path
+    'x"y',                # TOML string terminator
+    "x\ny",               # newline -> injected TOML line
+    "",                   # empty
+    "-leading-dash",      # must start alphanumeric
+]
+
+
+@pytest.mark.parametrize("bad", UNSAFE_CLIENT_IDS)
+def test_start_visitor_rejects_unsafe_client_id(bad, tmp_path, monkeypatch):
+    """client_id is interpolated into both a path and a config file, so
+    relay_manager must refuse unsafe values on its own -- registration
+    validates too, but this module must not depend on that."""
+    from lablink_allocator_service import relay_manager
+
+    monkeypatch.setattr(relay_manager, "VISITOR_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(relay_manager, "_visitors", {})
+
+    with patch(
+        "lablink_allocator_service.relay_manager.subprocess.Popen"
+    ) as mock_popen:
+        with pytest.raises(ValueError):
+            relay_manager.start_visitor(
+                client_id=bad, alias_octet=12, secret_key="sek",
+                server_addr="h", server_port=7000,
+            )
+    mock_popen.assert_not_called()
+    assert list(tmp_path.iterdir()) == []
+
+
+@pytest.mark.parametrize("bad", UNSAFE_CLIENT_IDS)
+def test_stop_visitor_ignores_unsafe_client_id_without_touching_fs(
+    bad, tmp_path, monkeypatch,
+):
+    """stop_visitor runs unconditionally on every unregister, so an unsafe
+    id must be a silent no-op rather than a raise (which would 500 the
+    unregister) -- and must never unlink a path derived from it."""
+    from lablink_allocator_service import relay_manager
+
+    monkeypatch.setattr(relay_manager, "VISITOR_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(relay_manager, "_visitors", {})
+    canary = tmp_path / "canary.toml"
+    canary.write_text("do not delete")
+
+    relay_manager.stop_visitor(bad)  # must not raise
+
+    assert canary.exists()
+
+
+def test_start_visitor_config_is_owner_readable_only(tmp_path, monkeypatch):
+    """The visitor config embeds the per-client STCP secretKey in
+    plaintext, so it must not be world-readable -- the CLI already writes
+    registration secrets at 0600."""
+    from lablink_allocator_service import relay_manager
+
+    conf_dir = tmp_path / "visitors"
+    monkeypatch.setattr(relay_manager, "VISITOR_CONFIG_DIR", conf_dir)
+    monkeypatch.setattr(relay_manager, "_visitors", {})
+
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None
+    with patch(
+        "lablink_allocator_service.relay_manager.subprocess.Popen",
+        return_value=fake_proc,
+    ):
+        relay_manager.start_visitor(
+            client_id="vm-1", alias_octet=12, secret_key="sek",
+            server_addr="h", server_port=7000,
+        )
+
+    assert (conf_dir / "vm-1.toml").stat().st_mode & 0o777 == 0o600
+    assert conf_dir.stat().st_mode & 0o777 == 0o700
+
+
+def test_visitor_config_escapes_string_values():
+    """Every interpolated string must be emitted as a properly escaped
+    TOML basic string, so a stray quote in operator-supplied config can't
+    corrupt the file."""
+    from lablink_allocator_service import relay_manager
+
+    toml = relay_manager._visitor_config_toml(
+        client_id="vm-1", alias_octet=12, secret_key='se"k',
+        server_addr='ho"st', server_port=7000,
+    )
+    parsed = tomllib.loads(toml)
+    assert parsed["serverAddr"] == 'ho"st'
+    assert parsed["serverPort"] == 7000
+    assert parsed["visitors"][0]["secretKey"] == 'se"k'
+    assert parsed["visitors"][0]["bindAddr"] == "127.0.0.12"
+    assert [v["bindPort"] for v in parsed["visitors"]] == [6080, 7070]
+
+
+def test_visitor_config_is_valid_toml_for_normal_input():
+    from lablink_allocator_service import relay_manager
+
+    toml = relay_manager._visitor_config_toml(
+        client_id="classroom-gpu-3", alias_octet=10, secret_key="s3cret",
+        server_addr="allocator.example.com", server_port=7000,
+    )
+    parsed = tomllib.loads(toml)
+    assert parsed["visitors"][0]["serverName"] == "classroom-gpu-3-kasmvnc"
+    assert parsed["visitors"][1]["serverName"] == "classroom-gpu-3-agent"

--- a/packages/allocator/tests/test_relay_manager.py
+++ b/packages/allocator/tests/test_relay_manager.py
@@ -37,9 +37,16 @@ def test_start_visitor_writes_config_and_spawns_frpc(tmp_path, monkeypatch):
 
 
 def test_start_visitor_is_idempotent_when_already_running(tmp_path, monkeypatch):
+    """A live visitor whose on-disk config already matches is left alone."""
     from lablink_allocator_service import relay_manager
 
     monkeypatch.setattr(relay_manager, "VISITOR_CONFIG_DIR", tmp_path)
+    args = dict(
+        client_id="vm-1", alias_octet=12, secret_key="sek",
+        server_addr="a", server_port=7000, auth_token="ctl-token",
+    )
+    # The config a previous call would have written for these exact args.
+    (tmp_path / "vm-1.toml").write_text(relay_manager._visitor_config_toml(**args))
     running_proc = MagicMock()
     running_proc.poll.return_value = None  # still running
     monkeypatch.setattr(relay_manager, "_visitors", {"vm-1": running_proc})
@@ -47,11 +54,43 @@ def test_start_visitor_is_idempotent_when_already_running(tmp_path, monkeypatch)
     with patch(
         "lablink_allocator_service.relay_manager.subprocess.Popen"
     ) as mock_popen:
-        relay_manager.start_visitor(
-            client_id="vm-1", alias_octet=12, secret_key="sek",
-            server_addr="a", server_port=7000, auth_token="ctl-token",
-        )
+        relay_manager.start_visitor(**args)
     mock_popen.assert_not_called()
+
+
+def test_start_visitor_replaces_live_visitor_when_secret_changed(
+    tmp_path, monkeypatch
+):
+    """Re-registration mints a NEW secret and alias octet (see
+    register_client), so a live visitor holding the previous pairing must be
+    replaced, not kept. Observed live 2026-07-30: the stale visitor kept
+    listening on the old alias with the old secret, frps answered
+    `visitor connection ... auth failed`, and every health signal still
+    reported the client as fine."""
+    from lablink_allocator_service import relay_manager
+
+    monkeypatch.setattr(relay_manager, "VISITOR_CONFIG_DIR", tmp_path)
+    old = dict(
+        client_id="vm-1", alias_octet=10, secret_key="old-secret",
+        server_addr="a", server_port=7000, auth_token="ctl-token",
+    )
+    (tmp_path / "vm-1.toml").write_text(relay_manager._visitor_config_toml(**old))
+    running_proc = MagicMock()
+    running_proc.poll.return_value = None  # still running
+    monkeypatch.setattr(relay_manager, "_visitors", {"vm-1": running_proc})
+
+    with patch(
+        "lablink_allocator_service.relay_manager.subprocess.Popen"
+    ) as mock_popen:
+        relay_manager.start_visitor(**{**old, "alias_octet": 11,
+                                      "secret_key": "new-secret"})
+
+    mock_popen.assert_called_once()
+    running_proc.terminate.assert_called_once()
+    content = (tmp_path / "vm-1.toml").read_text()
+    assert 'secretKey = "new-secret"' in content
+    assert 'bindAddr = "127.0.0.11"' in content
+    assert "old-secret" not in content
 
 
 def test_start_visitor_respawns_when_tracked_process_is_dead(tmp_path, monkeypatch):

--- a/packages/allocator/tests/test_relay_manager.py
+++ b/packages/allocator/tests/test_relay_manager.py
@@ -1,0 +1,127 @@
+"""Unit tests for relay_manager: per-client frpc-visitor subprocess
+lifecycle + frps liveness check."""
+from unittest.mock import MagicMock, patch
+
+
+def test_start_visitor_writes_config_and_spawns_frpc(tmp_path, monkeypatch):
+    from lablink_allocator_service import relay_manager
+
+    monkeypatch.setattr(relay_manager, "VISITOR_CONFIG_DIR", tmp_path)
+    monkeypatch.setattr(relay_manager, "_visitors", {})
+
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None
+    with patch(
+        "lablink_allocator_service.relay_manager.subprocess.Popen",
+        return_value=fake_proc,
+    ) as mock_popen:
+        relay_manager.start_visitor(
+            client_id="vm-1", alias_octet=12, secret_key="sek",
+            server_addr="allocator.example.com", server_port=7000,
+        )
+
+    config_path = tmp_path / "vm-1.toml"
+    assert config_path.exists()
+    content = config_path.read_text()
+    assert 'bindAddr = "127.0.0.12"' in content
+    assert "bindPort = 6080" in content
+    assert "bindPort = 7070" in content
+    assert 'secretKey = "sek"' in content
+    assert 'serverAddr = "allocator.example.com"' in content
+    assert "serverPort = 7000" in content
+    mock_popen.assert_called_once_with(["frpc", "-c", str(config_path)])
+    assert relay_manager._visitors["vm-1"] is fake_proc
+
+
+def test_start_visitor_is_idempotent_when_already_running(tmp_path, monkeypatch):
+    from lablink_allocator_service import relay_manager
+
+    monkeypatch.setattr(relay_manager, "VISITOR_CONFIG_DIR", tmp_path)
+    running_proc = MagicMock()
+    running_proc.poll.return_value = None  # still running
+    monkeypatch.setattr(relay_manager, "_visitors", {"vm-1": running_proc})
+
+    with patch(
+        "lablink_allocator_service.relay_manager.subprocess.Popen"
+    ) as mock_popen:
+        relay_manager.start_visitor(
+            client_id="vm-1", alias_octet=12, secret_key="sek",
+            server_addr="a", server_port=7000,
+        )
+    mock_popen.assert_not_called()
+
+
+def test_start_visitor_respawns_when_tracked_process_is_dead(tmp_path, monkeypatch):
+    """A visitor that crashed (poll() returns an exit code) must be
+    replaced, not treated as still-running -- otherwise a re-registration
+    after a crash silently leaves the client unreachable."""
+    from lablink_allocator_service import relay_manager
+
+    monkeypatch.setattr(relay_manager, "VISITOR_CONFIG_DIR", tmp_path)
+    dead_proc = MagicMock()
+    dead_proc.poll.return_value = 1  # exited
+    monkeypatch.setattr(relay_manager, "_visitors", {"vm-1": dead_proc})
+
+    new_proc = MagicMock()
+    new_proc.poll.return_value = None
+    with patch(
+        "lablink_allocator_service.relay_manager.subprocess.Popen",
+        return_value=new_proc,
+    ) as mock_popen:
+        relay_manager.start_visitor(
+            client_id="vm-1", alias_octet=12, secret_key="sek",
+            server_addr="a", server_port=7000,
+        )
+    mock_popen.assert_called_once()
+    assert relay_manager._visitors["vm-1"] is new_proc
+
+
+def test_stop_visitor_terminates_and_removes_config(tmp_path, monkeypatch):
+    from lablink_allocator_service import relay_manager
+
+    monkeypatch.setattr(relay_manager, "VISITOR_CONFIG_DIR", tmp_path)
+    config_path = tmp_path / "vm-1.toml"
+    config_path.write_text("stale config")
+
+    fake_proc = MagicMock()
+    fake_proc.poll.return_value = None
+    monkeypatch.setattr(relay_manager, "_visitors", {"vm-1": fake_proc})
+
+    relay_manager.stop_visitor("vm-1")
+
+    fake_proc.terminate.assert_called_once()
+    fake_proc.wait.assert_called_once_with(timeout=5)
+    assert not config_path.exists()
+    assert "vm-1" not in relay_manager._visitors
+
+
+def test_stop_visitor_is_noop_when_not_tracked(monkeypatch):
+    from lablink_allocator_service import relay_manager
+
+    monkeypatch.setattr(relay_manager, "_visitors", {})
+    relay_manager.stop_visitor("unknown")  # must not raise
+
+
+def test_frp_status_ok_when_port_reachable(monkeypatch):
+    from lablink_allocator_service import relay_manager
+
+    mock_cfg = type("Cfg", (), {"manual": type("M", (), {"frps_bind_port": 7000})()})()
+    monkeypatch.setattr(relay_manager, "get_config", lambda: mock_cfg)
+    with patch(
+        "lablink_allocator_service.relay_manager.socket.create_connection"
+    ) as mock_connect:
+        mock_connect.return_value.__enter__ = MagicMock()
+        mock_connect.return_value.__exit__ = MagicMock(return_value=False)
+        assert relay_manager.frp_status() == "ok"
+
+
+def test_frp_status_not_running_when_connection_refused(monkeypatch):
+    from lablink_allocator_service import relay_manager
+
+    mock_cfg = type("Cfg", (), {"manual": type("M", (), {"frps_bind_port": 7000})()})()
+    monkeypatch.setattr(relay_manager, "get_config", lambda: mock_cfg)
+    with patch(
+        "lablink_allocator_service.relay_manager.socket.create_connection",
+        side_effect=OSError("refused"),
+    ):
+        assert relay_manager.frp_status() == "not running"

--- a/packages/allocator/tests/test_validate_config.py
+++ b/packages/allocator/tests/test_validate_config.py
@@ -643,3 +643,101 @@ class TestParticipantExposureWeakPasswordGate:
         assert cfg.app.admin_password == MISSING_SECRET
         errors = get_config_errors(cfg)
         assert not any("admin_password" in e for e in errors)
+
+
+class TestRelayConnectivityValidation:
+    """connectivity='relay' must be an accepted value (it is a registered
+    entry in _CONNECTIVITY_BUILTIN) and must require the two fields the
+    registration route and frps startup cannot function without."""
+
+    def _make_cfg(
+        self,
+        connectivity="relay",
+        relay_server_addr="allocator.example.com:7000",
+        frps_auth_token="a-long-enough-frps-token",
+        overlay_tailnet="",
+        participant_exposure="none",
+    ):
+        from lablink_allocator_service.conf.structured_config import Config
+
+        cfg = Config()
+        cfg.provider = "manual"
+        cfg.ssl.provider = "none"
+        cfg.dns.enabled = False
+        cfg.dns.domain = ""
+        cfg.app.admin_password = "a-strong-enough-password"
+        cfg.manual.connectivity = connectivity
+        cfg.manual.relay_server_addr = relay_server_addr
+        cfg.manual.frps_auth_token = frps_auth_token
+        cfg.manual.overlay_tailnet = overlay_tailnet
+        cfg.manual.participant_exposure = participant_exposure
+        return cfg
+
+    def test_relay_is_a_valid_connectivity_value(self):
+        from lablink_allocator_service.validate_config import VALID_CONNECTIVITY
+
+        assert "relay" in VALID_CONNECTIVITY
+
+    def test_relay_accepted_with_addr_and_strong_token(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg())
+        assert not [e for e in errors if "relay" in e or "frps" in e]
+
+    def test_relay_without_server_addr_rejected(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(relay_server_addr=""))
+        assert any("relay_server_addr" in e for e in errors)
+
+    def test_relay_with_empty_token_rejected(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(frps_auth_token=""))
+        assert any("frps_auth_token" in e for e in errors)
+
+    def test_relay_with_weak_token_rejected(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(frps_auth_token="changeme"))
+        assert any("frps_auth_token" in e for e in errors)
+
+    def test_relay_with_short_token_rejected(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(frps_auth_token="short"))
+        assert any("frps_auth_token" in e for e in errors)
+
+    def test_relay_fields_ignored_when_not_relay(self):
+        """An operator who leaves the relay fields empty in a lan_direct
+        config must not be blocked by them."""
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(
+            self._make_cfg(
+                connectivity="lan_direct", relay_server_addr="", frps_auth_token=""
+            )
+        )
+        assert not [e for e in errors if "relay" in e or "frps" in e]
+
+    def test_relay_does_not_require_tailnet(self):
+        """relay reaches clients over its own tunnel, not a tailnet --
+        overlay_tailnet must stay optional unless Funnel is in play."""
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(overlay_tailnet=""))
+        assert not any("overlay_tailnet" in e for e in errors)
+
+    def test_relay_with_funnel_is_accepted(self):
+        """relay proxies sessions through the allocator's own nginx, same
+        as mesh_overlay, so the lan_direct mixed-content rejection must
+        NOT fire for relay."""
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(
+            self._make_cfg(
+                participant_exposure="tailscale_funnel",
+                overlay_tailnet="example.ts.net",
+            )
+        )
+        assert not any("mixed content" in e for e in errors)

--- a/packages/allocator/tests/test_validate_config.py
+++ b/packages/allocator/tests/test_validate_config.py
@@ -690,6 +690,51 @@ class TestRelayConnectivityValidation:
         errors = get_config_errors(self._make_cfg(relay_server_addr=""))
         assert any("relay_server_addr" in e for e in errors)
 
+    def test_relay_server_addr_without_port_rejected(self):
+        """The likeliest misconfiguration: host with no ':port'. Must be
+        caught here -- register_client does relay_server_addr.rpartition(":")
+        then int() on the port half, so a colonless value raises ValueError
+        and 500s the first relay registration instead of failing at
+        startup."""
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(
+            self._make_cfg(relay_server_addr="allocator.example.com")
+        )
+        assert any("relay_server_addr" in e for e in errors)
+
+    def test_relay_server_addr_with_empty_port_rejected(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(relay_server_addr="host:"))
+        assert any("relay_server_addr" in e for e in errors)
+
+    def test_relay_server_addr_with_non_numeric_port_rejected(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(relay_server_addr="host:abc"))
+        assert any("relay_server_addr" in e for e in errors)
+
+    def test_relay_server_addr_with_out_of_range_port_rejected(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(relay_server_addr="host:70000"))
+        assert any("relay_server_addr" in e for e in errors)
+
+    def test_relay_server_addr_with_missing_host_rejected(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(relay_server_addr=":7000"))
+        assert any("relay_server_addr" in e for e in errors)
+
+    def test_relay_server_addr_accepts_bracketed_ipv6(self):
+        """rpartition(':') handles '[::1]:7000' correctly, so the stricter
+        check must not reject it."""
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._make_cfg(relay_server_addr="[::1]:7000"))
+        assert not any("relay_server_addr" in e for e in errors)
+
     def test_relay_with_empty_token_rejected(self):
         from lablink_allocator_service.validate_config import get_config_errors
 


### PR DESCRIPTION
## Summary

- Adds `RelayClientConnectivity` — a third `ManualProvider` connectivity option for BYO clients whose network **won't carry Tailscale at all** (blocked protocol, or a no-third-party-VPN policy).
- Inverts the connection direction: instead of the allocator dialing *in* to a stable address, the client dials **out** through an `frp` tunnel, and a per-client `frpc`-visitor subprocess inside the allocator's container pulls that client's KasmVNC (`:6080`) and agent (`:7070`) ports down to a dedicated loopback alias.
- **Allocator-side foundation only.** Hand-curl + hand-run-`frpc` testable on its own; client-image/CLI wiring and `deploy_compose`/wizard support are separate follow-ups.

## Changes Made

| Area | Change |
|---|---|
| `providers/protocol.py` | New `requires_frp_check` capability flag on `ClientConnectivity` (set `False` on the three existing classes) |
| `relay_manager.py` *(new)* | `start_visitor` / `stop_visitor` / `frp_status` — per-client `frpc`-visitor subprocess lifecycle plus an `frps` liveness probe |
| `db/vms.py` | `get_relay_alias`, `allocate_relay_alias_octet` (both inside the existing `provider_metadata` JSONB — no migration) |
| `providers/connectivity/relay.py` *(new)* | `RelayClientConnectivity` + `_resolve_relay_alias`; registered as `_CONNECTIVITY_BUILTIN["relay"]` |
| `conf/structured_config.py` | `relay_server_addr`, `frps_bind_port`, `frps_auth_token` |
| `validate_config.py` | Admit `"relay"`; require `relay_server_addr`; reject a weak/empty `frps_auth_token` via a new `is_weak_frps_token` |
| `routes/health.py` | `"frp"` entry in `/api/health` when `requires_frp_check` is set |
| `routes/registration.py` | Relay registration path (alias + STCP secret minting, visitor spawn) and a feature-detected `cleanup_client_identity` hook on unregister |
| `Dockerfile` / `start.sh` | `frp` binaries; `frps` startup gated on `FRPS_AUTH_TOKEN` |

## Testing

- **842 passed, 19 skipped, 0 failed** (`pytest tests/ --ignore=tests/terraform`). Baseline before this branch was 767 passed, so this adds 75 tests. `tests/terraform` is excluded locally only — it shells out to the `terraform` binary and needs AWS credentials; CI runs the full tree.
- `ruff check src tests` — clean.
- Written test-first throughout: every test was run and confirmed failing for its intended reason before the implementation landed.
- **Manual verification of the image:** `docker build` succeeds; with `FRPS_AUTH_TOKEN` set, `frps` starts and listens on `:7000` with a correctly rendered `/tmp/frps.toml`. Without it, `frps` does **not** start and no config is written — confirming the gate is a true no-op for `lan_direct`/`mesh_overlay`.
- **Hand-tested end to end** (see the section below) — this is no longer outstanding.

## Design Decisions

- **Loopback-alias addressing (the load-bearing trick).** Each relay client gets its own `127.0.0.<n>`, and its visitor binds `<alias>:6080`/`<alias>:7070`. Because `fallback_fn` returns the alias as an ordinary "private IP" string, `client_session.prepare_browser_session`'s existing `f"{ip}:6080"` building keeps working — so there are **zero changes** to `client_session.py`, `routes/desktop.py`, `internal_proxy_auth.py`, or `lablink-nginx.conf`. This needs frp's **STCP** proxy type specifically: a plain TCP proxy binds via a server-wide `proxyBindAddr` with no per-proxy override, which could not put different clients on different aliases.
- **No sidecar.** Unlike Tailscale (which needs `NET_ADMIN`/`/dev/net/tun` and was deliberately isolated), `frp` needs no elevated capabilities, so `frps` and the visitors run in the allocator's own container — the same way `start.sh` already backgrounds Flask before foregrounding nginx.
- **One subprocess per client** rather than one shared `frpc` with N hot-reloaded `[[visitors]]` blocks, so correctness doesn't depend on frp's config-reload being race-free under concurrent registrations.
- **`relay_secret_key` is stored in plaintext, deliberately.** Unlike `client_secret` (only ever verified, so hashing is right), the STCP secret is **symmetric** — the allocator's own visitor must reproduce it verbatim. Blast radius is scoped by per-proxy `serverName` uniqueness; revocation is killing the visitor, not invalidating a hash.
- **Aliases are never recycled** (`MAX(octet)+1`). A dedicated allocation table would need migration machinery this repo avoids. Note the real bound: only the final octet varies, so this tops out around 245 concurrent relay clients — far beyond target deployment size, and the DB is fresh per deployment.
- **`frps_auth_token` is a scanner filter, not an independent trust layer.** It rides the same registration response any `register_token` holder can trigger, so it inherits that token's scope. It still earns its place: it stops internet scanners on the exposed control port and blocks proxy-name squatting. The trade-off is that `register_token` becomes the deployment's crown jewel.
- **Deploy-time selection, not runtime fallback** between `mesh_overlay` and `relay`. Auto-detecting "was this failure real or transient?" is the same category of judgment that already produced one open bug in this codebase; an operator can redeploy with a different `connectivity` value.
- **`frp` is kept an internal implementation detail** — no class name, config key, or `provider_metadata` key names it (only the `requires_frp_check` flag and `relay.py`'s own comments), consistent with how `mesh_overlay` avoids naming Tailscale.

## Follow-up commit

`c4a72269` fixes a defect found after the initial push: `relay_server_addr` was only checked for non-empty, but `register_client` parses it with `.rpartition(":")` + `int(port)`. Three malformed-but-non-empty values passed validation and then raised `ValueError`, 500ing the first relay registration — including the likeliest mistake, omitting the port entirely (`allocator.example.com`). That was precisely the failure the check's own comment claimed to prevent. It now requires `host:port` with a numeric port in 1–65535, with a test pinning that bracketed IPv6 (`[::1]:7000`) still parses.

## Security fixes (commit `33b7e8a9`)

A self-review of this PR turned up three defects, all now fixed with tests. Worth reading, since one was reachable by any `register_token` holder:

1. **Path traversal → arbitrary file write/delete.** `hostname` was validated only for truthiness; `register_client` returns it verbatim as `client_id`; `relay_manager` interpolated it straight into a path, so `'../../../../tmp/pwned'` escaped the config directory. `start_visitor` created/overwrote that path and `stop_visitor` unlinked it, as the allocator user. Now rejected at the registration boundary (400) **and** re-checked inside `relay_manager`, so the module is safe regardless of caller.
2. **TOML injection via the same field.** `client_id` went into four unquoted TOML string positions; a quote or newline corrupted the config so `frpc` failed to start, leaving that client silently unreachable (per-client visitor liveness isn't in `/api/health`). All interpolated strings now go through `json.dumps`, which also protects against a stray quote in operator-supplied `relay_server_addr`.
3. **Secrets world-readable.** The visitor config (per-client `secretKey`) and `/tmp/frps.toml` (`auth.token`) were both `0644`, while the CLI already writes registration secrets at `0600`. Now `0600` in a `0700` directory, created via `os.open` rather than write-then-chmod; `start.sh` uses `umask 077` in a subshell so it doesn't leak into nginx startup.

Note these are **not** caught by coverage gates — the original tests exercised the vulnerable code with well-formed hostnames only, which is exactly why CI was fully green with the bug present.

Known follow-ups deliberately left out of this PR: the `MAX(octet)+1` alias allocation is a read-then-write race under concurrent registration; there's no upper bound before the octet overflows past 255; `stop_visitor`'s `proc.wait(timeout=5)` can raise `TimeoutExpired` and orphan an untracked process; and `start_visitor` failing after the DB row is committed leaves a registered-but-unreachable client.

## Hand-test results (commits `ebe7d215`, `f21f8f73`)

Exercised for real with two containers on a Docker network: the allocator built from `Dockerfile.dev`, and a fake BYO client running `frpc` in proxy mode with throwaway HTTP services on `:7070`/`:6080`.

**It found a showstopper that no unit test could.** The allocator's per-client visitor is itself an `frpc` client, so it must present the deployment's `auth.token` when logging in to `frps`. It never did, so `frps` rejected every visitor login (`token in login doesn't match token from configuration`) and `frpc` exited immediately — while registration still returned a healthy 200 and `/api/health` still said `frp: ok` (correctly: `frps` was fine, it was the *per-client visitor* that died, and per-client liveness is deliberately not surfaced). **No relay client could ever have been reached.** Unit tests mock `Popen`, so the exit is unobservable, and they only assert the config keys we thought to check.

It also surfaced a second gap: only the prod `Dockerfile` got the `frp` binaries. `Dockerfile.dev` had none — the same parity gap the spec warned about for the client image and then wrongly dismissed for the allocator ("only one variant"). This matters more than it appears, because the prod Dockerfile installs `lablink-allocator-service` **from PyPI**, so `Dockerfile.dev` is the only image that can run unreleased relay code. A corollary worth knowing: CI's image build/verify jobs never exercise this branch's Python.

Verified working after the fixes:

| Check | Result |
|---|---|
| `frps` in-process, gated on `FRPS_AUTH_TOKEN` | running; `/api/health` → `{"frp":"ok"}` |
| Register with `{"relay": true}` | 200 with `relay_secret_key`, `relay_server_addr`, `frps_auth_token`; alias octet 10 |
| Visitor process | authenticates to `frps`, binds `127.0.0.10:6080` and `127.0.0.10:7070` |
| **Byte path** | `curl 127.0.0.10:7070/MARKER` from inside the allocator returns content served by the *client* container — visitor → frps → client frpc → client service |
| DB accessors (real Postgres) | `get_relay_alias` → `10` (int), `allocate_relay_alias_octet` → `11`, `_resolve_relay_alias` → `127.0.0.10`, unknown host → `RotationFailed` |
| Second client | gets octet 11; two independent visitors |
| Unregister | `cleanup_client_identity` kills only that client's visitor and removes only its config; the other survives |
| Traversal hostname | rejected 400; nothing written outside the visitor dir |
| File modes | visitor dir `700`, visitor config `600`, `/tmp/frps.toml` `600` |

Still not covered: the participant-facing leg (browser → nginx `/proxy/<token>` → alias) was not driven, since that needs a full VM-assignment flow with a real KasmVNC on the client. The alias-resolution function feeding it is verified against live Postgres.

## Reviewer notes

Two things I'd especially like eyes on:

1. **`routes/registration.py`'s response block** was converted from a `jsonify(...)` call into a dict so the relay fields can be added conditionally. That call had grown to 15 fields, and an earlier draft of this work would have rebuilt it from a stale 10-field list, silently dropping `repository`, `subject_software`, `startup_max_attempts`, `startup_base_delay_seconds`, and `startup_success_check_b64`. `test_register_response_preserves_all_non_relay_fields` now pins all 15 — please sanity-check the diff there anyway.
2. **`validate_config.VALID_CONNECTIVITY` and `providers/registry._CONNECTIVITY_BUILTIN`** are two independent enumerations of the same set. Adding `relay` to only the registry would leave every unit test green while `connectivity: relay` stayed rejected at config validation — i.e. the feature unreachable in any real deployment. Both are updated here; worth knowing for future connectivity modes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)


