### PR TITLE
feat(cli): relay connectivity deployment side — `lablink deploy`/`configure` wiring

### DIFF
--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -55,6 +55,9 @@ FUNNEL_ENABLE_RETRY_DELAY_SECONDS = 2
 # dependencies, so a cross-package import would fail there. Guarded by
 # test_deploy_compose.py::TestCanonicalUrlFile::test_filename_matches_allocator.
 CANONICAL_URL_FILENAME = "allocator-url"
+# Compose's own conventional override filename — auto-loaded from the project
+# directory with no `-f` needed. Only written when connectivity is "relay".
+RELAY_OVERRIDE_FILENAME = "docker-compose.override.yml"
 
 console = Console()
 
@@ -157,6 +160,19 @@ def render_compose_dir(
     template = resources.files("lablink_cli.templates").joinpath(template_name)
     (target / "docker-compose.yml").write_text(template.read_text())
 
+    # 1b. Relay adds an override rather than a third base template (see the
+    #     override file's own header). Deleted when connectivity isn't relay,
+    #     so a redeploy that switches away stops publishing frps's port —
+    #     `docker compose up` would otherwise keep honouring a stale override.
+    override_path = target / RELAY_OVERRIDE_FILENAME
+    if cfg.manual.connectivity == "relay":
+        override_template = resources.files("lablink_cli.templates").joinpath(
+            "docker-compose-relay-override.yml"
+        )
+        override_path.write_text(override_template.read_text())
+    else:
+        override_path.unlink(missing_ok=True)
+
     # 2. Render .env — only the values the compose template substitutes.
     #    No DB or admin creds here: they're inside config.yaml. Read the
     #    OLD .env (if any) before overwriting it, so a redeploy that
@@ -176,6 +192,14 @@ def render_compose_dir(
         env_lines.append(
             f"TAILSCALE_HOSTNAME=lablink-allocator-{cfg.deployment_name or 'lablink'}"
         )
+    if cfg.manual.connectivity == "relay":
+        # Both are substituted by the relay override; the token also has to
+        # reach the container's start.sh, which gates `frps` on it. Unlike
+        # TS_AUTHKEY there is no carry-forward-from-previous-.env dance —
+        # this value lives in config.yaml (minted by `lablink configure`),
+        # so every render already has it.
+        env_lines.append(f"FRPS_AUTH_TOKEN={cfg.manual.frps_auth_token}")
+        env_lines.append(f"FRPS_BIND_PORT={cfg.manual.frps_bind_port}")
     env_path.write_text("\n".join(env_lines) + "\n")
     env_path.chmod(0o600)
 
@@ -331,6 +355,43 @@ def run_deploy_compose(
             "allocator."
         )
         raise SystemExit(1)
+
+    # Preflight: relay's two load-bearing config values. get_config_errors()
+    # rejects both as well (so the wizard/`show-config`/`doctor` catch them),
+    # but `lablink deploy` never calls that validator for the manual provider
+    # and the allocator doesn't validate its config at startup either — this
+    # is the only gate a hand-edited config.yaml passes through. Without it,
+    # a missing token deploys an allocator whose start.sh silently skips frps
+    # (leaving every relay client dialling a port nothing listens on), and a
+    # malformed relay_server_addr turns into a 500 on the first relay
+    # registration rather than an error here.
+    if cfg.manual.connectivity == "relay":
+        from lablink_allocator_service.validate_config import (
+            MIN_FRPS_TOKEN_LENGTH,
+            is_weak_frps_token,
+        )
+
+        if not cfg.manual.relay_server_addr:
+            console.print(
+                "[red]manual.connectivity is 'relay' but "
+                "manual.relay_server_addr is empty.[/red]\n"
+                "Relay clients' frpc dial this host:port to reach the "
+                "allocator's frps — set it to an address reachable from the "
+                f"clients' network (e.g. 'allocator.example.com:"
+                f"{cfg.manual.frps_bind_port}')."
+            )
+            raise SystemExit(1)
+        if is_weak_frps_token(cfg.manual.frps_auth_token):
+            console.print(
+                "[red]manual.connectivity is 'relay' but "
+                "manual.frps_auth_token is empty, a known example value, or "
+                f"shorter than {MIN_FRPS_TOKEN_LENGTH} characters.[/red]\n"
+                "frps's control port is reachable from client networks by "
+                "construction and gets scanned within minutes of exposure — "
+                "set a strong token (`lablink configure` generates one) "
+                "before deploying."
+            )
+            raise SystemExit(1)
 
     # Preflight: docker on PATH.
     if shutil.which("docker") is None:
@@ -716,21 +777,24 @@ def _print_summary(
     # insert a hard newline mid-command — that would break the
     # operator's copy-paste.
     mesh_overlay = cfg.manual.connectivity == "mesh_overlay"
+    relay = cfg.manual.connectivity == "relay"
+    # Neither kind of off-LAN client can use the LAN URL above: a
+    # mesh-overlay client reaches the allocator over the tailnet, a relay
+    # client dials out to it from a network that won't carry Tailscale at
+    # all. Both need whatever address is actually routable from their side.
+    off_lan = mesh_overlay or relay
     # Only substitute when we actually have the real URL — funnel_active
     # can be True while funnel_url is None (enable succeeded but the
     # status lookup didn't match), and a guessed fallback here would be
     # exactly the wrong URL this function used to print.
-    funnel_url_used = mesh_overlay and funnel_active and bool(funnel_url)
+    funnel_url_used = off_lan and funnel_active and bool(funnel_url)
+    if funnel_url_used:
+        # When Funnel is live its public URL IS reachable from anywhere
+        # with internet access, so prefer it for the off-LAN hints
+        # specifically — lan_direct clients genuinely are on the LAN, so
+        # their own hint below keeps using register_url as-is.
+        register_url = funnel_url
     if mesh_overlay:
-        # A mesh-overlay client (e.g. a Run:AI-hosted workload) isn't on
-        # the allocator's LAN at all — the LAN URL above is unreachable
-        # from it regardless of whether we detected one. When Funnel is
-        # live, its public URL actually IS reachable from anywhere with
-        # internet access, so prefer it here specifically — but only for
-        # this mesh-overlay hint; lan_direct clients genuinely are on the
-        # LAN, so their own hint below keeps using register_url as-is.
-        if funnel_url_used:
-            register_url = funnel_url
         console.print(
             "\n[bold]Next step:[/bold] for each mesh-overlay client "
             "(e.g. a Run:AI-hosted workload), open a terminal inside "
@@ -742,6 +806,18 @@ def _print_summary(
             f"--register-token {register_token or '<token>'} "
             "--overlay-hostname <name> --tailscale-authkey <key>"
         )
+    elif relay:
+        console.print(
+            "\n[bold]Next step:[/bold] for each relay client (a box or "
+            "workload whose network won't carry Tailscale), open a terminal "
+            "inside it and run (hostname/machine-identity/GPU are "
+            "auto-detected; the tunnel's secrets are minted by the "
+            "allocator, so --relay takes no arguments):"
+        )
+        register_cmd = (
+            f"  lablink client register --allocator-url {register_url} "
+            f"--register-token {register_token or '<token>'} --relay"
+        )
     else:
         console.print("\n[bold]Next step:[/bold] on each BYO box on the same LAN, run")
         register_cmd = (
@@ -749,12 +825,26 @@ def _print_summary(
             f"--register-token {register_token or '<token>'}"
         )
     console.print(register_cmd, soft_wrap=True, highlight=False)
-    if mesh_overlay:
+    if off_lan:
         console.print(
             "  [dim]Registering ahead of time from elsewhere instead? "
             "Add --no-run-locally to print secrets for your own "
             "workload submission instead of running here, along with "
             "--hostname/--machine-identity.[/dim]"
+        )
+    if relay:
+        # The stack publishes frps's port on this host, but getting the
+        # address clients are told to dial (manual.relay_server_addr) to
+        # land on it is outside what compose can do — and Funnel is not an
+        # option for it, since Funnel only carries HTTPS, not raw TCP.
+        console.print(
+            f"  [dim]frps is published on this host at port "
+            f"{cfg.manual.frps_bind_port}; clients dial "
+            f"{cfg.manual.relay_server_addr}. Make sure that address routes "
+            "here (port-forward, VPN, public IP) — Tailscale Funnel can't "
+            "carry it.[/dim]",
+            soft_wrap=True,
+            highlight=False,
         )
     if not lan_url and not funnel_url_used:
         # If we fell back to localhost, the printed command only works

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -55,9 +55,6 @@ FUNNEL_ENABLE_RETRY_DELAY_SECONDS = 2
 # dependencies, so a cross-package import would fail there. Guarded by
 # test_deploy_compose.py::TestCanonicalUrlFile::test_filename_matches_allocator.
 CANONICAL_URL_FILENAME = "allocator-url"
-# Compose's own conventional override filename — auto-loaded from the project
-# directory with no `-f` needed. Only written when connectivity is "relay".
-RELAY_OVERRIDE_FILENAME = "docker-compose.override.yml"
 
 console = Console()
 
@@ -161,10 +158,12 @@ def render_compose_dir(
     (target / "docker-compose.yml").write_text(template.read_text())
 
     # 1b. Relay adds an override rather than a third base template (see the
-    #     override file's own header). Deleted when connectivity isn't relay,
-    #     so a redeploy that switches away stops publishing frps's port —
-    #     `docker compose up` would otherwise keep honouring a stale override.
-    override_path = target / RELAY_OVERRIDE_FILENAME
+    #     override file's own header). Compose auto-loads this filename from
+    #     the project directory, with no `-f` needed. Deleted when
+    #     connectivity isn't relay, so a redeploy that switches away stops
+    #     publishing frps's port — `docker compose up` would otherwise keep
+    #     honouring a stale override.
+    override_path = target / "docker-compose.override.yml"
     if cfg.manual.connectivity == "relay":
         override_template = resources.files("lablink_cli.templates").joinpath(
             "docker-compose-relay-override.yml"

--- a/packages/cli/src/lablink_cli/templates/docker-compose-relay-override.yml
+++ b/packages/cli/src/lablink_cli/templates/docker-compose-relay-override.yml
@@ -1,0 +1,29 @@
+# Rendered by `lablink deploy` (manual provider, connectivity: relay) — DO
+# NOT edit by hand. Re-run `lablink deploy` to regenerate after config
+# changes.
+#
+# An override rather than a third base template: `docker-compose.yml` already
+# forks on whether a Tailscale sidecar is needed, and relay is independent of
+# that fork — a base-template variant per combination would be four files.
+# Compose auto-loads `docker-compose.override.yml` from the project directory
+# (which is what `docker compose up` runs in) and *concatenates* `ports` with
+# the base file's, so this publishes frps's control port without touching
+# either base template. render_compose_dir deletes this file when connectivity
+# is no longer relay, which is what un-publishes that port on the next deploy.
+#
+# FRPS_AUTH_TOKEN is what the allocator image's start.sh gates its `frps`
+# launch on — no token, no tunnel server. It is referenced from `.env` rather
+# than inlined here so every deployment secret stays in the one file
+# render_compose_dir already chmods to 0600.
+services:
+  allocator:
+    environment:
+      - FRPS_AUTH_TOKEN=${FRPS_AUTH_TOKEN}
+      - FRPS_BIND_PORT=${FRPS_BIND_PORT}
+    ports:
+      # Relay clients' frpc dial this port from outside the operator's host,
+      # so unlike the allocator's HTTP port it is published host:container
+      # 1:1 — manual.relay_server_addr is what the clients are told to dial,
+      # and making that address land here (port-forward, VPN, public IP) is
+      # the operator's job, not this stack's.
+      - "${FRPS_BIND_PORT}:${FRPS_BIND_PORT}"

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import secrets
 from pathlib import Path
 
 from textual import on
@@ -22,6 +23,7 @@ from textual.widgets import (
 )
 from textual.widgets.option_list import Option
 
+from lablink_allocator_service.validate_config import is_weak_frps_token
 from lablink_cli.config.schema import (
     AMI_MAP,
     AWS_REGIONS,
@@ -309,7 +311,9 @@ class ManualConnectivityScreen(Screen):
                 "How the student's browser reaches a client's KasmVNC desktop.\n"
                 "lan_direct: the client is on the allocator's own LAN (default).\n"
                 "mesh_overlay: the client isn't on the allocator's LAN (e.g. a\n"
-                "Run:AI-hosted workload) — reached over a Tailscale tailnet instead.",
+                "Run:AI-hosted workload) — reached over a Tailscale tailnet instead.\n"
+                "relay: the client dials out to the allocator through an frp\n"
+                "tunnel — for networks that won't carry Tailscale at all.",
                 classes="step-description",
             )
 
@@ -325,6 +329,11 @@ class ManualConnectivityScreen(Screen):
                     value=(current == "mesh_overlay"),
                     id="connectivity-mesh-overlay",
                 )
+                yield RadioButton(
+                    "relay — client dials out through an frp tunnel",
+                    value=(current == "relay"),
+                    id="connectivity-relay",
+                )
 
             yield Label(
                 "Tailscale tailnet domain (used by mesh_overlay and/or "
@@ -335,6 +344,24 @@ class ManualConnectivityScreen(Screen):
                 value=cfg.manual.overlay_tailnet or "",
                 placeholder="example.ts.net",
                 id="overlay-tailnet",
+            )
+
+            # Shown unconditionally, same as the tailnet field above — the
+            # validator below is what enforces "required for relay", so the
+            # screen needs no show/hide wiring. The matching frps_auth_token
+            # is generated on Next rather than collected: the allocator hands
+            # it to each client in the registration response, so the operator
+            # never types it anywhere.
+            yield Label(
+                "Relay server address (used by relay, the host:port clients' "
+                "frpc dial to reach this allocator, e.g. "
+                "allocator.example.com:7000)",
+                classes="field-label",
+            )
+            yield Input(
+                value=cfg.manual.relay_server_addr or "",
+                placeholder="allocator.example.com:7000",
+                id="relay-server-addr",
             )
 
             yield Label(
@@ -386,10 +413,27 @@ class ManualConnectivityScreen(Screen):
         chosen = "lan_direct"
         if rb.pressed_button and rb.pressed_button.id == "connectivity-mesh-overlay":
             chosen = "mesh_overlay"
+        elif rb.pressed_button and rb.pressed_button.id == "connectivity-relay":
+            chosen = "relay"
         cfg.manual.connectivity = chosen
         cfg.manual.overlay_tailnet = self.query_one(
             "#overlay-tailnet", Input
         ).value.strip()
+        cfg.manual.relay_server_addr = self.query_one(
+            "#relay-server-addr", Input
+        ).value.strip()
+
+        # Mint the frp control token instead of asking for it. It is
+        # machine-to-machine only (the allocator returns it to each client in
+        # the registration response), and the validator below rejects weak or
+        # empty ones — so without this, choosing relay would deadlock the
+        # wizard on a field the operator has no way to fill in usefully. Only
+        # generated when what's on record wouldn't pass that check, so a
+        # deliberately-set strong token survives re-running `lablink
+        # configure` (regenerating would silently break every already-
+        # registered client, whose frpc still holds the old value).
+        if chosen == "relay" and is_weak_frps_token(cfg.manual.frps_auth_token):
+            cfg.manual.frps_auth_token = secrets.token_urlsafe(32)
 
         rb_exposure = self.query_one("#participant-exposure-select", RadioSet)
         chosen_exposure = "none"
@@ -406,6 +450,8 @@ class ManualConnectivityScreen(Screen):
                 "connectivity" in e
                 or "overlay_tailnet" in e
                 or "participant_exposure" in e
+                or "relay_server_addr" in e
+                or "frps_auth_token" in e
             )
             # admin_password isn't collected until deploy time (resolve_admin_
             # credentials runs in deploy_compose.py, not the wizard) — the

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -307,13 +307,12 @@ class ManualConnectivityScreen(Screen):
                 "Client connectivity",
                 classes="step-title",
             )
+            # Kept to two lines on purpose: the radio labels below already
+            # name each mode, and every extra line of prose here pushes the
+            # address field further past the fold of a 24-row terminal —
+            # where nothing scrolls it back into view (Tab doesn't, measured).
             yield Label(
-                "How the student's browser reaches a client's KasmVNC desktop.\n"
-                "lan_direct: the client is on the allocator's own LAN (default).\n"
-                "mesh_overlay: the client isn't on the allocator's LAN (e.g. a\n"
-                "Run:AI-hosted workload) — reached over a Tailscale tailnet instead.\n"
-                "relay: the client dials out to the allocator through an frp\n"
-                "tunnel — for networks that won't carry Tailscale at all.",
+                "How the student's browser reaches a client's KasmVNC desktop.",
                 classes="step-description",
             )
 
@@ -335,34 +334,36 @@ class ManualConnectivityScreen(Screen):
                     id="connectivity-relay",
                 )
 
-            yield Label(
-                "Tailscale tailnet domain (used by mesh_overlay and/or "
-                "participant exposure below, e.g. example.ts.net)",
-                classes="field-label",
-            )
-            yield Input(
-                value=cfg.manual.overlay_tailnet or "",
-                placeholder="example.ts.net",
-                id="overlay-tailnet",
-            )
+            # Both mode-specific fields live in their own container so
+            # _sync_mode_fields can hide the one this deployment doesn't
+            # use. Every label line stays under ~70 columns: a single long
+            # line widens the whole VerticalScroll past an 80-column
+            # terminal, which clips *every* label on the screen
+            # horizontally, and the wizard has no other line-wrapping.
+            with Container(id="overlay-tailnet-field"):
+                yield Label(
+                    "Tailscale tailnet domain — mesh_overlay and/or Funnel",
+                    classes="field-label",
+                )
+                yield Input(
+                    value=cfg.manual.overlay_tailnet or "",
+                    placeholder="example.ts.net",
+                    id="overlay-tailnet",
+                )
 
-            # Shown unconditionally, same as the tailnet field above — the
-            # validator below is what enforces "required for relay", so the
-            # screen needs no show/hide wiring. The matching frps_auth_token
-            # is generated on Next rather than collected: the allocator hands
-            # it to each client in the registration response, so the operator
-            # never types it anywhere.
-            yield Label(
-                "Relay server address (used by relay, the host:port clients' "
-                "frpc dial to reach this allocator, e.g. "
-                "allocator.example.com:7000)",
-                classes="field-label",
-            )
-            yield Input(
-                value=cfg.manual.relay_server_addr or "",
-                placeholder="allocator.example.com:7000",
-                id="relay-server-addr",
-            )
+            # The matching frps_auth_token is generated on Next rather than
+            # collected: the allocator hands it to each client in the
+            # registration response, so the operator never types it.
+            with Container(id="relay-server-addr-field"):
+                yield Label(
+                    "Relay server address — host:port the clients' frpc dial",
+                    classes="field-label",
+                )
+                yield Input(
+                    value=cfg.manual.relay_server_addr or "",
+                    placeholder="allocator.example.com:7000",
+                    id="relay-server-addr",
+                )
 
             yield Label(
                 "Participant exposure",
@@ -370,13 +371,8 @@ class ManualConnectivityScreen(Screen):
             )
             yield Label(
                 "How participants (not clients) reach the allocator when it\n"
-                "isn't on their LAN. Independent of connectivity above — you\n"
-                "can combine either connectivity option with either exposure\n"
-                "option.\n"
-                "none: allocator stays LAN-only, as today (default).\n"
-                "tailscale_funnel: publish the allocator itself to\n"
-                "participants over the public internet via Tailscale Funnel —\n"
-                "no Tailscale install needed on their side.",
+                "isn't on their LAN. Independent of connectivity above — any\n"
+                "combination of the two is allowed.",
                 classes="step-description",
             )
             with RadioSet(id="participant-exposure-select"):
@@ -401,6 +397,38 @@ class ManualConnectivityScreen(Screen):
 
     def on_mount(self) -> None:
         self.query_one("#connectivity-error").display = False
+        self._sync_mode_fields()
+
+    def _pressed(self, selector: str) -> str:
+        rb = self.query_one(selector, RadioSet)
+        return (rb.pressed_button.id or "") if rb.pressed_button else ""
+
+    @on(RadioSet.Changed)
+    def _on_mode_changed(self, event: RadioSet.Changed) -> None:
+        self._sync_mode_fields()
+
+    def _sync_mode_fields(self) -> None:
+        """Show only the address field the chosen mode actually needs.
+
+        Driven by BOTH radio sets, not just connectivity: the tailnet
+        domain is required by mesh_overlay *and* by tailscale_funnel
+        exposure, so a relay deployment that also publishes itself via
+        Funnel still needs it. Hiding the unused one keeps this screen
+        inside a 24-row terminal — with both fields always rendered, the
+        relay input landed below the fold and was reachable only by
+        tabbing blind.
+        """
+        connectivity = self._pressed("#connectivity-select")
+        funnel = (
+            self._pressed("#participant-exposure-select")
+            == "participant-exposure-funnel"
+        )
+        self.query_one("#relay-server-addr-field").display = (
+            connectivity == "connectivity-relay"
+        )
+        self.query_one("#overlay-tailnet-field").display = (
+            connectivity == "connectivity-mesh-overlay" or funnel
+        )
 
     @on(Button.Pressed, "#back")
     def _back(self) -> None:
@@ -409,12 +437,10 @@ class ManualConnectivityScreen(Screen):
     @on(Button.Pressed, "#next")
     def _next(self) -> None:
         cfg = self.app.config
-        rb = self.query_one("#connectivity-select", RadioSet)
-        pressed = rb.pressed_button.id if rb.pressed_button else ""
         chosen = {
             "connectivity-mesh-overlay": "mesh_overlay",
             "connectivity-relay": "relay",
-        }.get(pressed, "lan_direct")
+        }.get(self._pressed("#connectivity-select"), "lan_direct")
         cfg.manual.connectivity = chosen
         cfg.manual.overlay_tailnet = self.query_one(
             "#overlay-tailnet", Input
@@ -435,14 +461,12 @@ class ManualConnectivityScreen(Screen):
         if chosen == "relay" and is_weak_frps_token(cfg.manual.frps_auth_token):
             cfg.manual.frps_auth_token = secrets.token_urlsafe(32)
 
-        rb_exposure = self.query_one("#participant-exposure-select", RadioSet)
-        chosen_exposure = "none"
-        if (
-            rb_exposure.pressed_button
-            and rb_exposure.pressed_button.id == "participant-exposure-funnel"
-        ):
-            chosen_exposure = "tailscale_funnel"
-        cfg.manual.participant_exposure = chosen_exposure
+        cfg.manual.participant_exposure = (
+            "tailscale_funnel"
+            if self._pressed("#participant-exposure-select")
+            == "participant-exposure-funnel"
+            else "none"
+        )
 
         errors = [
             e for e in validate_config(cfg)

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -410,11 +410,11 @@ class ManualConnectivityScreen(Screen):
     def _next(self) -> None:
         cfg = self.app.config
         rb = self.query_one("#connectivity-select", RadioSet)
-        chosen = "lan_direct"
-        if rb.pressed_button and rb.pressed_button.id == "connectivity-mesh-overlay":
-            chosen = "mesh_overlay"
-        elif rb.pressed_button and rb.pressed_button.id == "connectivity-relay":
-            chosen = "relay"
+        pressed = rb.pressed_button.id if rb.pressed_button else ""
+        chosen = {
+            "connectivity-mesh-overlay": "mesh_overlay",
+            "connectivity-relay": "relay",
+        }.get(pressed, "lan_direct")
         cfg.manual.connectivity = chosen
         cfg.manual.overlay_tailnet = self.query_one(
             "#overlay-tailnet", Input

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -656,21 +656,6 @@ class TestRelayPreflight:
             run_deploy_compose(cfg, yes=True, workdir_root=tmp_path)
         assert "frps_auth_token" in capsys.readouterr().out
 
-    def test_relay_needs_no_tailscale_authkey(self, tmp_path):
-        """Regression guard: relay exists for networks that can't run
-        Tailscale, so it must not be caught by the sidecar authkey gate.
-        Reaching the docker-on-PATH preflight (or beyond) is enough — the
-        authkey check runs before it and would have exited first."""
-        from lablink_cli.commands.deploy_compose import run_deploy_compose
-
-        with (
-            patch(
-                "lablink_cli.commands.deploy_compose.shutil.which", return_value=None
-            ),
-            pytest.raises(SystemExit),
-        ):
-            run_deploy_compose(_relay_cfg(), yes=True, workdir_root=tmp_path)
-
 
 class TestComposeUp:
     @patch("lablink_cli.commands.deploy_compose.subprocess.run")

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -19,6 +19,9 @@ def _manual_cfg(
     connectivity="lan_direct",
     overlay_tailnet="",
     participant_exposure="none",
+    relay_server_addr="",
+    frps_auth_token="",
+    frps_bind_port=7000,
 ):
     cfg = Config()
     cfg.provider = "manual"
@@ -30,7 +33,19 @@ def _manual_cfg(
     cfg.manual.connectivity = connectivity
     cfg.manual.overlay_tailnet = overlay_tailnet
     cfg.manual.participant_exposure = participant_exposure
+    cfg.manual.relay_server_addr = relay_server_addr
+    cfg.manual.frps_auth_token = frps_auth_token
+    cfg.manual.frps_bind_port = frps_bind_port
     return cfg
+
+
+def _relay_cfg(**kwargs):
+    """A relay config that passes every preflight, so a test overriding one
+    value is testing that value and not a missing prerequisite."""
+    kwargs.setdefault("connectivity", "relay")
+    kwargs.setdefault("relay_server_addr", "allocator.example.com:7000")
+    kwargs.setdefault("frps_auth_token", "a-strong-enough-frps-token")
+    return _manual_cfg(**kwargs)
 
 
 class TestRenderComposeDir:
@@ -144,6 +159,80 @@ class TestRenderComposeDir:
             "ALLOCATOR_IMAGE=ghcr.io/talmolab/lablink-allocator-image:v1.2.3"
             in env_content
         )
+
+
+class TestRenderComposeDirRelay:
+    def test_env_carries_token_and_bind_port(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _relay_cfg(frps_bind_port=7100)
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        env_content = (target / ".env").read_text()
+        assert "FRPS_AUTH_TOKEN=a-strong-enough-frps-token" in env_content
+        assert "FRPS_BIND_PORT=7100" in env_content
+        # The token is a deployment secret; it may only ever land in the
+        # file render_compose_dir chmods to 0600.
+        assert (target / ".env").stat().st_mode & 0o777 == 0o600
+        assert "a-strong-enough-frps-token" not in (
+            target / "docker-compose.override.yml"
+        ).read_text()
+
+    def test_override_publishes_port_and_sets_container_env(self, tmp_path):
+        """The allocator image's start.sh gates `frps` on FRPS_AUTH_TOKEN
+        reaching the *container*, and relay clients dial the published port
+        from outside this host — both come from the override file."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _relay_cfg()
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        override = (target / "docker-compose.override.yml").read_text()
+        assert "FRPS_AUTH_TOKEN=${FRPS_AUTH_TOKEN}" in override
+        assert "FRPS_BIND_PORT=${FRPS_BIND_PORT}" in override
+        assert '"${FRPS_BIND_PORT}:${FRPS_BIND_PORT}"' in override
+        # Must attach to the allocator service — anything else and compose
+        # would declare a second service instead of merging into it.
+        assert "allocator:" in override
+
+    def test_non_relay_writes_no_override_or_env(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(connectivity="lan_direct")
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        assert not (target / "docker-compose.override.yml").exists()
+        assert "FRPS" not in (target / ".env").read_text()
+
+    def test_switching_away_from_relay_removes_stale_override(self, tmp_path):
+        """Regression: compose auto-loads docker-compose.override.yml from
+        the project directory, so a leftover file would keep publishing
+        frps's port on every later deploy of a non-relay config."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        target = tmp_path / "compose"
+        render_compose_dir(_relay_cfg(), target)
+        assert (target / "docker-compose.override.yml").exists()
+
+        render_compose_dir(_manual_cfg(connectivity="lan_direct"), target)
+        assert not (target / "docker-compose.override.yml").exists()
+
+    def test_relay_uses_plain_base_template_no_sidecar(self, tmp_path):
+        """relay needs no Tailscale at all — that's the entire point of it.
+        The base template must stay the sidecar-free one, with the override
+        supplying the only relay-specific bits."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _relay_cfg()
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        compose_yaml = (target / "docker-compose.yml").read_text()
+        assert "tailscale/tailscale" not in compose_yaml
+        assert "TS_AUTHKEY" not in (target / ".env").read_text()
 
 
 class TestRenderComposeDirMeshOverlay:
@@ -538,6 +627,49 @@ class TestLanDirectFunnelRejectedAtDeploy:
         assert "'tailscale_funnel'" in out
         assert "'lan_direct'" in out
         assert "mesh_overlay" in out
+
+
+class TestRelayPreflight:
+    """`get_config_errors` rejects both of these too, but `lablink deploy`
+    never calls that validator for the manual provider and the allocator
+    doesn't validate its config at startup — this is the only gate a
+    hand-edited config.yaml passes through."""
+
+    def test_missing_relay_server_addr_is_rejected(self, tmp_path, capsys):
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cfg = _relay_cfg(relay_server_addr="")
+        with pytest.raises(SystemExit):
+            run_deploy_compose(cfg, yes=True, workdir_root=tmp_path)
+        assert "relay_server_addr" in capsys.readouterr().out
+
+    @pytest.mark.parametrize("token", ["", "lablink", "short"])
+    def test_weak_frps_token_is_rejected(self, token, tmp_path, capsys):
+        """An empty token silently disables frps inside the container (start.sh
+        gates on it), and a guessable one is exposed to the same scanning as a
+        Funnel-published admin panel — frps's port is reachable from client
+        networks by construction."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cfg = _relay_cfg(frps_auth_token=token)
+        with pytest.raises(SystemExit):
+            run_deploy_compose(cfg, yes=True, workdir_root=tmp_path)
+        assert "frps_auth_token" in capsys.readouterr().out
+
+    def test_relay_needs_no_tailscale_authkey(self, tmp_path):
+        """Regression guard: relay exists for networks that can't run
+        Tailscale, so it must not be caught by the sidecar authkey gate.
+        Reaching the docker-on-PATH preflight (or beyond) is enough — the
+        authkey check runs before it and would have exited first."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        with (
+            patch(
+                "lablink_cli.commands.deploy_compose.shutil.which", return_value=None
+            ),
+            pytest.raises(SystemExit),
+        ):
+            run_deploy_compose(_relay_cfg(), yes=True, workdir_root=tmp_path)
 
 
 class TestComposeUp:
@@ -1459,6 +1591,75 @@ class TestPrintSummaryMeshOverlay:
         assert "--overlay-hostname" not in out
         assert "--tailscale-authkey" not in out
         assert "--no-run-locally" not in out
+
+
+class TestPrintSummaryRelay:
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_next_step_shows_valueless_relay_flag(self, mock_extract, mock_lan, capsys):
+        """--relay takes no arguments (every tunnel value is minted by the
+        allocator), and a relay client is not on the LAN — so neither the
+        lan_direct wording nor mesh_overlay's flags belong here."""
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        token = "abc123def456ghi789jklmnop"
+        mock_extract.return_value = token
+        mock_lan.return_value = "192.168.1.42"
+
+        _print_summary(_relay_cfg())
+
+        out = capsys.readouterr().out
+        assert f"--register-token {token} --relay" in out
+        assert "on the same LAN" not in out
+        assert "--overlay-hostname" not in out
+        assert "--tailscale-authkey" not in out
+        # Same off-LAN opt-out hint mesh_overlay gets.
+        assert "--no-run-locally" in out
+
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_reports_published_port_and_dialled_address(
+        self, mock_extract, mock_lan, capsys
+    ):
+        """Publishing the port is all compose can do; making
+        relay_server_addr route to it is the operator's job, so say both."""
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        mock_extract.return_value = "tok"
+        mock_lan.return_value = "192.168.1.42"
+
+        _print_summary(
+            _relay_cfg(relay_server_addr="relay.example.com:7100", frps_bind_port=7100)
+        )
+
+        out = capsys.readouterr().out
+        assert "7100" in out
+        assert "relay.example.com:7100" in out
+
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_register_hint_uses_public_url_when_funnel_active(
+        self, mock_extract, mock_lan, capsys
+    ):
+        """A relay client is off-LAN by definition, so the LAN IP is the
+        wrong address to hand it — prefer the Funnel URL when one is live,
+        exactly as the mesh-overlay hint does."""
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        mock_extract.return_value = "tok"
+        mock_lan.return_value = "192.168.1.42"
+
+        _print_summary(
+            _relay_cfg(participant_exposure="tailscale_funnel"),
+            funnel_active=True,
+            funnel_url="https://lablink-allocator-testlab.example.ts.net",
+        )
+
+        out = capsys.readouterr().out
+        assert (
+            "--allocator-url https://lablink-allocator-testlab.example.ts.net" in out
+        )
+        assert "--allocator-url http://192.168.1.42" not in out
 
 
 class TestPrintSummaryFunnel:

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -492,20 +492,27 @@ def test_dns_advanced_eip_radio_is_scrollable_into_view():
 # ---------------------------------------------------------------------------
 def _drive_connectivity_screen(
     *,
-    choose_mesh_overlay: bool,
+    choose_mesh_overlay: bool = False,
+    choose_relay: bool = False,
     overlay_tailnet: str = "",
+    relay_server_addr: str = "",
+    existing_frps_token: str = "",
     choose_funnel: bool = False,
 ):
     """Push ManualConnectivityScreen directly, drive it, return
-    (cfg.manual.connectivity, cfg.manual.overlay_tailnet,
-    cfg.manual.participant_exposure, screen_stack_grew)."""
+    (cfg.manual, screen_stack_grew).
+
+    `existing_frps_token` seeds cfg.manual.frps_auth_token, so tests can
+    check both halves of the generate-only-if-weak rule.
+    """
     import asyncio
     from textual.widgets import Input, RadioButton, RadioSet
 
     cfg, app = _build_cfg_and_app()
     cfg.provider = "manual"
+    cfg.manual.frps_auth_token = existing_frps_token
 
-    async def _run() -> tuple[str, str, str, int]:
+    async def _run():
         from lablink_cli.tui.wizard import ManualConnectivityScreen
 
         async with app.run_test() as pilot:
@@ -521,6 +528,14 @@ def _drive_connectivity_screen(
                     if btn.id == "connectivity-mesh-overlay":
                         btn.value = True
                 screen.query_one("#overlay-tailnet", Input).value = overlay_tailnet
+            if choose_relay:
+                radio_set = screen.query_one("#connectivity-select", RadioSet)
+                for btn in radio_set.query(RadioButton):
+                    if btn.id == "connectivity-relay":
+                        btn.value = True
+                screen.query_one(
+                    "#relay-server-addr", Input
+                ).value = relay_server_addr
             if choose_funnel:
                 exposure_set = screen.query_one(
                     "#participant-exposure-select", RadioSet
@@ -535,42 +550,102 @@ def _drive_connectivity_screen(
             await pilot.pause()
             screen._next()
             await pilot.pause()
-            return (
-                cfg.manual.connectivity,
-                cfg.manual.overlay_tailnet,
-                cfg.manual.participant_exposure,
-                len(app.screen_stack) - stack_before,
-            )
+            return cfg.manual, len(app.screen_stack) - stack_before
 
     return asyncio.run(_run())
 
 
 def test_connectivity_screen_defaults_to_lan_direct():
-    connectivity, tailnet, exposure, stack_delta = _drive_connectivity_screen(
-        choose_mesh_overlay=False
-    )
-    assert connectivity == "lan_direct"
-    assert exposure == "none"
+    manual, stack_delta = _drive_connectivity_screen(choose_mesh_overlay=False)
+    assert manual.connectivity == "lan_direct"
+    assert manual.participant_exposure == "none"
     assert stack_delta == 1, "valid submission should push DnsScreen"
 
 
 def test_connectivity_screen_writes_mesh_overlay_and_tailnet():
-    connectivity, tailnet, exposure, stack_delta = _drive_connectivity_screen(
+    manual, stack_delta = _drive_connectivity_screen(
         choose_mesh_overlay=True, overlay_tailnet="example.ts.net"
     )
-    assert connectivity == "mesh_overlay"
-    assert tailnet == "example.ts.net"
-    assert exposure == "none"
+    assert manual.connectivity == "mesh_overlay"
+    assert manual.overlay_tailnet == "example.ts.net"
+    assert manual.participant_exposure == "none"
     assert stack_delta == 1, "valid submission should push DnsScreen"
 
 
 def test_connectivity_screen_blocks_next_when_tailnet_missing():
     """mesh_overlay chosen but no tailnet domain → validation error, no push."""
-    connectivity, tailnet, exposure, stack_delta = _drive_connectivity_screen(
+    manual, stack_delta = _drive_connectivity_screen(
         choose_mesh_overlay=True, overlay_tailnet=""
     )
-    assert connectivity == "mesh_overlay"
+    assert manual.connectivity == "mesh_overlay"
     assert stack_delta == 0, "invalid submission must not push DnsScreen"
+
+
+def test_connectivity_screen_writes_relay_and_generates_strong_token():
+    """relay's frps_auth_token is machine-to-machine (the allocator returns
+    it to each client at registration), so the wizard mints it rather than
+    asking — without that, the validator's weak-token rule would block the
+    screen on a field the operator has no way to fill in usefully."""
+    from lablink_allocator_service.validate_config import is_weak_frps_token
+
+    manual, stack_delta = _drive_connectivity_screen(
+        choose_relay=True, relay_server_addr="allocator.example.com:7000"
+    )
+    assert manual.connectivity == "relay"
+    assert manual.relay_server_addr == "allocator.example.com:7000"
+    assert not is_weak_frps_token(manual.frps_auth_token)
+    assert stack_delta == 1, "valid submission should push DnsScreen"
+
+
+def test_connectivity_screen_blocks_next_when_relay_server_addr_missing():
+    manual, stack_delta = _drive_connectivity_screen(
+        choose_relay=True, relay_server_addr=""
+    )
+    assert manual.connectivity == "relay"
+    assert stack_delta == 0, "invalid submission must not push DnsScreen"
+
+
+def test_connectivity_screen_blocks_next_when_relay_server_addr_malformed():
+    """The validator's host:port check has to reach the error label — it is
+    filtered by substring, so a mismatch there would silently let a config
+    through that 500s the first relay registration."""
+    manual, stack_delta = _drive_connectivity_screen(
+        choose_relay=True, relay_server_addr="allocator.example.com"
+    )
+    assert stack_delta == 0, "invalid submission must not push DnsScreen"
+
+
+def test_connectivity_screen_preserves_existing_strong_frps_token():
+    """Regenerating on every `lablink configure` run would break every
+    already-registered client, whose frpc still holds the old token."""
+    existing = "an-already-strong-frps-token"
+    manual, stack_delta = _drive_connectivity_screen(
+        choose_relay=True,
+        relay_server_addr="allocator.example.com:7000",
+        existing_frps_token=existing,
+    )
+    assert manual.frps_auth_token == existing
+    assert stack_delta == 1
+
+
+def test_connectivity_screen_replaces_weak_frps_token():
+    from lablink_allocator_service.validate_config import is_weak_frps_token
+
+    manual, stack_delta = _drive_connectivity_screen(
+        choose_relay=True,
+        relay_server_addr="allocator.example.com:7000",
+        existing_frps_token="lablink",
+    )
+    assert manual.frps_auth_token != "lablink"
+    assert not is_weak_frps_token(manual.frps_auth_token)
+    assert stack_delta == 1
+
+
+def test_connectivity_screen_mints_no_frps_token_for_other_connectivity():
+    """A token is only meaningful for relay; minting one for lan_direct
+    would put an unused secret in every config.yaml."""
+    manual, _ = _drive_connectivity_screen(choose_mesh_overlay=False)
+    assert manual.frps_auth_token == ""
 
 
 def _drive_startup_retry_fields(
@@ -643,14 +718,14 @@ def test_connectivity_screen_writes_tailscale_funnel_independent_of_connectivity
     since lan_direct sends participants straight to a client's LAN IP,
     bypassing the allocator Funnel exposes. mesh_overlay + funnel is the
     valid combination."""
-    connectivity, tailnet, exposure, stack_delta = _drive_connectivity_screen(
+    manual, stack_delta = _drive_connectivity_screen(
         choose_mesh_overlay=True,
         choose_funnel=True,
         overlay_tailnet="example.ts.net",
     )
-    assert connectivity == "mesh_overlay"
-    assert exposure == "tailscale_funnel"
-    assert tailnet == "example.ts.net"
+    assert manual.connectivity == "mesh_overlay"
+    assert manual.participant_exposure == "tailscale_funnel"
+    assert manual.overlay_tailnet == "example.ts.net"
     assert stack_delta == 1, "valid submission should push DnsScreen"
 
 
@@ -659,23 +734,23 @@ def test_connectivity_screen_blocks_lan_direct_with_funnel():
     LAN IP, bypassing the allocator — unreachable off-LAN and blocked as
     mixed content once the allocator itself is Funnel-exposed. Rejected
     even with a tailnet domain supplied, unlike the missing-tailnet case."""
-    connectivity, tailnet, exposure, stack_delta = _drive_connectivity_screen(
+    manual, stack_delta = _drive_connectivity_screen(
         choose_mesh_overlay=False,
         choose_funnel=True,
         overlay_tailnet="example.ts.net",
     )
-    assert connectivity == "lan_direct"
-    assert exposure == "tailscale_funnel"
+    assert manual.connectivity == "lan_direct"
+    assert manual.participant_exposure == "tailscale_funnel"
     assert stack_delta == 0, "invalid combination must not push DnsScreen"
 
 
 def test_connectivity_screen_blocks_next_when_funnel_missing_tailnet():
     """tailscale_funnel chosen but no tailnet domain → validation error,
     no push — same requirement mesh_overlay already has, generalized."""
-    connectivity, tailnet, exposure, stack_delta = _drive_connectivity_screen(
+    manual, stack_delta = _drive_connectivity_screen(
         choose_mesh_overlay=False, choose_funnel=True, overlay_tailnet=""
     )
-    assert exposure == "tailscale_funnel"
+    assert manual.participant_exposure == "tailscale_funnel"
     assert stack_delta == 0, "invalid submission must not push DnsScreen"
 
 
@@ -683,12 +758,12 @@ def test_connectivity_screen_funnel_does_not_block_on_unset_admin_password():
     """The weak-admin-password gate is deferred to deploy time (the wizard
     never collects app.admin_password) — choosing tailscale_funnel here
     must not be spuriously blocked by that check."""
-    connectivity, tailnet, exposure, stack_delta = _drive_connectivity_screen(
+    manual, stack_delta = _drive_connectivity_screen(
         choose_mesh_overlay=True,
         choose_funnel=True,
         overlay_tailnet="example.ts.net",
     )
-    assert exposure == "tailscale_funnel"
+    assert manual.participant_exposure == "tailscale_funnel"
     assert stack_delta == 1, (
         "a real requirement (tailnet) blocks progression; an unset "
         "admin_password (not yet collected at this wizard stage) must not"


### PR DESCRIPTION
Plan 3 of 3 for relay connectivity, stacked on #417 (which is stacked on #416). **Review/merge #416 → #417 → this.** Diff shown against `andrew/feat-relay-client-plan2`; only the two commits here are new.

## Summary

- `lablink deploy` now renders the `frps` env + published control port for a `connectivity: relay` deployment, so it no longer needs a hand-set `FRPS_AUTH_TOKEN` on the container.
- `lablink configure` can now produce a relay config at all — it gains the third connectivity radio, a `relay_server_addr` input, and mints the `frps_auth_token` the operator has no way to supply.
- Together these close the last "hand-edited `config.yaml`" gap called out in #416/#417: relay is now reachable through the normal configure → deploy → `register --relay` path.

## Changes Made

**`deploy_compose.py`**
- `.env` gains `FRPS_AUTH_TOKEN` + `FRPS_BIND_PORT` when connectivity is relay. That file is already mode `0600`, which is where a deployment secret belongs — the override references it rather than inlining the token.
- New `templates/docker-compose-relay-override.yml`, rendered as `docker-compose.override.yml`, supplying the container env and publishing `${FRPS_BIND_PORT}:${FRPS_BIND_PORT}`. Deleted whenever connectivity isn't relay.
- Two preflights: empty `relay_server_addr`, and weak/empty `frps_auth_token` (via Plan 1's `is_weak_frps_token`).
- `_print_summary` treats relay as off-LAN alongside `mesh_overlay` (prefers the Funnel URL, shows the `--no-run-locally` note), prints the valueless `--relay` register command, and names both the published port and the address clients dial.

**`tui/wizard.py`**
- Third `relay` radio + `relay_server_addr` input on `ManualConnectivityScreen`, shown unconditionally like the tailnet field above it — the validator enforces "required for relay", so no show/hide wiring.
- `secrets.token_urlsafe(32)` minted into `frps_auth_token` on Next, only when the value on record is weak.
- Error filter extended to `relay_server_addr` / `frps_auth_token` so those validator messages actually reach the screen's error label.

## Testing

712 CLI tests pass (+27 new), `ruff check src tests` clean.

- `TestRenderComposeDirRelay` — env lines carry token/port, token never lands outside `.env`, override sets container env + publishes the port, non-relay writes neither, switching away deletes a stale override, relay keeps the sidecar-free base template.
- `TestRelayPreflight` — missing address and each flavour of weak token rejected; relay is *not* caught by the Tailscale-authkey gate (it exists for networks that can't run Tailscale).
- `TestPrintSummaryRelay` — valueless `--relay` with no overlay flags, published port + dialled address reported, Funnel URL preferred over the LAN IP.
- Wizard: relay writes the address and a strong token, missing *and* malformed addresses block progression, an existing strong token survives, a weak one is replaced, non-relay mints nothing.

**Verified against the real `docker compose` binary**, not just asserted in tests: a rendered relay workdir's `docker compose config` merges to both `80:5000` and `7100:7100` with `FRPS_AUTH_TOKEN`/`FRPS_BIND_PORT` substituted from `.env` — for the plain base template and for the Funnel/sidecar one.

Not covered: a live `configure → deploy → register --relay` run. That needs an allocator image containing #416's frp install, and the published `linux-amd64-latest` predates it (`pull_policy: always` blocks substituting a local dev image without hand-editing the rendered compose file).

## Design Decisions

- **An override file, not a third base template.** The base template already forks on whether a Tailscale sidecar is needed, and relay is orthogonal to that fork — a variant per combination is four files. Compose auto-loads `docker-compose.override.yml` from the project directory (which is what `docker compose up` runs in) and *concatenates* `ports`, so relay adds its port without touching either base template. The cost is that the override must be deleted when connectivity changes, which `render_compose_dir` does and a regression test pins.
- **The token is generated, not collected.** It is machine-to-machine only, and Plan 1's validator rejects weak values — collecting it would deadlock the ReviewScreen on a field the operator can't usefully fill. Regenerating on every `configure` run would silently break already-registered clients, hence generate-only-if-weak.
- **Deploy-time preflights duplicate `get_config_errors` on purpose.** `lablink deploy` never calls that validator for the manual provider, and the allocator doesn't validate its config at startup — so for a hand-edited `config.yaml` this is the only gate. Same reasoning as the existing `lan_direct` + `tailscale_funnel` preflight next to it.
- **Publishing the port is where this stops.** Making `manual.relay_server_addr` route to the published port (port-forward, VPN, public IP) stays the operator's choice, as #416's design states — and Funnel is not an option for it, since Funnel carries HTTPS, not raw TCP. The summary says so rather than the code pretending to automate it.
- **No docs changes.** Nothing under `docs/` documents `mesh_overlay` either; connectivity modes are spec-documented only.

## Related Issues

Completes the relay connectivity roadmap: #416 (allocator foundation) → #417 (client + `register --relay`) → this (deployment wiring).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)