### PR TITLE
feat: reverse_tunnel connectivity — client dials out over the allocator's existing HTTPS address

### DIFF
--- a/packages/allocator/Dockerfile
+++ b/packages/allocator/Dockerfile
@@ -62,6 +62,18 @@ RUN for f in /usr/share/kasmvnc/www/assets/ui-*.js; do \
             || { echo "ERROR: sed did not remove the clobber from $f"; exit 1; }; \
     done
 
+# wstunnel -- reverse-tunnel connectivity's server side. A single static Go/Rust
+# binary; harmless when unused, since start.sh only launches it when
+# CONNECTIVITY_MODE=reverse_tunnel. Must stay in lockstep with Dockerfile.dev
+# and with the client images.
+ARG WSTUNNEL_VERSION=10.6.2
+RUN curl -L -o /tmp/wstunnel.tar.gz \
+      "https://github.com/erebe/wstunnel/releases/download/v${WSTUNNEL_VERSION}/wstunnel_${WSTUNNEL_VERSION}_linux_amd64.tar.gz" && \
+    tar -xzf /tmp/wstunnel.tar.gz -C /tmp && \
+    mv /tmp/wstunnel /usr/local/bin/wstunnel && \
+    chmod +x /usr/local/bin/wstunnel && \
+    rm -f /tmp/wstunnel.tar.gz
+
 COPY lablink-nginx.conf /etc/nginx/conf.d/lablink.conf
 
 # Disable nginx's default site so it doesn't compete with lablink-nginx.conf.

--- a/packages/allocator/Dockerfile.dev
+++ b/packages/allocator/Dockerfile.dev
@@ -58,6 +58,18 @@ RUN for f in /usr/share/kasmvnc/www/assets/ui-*.js; do \
             || { echo "ERROR: sed did not remove the clobber from $f"; exit 1; }; \
     done
 
+# wstunnel -- reverse-tunnel connectivity's server side. A single static Go/Rust
+# binary; harmless when unused, since start.sh only launches it when
+# CONNECTIVITY_MODE=reverse_tunnel. Must stay in lockstep with Dockerfile.dev
+# and with the client images.
+ARG WSTUNNEL_VERSION=10.6.2
+RUN curl -L -o /tmp/wstunnel.tar.gz \
+      "https://github.com/erebe/wstunnel/releases/download/v${WSTUNNEL_VERSION}/wstunnel_${WSTUNNEL_VERSION}_linux_amd64.tar.gz" && \
+    tar -xzf /tmp/wstunnel.tar.gz -C /tmp && \
+    mv /tmp/wstunnel /usr/local/bin/wstunnel && \
+    chmod +x /usr/local/bin/wstunnel && \
+    rm -f /tmp/wstunnel.tar.gz
+
 COPY lablink-nginx.conf /etc/nginx/conf.d/lablink.conf
 
 # Disable nginx's default site so it doesn't compete with lablink-nginx.conf.

--- a/packages/allocator/lablink-nginx.conf
+++ b/packages/allocator/lablink-nginx.conf
@@ -9,8 +9,10 @@
 #   /proxy/<token>        → WebSocket; auth_request to Flask first,
 #                           then proxy to the upstream KasmVNC
 #   /internal/proxy_auth  → internal; only reachable from auth_request
-#   /tunnel/<prefix>      → WebSocket; auth_request to Flask first,
-#                           then proxy to the loopback-bound tunnel server
+#   /tun-<prefix>[/...]   → WebSocket; auth_request to Flask first,
+#                           then proxy to the loopback-bound tunnel server.
+#                           Prefix must be the URL's first path segment
+#                           (see the location block for why).
 #   /internal/tunnel_auth → internal; only reachable from auth_request
 
 upstream flask {
@@ -97,14 +99,27 @@ server {
     # Reverse-tunnel attach point. Same auth_request shape as /proxy/<token>:
     # nginx pauses the WebSocket upgrade, asks Flask whether this client may
     # attach, and only then proxies to the loopback-bound tunnel server.
-    # Verified in a spike: a wrong token yields 401 at the handshake and the
-    # client never attaches.
-    location ~ ^/tunnel/ {
+    # Verified in a spike: a wrong token yields 401 at the handshake, but the
+    # client RETRIES rather than exiting, so the client side must detect that
+    # itself -- nginx rejecting the handshake is not itself an exit signal.
+    #
+    # The prefix must be the URL's first path segment, not a sub-path under
+    # some shared "/tunnel/" root: the tunnel server's own per-client
+    # restriction matcher only inspects the first path segment (see
+    # tunnel_manager.py's module docstring), and the client's real request
+    # path is /<prefix>/events -- so the prefix has to be captured here, at
+    # the front of the path, rather than re-derived from the end of the URI.
+    location ~ ^/(?<tunnel_prefix>tun-[A-Za-z0-9._-]+)(/|$) {
         auth_request           /internal/tunnel_auth;
         proxy_pass             http://127.0.0.1:8080;
         proxy_http_version     1.1;
         proxy_set_header       Upgrade        $http_upgrade;
         proxy_set_header       Connection     "upgrade";
+        # Don't forward the client's bearer secret to the tunnel process --
+        # it has nothing to do with the WebSocket payload and would
+        # otherwise land in the tunnel server's own DEBUG log. Mirrors
+        # /proxy/<token> not passing its cookie upstream either.
+        proxy_set_header       Authorization  "";
         proxy_read_timeout     86400s;
         proxy_send_timeout     86400s;
     }
@@ -114,7 +129,10 @@ server {
         proxy_pass            http://flask/internal/tunnel_auth;
         proxy_pass_request_body off;
         proxy_set_header      Content-Length "";
-        proxy_set_header      X-Original-URI $request_uri;
-        proxy_set_header      X-Tunnel-Auth  $http_authorization;
+        # Hand the prefix nginx already captured to Flask as its own header,
+        # rather than a full URI Flask would have to re-parse -- nginx and
+        # Flask must never disagree about which client is attaching.
+        proxy_set_header      X-Tunnel-Prefix $tunnel_prefix;
+        proxy_set_header      X-Tunnel-Auth   $http_authorization;
     }
 }

--- a/packages/allocator/lablink-nginx.conf
+++ b/packages/allocator/lablink-nginx.conf
@@ -9,6 +9,9 @@
 #   /proxy/<token>        → WebSocket; auth_request to Flask first,
 #                           then proxy to the upstream KasmVNC
 #   /internal/proxy_auth  → internal; only reachable from auth_request
+#   /tunnel/<prefix>      → WebSocket; auth_request to Flask first,
+#                           then proxy to the loopback-bound tunnel server
+#   /internal/tunnel_auth → internal; only reachable from auth_request
 
 upstream flask {
     server 127.0.0.1:8000;
@@ -89,5 +92,29 @@ server {
         proxy_set_header      Content-Length "";
         proxy_set_header      X-Original-URI $request_uri;
         proxy_set_header      Cookie $http_cookie;
+    }
+
+    # Reverse-tunnel attach point. Same auth_request shape as /proxy/<token>:
+    # nginx pauses the WebSocket upgrade, asks Flask whether this client may
+    # attach, and only then proxies to the loopback-bound tunnel server.
+    # Verified in a spike: a wrong token yields 401 at the handshake and the
+    # client never attaches.
+    location ~ ^/tunnel/ {
+        auth_request           /internal/tunnel_auth;
+        proxy_pass             http://127.0.0.1:8080;
+        proxy_http_version     1.1;
+        proxy_set_header       Upgrade        $http_upgrade;
+        proxy_set_header       Connection     "upgrade";
+        proxy_read_timeout     86400s;
+        proxy_send_timeout     86400s;
+    }
+
+    location = /internal/tunnel_auth {
+        internal;
+        proxy_pass            http://flask/internal/tunnel_auth;
+        proxy_pass_request_body off;
+        proxy_set_header      Content-Length "";
+        proxy_set_header      X-Original-URI $request_uri;
+        proxy_set_header      X-Tunnel-Auth  $http_authorization;
     }
 }

--- a/packages/allocator/pyproject.toml
+++ b/packages/allocator/pyproject.toml
@@ -21,6 +21,7 @@ dependencies = [
   "apscheduler~=3.11.1",
   "urllib3>=2.3.0,<3.0",
   "argon2-cffi~=23.1.0",
+  "pyyaml>=6.0",
 ]
 description = "VM Allocator Service Package for Lablink"
 name = "lablink-allocator-service"

--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -292,7 +292,26 @@ class VmDatabase:
     _TUNNEL_ALIAS_BASE = 10
 
     def allocate_tunnel_alias_octet(self) -> int:
-        """Next unused loopback-alias octet for a reverse-tunnel client.
+        """Atomically claim the next unused loopback-alias octet for a
+        reverse-tunnel client.
+
+        Used to be a bare ``SELECT MAX((provider_metadata->>...)::int)``
+        over client rows -- a pure read with no claim, so two concurrent
+        registrations could observe the same "current max" before either
+        one's INSERT was even issued and mint the same octet. A classroom
+        registering many clients at once is the normal case, and this
+        repo already has a documented VM-assignment race of exactly this
+        shape (see assign_vm).
+
+        Fixed with a counter row in the existing ``settings`` table
+        (still no schema change): ``INSERT ... ON CONFLICT DO UPDATE`` is
+        a single statement that self-initializes the counter on first use
+        and otherwise increments it, both atomically. Postgres re-checks
+        the UPDATE arm's SET expression against the row's just-committed
+        value for any caller that was blocked waiting on it, so two
+        interleaved calls can never return the same value (verified with
+        concurrent threads against a real Postgres in
+        test_allocate_tunnel_alias_octet_concurrent_returns_distinct_octets).
 
         Never recycled: what actually revokes a departed client's
         reachability is dropping its tunnel restriction (see
@@ -304,12 +323,15 @@ class VmDatabase:
         """
         with self._cursor as cursor:
             cursor.execute(
-                f"SELECT MAX((provider_metadata->>'tunnel_alias_octet')::int) "
-                f"FROM {self.table_name};"
+                "INSERT INTO settings (key, value) "
+                "VALUES ('tunnel_alias_next_octet', %s) "
+                "ON CONFLICT (key) DO UPDATE "
+                "SET value = (settings.value::int + 1)::text "
+                "RETURNING value::int;",
+                (str(self._TUNNEL_ALIAS_BASE),),
             )
             row = cursor.fetchone()
-        highest = row[0] if row else None
-        return highest + 1 if highest is not None else self._TUNNEL_ALIAS_BASE
+        return row[0]
 
     def get_tunnel_alias(self, hostname: str):
         """Loopback-alias octet for a reverse-tunnel client, or None."""

--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -343,12 +343,24 @@ class VmDatabase:
             row = cursor.fetchone()
         return row[0]
 
+    # Every read of tunnel metadata below filters through this. The metadata
+    # is client-supplied and the sentinel check that would reject a forged one
+    # is gated on `provider == "manual"` (routes/registration.py), so a
+    # `provider: "aws"` registration stores arbitrary tunnel_* keys verbatim.
+    # The sentinel arm restricts these reads to rows the allocator minted; the
+    # regex arm is what makes the int() calls below total.
+    _TUNNEL_ROW_SQL = (
+        "provider_metadata->>'reverse_tunnel' = 'true' "
+        "AND provider_metadata->>'tunnel_alias_octet' ~ '^[0-9]+$'"
+    )
+
     def get_tunnel_alias(self, hostname: str):
         """Loopback-alias octet for a reverse-tunnel client, or None."""
         with self._cursor as cursor:
             cursor.execute(
                 f"SELECT provider_metadata->>'tunnel_alias_octet' "
-                f"FROM {self.table_name} WHERE hostname = %s;",
+                f"FROM {self.table_name} WHERE hostname = %s "
+                f"AND {self._TUNNEL_ROW_SQL};",
                 (hostname,),
             )
             row = cursor.fetchone()
@@ -368,7 +380,7 @@ class VmDatabase:
             cursor.execute(
                 f"SELECT provider_metadata->>'tunnel_alias_octet' "
                 f"FROM {self.table_name} "
-                f"WHERE provider_metadata->>'tunnel_alias_octet' IS NOT NULL;"
+                f"WHERE {self._TUNNEL_ROW_SQL};"
             )
             rows = cursor.fetchall()
         return [int(r[0]) for r in rows]
@@ -376,16 +388,35 @@ class VmDatabase:
     def get_tunnel_path_prefix(self, prefix: str):
         """(client_id, prefix) for the client owning this tunnel path
         prefix, or None. The prefix is stored at registration rather than
-        recomputed here so this stays a single indexed-ish lookup."""
+        recomputed here so this stays a single indexed-ish lookup.
+
+        Ambiguity is None, not a coin flip: this lookup is the only thing
+        binding a presented secret to an identity (see
+        routes/internal_proxy_auth.py's tunnel_auth), and the column has no
+        uniqueness constraint, so `fetchone()` on a duplicate would pick a
+        row by undefined ordering and then authenticate against THAT row's
+        secret. Refusing outright turns it into a 401 someone can find in
+        the log instead of an intermittent wrong-client attach.
+        """
         with self._cursor as cursor:
             cursor.execute(
                 f"SELECT hostname, provider_metadata->>'tunnel_path_prefix' "
                 f"FROM {self.table_name} "
-                f"WHERE provider_metadata->>'tunnel_path_prefix' = %s;",
+                f"WHERE provider_metadata->>'tunnel_path_prefix' = %s "
+                f"AND {self._TUNNEL_ROW_SQL};",
                 (prefix,),
             )
-            row = cursor.fetchone()
-        return (row[0], row[1]) if row else None
+            rows = cursor.fetchall()
+        if len(rows) != 1:
+            if rows:
+                logger.error(
+                    "Refusing tunnel auth: %d rows claim path prefix %r "
+                    "(expected exactly 1)",
+                    len(rows),
+                    prefix,
+                )
+            return None
+        return rows[0]
 
     def list_hosts_by_provider(self, provider: str) -> list:
         with self._cursor as cursor:

--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -324,6 +324,20 @@ class VmDatabase:
             return None
         return int(row[0])
 
+    def get_tunnel_path_prefix(self, prefix: str):
+        """(client_id, prefix) for the client owning this tunnel path
+        prefix, or None. The prefix is stored at registration rather than
+        recomputed here so this stays a single indexed-ish lookup."""
+        with self._cursor as cursor:
+            cursor.execute(
+                f"SELECT hostname, provider_metadata->>'tunnel_path_prefix' "
+                f"FROM {self.table_name} "
+                f"WHERE provider_metadata->>'tunnel_path_prefix' = %s;",
+                (prefix,),
+            )
+            row = cursor.fetchone()
+        return (row[0], row[1]) if row else None
+
     def list_hosts_by_provider(self, provider: str) -> list:
         with self._cursor as cursor:
             cursor.execute(

--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -289,6 +289,41 @@ class VmDatabase:
                 )
                 raise
 
+    _TUNNEL_ALIAS_BASE = 10
+
+    def allocate_tunnel_alias_octet(self) -> int:
+        """Next unused loopback-alias octet for a reverse-tunnel client.
+
+        Never recycled: what actually revokes a departed client's
+        reachability is dropping its tunnel restriction (see
+        tunnel_manager.revoke_client), not reclaiming the integer, and a
+        pool table would need the migration machinery this codebase
+        deliberately avoids. Only the final octet varies, so this tops out
+        near 245 concurrent clients — far past any deployment this product
+        targets, and deployments are ephemeral with a fresh DB each time.
+        """
+        with self._cursor as cursor:
+            cursor.execute(
+                f"SELECT MAX((provider_metadata->>'tunnel_alias_octet')::int) "
+                f"FROM {self.table_name};"
+            )
+            row = cursor.fetchone()
+        highest = row[0] if row else None
+        return highest + 1 if highest is not None else self._TUNNEL_ALIAS_BASE
+
+    def get_tunnel_alias(self, hostname: str):
+        """Loopback-alias octet for a reverse-tunnel client, or None."""
+        with self._cursor as cursor:
+            cursor.execute(
+                f"SELECT provider_metadata->>'tunnel_alias_octet' "
+                f"FROM {self.table_name} WHERE hostname = %s;",
+                (hostname,),
+            )
+            row = cursor.fetchone()
+        if not row or row[0] is None:
+            return None
+        return int(row[0])
+
     def list_hosts_by_provider(self, provider: str) -> list:
         with self._cursor as cursor:
             cursor.execute(

--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -313,13 +313,23 @@ class VmDatabase:
         concurrent threads against a real Postgres in
         test_allocate_tunnel_alias_octet_concurrent_returns_distinct_octets).
 
-        Never recycled: what actually revokes a departed client's
-        reachability is dropping its tunnel restriction (see
-        tunnel_manager.revoke_client), not reclaiming the integer, and a
-        pool table would need the migration machinery this codebase
-        deliberately avoids. Only the final octet varies, so this tops out
-        near 245 concurrent clients — far past any deployment this product
-        targets, and deployments are ephemeral with a fresh DB each time.
+        Monotonic and never recycled -- and, unlike the old MAX-based
+        read, now consumed by every *allocation attempt*, not just every
+        distinct live client: a registration that later 409s (hijack
+        conflict) or IntegrityErrors, and every legitimate
+        re-registration of the same client, each burn one more integer,
+        since the counter is claimed before ``register_client`` is ever
+        called. A pool table would let a value be reclaimed when its
+        client leaves, but needs the migration machinery this codebase
+        deliberately avoids, so this tops out at 254 allocation attempts
+        *ever* for the deployment's lifetime -- not 245 concurrent
+        clients. Callers MUST range-check the return value before using
+        it (see routes/registration.py, which returns 503 rather than
+        calling tunnel_manager.authorize_client with an out-of-range
+        octet) -- deployments are ephemeral with a fresh DB each time, so
+        this ceiling resets on redeploy, but a long-lived deployment with
+        enough registration churn can still exhaust it well before 254
+        distinct clients were ever simultaneously live.
         """
         with self._cursor as cursor:
             cursor.execute(

--- a/packages/allocator/src/lablink_allocator_service/db/vms.py
+++ b/packages/allocator/src/lablink_allocator_service/db/vms.py
@@ -356,6 +356,23 @@ class VmDatabase:
             return None
         return int(row[0])
 
+    def list_tunnel_aliases(self) -> list[int]:
+        """Alias octets of every registered reverse-tunnel client.
+
+        Used by health to compare *registered* clients against the set of
+        aliases with a socket actually attached right now (see
+        routes/health.py's tunnel check) -- a registered client isn't
+        necessarily a connected one.
+        """
+        with self._cursor as cursor:
+            cursor.execute(
+                f"SELECT provider_metadata->>'tunnel_alias_octet' "
+                f"FROM {self.table_name} "
+                f"WHERE provider_metadata->>'tunnel_alias_octet' IS NOT NULL;"
+            )
+            rows = cursor.fetchall()
+        return [int(r[0]) for r in rows]
+
     def get_tunnel_path_prefix(self, prefix: str):
         """(client_id, prefix) for the client owning this tunnel path
         prefix, or None. The prefix is stored at registration rather than

--- a/packages/allocator/src/lablink_allocator_service/providers/connectivity/reverse_tunnel.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/connectivity/reverse_tunnel.py
@@ -1,0 +1,63 @@
+"""Reverse-tunnel connectivity: browser -> allocator nginx -> client
+KasmVNC, reached through a tunnel the client dials OUT to the allocator's
+own HTTPS address and holds open. For clients that can neither accept
+inbound connections nor run Tailscale.
+
+The tunnel implementation is an internal detail; nothing in this module's
+public shape names it. See tunnel_manager."""
+from __future__ import annotations
+
+from lablink_allocator_service import tunnel_manager
+from lablink_allocator_service.client_session import (
+    BrowserSessionTarget,
+    RotationFailed,
+    prepare_browser_session,
+)
+from lablink_allocator_service.providers.protocol import ClientJoinMaterial
+
+
+def _db():
+    from lablink_allocator_service import main
+
+    return main.database
+
+
+def _resolve_tunnel_alias(hostname: str) -> str:
+    """Resolve *hostname*'s assigned loopback alias, for
+    prepare_browser_session's fallback_fn extension point — the same hook
+    MeshOverlayClientConnectivity uses, so client_session stays free of
+    any tunnel-specific import.
+
+    Returns a bare address with no port so prepare_browser_session's
+    hardcoded :6080/:7070 land on this client's own bindings."""
+    octet = _db().get_tunnel_alias(hostname)
+    if octet is None:
+        raise RotationFailed(f"no tunnel alias recorded for {hostname}")
+    return f"127.0.0.{octet}"
+
+
+class ReverseTunnelClientConnectivity:
+    name = "reverse_tunnel"
+    requires_tailscale_check = False
+    requires_tunnel_check = True
+
+    def prepare_browser_session(self, **kwargs) -> BrowserSessionTarget:
+        kwargs.setdefault("fallback_fn", _resolve_tunnel_alias)
+        return prepare_browser_session(**kwargs)
+
+    def make_join_material(
+        self,
+        *,
+        allocator_url: str,
+        client_image: str,
+        register_token: str,
+    ) -> ClientJoinMaterial:
+        return ClientJoinMaterial(
+            register_token=register_token,
+            allocator_url=allocator_url,
+            connectivity=self.name,
+            client_image=client_image,
+        )
+
+    def cleanup_client_identity(self, *, hostname: str) -> None:
+        tunnel_manager.revoke_client(hostname)

--- a/packages/allocator/src/lablink_allocator_service/providers/registry.py
+++ b/packages/allocator/src/lablink_allocator_service/providers/registry.py
@@ -14,6 +14,9 @@ from lablink_allocator_service.providers.connectivity.lan_direct import (
 from lablink_allocator_service.providers.connectivity.mesh_overlay import (
     MeshOverlayClientConnectivity,
 )
+from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+    ReverseTunnelClientConnectivity,
+)
 from lablink_allocator_service.providers.protocol import ComputeProvider
 
 logger = logging.getLogger(__name__)
@@ -31,6 +34,7 @@ _BUILTIN: dict[str, type] = {"aws": AWSProvider, "manual": ManualProvider}
 _CONNECTIVITY_BUILTIN: dict[str, type] = {
     "lan_direct": LANDirectClientConnectivity,
     "mesh_overlay": MeshOverlayClientConnectivity,
+    "reverse_tunnel": ReverseTunnelClientConnectivity,
 }
 
 

--- a/packages/allocator/src/lablink_allocator_service/routes/desktop.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/desktop.py
@@ -110,8 +110,18 @@ def _render_admin_session_page(ws_url: str, hostname: str) -> str:
 
     Unlike the student/peek paths (a bare redirect), this renders
     directly, since the Release form needs to know the hostname.
+
+    Both extras exist only because the viewer is framed here. The Kasm
+    bundle detects framing (`window.self !== window.top`) and without
+    `show_control_bar=1` defaults clipboard_up/down/seamless to false and
+    resize to off — killing copy/paste with no manual fallback. And an
+    iframe without `allowfullscreen` can't enter fullscreen, which is the
+    only place the viewer calls `navigator.keyboard.lock()`.
     """
-    viewer_src = f"/static/novnc/vnc.html?path={ws_url}&autoconnect=1&resize=remote"
+    viewer_src = (
+        f"/static/novnc/vnc.html?path={ws_url}"
+        "&autoconnect=1&resize=remote&show_control_bar=1"
+    )
     release_action = f"/admin/instances/{quote(hostname, safe='')}/release"
     safe_hostname = html.escape(hostname)
     return f"""<!doctype html>
@@ -136,5 +146,5 @@ def _render_admin_session_page(ws_url: str, hostname: str) -> str:
     <button type="submit">Release</button>
   </form>
 </header>
-<iframe src="{viewer_src}"></iframe>
+<iframe src="{viewer_src}" allowfullscreen></iframe>
 """

--- a/packages/allocator/src/lablink_allocator_service/routes/health.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/health.py
@@ -12,6 +12,11 @@ from flask import Blueprint, current_app, jsonify
 
 bp = Blueprint("health", __name__)
 
+# Shared by _tunnel_status() (which produces it) and health_check() (which
+# excludes it from the readiness gate). One constant rather than two literals
+# so the two can't drift apart.
+_UNATTACHED_SUFFIX = " client(s) not attached"
+
 
 def _tailscale_status() -> str:
     """Return "ok" / "not joined" for the allocator's own tailnet
@@ -71,7 +76,7 @@ def _tunnel_status() -> str:
     except psycopg2.Error:
         return "client list unavailable"
     missing = expected - tunnel_manager.attached_aliases()
-    return f"{len(missing)} client(s) not attached" if missing else "ok"
+    return f"{len(missing)}{_UNATTACHED_SUFFIX}" if missing else "ok"
 
 
 @bp.route("/api/health", methods=["GET"])
@@ -94,7 +99,19 @@ def health_check():
     if getattr(connectivity, "requires_tunnel_check", False):
         checks["tunnel"] = _tunnel_status()
 
-    all_ready = all(v == "ok" for v in checks.values())
+    # A registered client whose tunnel isn't attached is reported but does not
+    # gate readiness: the allocator is serving fine, and nothing about one
+    # student's dead tunnel makes it unready. Gating on it also deadlocked the
+    # client's own startup — a registering client is "not attached" by
+    # definition until its tunnel is up, and it won't bring that tunnel up
+    # while this endpoint answers 503 (observed live 2026-07-31). The other
+    # tunnel values (server down, DB error) DO gate: those are the allocator's
+    # own dependencies failing.
+    all_ready = all(
+        v == "ok"
+        for k, v in checks.items()
+        if not (k == "tunnel" and v.endswith(_UNATTACHED_SUFFIX))
+    )
     status = "healthy" if all_ready else "starting"
     code = 200 if all_ready else 503
 

--- a/packages/allocator/src/lablink_allocator_service/routes/health.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/health.py
@@ -43,6 +43,24 @@ def _tailscale_status() -> str:
     return "ok" if result.returncode == 0 and "inet " in result.stdout else "not joined"
 
 
+def _tunnel_status() -> str:
+    """Tunnel health as a *pairing* property, not a process one.
+
+    tunnel_manager.tunnel_status() only says the shared server is up. A
+    client whose tunnel died leaves its alias bound for the idle timeout,
+    and connections to that orphan hang rather than fail -- so a registered
+    client with no listening alias is the condition worth reporting.
+    """
+    from lablink_allocator_service import main, tunnel_manager
+
+    server = tunnel_manager.tunnel_status()
+    if server != "ok":
+        return server
+    expected = set(main.database.list_tunnel_aliases())
+    missing = expected - tunnel_manager.attached_aliases()
+    return f"{len(missing)} client(s) not attached" if missing else "ok"
+
+
 @bp.route("/api/health", methods=["GET"])
 def health_check():
     """Return structured readiness status."""
@@ -57,10 +75,11 @@ def health_check():
             "ok" if main.reboot_service is not None else "not initialized"
         ),
     }
-    if current_app.config[
-        "LABLINK_PROVIDER"
-    ].client_connectivity.requires_tailscale_check:
+    connectivity = current_app.config["LABLINK_PROVIDER"].client_connectivity
+    if connectivity.requires_tailscale_check:
         checks["tailscale"] = _tailscale_status()
+    if getattr(connectivity, "requires_tunnel_check", False):
+        checks["tunnel"] = _tunnel_status()
 
     all_ready = all(v == "ok" for v in checks.values())
     status = "healthy" if all_ready else "starting"

--- a/packages/allocator/src/lablink_allocator_service/routes/health.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/health.py
@@ -7,6 +7,7 @@ only once every check passes, 503 + "starting" otherwise.
 import subprocess
 import time
 
+import psycopg2
 from flask import Blueprint, current_app, jsonify
 
 bp = Blueprint("health", __name__)
@@ -50,13 +51,25 @@ def _tunnel_status() -> str:
     client whose tunnel died leaves its alias bound for the idle timeout,
     and connections to that orphan hang rather than fail -- so a registered
     client with no listening alias is the condition worth reporting.
+
+    Guards the same "not initialized" window the top-level `database`
+    check already names, and catches psycopg2.Error the same way
+    `_tailscale_status` catches its own external call's (OSError,
+    TimeoutExpired) -- so a transient Postgres problem (pool exhaustion,
+    a brief restart) degrades this one check's value instead of raising
+    out of the route and 500ing the whole endpoint.
     """
     from lablink_allocator_service import main, tunnel_manager
 
     server = tunnel_manager.tunnel_status()
     if server != "ok":
         return server
-    expected = set(main.database.list_tunnel_aliases())
+    if main.database is None:
+        return "not initialized"
+    try:
+        expected = set(main.database.list_tunnel_aliases())
+    except psycopg2.Error:
+        return "client list unavailable"
     missing = expected - tunnel_manager.attached_aliases()
     return f"{len(missing)} client(s) not attached" if missing else "ok"
 

--- a/packages/allocator/src/lablink_allocator_service/routes/internal_proxy_auth.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/internal_proxy_auth.py
@@ -83,17 +83,27 @@ def tunnel_auth():
 
     The path prefix identifies which client is attaching; the bearer token
     is what authenticates it. Both must agree, so a client cannot attach
-    under another client's prefix even with a valid secret of its own --
-    and tunnel_manager's restrictions then stop it binding another
-    client's alias even if it somehow did.
+    under another client's prefix even holding a valid secret of its own.
+
+    This check is the ONLY binding between a secret and an identity.
+    tunnel_manager's restrictions are keyed by path prefix, so they grant
+    whatever alias the presented path claims -- they constrain a client to
+    one alias, they do not prove who the client is. Do not describe them as
+    a second authentication layer.
     """
     from lablink_allocator_service import main
     from lablink_allocator_service.secret_hash import verify_secret_cached
 
-    uri = request.headers.get("X-Original-URI", "")
-    token = (request.headers.get("X-Tunnel-Auth") or "").removeprefix("Bearer ").strip()
-    prefix = uri.rstrip("/").rpartition("/")[2]
-    if not prefix or not token:
+    # nginx captured the prefix from the FIRST path segment and passed it
+    # here; do not re-derive it from the URI. The client's request path is
+    # /<prefix>/events, so last-segment extraction yields "events" and 401s
+    # every legitimate attach (measured against the real client).
+    prefix = (request.headers.get("X-Tunnel-Prefix") or "").strip()
+    auth = request.headers.get("X-Tunnel-Auth") or ""
+    if not prefix or not auth.startswith("Bearer "):
+        return _unauth()
+    token = auth[len("Bearer "):].strip()
+    if not token:
         return _unauth()
 
     found = main.database.get_tunnel_path_prefix(prefix)

--- a/packages/allocator/src/lablink_allocator_service/routes/internal_proxy_auth.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/internal_proxy_auth.py
@@ -75,3 +75,32 @@ def proxy_auth():
     resp.headers["X-Upstream"] = upstream
     resp.headers["X-Auth-Basic"] = f"Basic {encoded}"
     return resp
+
+
+@bp.route("/internal/tunnel_auth", methods=["GET", "POST"])
+def tunnel_auth():
+    """nginx auth_request gate for the reverse-tunnel WebSocket upgrade.
+
+    The path prefix identifies which client is attaching; the bearer token
+    is what authenticates it. Both must agree, so a client cannot attach
+    under another client's prefix even with a valid secret of its own --
+    and tunnel_manager's restrictions then stop it binding another
+    client's alias even if it somehow did.
+    """
+    from lablink_allocator_service import main
+    from lablink_allocator_service.secret_hash import verify_secret_cached
+
+    uri = request.headers.get("X-Original-URI", "")
+    token = (request.headers.get("X-Tunnel-Auth") or "").removeprefix("Bearer ").strip()
+    prefix = uri.rstrip("/").rpartition("/")[2]
+    if not prefix or not token:
+        return _unauth()
+
+    found = main.database.get_tunnel_path_prefix(prefix)
+    if not found:
+        return _unauth()
+    client_id, _ = found
+    stored = main.database.get_client_secret_hash(client_id)
+    if not stored or not verify_secret_cached(client_id, token, stored):
+        return _unauth()
+    return make_response(("", 200))

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -315,6 +315,20 @@ def unregister_client(client_id):
     if not deleted:
         return jsonify({"error": "Client not found."}), 404
 
+    # Give the connectivity strategy a chance to drop any identity it
+    # minted for this client (e.g. reverse_tunnel's restrictions-file
+    # rule) -- optional because most strategies need no such cleanup, so
+    # it isn't part of the ClientConnectivity protocol.
+    prov = current_app.config.get("LABLINK_PROVIDER") or get_provider(
+        main.cfg.get("provider", None),
+        region=main.cfg.app.region,
+        terraform_dir=str(main.TERRAFORM_DIR),
+        connectivity=main.cfg.manual.connectivity,
+    )
+    cleanup = getattr(prov.client_connectivity, "cleanup_client_identity", None)
+    if cleanup is not None:
+        cleanup(hostname=client_id)
+
     return jsonify(client_id=client_id, status="unregistered"), 200
 
 

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 import base64
 from datetime import datetime
 import psycopg2
+import re
 import secrets
 
 from flask import Blueprint, current_app, jsonify, request
@@ -25,6 +26,13 @@ from lablink_allocator_service.secret_hash import (
 from lablink_allocator_service.utils.config_helpers import canonical_base_url
 
 bp = Blueprint("registration", __name__)
+
+# A registering client's self-declared hostname becomes its client_id, which
+# is the DB primary key AND (under reverse_tunnel) is interpolated into a
+# generated config file and a filesystem path. Constrain it here, at the
+# boundary, so nothing downstream has to trust it; tunnel_manager re-checks
+# the same shape on its own as defense in depth.
+_VALID_HOSTNAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,252}$")
 
 
 @bp.route("/api/v1/clients/register", methods=["POST"])
@@ -47,6 +55,14 @@ def register_client():
     machine_identity = body.get("machine_identity")
     if not hostname or not machine_identity:
         return jsonify({"error": "hostname and machine_identity required."}), 400
+    if not _VALID_HOSTNAME.fullmatch(hostname):
+        return jsonify({
+            "error": (
+                "hostname must start with a letter or digit and contain only "
+                "letters, digits, dots, dashes and underscores (max 253 "
+                "characters)."
+            )
+        }), 400
 
     provider = body.get("provider", "aws")
     provider_metadata = body.get("provider_metadata") or {}
@@ -86,7 +102,44 @@ def register_client():
                 )
             }), 400
 
+        # Same shape as the mesh_overlay check above: a reverse_tunnel
+        # registration (--tunnel) against a non-tunnel allocator, or a
+        # plain registration against a tunnel allocator, must be rejected
+        # at registration time rather than failing opaquely later.
+        expects_tunnel = prov.client_connectivity.name == "reverse_tunnel"
+        has_tunnel = provider_metadata.get("reverse_tunnel") is True
+        if expects_tunnel and not has_tunnel:
+            return jsonify({
+                "error": (
+                    "This allocator is configured for reverse_tunnel "
+                    "connectivity -- register with --tunnel."
+                )
+            }), 400
+        if not expects_tunnel and has_tunnel:
+            return jsonify({
+                "error": (
+                    "This allocator is not configured for reverse_tunnel "
+                    "connectivity -- --tunnel is not applicable here."
+                )
+            }), 400
+
     client_secret = secrets.token_urlsafe(32)
+
+    # Reverse-tunnel clients need two allocator-owned values minted before
+    # the row is written: a loopback alias (the address nginx will dial) and
+    # a path prefix identifying this client at the tunnel endpoint.
+    tunnel_alias_octet = None
+    tunnel_prefix = None
+    if provider == "manual" and provider_metadata.get("reverse_tunnel") is True:
+        from lablink_allocator_service import tunnel_manager
+
+        tunnel_alias_octet = main.database.allocate_tunnel_alias_octet()
+        tunnel_prefix = tunnel_manager.path_prefix(hostname, client_secret)
+        provider_metadata = {
+            **provider_metadata,
+            "tunnel_alias_octet": tunnel_alias_octet,
+            "tunnel_path_prefix": tunnel_prefix,
+        }
 
     try:
         client_id = main.database.register_client(
@@ -103,6 +156,18 @@ def register_client():
         return jsonify({"error": "registration conflict"}), 409
     if client_id is None:
         return jsonify({"error": "registration conflict"}), 409
+
+    if tunnel_prefix is not None:
+        from lablink_allocator_service import tunnel_manager
+
+        # Authorize AFTER the row exists: the restrictions file is what lets
+        # this client bind its alias, and it must never name an alias no row
+        # claims. Re-registration overwrites the client's single rule, so a
+        # new alias/prefix cannot leave the old one authorized.
+        tunnel_manager.authorize_client(
+            client_id=client_id, alias_octet=tunnel_alias_octet,
+            prefix=tunnel_prefix,
+        )
 
     allocator_url = canonical_base_url(request)
     # cfg.machine.repository is the tutorial-repo-to-clone URL (shipped to
@@ -162,7 +227,7 @@ def register_client():
     repository = main.cfg.machine.repository or ""
     subject_software = main.cfg.machine.software or ""
 
-    return jsonify(
+    response = dict(
         client_id=client_id,
         client_secret=client_secret,
         agent_token=main.AGENT_TOKEN,
@@ -184,7 +249,18 @@ def register_client():
             else ""
         ),
         monitoring=monitoring,
-    ), 200
+    )
+
+    if tunnel_prefix is not None:
+        # Base address only. The client passes the prefix via -P; the
+        # tunnel tool ignores any path in the URL it dials (measured), so
+        # embedding the prefix here would silently produce the wrong
+        # request path.
+        response["tunnel_url"] = allocator_url.rstrip("/")
+        response["tunnel_path_prefix"] = tunnel_prefix
+        response["tunnel_bind_addr"] = f"127.0.0.{tunnel_alias_octet}"
+
+    return jsonify(response), 200
 
 
 @bp.route("/api/v1/clients/<client_id>/status", methods=["GET"])

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -55,7 +55,7 @@ def register_client():
     machine_identity = body.get("machine_identity")
     if not hostname or not machine_identity:
         return jsonify({"error": "hostname and machine_identity required."}), 400
-    if not _VALID_HOSTNAME.fullmatch(hostname):
+    if not isinstance(hostname, str) or not _VALID_HOSTNAME.fullmatch(hostname):
         return jsonify({
             "error": (
                 "hostname must start with a letter or digit and contain only "
@@ -134,6 +134,18 @@ def register_client():
         from lablink_allocator_service import tunnel_manager
 
         tunnel_alias_octet = main.database.allocate_tunnel_alias_octet()
+        # Range-check BEFORE writing the row: allocate_tunnel_alias_octet
+        # never recycles, so a deployment can exhaust it (see its
+        # docstring), and authorize_client would raise ValueError on an
+        # out-of-range octet -- but only after register_client already
+        # inserted the row, which would surface as an unhandled 500.
+        if not tunnel_manager.is_valid_alias_octet(tunnel_alias_octet):
+            return jsonify({
+                "error": (
+                    "This deployment has run out of reverse-tunnel "
+                    "loopback aliases; no more clients can register."
+                )
+            }), 503
         tunnel_prefix = tunnel_manager.path_prefix(hostname, client_secret)
         provider_metadata = {
             **provider_metadata,

--- a/packages/allocator/src/lablink_allocator_service/routes/registration.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/registration.py
@@ -128,11 +128,11 @@ def register_client():
     # Reverse-tunnel clients need two allocator-owned values minted before
     # the row is written: a loopback alias (the address nginx will dial) and
     # a path prefix identifying this client at the tunnel endpoint.
+    from lablink_allocator_service import tunnel_manager
+
     tunnel_alias_octet = None
     tunnel_prefix = None
     if provider == "manual" and provider_metadata.get("reverse_tunnel") is True:
-        from lablink_allocator_service import tunnel_manager
-
         tunnel_alias_octet = main.database.allocate_tunnel_alias_octet()
         # Range-check BEFORE writing the row: allocate_tunnel_alias_octet
         # never recycles, so a deployment can exhaust it (see its
@@ -170,8 +170,6 @@ def register_client():
         return jsonify({"error": "registration conflict"}), 409
 
     if tunnel_prefix is not None:
-        from lablink_allocator_service import tunnel_manager
-
         # Authorize AFTER the row exists: the restrictions file is what lets
         # this client bind its alias, and it must never name an alias no row
         # claims. Re-registration overwrites the client's single rule, so a

--- a/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
@@ -18,48 +18,26 @@ prefix. This module owns the two things the allocator must control:
    being refused (measured: 12s, no response). Health must therefore
    observe the pairing, not the process or the port.
 
-Schema note: verified against the real wstunnel v10.6.2 binary (image tag
-"v10.6.2", not "10.6.2" -- ghcr.io only publishes the v-prefixed tag). The
-brief's `port: [{start: N, end: N}, ...]` form is rejected with
-`invalid type: map, expected a string`; the accepted shape is a list of
-port-number strings, each parsed as a single-port range:
+Two facts measured against the pinned wstunnel v10.6.2 binary, both of
+which the rendered file's shape depends on -- re-verify when bumping it:
 
-    restrictions:
-      - name: vm-1
-        match:
-          - !PathPrefix "tun-vm-1-abc123"
-        allow:
-          - !ReverseTunnel
-            port: ["6080", "7070"]
-            cidr: ["127.0.0.10/32"]
+* `allow[].port` takes a list of port-number STRINGS, each parsed as a
+  single-port range (`port: [6080..=6080, ...]` under --log-lvl DEBUG).
+  A `[{start: N, end: N}]` form is rejected outright.
+* `!PathPrefix` compares ONLY the client's first path segment, so a match
+  value like `tunnel/<prefix>` can never fire and the failure is a silent
+  deny-all. The match value must BE the whole first segment, which is why
+  `path_prefix()` returns `tun-<client_id>-<digest>` at the root rather
+  than nesting under a shared "tunnel/". Confirmed end to end: a client
+  presenting another client's alias in `-R` was refused with "Rejecting
+  connection with not allowed destination".
 
-Confirmed via `--log-lvl DEBUG`, which echoes the parsed rule back as
-`port: [6080..=6080, 7070..=7070]`. Re-verify when bumping the pinned
-version.
-
-`!PathPrefix` matches ONLY the client's first path segment (also verified
-against 10.6.2): a match value of `tunnel/<prefix>` can never fire against
-a client dialing in on `-P tunnel/<prefix>`, because wstunnel only ever
-compares that first segment to the match string. The only way this rule
-can both match AND stay per-client is for the match value to BE the whole
-first segment -- so the prefix itself must be dialed as the first segment
-(no shared "tunnel/" root), which is why `path_prefix()` below returns
-`tun-<client_id>-<digest>` rather than something nested under a shared
-prefix. Confirmed end to end: a client presenting its own prefix as the
-first path segment was accepted onto its own alias; the same client
-presenting another client's alias in `-R` was refused with "Rejecting
-connection with not allowed destination".
-
-Security note: `client_id` is the DB `hostname`, which reaches this module
-from client-controlled registration input -- it is NOT validated upstream
-beyond truthiness. Every function that renders it into the restrictions
-file therefore validates it here (see `_is_safe_client_id`) rather than
-trusting the caller, and rendering itself goes through `yaml.safe_dump`
-(not f-string/string-building) so a value that somehow slipped past
-validation still can't forge YAML structure. Both are load-bearing: the
-charset check is what stops a multi-line hostname from ever reaching the
-renderer, and safe_dump is what stops any single-line-but-still-special
-YAML character (quotes, colons, `#`, etc.) from doing so.
+Security note: `client_id` is the DB `hostname`, which arrives from
+client-controlled registration input. Two independent guards, both
+load-bearing: `_is_safe()` rejects the charset (what stops a multi-line
+hostname reaching the renderer at all), and `yaml.safe_dump` does the
+rendering (what stops a single-line-but-special value -- quotes, colons,
+`#` -- forging YAML structure if it ever slipped past).
 """
 from __future__ import annotations
 
@@ -77,15 +55,13 @@ TUNNEL_PORTS = (6080, 7070)
 # Where the tunnel server listens inside the container; nginx proxies to it.
 TUNNEL_SERVER_PORT = 8080
 
-# client_id is the DB hostname: registration only checks it's truthy (see
-# routes/registration.py), so this module can't trust it arrived sane.
-# Reject anything outside a conservative charset rather than trying to
-# escape it -- it ends up as a YAML mapping key/value AND a path segment
-# (via path_prefix), so "sanitize" would need to satisfy both consumers.
-_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,252}$")
-# path_prefix() = "tun-<client_id>-<digest>" (digest is 16 hex chars), so
-# the same charset applies with a little headroom for that prefix/suffix.
-_PREFIX_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,299}$")
+# Values reaching the renderer end up as a YAML mapping key/value AND a
+# path segment, so reject an unsafe charset rather than trying to escape
+# it -- "sanitize" would have to satisfy both consumers.
+_SAFE_RE = re.compile(r"[A-Za-z0-9][A-Za-z0-9._-]*")
+# A hostname's own cap; path_prefix() adds "tun-" + "-<16 hex>" on top.
+_MAX_CLIENT_ID_LEN = 253
+_MAX_PREFIX_LEN = 300
 
 # A rendered restriction is one octet in a 127.0.0.0/8 /32 CIDR. 0 and 255
 # are excluded as the conventional network/broadcast-shaped ends of a
@@ -94,18 +70,13 @@ _MIN_ALIAS_OCTET = 1
 _MAX_ALIAS_OCTET = 254
 
 
-def _is_safe_client_id(client_id: str) -> bool:
-    # fullmatch, not match: `match` + a `$`-anchored pattern still accepts
-    # a single trailing newline ("vm-1\n"), since Python's `$` matches just
+def _is_safe(value: str, max_len: int) -> bool:
+    # fullmatch, not match: `match` + a `$`-anchored pattern still accepts a
+    # single trailing newline ("vm-1\n"), since Python's `$` matches just
     # before a trailing newline as well as end-of-string. safe_dump blocks
-    # the actual YAML-injection exploit either way, but this boundary
-    # check is what the module docstring claims stops a trailing newline
-    # at all, so it must actually do that.
-    return bool(_CLIENT_ID_RE.fullmatch(client_id))
-
-
-def _is_safe_prefix(prefix: str) -> bool:
-    return bool(_PREFIX_RE.fullmatch(prefix))
+    # the actual YAML-injection exploit either way, but this boundary check
+    # is what the docstring claims stops a trailing newline at all.
+    return len(value) <= max_len and bool(_SAFE_RE.fullmatch(value))
 
 
 def is_valid_alias_octet(octet: int) -> bool:
@@ -150,9 +121,11 @@ def _represent_reverse_tunnel(dumper: yaml.Dumper, data: "_ReverseTunnelRule"):
 yaml.SafeDumper.add_representer(_PathPrefix, _represent_path_prefix)
 yaml.SafeDumper.add_representer(_ReverseTunnelRule, _represent_reverse_tunnel)
 
-# So _render()'s self-check (below) can round-trip its own output: SafeLoader
-# has no constructor for our custom tags by default and would otherwise
-# raise before the check ever ran.
+# Load-bearing, do not delete: SafeLoader has no constructor for our custom
+# tags by default, so without these BOTH _render()'s self-check and
+# _hydrate_from_disk() raise on the tagged file we ourselves wrote. In
+# hydration's case the raise is swallowed by its own except, which silently
+# turns "reload every rule after a restart" into "drop them all".
 yaml.SafeLoader.add_constructor(
     "!PathPrefix", lambda loader, node: loader.construct_scalar(node)
 )
@@ -266,9 +239,9 @@ def authorize_client(*, client_id: str, alias_octet: int, prefix: str) -> None:
     so it's validated here rather than assumed clean by callers.
     """
     _hydrate_from_disk()
-    if not _is_safe_client_id(client_id):
+    if not _is_safe(client_id, _MAX_CLIENT_ID_LEN):
         raise ValueError(f"unsafe client_id for tunnel restrictions: {client_id!r}")
-    if not _is_safe_prefix(prefix):
+    if not _is_safe(prefix, _MAX_PREFIX_LEN):
         raise ValueError(f"unsafe prefix for tunnel restrictions: {prefix!r}")
     if not is_valid_alias_octet(alias_octet):
         raise ValueError(

--- a/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
@@ -1,0 +1,143 @@
+"""Reverse-tunnel connectivity's server-side bookkeeping.
+
+One `wstunnel` server runs for the whole deployment (started by start.sh),
+and each client attaches to it over a WebSocket carrying its own path
+prefix. This module owns the two things the allocator must control:
+
+1. The restrictions file. wstunnel's reverse-tunnel bind address is chosen
+   by the CLIENT, so without restrictions any client holding a valid
+   client_secret could bind another client's loopback alias and receive
+   that client's student sessions. Each rule pins one path prefix to one
+   /32 alias and the two ports we tunnel. wstunnel reloads the file
+   automatically when it changes, so no restart or signal is needed.
+
+2. Which aliases actually have a client attached. A bound port is NOT
+   evidence of an attached client: wstunnel keeps a reverse-tunnel
+   listener bound for --remote-to-local-server-idle-timeout after the
+   client leaves, and connections to an orphaned listener hang rather than
+   being refused (measured: 12s, no response). Health must therefore
+   observe the pairing, not the process or the port.
+
+Schema note: verified against the real wstunnel v10.6.2 binary (image tag
+"v10.6.2", not "10.6.2" -- ghcr.io only publishes the v-prefixed tag). The
+brief's `port: [{start: N, end: N}, ...]` form is rejected with
+`invalid type: map, expected a string`; the accepted shape is a list of
+port-number strings, each parsed as a single-port range:
+
+    restrictions:
+      - name: vm-1
+        match:
+          - !PathPrefix "tunnel/vm-1-abc123"
+        allow:
+          - !ReverseTunnel
+            port: ["6080", "7070"]
+            cidr: ["127.0.0.10/32"]
+
+Confirmed via `--log-lvl DEBUG`, which echoes the parsed rule back as
+`port: [6080..=6080, 7070..=7070]`. Re-verify when bumping the pinned
+version.
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import socket
+from pathlib import Path
+
+TUNNEL_DIR = Path("/tmp/lablink-tunnel")
+RESTRICTIONS_PATH = TUNNEL_DIR / "restrictions.yaml"
+TUNNEL_PORTS = (6080, 7070)
+# Where the tunnel server listens inside the container; nginx proxies to it.
+TUNNEL_SERVER_PORT = 8080
+
+# client_id -> (alias_octet, prefix). Module-level, like secret_hash's
+# cache: one allocator process per deployment.
+_restrictions: dict[str, tuple[int, str]] = {}
+
+
+def path_prefix(client_id: str, secret: str) -> str:
+    """Per-client URL segment: `<client_id>-<digest>`.
+
+    Derived from the client's own secret so it is stable across restarts
+    and needs no storage of its own. It identifies the client to
+    /internal/tunnel_auth; the bearer token is what authenticates.
+    """
+    digest = hashlib.sha256(f"{client_id}:{secret}".encode()).hexdigest()[:16]
+    return f"{client_id}-{digest}"
+
+
+def _render() -> str:
+    lines = ["restrictions:"]
+    for client_id, (octet, prefix) in sorted(_restrictions.items()):
+        ports = ", ".join(f'"{p}"' for p in TUNNEL_PORTS)
+        lines += [
+            f"  - name: {client_id}",
+            "    match:",
+            f'      - !PathPrefix "tunnel/{prefix}"',
+            "    allow:",
+            "      - !ReverseTunnel",
+            f"        port: [{ports}]",
+            f'        cidr: ["127.0.0.{octet}/32"]',
+        ]
+    return "\n".join(lines) + "\n"
+
+
+def _write() -> None:
+    TUNNEL_DIR.mkdir(parents=True, exist_ok=True)
+    TUNNEL_DIR.chmod(0o700)
+    # Create at 0600 up front rather than write-then-chmod: the file names
+    # each client's path prefix, which is derived from its secret.
+    fd = os.open(RESTRICTIONS_PATH, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    with os.fdopen(fd, "w") as handle:
+        handle.write(_render())
+    os.chmod(RESTRICTIONS_PATH, 0o600)
+
+
+def authorize_client(*, client_id: str, alias_octet: int, prefix: str) -> None:
+    """Permit exactly this client to bind exactly its own alias."""
+    _restrictions[client_id] = (alias_octet, prefix)
+    _write()
+
+
+def revoke_client(client_id: str) -> None:
+    """Drop this client's permission. No-op if it was never a tunnel client."""
+    if _restrictions.pop(client_id, None) is None:
+        return
+    _write()
+
+
+def _proc_net_tcp() -> str:
+    try:
+        return Path("/proc/net/tcp").read_text()
+    except OSError:
+        return ""
+
+
+def attached_aliases() -> set[int]:
+    """Alias octets with a listening reverse-tunnel socket right now.
+
+    Parses /proc/net/tcp because there is no wstunnel API for it. State
+    "0A" is TCP_LISTEN; local_address is `<hex ip>:<hex port>` with the IP
+    in network-reversed byte order, so 127.0.0.10 is 0A00007F.
+    """
+    found: set[int] = set()
+    for line in _proc_net_tcp().splitlines()[1:]:
+        parts = line.split()
+        if len(parts) < 4 or parts[3] != "0A":
+            continue
+        hex_ip, _, hex_port = parts[1].partition(":")
+        if len(hex_ip) != 8 or not hex_ip.upper().endswith("00007F"):
+            continue
+        if int(hex_port, 16) not in TUNNEL_PORTS:
+            continue
+        found.add(int(hex_ip[:2], 16))
+    return found
+
+
+def tunnel_status() -> str:
+    """"ok" iff the shared tunnel server is accepting connections."""
+    try:
+        with socket.create_connection(("127.0.0.1", TUNNEL_SERVER_PORT), timeout=2):
+            return "ok"
+    except OSError:
+        return "not running"

--- a/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
@@ -95,11 +95,27 @@ _MAX_ALIAS_OCTET = 254
 
 
 def _is_safe_client_id(client_id: str) -> bool:
-    return bool(_CLIENT_ID_RE.match(client_id))
+    # fullmatch, not match: `match` + a `$`-anchored pattern still accepts
+    # a single trailing newline ("vm-1\n"), since Python's `$` matches just
+    # before a trailing newline as well as end-of-string. safe_dump blocks
+    # the actual YAML-injection exploit either way, but this boundary
+    # check is what the module docstring claims stops a trailing newline
+    # at all, so it must actually do that.
+    return bool(_CLIENT_ID_RE.fullmatch(client_id))
 
 
 def _is_safe_prefix(prefix: str) -> bool:
-    return bool(_PREFIX_RE.match(prefix))
+    return bool(_PREFIX_RE.fullmatch(prefix))
+
+
+def is_valid_alias_octet(octet: int) -> bool:
+    """True iff *octet* is in the range a /32 loopback rule can express.
+
+    Exposed so callers (routes/registration.py) can reject an
+    out-of-range allocation with a clean error response before writing a
+    client row, instead of finding out only when authorize_client raises.
+    """
+    return _MIN_ALIAS_OCTET <= octet <= _MAX_ALIAS_OCTET
 
 
 # client_id -> (alias_octet, prefix). Module-level, like secret_hash's
@@ -212,7 +228,7 @@ def authorize_client(*, client_id: str, alias_octet: int, prefix: str) -> None:
         raise ValueError(f"unsafe client_id for tunnel restrictions: {client_id!r}")
     if not _is_safe_prefix(prefix):
         raise ValueError(f"unsafe prefix for tunnel restrictions: {prefix!r}")
-    if not (_MIN_ALIAS_OCTET <= alias_octet <= _MAX_ALIAS_OCTET):
+    if not is_valid_alias_octet(alias_octet):
         raise ValueError(
             f"alias_octet {alias_octet!r} out of range "
             f"[{_MIN_ALIAS_OCTET}, {_MAX_ALIAS_OCTET}]"

--- a/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
@@ -27,7 +27,7 @@ port-number strings, each parsed as a single-port range:
     restrictions:
       - name: vm-1
         match:
-          - !PathPrefix "tunnel/vm-1-abc123"
+          - !PathPrefix "tun-vm-1-abc123"
         allow:
           - !ReverseTunnel
             port: ["6080", "7070"]
@@ -36,6 +36,19 @@ port-number strings, each parsed as a single-port range:
 Confirmed via `--log-lvl DEBUG`, which echoes the parsed rule back as
 `port: [6080..=6080, 7070..=7070]`. Re-verify when bumping the pinned
 version.
+
+`!PathPrefix` matches ONLY the client's first path segment (also verified
+against 10.6.2): a match value of `tunnel/<prefix>` can never fire against
+a client dialing in on `-P tunnel/<prefix>`, because wstunnel only ever
+compares that first segment to the match string. The only way this rule
+can both match AND stay per-client is for the match value to BE the whole
+first segment -- so the prefix itself must be dialed as the first segment
+(no shared "tunnel/" root), which is why `path_prefix()` below returns
+`tun-<client_id>-<digest>` rather than something nested under a shared
+prefix. Confirmed end to end: a client presenting its own prefix as the
+first path segment was accepted onto its own alias; the same client
+presenting another client's alias in `-R` was refused with "Rejecting
+connection with not allowed destination".
 
 Security note: `client_id` is the DB `hostname`, which reaches this module
 from client-controlled registration input -- it is NOT validated upstream
@@ -125,14 +138,22 @@ yaml.SafeLoader.add_constructor(
 
 
 def path_prefix(client_id: str, secret: str) -> str:
-    """Per-client URL segment: `<client_id>-<digest>`.
+    """Per-client value the client must dial as its first path segment.
+
+    `tun-<client_id>-<digest>`. Must BE the first path segment, not a
+    sub-path under some shared root: wstunnel's `!PathPrefix` restriction
+    matcher only inspects the first segment (see the module docstring), so
+    a value like "tunnel/<this>" could never match. The `tun-` marker is
+    what lets nginx tell a tunnel attach apart from an application route
+    now that the prefix sits at the URL root instead of under a fixed
+    "tunnel/" segment.
 
     Derived from the client's own secret so it is stable across restarts
     and needs no storage of its own. It identifies the client to
     /internal/tunnel_auth; the bearer token is what authenticates.
     """
     digest = hashlib.sha256(f"{client_id}:{secret}".encode()).hexdigest()[:16]
-    return f"{client_id}-{digest}"
+    return f"tun-{client_id}-{digest}"
 
 
 def _render() -> str:
@@ -140,7 +161,10 @@ def _render() -> str:
         "restrictions": [
             {
                 "name": client_id,
-                "match": [_PathPrefix(f"tunnel/{prefix}")],
+                # !PathPrefix matches only the first path segment (measured
+                # against 10.6.2), so the match value must BE the prefix,
+                # not "tunnel/<prefix>" -- the latter can never fire.
+                "match": [_PathPrefix(prefix)],
                 "allow": [
                     _ReverseTunnelRule(
                         {

--- a/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
@@ -83,8 +83,8 @@ TUNNEL_SERVER_PORT = 8080
 # escape it -- it ends up as a YAML mapping key/value AND a path segment
 # (via path_prefix), so "sanitize" would need to satisfy both consumers.
 _CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,252}$")
-# path_prefix() = "<client_id>-<digest>" (digest is 16 hex chars), so the
-# same charset applies with a little headroom for that suffix.
+# path_prefix() = "tun-<client_id>-<digest>" (digest is 16 hex chars), so
+# the same charset applies with a little headroom for that prefix/suffix.
 _PREFIX_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,299}$")
 
 # A rendered restriction is one octet in a 127.0.0.0/8 /32 CIDR. 0 and 255
@@ -121,6 +121,14 @@ def is_valid_alias_octet(octet: int) -> bool:
 # client_id -> (alias_octet, prefix). Module-level, like secret_hash's
 # cache: one allocator process per deployment.
 _restrictions: dict[str, tuple[int, str]] = {}
+# True once this process has attempted to load _restrictions from disk.
+# `restart: unless-stopped` leaves the restrictions file (and the DB) in
+# place across a crash/restart -- only a container *recreate* wipes both
+# together, so the two stay consistent. Without this, _write() renders the
+# WHOLE file from this in-memory dict, so the first authorize_client() call
+# after a bare restart would silently drop every previously-authorized
+# client's rule.
+_hydrated = False
 
 
 class _PathPrefix(str):
@@ -215,6 +223,39 @@ def _write() -> None:
     os.chmod(RESTRICTIONS_PATH, 0o600)
 
 
+def _hydrate_from_disk() -> None:
+    """Load _restrictions from the on-disk file, once per process.
+
+    Runs before the first authorize_client()/revoke_client() mutation so a
+    freshly-restarted process doesn't treat "empty in-memory dict" as
+    "no clients have tunnels" -- see _hydrated's comment. Best-effort: a
+    missing or malformed file just means "nothing to load" rather than a
+    failure at import time or on the first registration after a restart.
+    """
+    global _hydrated
+    if _hydrated:
+        return
+    _hydrated = True  # only ever try once, even if this fails
+    try:
+        text = RESTRICTIONS_PATH.read_text()
+    except OSError:
+        return
+    try:
+        doc = yaml.safe_load(text) or {}
+        loaded: dict[str, tuple[int, str]] = {}
+        for entry in doc.get("restrictions") or []:
+            name = entry["name"]
+            prefix = str(entry["match"][0])
+            cidr = entry["allow"][0]["cidr"][0]
+            octet = int(cidr.rsplit(".", 1)[-1].split("/")[0])
+            loaded[name] = (octet, prefix)
+    except (yaml.YAMLError, KeyError, IndexError, TypeError, ValueError):
+        # Malformed file: fall back to empty rather than raising, and
+        # rather than trusting a partially-parsed (possibly corrupt) set.
+        return
+    _restrictions.update(loaded)
+
+
 def authorize_client(*, client_id: str, alias_octet: int, prefix: str) -> None:
     """Permit exactly this client to bind exactly its own alias.
 
@@ -224,6 +265,7 @@ def authorize_client(*, client_id: str, alias_octet: int, prefix: str) -> None:
     boundary: client_id is attacker-controlled (see the module docstring),
     so it's validated here rather than assumed clean by callers.
     """
+    _hydrate_from_disk()
     if not _is_safe_client_id(client_id):
         raise ValueError(f"unsafe client_id for tunnel restrictions: {client_id!r}")
     if not _is_safe_prefix(prefix):
@@ -246,6 +288,7 @@ def revoke_client(client_id: str) -> None:
     behavior. This also has to stay a no-op, not raise -- it runs on every
     client unregister.
     """
+    _hydrate_from_disk()
     if _restrictions.pop(client_id, None) is None:
         return
     _write()

--- a/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
+++ b/packages/allocator/src/lablink_allocator_service/tunnel_manager.py
@@ -36,13 +36,27 @@ port-number strings, each parsed as a single-port range:
 Confirmed via `--log-lvl DEBUG`, which echoes the parsed rule back as
 `port: [6080..=6080, 7070..=7070]`. Re-verify when bumping the pinned
 version.
+
+Security note: `client_id` is the DB `hostname`, which reaches this module
+from client-controlled registration input -- it is NOT validated upstream
+beyond truthiness. Every function that renders it into the restrictions
+file therefore validates it here (see `_is_safe_client_id`) rather than
+trusting the caller, and rendering itself goes through `yaml.safe_dump`
+(not f-string/string-building) so a value that somehow slipped past
+validation still can't forge YAML structure. Both are load-bearing: the
+charset check is what stops a multi-line hostname from ever reaching the
+renderer, and safe_dump is what stops any single-line-but-still-special
+YAML character (quotes, colons, `#`, etc.) from doing so.
 """
 from __future__ import annotations
 
 import hashlib
 import os
+import re
 import socket
 from pathlib import Path
+
+import yaml
 
 TUNNEL_DIR = Path("/tmp/lablink-tunnel")
 RESTRICTIONS_PATH = TUNNEL_DIR / "restrictions.yaml"
@@ -50,9 +64,64 @@ TUNNEL_PORTS = (6080, 7070)
 # Where the tunnel server listens inside the container; nginx proxies to it.
 TUNNEL_SERVER_PORT = 8080
 
+# client_id is the DB hostname: registration only checks it's truthy (see
+# routes/registration.py), so this module can't trust it arrived sane.
+# Reject anything outside a conservative charset rather than trying to
+# escape it -- it ends up as a YAML mapping key/value AND a path segment
+# (via path_prefix), so "sanitize" would need to satisfy both consumers.
+_CLIENT_ID_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,252}$")
+# path_prefix() = "<client_id>-<digest>" (digest is 16 hex chars), so the
+# same charset applies with a little headroom for that suffix.
+_PREFIX_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._-]{0,299}$")
+
+# A rendered restriction is one octet in a 127.0.0.0/8 /32 CIDR. 0 and 255
+# are excluded as the conventional network/broadcast-shaped ends of a
+# /24-sized block, even though loopback doesn't strictly enforce that.
+_MIN_ALIAS_OCTET = 1
+_MAX_ALIAS_OCTET = 254
+
+
+def _is_safe_client_id(client_id: str) -> bool:
+    return bool(_CLIENT_ID_RE.match(client_id))
+
+
+def _is_safe_prefix(prefix: str) -> bool:
+    return bool(_PREFIX_RE.match(prefix))
+
+
 # client_id -> (alias_octet, prefix). Module-level, like secret_hash's
 # cache: one allocator process per deployment.
 _restrictions: dict[str, tuple[int, str]] = {}
+
+
+class _PathPrefix(str):
+    """Marker type so the dumper below emits `!PathPrefix "value"`."""
+
+
+class _ReverseTunnelRule(dict):
+    """Marker type so the dumper below emits `!ReverseTunnel {...}`."""
+
+
+def _represent_path_prefix(dumper: yaml.Dumper, data: "_PathPrefix"):
+    return dumper.represent_scalar("!PathPrefix", str(data))
+
+
+def _represent_reverse_tunnel(dumper: yaml.Dumper, data: "_ReverseTunnelRule"):
+    return dumper.represent_mapping("!ReverseTunnel", dict(data))
+
+
+yaml.SafeDumper.add_representer(_PathPrefix, _represent_path_prefix)
+yaml.SafeDumper.add_representer(_ReverseTunnelRule, _represent_reverse_tunnel)
+
+# So _render()'s self-check (below) can round-trip its own output: SafeLoader
+# has no constructor for our custom tags by default and would otherwise
+# raise before the check ever ran.
+yaml.SafeLoader.add_constructor(
+    "!PathPrefix", lambda loader, node: loader.construct_scalar(node)
+)
+yaml.SafeLoader.add_constructor(
+    "!ReverseTunnel", lambda loader, node: loader.construct_mapping(node)
+)
 
 
 def path_prefix(client_id: str, secret: str) -> str:
@@ -67,19 +136,32 @@ def path_prefix(client_id: str, secret: str) -> str:
 
 
 def _render() -> str:
-    lines = ["restrictions:"]
-    for client_id, (octet, prefix) in sorted(_restrictions.items()):
-        ports = ", ".join(f'"{p}"' for p in TUNNEL_PORTS)
-        lines += [
-            f"  - name: {client_id}",
-            "    match:",
-            f'      - !PathPrefix "tunnel/{prefix}"',
-            "    allow:",
-            "      - !ReverseTunnel",
-            f"        port: [{ports}]",
-            f'        cidr: ["127.0.0.{octet}/32"]',
+    doc = {
+        "restrictions": [
+            {
+                "name": client_id,
+                "match": [_PathPrefix(f"tunnel/{prefix}")],
+                "allow": [
+                    _ReverseTunnelRule(
+                        {
+                            "port": [str(p) for p in TUNNEL_PORTS],
+                            "cidr": [f"127.0.0.{octet}/32"],
+                        }
+                    )
+                ],
+            }
+            for client_id, (octet, prefix) in sorted(_restrictions.items())
         ]
-    return "\n".join(lines) + "\n"
+    }
+    text = yaml.safe_dump(doc, default_flow_style=False, sort_keys=False)
+    # Belt and braces: authorize_client already rejects an unsafe client_id
+    # before it ever reaches here, and safe_dump can't be tricked into
+    # emitting extra YAML structure from a string value. This re-parses the
+    # output and checks the entry count so a future regression (e.g. someone
+    # reverting to f-string rendering) fails loudly here instead of quietly
+    # widening a client's access.
+    assert len(yaml.safe_load(text)["restrictions"]) == len(_restrictions)
+    return text
 
 
 def _write() -> None:
@@ -94,13 +176,36 @@ def _write() -> None:
 
 
 def authorize_client(*, client_id: str, alias_octet: int, prefix: str) -> None:
-    """Permit exactly this client to bind exactly its own alias."""
+    """Permit exactly this client to bind exactly its own alias.
+
+    Raises ValueError -- before any file work -- if client_id/prefix carry
+    characters this module can't safely render, or if alias_octet is
+    outside the range a /32 loopback rule can express. This is the trust
+    boundary: client_id is attacker-controlled (see the module docstring),
+    so it's validated here rather than assumed clean by callers.
+    """
+    if not _is_safe_client_id(client_id):
+        raise ValueError(f"unsafe client_id for tunnel restrictions: {client_id!r}")
+    if not _is_safe_prefix(prefix):
+        raise ValueError(f"unsafe prefix for tunnel restrictions: {prefix!r}")
+    if not (_MIN_ALIAS_OCTET <= alias_octet <= _MAX_ALIAS_OCTET):
+        raise ValueError(
+            f"alias_octet {alias_octet!r} out of range "
+            f"[{_MIN_ALIAS_OCTET}, {_MAX_ALIAS_OCTET}]"
+        )
     _restrictions[client_id] = (alias_octet, prefix)
     _write()
 
 
 def revoke_client(client_id: str) -> None:
-    """Drop this client's permission. No-op if it was never a tunnel client."""
+    """Drop this client's permission. No-op if it was never a tunnel client.
+
+    No client_id validation here: an unsafe id can never have made it into
+    _restrictions in the first place (authorize_client rejects it before
+    writing), so the plain dict.pop miss already gives the right no-op
+    behavior. This also has to stay a no-op, not raise -- it runs on every
+    client unregister.
+    """
     if _restrictions.pop(client_id, None) is None:
         return
     _write()

--- a/packages/allocator/src/lablink_allocator_service/validate_config.py
+++ b/packages/allocator/src/lablink_allocator_service/validate_config.py
@@ -28,8 +28,10 @@ VALID_PROVIDERS = ("aws", "manual")
 
 # manual.connectivity — must stay in sync with the connectivity registry
 # (_CONNECTIVITY_BUILTIN in providers/registry.py). "mesh_overlay" reaches
-# clients that aren't on the allocator's own LAN over a Tailscale tailnet.
-VALID_CONNECTIVITY = ("lan_direct", "mesh_overlay")
+# clients over a Tailscale tailnet; "reverse_tunnel" reaches them through a
+# tunnel the client dials out to this allocator and holds open, for networks
+# that won't carry Tailscale.
+VALID_CONNECTIVITY = ("lan_direct", "mesh_overlay", "reverse_tunnel")
 
 # manual.participant_exposure — how participants (not clients) reach the
 # allocator when it isn't on their LAN. Independent of connectivity above;

--- a/packages/allocator/start.sh
+++ b/packages/allocator/start.sh
@@ -63,6 +63,31 @@ fi
 
 echo "[allocator] Using config: $CONFIG_DIR/$CONFIG_NAME"
 
+# Which connectivity mode this deployment runs. Read from the mounted config
+# rather than an env var: the reverse-tunnel mode deliberately adds nothing to
+# the compose stack (no env, no port), so the config file is the only source.
+# Empty on any failure -- a missing/unparseable config means the tunnel server
+# simply does not start, and Flask's own config loading will report the real
+# problem.
+CONNECTIVITY_MODE=$(python3 -c "import yaml; print((yaml.safe_load(open('/config/config.yaml')) or {}).get('manual', {}).get('connectivity', ''))" 2>/dev/null || echo "")
+
+# Reverse-tunnel connectivity: run the shared tunnel server clients attach
+# to. Bound to loopback only -- nginx is the sole way in, so the WebSocket
+# upgrade always passes through auth_request. Gated on the configured mode so
+# lan_direct/mesh_overlay deployments never start it.
+if [ "$CONNECTIVITY_MODE" = "reverse_tunnel" ]; then
+  echo "Starting tunnel server on 127.0.0.1:8080..."
+  mkdir -p /tmp/lablink-tunnel && chmod 700 /tmp/lablink-tunnel
+  # Seed an empty document: wstunnel will not start if --restrict-config
+  # points at a missing file, and the first client registers later.
+  [ -f /tmp/lablink-tunnel/restrictions.yaml ] || \
+    printf 'restrictions:\n' > /tmp/lablink-tunnel/restrictions.yaml
+  chmod 600 /tmp/lablink-tunnel/restrictions.yaml
+  wstunnel server ws://127.0.0.1:8080 \
+    --restrict-config /tmp/lablink-tunnel/restrictions.yaml \
+    --remote-to-local-server-idle-timeout 20s &
+fi
+
 # Start Flask in the background (binds 127.0.0.1:8000).
 echo "Starting Flask app on 127.0.0.1:8000..."
 lablink-allocator &

--- a/packages/allocator/start.sh
+++ b/packages/allocator/start.sh
@@ -69,7 +69,11 @@ echo "[allocator] Using config: $CONFIG_DIR/$CONFIG_NAME"
 # Empty on any failure -- a missing/unparseable config means the tunnel server
 # simply does not start, and Flask's own config loading will report the real
 # problem.
-CONNECTIVITY_MODE=$(python3 -c "import yaml; print((yaml.safe_load(open('/config/config.yaml')) or {}).get('manual', {}).get('connectivity', ''))" 2>/dev/null || echo "")
+# Must read the same "$CONFIG_DIR/$CONFIG_NAME" echoed above, never a
+# hardcoded /config/config.yaml: both are overridable env knobs, and if this
+# read and Flask disagree the tunnel server never starts while Flask still
+# reports reverse_tunnel -- /api/health then 503s forever.
+CONNECTIVITY_MODE=$(python3 -c "import sys, yaml; print((yaml.safe_load(open(sys.argv[1])) or {}).get('manual', {}).get('connectivity', ''))" "$CONFIG_DIR/$CONFIG_NAME" 2>/dev/null || echo "")
 
 # Reverse-tunnel connectivity: run the shared tunnel server clients attach
 # to. Bound to loopback only -- nginx is the sole way in, so the WebSocket

--- a/packages/allocator/tests/db/conftest.py
+++ b/packages/allocator/tests/db/conftest.py
@@ -68,14 +68,6 @@ def db_instance(mock_db_connection):
 
 
 @pytest.fixture
-def db_with_mock_cursor(db_instance, mock_db_connection):
-    """(VmDatabase, mock cursor) tuple for tests that destructure both at
-    once instead of pulling mock_cursor out of mock_db_connection."""
-    _, mock_cursor, _ = mock_db_connection
-    return db_instance, mock_cursor
-
-
-@pytest.fixture
 def schedule_db_instance(mock_db_connection):
     """A ScheduleDatabase over the same mocked pool as db_instance."""
     mock_conn, mock_cursor, mock_pool = mock_db_connection

--- a/packages/allocator/tests/db/conftest.py
+++ b/packages/allocator/tests/db/conftest.py
@@ -68,6 +68,14 @@ def db_instance(mock_db_connection):
 
 
 @pytest.fixture
+def db_with_mock_cursor(db_instance, mock_db_connection):
+    """(VmDatabase, mock cursor) tuple for tests that destructure both at
+    once instead of pulling mock_cursor out of mock_db_connection."""
+    _, mock_cursor, _ = mock_db_connection
+    return db_instance, mock_cursor
+
+
+@pytest.fixture
 def schedule_db_instance(mock_db_connection):
     """A ScheduleDatabase over the same mocked pool as db_instance."""
     mock_conn, mock_cursor, mock_pool = mock_db_connection

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1,3 +1,5 @@
+import logging
+
 import pytest
 from unittest.mock import MagicMock, patch, ANY
 
@@ -1626,7 +1628,8 @@ def test_list_tunnel_aliases_returns_ints(db_instance, mock_db_connection):
     assert db_instance.list_tunnel_aliases() == [10, 11]
     db_instance.cursor.execute.assert_called_with(
         "SELECT provider_metadata->>'tunnel_alias_octet' FROM vms "
-        "WHERE provider_metadata->>'tunnel_alias_octet' IS NOT NULL;"
+        "WHERE provider_metadata->>'reverse_tunnel' = 'true' "
+        "AND provider_metadata->>'tunnel_alias_octet' ~ '^[0-9]+$';"
     )
 
 
@@ -1636,3 +1639,65 @@ def test_list_tunnel_aliases_empty_when_none_registered(
     _, mock_cursor, _ = mock_db_connection
     mock_cursor.fetchall.return_value = []
     assert db_instance.list_tunnel_aliases() == []
+
+
+@pytest.mark.parametrize(
+    "method,args",
+    [
+        ("list_tunnel_aliases", ()),
+        ("get_tunnel_alias", ("vm-1",)),
+    ],
+)
+def test_tunnel_alias_reads_only_trust_allocator_minted_rows(
+    db_instance, mock_db_connection, method, args
+):
+    """provider_metadata is client-supplied and the sentinel check that would
+    reject a forged one is gated on `provider == "manual"`, so a
+    `provider: "aws"` row can carry arbitrary tunnel_* keys. Without the
+    sentinel arm a forged octet could name ANOTHER client's alias and hand a
+    student that client's desktop (octets are sequential from 10); without the
+    regex arm a non-numeric one reached int() and 500'd /api/health."""
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchall.return_value = []
+    mock_cursor.fetchone.return_value = None
+    getattr(db_instance, method)(*args)
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "provider_metadata->>'reverse_tunnel' = 'true'" in sql
+    assert "~ '^[0-9]+$'" in sql
+
+
+def test_get_tunnel_path_prefix_returns_the_single_owner(
+    db_instance, mock_db_connection
+):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchall.return_value = [("vm-1", "tun-vm-1-abc")]
+    assert db_instance.get_tunnel_path_prefix("tun-vm-1-abc") == (
+        "vm-1", "tun-vm-1-abc",
+    )
+    sql, params = mock_cursor.execute.call_args[0]
+    assert "provider_metadata->>'tunnel_path_prefix' = %s" in sql
+    assert "provider_metadata->>'reverse_tunnel' = 'true'" in sql
+    assert params == ("tun-vm-1-abc",)
+
+
+def test_get_tunnel_path_prefix_unknown_is_none(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchall.return_value = []
+    assert db_instance.get_tunnel_path_prefix("tun-nobody-000") is None
+
+
+def test_get_tunnel_path_prefix_refuses_an_ambiguous_match(
+    db_instance, mock_db_connection, caplog
+):
+    """This lookup is the only binding between a presented secret and an
+    identity (tunnel_auth), and the column has no uniqueness constraint --
+    so a duplicate must fail closed rather than let fetchone() pick a row
+    by undefined ordering and then authenticate against THAT row's secret."""
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchall.return_value = [
+        ("vm-1", "tun-collide"),
+        ("vm-2", "tun-collide"),
+    ]
+    with caplog.at_level(logging.ERROR):
+        assert db_instance.get_tunnel_path_prefix("tun-collide") is None
+    assert "tun-collide" in caplog.text

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1525,23 +1525,43 @@ def test_clear_unhealthy_only_clears_the_allocator_set_flag(db_instance):
     assert params == ("LAPTOP-M8NLMMGL",)
 
 
-class TestTunnelAlias:
-    def test_first_allocation_returns_base(self, db_with_mock_cursor):
-        db, cursor = db_with_mock_cursor
-        cursor.fetchone.return_value = (None,)
-        assert db.allocate_tunnel_alias_octet() == 10
+def test_allocate_tunnel_alias_octet_returns_base_when_empty(
+    db_instance, mock_db_connection
+):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = (None,)
+    assert db_instance.allocate_tunnel_alias_octet() == 10
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "provider_metadata->>'tunnel_alias_octet'" in sql
+    assert "MAX(" in sql
 
-    def test_next_allocation_increments(self, db_with_mock_cursor):
-        db, cursor = db_with_mock_cursor
-        cursor.fetchone.return_value = (11,)
-        assert db.allocate_tunnel_alias_octet() == 12
 
-    def test_get_tunnel_alias_returns_int(self, db_with_mock_cursor):
-        db, cursor = db_with_mock_cursor
-        cursor.fetchone.return_value = ("10",)
-        assert db.get_tunnel_alias("vm-1") == 10
+def test_allocate_tunnel_alias_octet_increments_from_max(
+    db_instance, mock_db_connection
+):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = (11,)
+    assert db_instance.allocate_tunnel_alias_octet() == 12
+    sql = mock_cursor.execute.call_args[0][0]
+    assert "provider_metadata->>'tunnel_alias_octet'" in sql
+    assert "MAX(" in sql
 
-    def test_get_tunnel_alias_missing_is_none(self, db_with_mock_cursor):
-        db, cursor = db_with_mock_cursor
-        cursor.fetchone.return_value = (None,)
-        assert db.get_tunnel_alias("vm-1") is None
+
+def test_get_tunnel_alias_returns_int(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = ("10",)
+    assert db_instance.get_tunnel_alias("vm-1") == 10
+    sql, params = mock_cursor.execute.call_args[0]
+    assert "provider_metadata->>'tunnel_alias_octet'" in sql
+    assert "WHERE hostname = %s" in sql
+    assert params == ("vm-1",)
+
+
+def test_get_tunnel_alias_missing_is_none(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchone.return_value = (None,)
+    assert db_instance.get_tunnel_alias("vm-1") is None
+    sql, params = mock_cursor.execute.call_args[0]
+    assert "provider_metadata->>'tunnel_alias_octet'" in sql
+    assert "WHERE hostname = %s" in sql
+    assert params == ("vm-1",)

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1523,3 +1523,25 @@ def test_clear_unhealthy_only_clears_the_allocator_set_flag(db_instance):
     assert "healthy = NULL" in sql
     assert "healthy = 'Unhealthy'" in sql  # the WHERE guard
     assert params == ("LAPTOP-M8NLMMGL",)
+
+
+class TestTunnelAlias:
+    def test_first_allocation_returns_base(self, db_with_mock_cursor):
+        db, cursor = db_with_mock_cursor
+        cursor.fetchone.return_value = (None,)
+        assert db.allocate_tunnel_alias_octet() == 10
+
+    def test_next_allocation_increments(self, db_with_mock_cursor):
+        db, cursor = db_with_mock_cursor
+        cursor.fetchone.return_value = (11,)
+        assert db.allocate_tunnel_alias_octet() == 12
+
+    def test_get_tunnel_alias_returns_int(self, db_with_mock_cursor):
+        db, cursor = db_with_mock_cursor
+        cursor.fetchone.return_value = ("10",)
+        assert db.get_tunnel_alias("vm-1") == 10
+
+    def test_get_tunnel_alias_missing_is_none(self, db_with_mock_cursor):
+        db, cursor = db_with_mock_cursor
+        cursor.fetchone.return_value = (None,)
+        assert db.get_tunnel_alias("vm-1") is None

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1618,3 +1618,21 @@ def test_get_tunnel_alias_missing_is_none(db_instance, mock_db_connection):
     assert "provider_metadata->>'tunnel_alias_octet'" in sql
     assert "WHERE hostname = %s" in sql
     assert params == ("vm-1",)
+
+
+def test_list_tunnel_aliases_returns_ints(db_instance, mock_db_connection):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchall.return_value = [("10",), ("11",)]
+    assert db_instance.list_tunnel_aliases() == [10, 11]
+    db_instance.cursor.execute.assert_called_with(
+        "SELECT provider_metadata->>'tunnel_alias_octet' FROM vms "
+        "WHERE provider_metadata->>'tunnel_alias_octet' IS NOT NULL;"
+    )
+
+
+def test_list_tunnel_aliases_empty_when_none_registered(
+    db_instance, mock_db_connection
+):
+    _, mock_cursor, _ = mock_db_connection
+    mock_cursor.fetchall.return_value = []
+    assert db_instance.list_tunnel_aliases() == []

--- a/packages/allocator/tests/db/test_vms.py
+++ b/packages/allocator/tests/db/test_vms.py
@@ -1528,23 +1528,76 @@ def test_clear_unhealthy_only_clears_the_allocator_set_flag(db_instance):
 def test_allocate_tunnel_alias_octet_returns_base_when_empty(
     db_instance, mock_db_connection
 ):
+    """First-ever allocation self-initializes the settings counter at
+    _TUNNEL_ALIAS_BASE via the INSERT arm of the upsert."""
     _, mock_cursor, _ = mock_db_connection
-    mock_cursor.fetchone.return_value = (None,)
+    mock_cursor.fetchone.return_value = (10,)
     assert db_instance.allocate_tunnel_alias_octet() == 10
-    sql = mock_cursor.execute.call_args[0][0]
-    assert "provider_metadata->>'tunnel_alias_octet'" in sql
-    assert "MAX(" in sql
+    sql, params = mock_cursor.execute.call_args[0]
+    assert "settings" in sql
+    assert "ON CONFLICT" in sql
+    assert params == ("10",)
 
 
 def test_allocate_tunnel_alias_octet_increments_from_max(
     db_instance, mock_db_connection
 ):
+    """A subsequent allocation takes the ON CONFLICT DO UPDATE arm,
+    atomically incrementing the existing counter row."""
     _, mock_cursor, _ = mock_db_connection
-    mock_cursor.fetchone.return_value = (11,)
+    mock_cursor.fetchone.return_value = (12,)
     assert db_instance.allocate_tunnel_alias_octet() == 12
-    sql = mock_cursor.execute.call_args[0][0]
-    assert "provider_metadata->>'tunnel_alias_octet'" in sql
-    assert "MAX(" in sql
+    sql, params = mock_cursor.execute.call_args[0]
+    assert "settings" in sql
+    assert "ON CONFLICT" in sql
+    assert "value::int + 1" in sql
+    assert params == ("10",)
+
+
+def test_allocate_tunnel_alias_octet_concurrent_returns_distinct_octets(real_db):
+    """Two interleaved allocations must never return the same octet.
+
+    allocate_tunnel_alias_octet() used to be a bare SELECT MAX(...): two
+    concurrent registrations could read the same "current max" before
+    either wrote anything and mint the same octet -- this repo's own
+    documented VM-assignment race (see assign_vm), just with a read that
+    never claims anything. The fix is a single atomic UPSERT against a
+    counter row in `settings`, verified here with real interleaved
+    threads against a real Postgres."""
+    import threading
+
+    with real_db._cursor as cur:
+        cur.execute(
+            "CREATE TABLE IF NOT EXISTS settings ("
+            "key TEXT PRIMARY KEY, value TEXT NOT NULL)"
+        )
+        cur.execute("DELETE FROM settings WHERE key = 'tunnel_alias_next_octet'")
+
+    n = 8
+    barrier = threading.Barrier(n)
+    results: list = []
+    errors: list[BaseException] = []
+    lock = threading.Lock()
+
+    def allocate():
+        try:
+            barrier.wait(timeout=5)
+            octet = real_db.allocate_tunnel_alias_octet()
+            with lock:
+                results.append(octet)
+        except BaseException as e:  # noqa: BLE001
+            with lock:
+                errors.append(e)
+
+    threads = [threading.Thread(target=allocate) for _ in range(n)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join(timeout=5)
+
+    assert not errors, f"Thread errors: {errors}"
+    assert len(results) == n
+    assert len(set(results)) == n, f"Duplicate octets allocated: {results}"
 
 
 def test_get_tunnel_alias_returns_int(db_instance, mock_db_connection):

--- a/packages/allocator/tests/test_desktop_route.py
+++ b/packages/allocator/tests/test_desktop_route.py
@@ -226,10 +226,15 @@ def test_desktop_admin_session_renders_wrapper_with_release_form(
         '<form method="POST" action="/admin/instances/host-troubleshoot/release">'
         in body
     )
+    # show_control_bar=1 and allowfullscreen are both required by the framed
+    # viewer: without the first the Kasm bundle defaults clipboard off (it
+    # detects `window.self !== window.top`), and without the second it can
+    # never reach the fullscreen handler that calls navigator.keyboard.lock.
     assert (
         'src="/static/novnc/vnc.html?path=proxy/tok-admin'
-        '&autoconnect=1&resize=remote"' in body
+        '&autoconnect=1&resize=remote&show_control_bar=1"' in body
     )
+    assert "allowfullscreen" in body
 
 
 def test_desktop_admin_session_escapes_hostname(desktop_client_with_row):

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -5,6 +5,35 @@ from __future__ import annotations
 import subprocess
 from unittest.mock import MagicMock
 
+import pytest
+
+
+@pytest.fixture
+def health_client(app, monkeypatch):
+    """HTTP client wired for reverse-tunnel health checks: a stub provider
+    whose client_connectivity requires the tunnel check (the real
+    ReverseTunnelClientConnectivity, which sets requires_tunnel_check =
+    True), and a fake db standing in for main.database.
+
+    Returns (test_client, fake_db).
+    """
+    from lablink_allocator_service import main
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        ReverseTunnelClientConnectivity,
+    )
+
+    class _StubProvider:
+        client_connectivity = ReverseTunnelClientConnectivity()
+
+    app.config["LABLINK_PROVIDER"] = _StubProvider()
+
+    fake_db = MagicMock()
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+    monkeypatch.setattr(main, "scheduler_service", MagicMock(), raising=False)
+    monkeypatch.setattr(main, "reboot_service", MagicMock(), raising=False)
+
+    return app.test_client(), fake_db
+
 
 class TestTailscaleStatus:
     """Unit tests for _tailscale_status(), which shells out to `ip` to
@@ -192,3 +221,57 @@ class TestHealthEndpoint:
         data = resp.get_json()
         assert data["status"] == "starting"
         assert data["checks"]["tailscale"] == "not joined"
+
+
+class TestTunnelStatus:
+    """Health for reverse_tunnel must report *attachment*, not liveness: a
+    bound loopback listener survives for the idle timeout after its client
+    disconnects, and connections to that orphan hang rather than fail, so
+    the shared tunnel server being up says nothing about any one client."""
+
+    def test_health_reports_unattached_clients(self, health_client, monkeypatch):
+        """A bound port is not evidence of an attached client: wstunnel keeps
+        the listener for its idle timeout after the client leaves, and
+        connections to an orphan hang instead of failing."""
+        from lablink_allocator_service import tunnel_manager
+
+        monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "ok")
+        monkeypatch.setattr(tunnel_manager, "attached_aliases", lambda: {10})
+        client, fake_db = health_client
+        fake_db.list_tunnel_aliases.return_value = [10, 11]
+
+        body = client.get("/api/health").get_json()
+        assert body["checks"]["tunnel"] == "1 client(s) not attached"
+
+    def test_health_ok_when_every_client_is_attached(self, health_client, monkeypatch):
+        from lablink_allocator_service import tunnel_manager
+
+        monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "ok")
+        monkeypatch.setattr(tunnel_manager, "attached_aliases", lambda: {10, 11})
+        client, fake_db = health_client
+        fake_db.list_tunnel_aliases.return_value = [10, 11]
+
+        assert client.get("/api/health").get_json()["checks"]["tunnel"] == "ok"
+
+    def test_health_reports_server_down(self, health_client, monkeypatch):
+        from lablink_allocator_service import tunnel_manager
+
+        monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "not running")
+        client, fake_db = health_client
+        fake_db.list_tunnel_aliases.return_value = []
+        assert client.get("/api/health").get_json()["checks"]["tunnel"] == "not running"
+
+    def test_tunnel_check_absent_when_not_reverse_tunnel(self, client, monkeypatch):
+        """A connectivity strategy that doesn't require a tunnel check
+        (e.g. lan_direct/allocator_proxied/mesh_overlay) must not add a
+        tunnel key — byte-identical health payload to today for every
+        existing deployment."""
+        from lablink_allocator_service import main as main_mod
+
+        monkeypatch.setattr(main_mod, "database", MagicMock())
+        monkeypatch.setattr(main_mod, "scheduler_service", MagicMock())
+        monkeypatch.setattr(main_mod, "reboot_service", MagicMock())
+
+        resp = client.get("/api/health")
+        assert resp.status_code == 200
+        assert "tunnel" not in resp.get_json()["checks"]

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -261,6 +261,54 @@ class TestTunnelStatus:
         fake_db.list_tunnel_aliases.return_value = []
         assert client.get("/api/health").get_json()["checks"]["tunnel"] == "not running"
 
+    def test_health_ok_when_no_clients_registered(self, health_client, monkeypatch):
+        """Shared server up, zero registered tunnel clients: the empty
+        set has nothing missing from it, so this is the logically safe
+        'ok' case, not a degenerate one."""
+        from lablink_allocator_service import tunnel_manager
+
+        monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "ok")
+        monkeypatch.setattr(tunnel_manager, "attached_aliases", lambda: {10})
+        client, fake_db = health_client
+        fake_db.list_tunnel_aliases.return_value = []
+
+        assert client.get("/api/health").get_json()["checks"]["tunnel"] == "ok"
+
+    def test_health_degrades_when_db_query_fails(self, health_client, monkeypatch):
+        """A transient Postgres problem (pool exhaustion, a brief restart)
+        while the tunnel server is up must degrade this one check's value,
+        not raise out of the route and 500 the whole endpoint -- the same
+        contract _tailscale_status keeps for its own external call."""
+        import psycopg2
+
+        from lablink_allocator_service import tunnel_manager
+
+        monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "ok")
+        client, fake_db = health_client
+        fake_db.list_tunnel_aliases.side_effect = psycopg2.OperationalError(
+            "connection pool exhausted"
+        )
+
+        resp = client.get("/api/health")
+        assert resp.status_code == 503
+        assert resp.get_json()["checks"]["tunnel"] == "client list unavailable"
+
+    def test_health_tunnel_not_initialized_when_db_absent(
+        self, health_client, monkeypatch
+    ):
+        """main.database can in principle be None (mirrors the top-level
+        `database` check's own guard); _tunnel_status must report that
+        rather than raise AttributeError reaching for list_tunnel_aliases."""
+        from lablink_allocator_service import main
+        from lablink_allocator_service import tunnel_manager
+
+        monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "ok")
+        client, _fake_db = health_client
+        monkeypatch.setattr(main, "database", None)
+
+        resp = client.get("/api/health")
+        assert resp.get_json()["checks"]["tunnel"] == "not initialized"
+
     def test_tunnel_check_absent_when_not_reverse_tunnel(self, client, monkeypatch):
         """A connectivity strategy that doesn't require a tunnel check
         (e.g. lan_direct/allocator_proxied/mesh_overlay) must not add a

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -229,20 +229,6 @@ class TestTunnelStatus:
     disconnects, and connections to that orphan hang rather than fail, so
     the shared tunnel server being up says nothing about any one client."""
 
-    def test_health_reports_unattached_clients(self, health_client, monkeypatch):
-        """A bound port is not evidence of an attached client: wstunnel keeps
-        the listener for its idle timeout after the client leaves, and
-        connections to an orphan hang instead of failing."""
-        from lablink_allocator_service import tunnel_manager
-
-        monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "ok")
-        monkeypatch.setattr(tunnel_manager, "attached_aliases", lambda: {10})
-        client, fake_db = health_client
-        fake_db.list_tunnel_aliases.return_value = [10, 11]
-
-        body = client.get("/api/health").get_json()
-        assert body["checks"]["tunnel"] == "1 client(s) not attached"
-
     def test_unattached_client_does_not_make_the_allocator_unready(
         self, health_client, monkeypatch
     ):
@@ -288,19 +274,6 @@ class TestTunnelStatus:
         # shared server being down IS the allocator's own dependency failing,
         # so it must still gate readiness.
         assert resp.status_code == 503
-
-    def test_health_ok_when_no_clients_registered(self, health_client, monkeypatch):
-        """Shared server up, zero registered tunnel clients: the empty
-        set has nothing missing from it, so this is the logically safe
-        'ok' case, not a degenerate one."""
-        from lablink_allocator_service import tunnel_manager
-
-        monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "ok")
-        monkeypatch.setattr(tunnel_manager, "attached_aliases", lambda: {10})
-        client, fake_db = health_client
-        fake_db.list_tunnel_aliases.return_value = []
-
-        assert client.get("/api/health").get_json()["checks"]["tunnel"] == "ok"
 
     def test_health_degrades_when_db_query_fails(self, health_client, monkeypatch):
         """A transient Postgres problem (pool exhaustion, a brief restart)

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -243,6 +243,28 @@ class TestTunnelStatus:
         body = client.get("/api/health").get_json()
         assert body["checks"]["tunnel"] == "1 client(s) not attached"
 
+    def test_unattached_client_does_not_make_the_allocator_unready(
+        self, health_client, monkeypatch
+    ):
+        """Reported, but not a 503. Observed live 2026-07-31: gating the code
+        on client attachment deadlocked client startup -- a registering client
+        is unattached by definition until its tunnel is up, its own preflight
+        probe waited for a green health check, and that check could not go
+        green until the tunnel it was blocking came up. It also failed
+        deploy_compose's health poll and made `lablink status` call the
+        allocator unhealthy because a *client* was down."""
+        from lablink_allocator_service import tunnel_manager
+
+        monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "ok")
+        monkeypatch.setattr(tunnel_manager, "attached_aliases", lambda: set())
+        client, fake_db = health_client
+        fake_db.list_tunnel_aliases.return_value = [10]
+
+        resp = client.get("/api/health")
+        assert resp.status_code == 200, resp.get_json()
+        assert resp.get_json()["status"] == "healthy"
+        assert resp.get_json()["checks"]["tunnel"] == "1 client(s) not attached"
+
     def test_health_ok_when_every_client_is_attached(self, health_client, monkeypatch):
         from lablink_allocator_service import tunnel_manager
 
@@ -259,7 +281,13 @@ class TestTunnelStatus:
         monkeypatch.setattr(tunnel_manager, "tunnel_status", lambda: "not running")
         client, fake_db = health_client
         fake_db.list_tunnel_aliases.return_value = []
-        assert client.get("/api/health").get_json()["checks"]["tunnel"] == "not running"
+        resp = client.get("/api/health")
+        assert resp.get_json()["checks"]["tunnel"] == "not running"
+        # The other side of the line drawn by
+        # test_unattached_client_does_not_make_the_allocator_unready: the
+        # shared server being down IS the allocator's own dependency failing,
+        # so it must still gate readiness.
+        assert resp.status_code == 503
 
     def test_health_ok_when_no_clients_registered(self, health_client, monkeypatch):
         """Shared server up, zero registered tunnel clients: the empty

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -949,3 +949,44 @@ def test_register_rejects_a_malformed_hostname(reg_client, bad):
     )
     assert r.status_code == 400
     fake_db.register_client.assert_not_called()
+
+
+def test_register_rejects_a_non_string_hostname(reg_client):
+    """A non-string hostname (e.g. a bare JSON int) must 400, not 500 --
+    _VALID_HOSTNAME.fullmatch(hostname) raises TypeError on anything that
+    isn't str/bytes-like."""
+    client, fake_db = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": 12345, "machine_identity": "i-1"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 400
+    fake_db.register_client.assert_not_called()
+
+
+def test_register_rejects_when_tunnel_alias_octets_are_exhausted(reg_client):
+    """allocate_tunnel_alias_octet() never recycles (see its docstring),
+    so a long-lived deployment can exhaust the 1-254 range. That must
+    surface as a clean 503 before the row is written -- not an unhandled
+    500 from authorize_client raising on an out-of-range octet after
+    register_client already inserted the row."""
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        ReverseTunnelClientConnectivity,
+    )
+
+    client, fake_db = reg_client
+    client.application.config["LABLINK_PROVIDER"].client_connectivity = (
+        ReverseTunnelClientConnectivity()
+    )
+    fake_db.allocate_tunnel_alias_octet.return_value = 255
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual", "provider_metadata": {"reverse_tunnel": True},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 503
+    fake_db.register_client.assert_not_called()

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -841,7 +841,6 @@ def test_overlay_hostname_404_when_not_an_overlay_client(client, monkeypatch):
 # ---- reverse_tunnel registration ------------------------------------------
 
 def test_reverse_tunnel_registration_mints_alias_and_prefix(reg_client, monkeypatch):
-    from lablink_allocator_service import main
     from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
         ReverseTunnelClientConnectivity,
     )
@@ -856,12 +855,15 @@ def test_reverse_tunnel_registration_mints_alias_and_prefix(reg_client, monkeypa
         "lablink_allocator_service.tunnel_manager.authorize_client",
         lambda **kw: authorized.update(kw),
     )
-    # canonical_base_url only echoes the public https scheme/host once
-    # ssl.provider != "none" opens the ProxyFix gate (see
-    # test_register_response_honors_x_forwarded_proto) -- otherwise the
-    # Flask test client's default request.host_url ("http://localhost/")
-    # would be used instead.
-    monkeypatch.setattr(main.cfg.ssl, "provider", "letsencrypt", raising=False)
+    # No ssl.provider override and no X-Forwarded-* headers: reverse_tunnel
+    # is a manual-provider-only connectivity mode, and manual deployments
+    # only ever run ssl.provider: none (see canonical_base_url's
+    # docstring), which keeps the ProxyFix gate shut regardless of what
+    # headers a caller sends. The realistic response here is the plain
+    # http:// Flask test client default -- the CLI, not the allocator, is
+    # what compensates for that (see register.py's TUNNEL_URL, which
+    # prefers its own resolved_url over this field's value for exactly
+    # this reason).
 
     r = client.post(
         "/api/v1/clients/register",
@@ -869,11 +871,7 @@ def test_reverse_tunnel_registration_mints_alias_and_prefix(reg_client, monkeypa
             "hostname": "vm-1", "machine_identity": "i-1",
             "provider": "manual", "provider_metadata": {"reverse_tunnel": True},
         },
-        headers={
-            "Authorization": "Bearer tk_test_register",
-            "X-Forwarded-Proto": "https",
-            "X-Forwarded-Host": "allocator.example.com",
-        },
+        headers={"Authorization": "Bearer tk_test_register"},
     )
     assert r.status_code == 200
     body = r.get_json()
@@ -882,7 +880,11 @@ def test_reverse_tunnel_registration_mints_alias_and_prefix(reg_client, monkeypa
     # The URL is the allocator's BASE address; the prefix travels separately
     # because the client passes it with -P and ignores the URL's path.
     assert "/tunnel/" not in body["tunnel_url"]
-    assert body["tunnel_url"].rstrip("/") == "https://allocator.example.com"
+    # Realistic manual topology: canonical_base_url falls back to
+    # request.host_url, which is http:// here (no canonical-url file, no
+    # trusted X-Forwarded-Proto) -- this is NOT an https guarantee, and
+    # nothing downstream of this response should assume one.
+    assert body["tunnel_url"].startswith("http://")
 
     kw = fake_db.register_client.call_args.kwargs
     assert kw["provider_metadata"]["tunnel_alias_octet"] == 12

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -546,6 +546,56 @@ def test_unregister_success(reg_client):
     fake_db.unregister_client.assert_called_once_with("vm-1")
 
 
+def test_unregister_revokes_a_reverse_tunnel_clients_restrictions_rule(
+    reg_client, monkeypatch
+):
+    """cleanup_client_identity was dead code (called by nothing); wired
+    into unregister so a departed tunnel client's restrictions-file rule
+    doesn't linger forever, growing the file on every re-registration."""
+    from lablink_allocator_service.secret_hash import hash_secret
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        ReverseTunnelClientConnectivity,
+    )
+
+    client, fake_db = reg_client
+    client.application.config["LABLINK_PROVIDER"].client_connectivity = (
+        ReverseTunnelClientConnectivity()
+    )
+    fake_db.get_client_secret_hash.return_value = hash_secret("sek")
+    fake_db.unregister_client.return_value = True
+    revoked = {}
+    monkeypatch.setattr(
+        "lablink_allocator_service.tunnel_manager.revoke_client",
+        lambda client_id: revoked.setdefault("client_id", client_id),
+    )
+
+    r = client.delete(
+        "/api/v1/clients/vm-1",
+        headers={"Authorization": "Bearer sek"},
+    )
+
+    assert r.status_code == 200
+    assert revoked == {"client_id": "vm-1"}
+
+
+def test_unregister_skips_cleanup_for_connectivity_without_it(reg_client):
+    """The default reg_client provider (AllocatorProxiedClientConnectivity)
+    has no cleanup_client_identity -- the optional-hook lookup must not
+    raise for connectivity modes that need no such cleanup."""
+    from lablink_allocator_service.secret_hash import hash_secret
+
+    client, fake_db = reg_client
+    fake_db.get_client_secret_hash.return_value = hash_secret("sek")
+    fake_db.unregister_client.return_value = True
+
+    r = client.delete(
+        "/api/v1/clients/vm-1",
+        headers={"Authorization": "Bearer sek"},
+    )
+
+    assert r.status_code == 200
+
+
 # ---- GET /api/v1/clients (list endpoint) ---------------------------------
 
 def test_list_clients_rejects_missing_auth(reg_client):

--- a/packages/allocator/tests/test_registration_api.py
+++ b/packages/allocator/tests/test_registration_api.py
@@ -1,6 +1,8 @@
 """Tests for the registration API + register-token at-rest hashing."""
 from unittest.mock import MagicMock
 
+import pytest
+
 
 def test_register_token_global_exists():
     from lablink_allocator_service import main
@@ -834,3 +836,116 @@ def test_overlay_hostname_404_when_not_an_overlay_client(client, monkeypatch):
     )
 
     assert resp.status_code == 404
+
+
+# ---- reverse_tunnel registration ------------------------------------------
+
+def test_reverse_tunnel_registration_mints_alias_and_prefix(reg_client, monkeypatch):
+    from lablink_allocator_service import main
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        ReverseTunnelClientConnectivity,
+    )
+
+    client, fake_db = reg_client
+    client.application.config["LABLINK_PROVIDER"].client_connectivity = (
+        ReverseTunnelClientConnectivity()
+    )
+    fake_db.allocate_tunnel_alias_octet.return_value = 12
+    authorized = {}
+    monkeypatch.setattr(
+        "lablink_allocator_service.tunnel_manager.authorize_client",
+        lambda **kw: authorized.update(kw),
+    )
+    # canonical_base_url only echoes the public https scheme/host once
+    # ssl.provider != "none" opens the ProxyFix gate (see
+    # test_register_response_honors_x_forwarded_proto) -- otherwise the
+    # Flask test client's default request.host_url ("http://localhost/")
+    # would be used instead.
+    monkeypatch.setattr(main.cfg.ssl, "provider", "letsencrypt", raising=False)
+
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual", "provider_metadata": {"reverse_tunnel": True},
+        },
+        headers={
+            "Authorization": "Bearer tk_test_register",
+            "X-Forwarded-Proto": "https",
+            "X-Forwarded-Host": "allocator.example.com",
+        },
+    )
+    assert r.status_code == 200
+    body = r.get_json()
+    assert body["tunnel_bind_addr"] == "127.0.0.12"
+    assert body["tunnel_path_prefix"].startswith("tun-vm-1-")
+    # The URL is the allocator's BASE address; the prefix travels separately
+    # because the client passes it with -P and ignores the URL's path.
+    assert "/tunnel/" not in body["tunnel_url"]
+    assert body["tunnel_url"].rstrip("/") == "https://allocator.example.com"
+
+    kw = fake_db.register_client.call_args.kwargs
+    assert kw["provider_metadata"]["tunnel_alias_octet"] == 12
+    assert kw["provider_metadata"]["tunnel_path_prefix"] == body["tunnel_path_prefix"]
+    # The client may bind only its own alias.
+    assert authorized == {
+        "client_id": "vm-1", "alias_octet": 12,
+        "prefix": body["tunnel_path_prefix"],
+    }
+
+
+def test_plain_registration_against_a_tunnel_allocator_is_rejected(reg_client):
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        ReverseTunnelClientConnectivity,
+    )
+
+    client, fake_db = reg_client
+    client.application.config["LABLINK_PROVIDER"].client_connectivity = (
+        ReverseTunnelClientConnectivity()
+    )
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": "vm-1", "machine_identity": "i-1", "provider": "manual"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 400
+    assert "reverse_tunnel" in r.get_json()["error"]
+    fake_db.register_client.assert_not_called()
+
+
+def test_tunnel_sentinel_against_a_lan_direct_allocator_is_rejected(reg_client):
+    client, fake_db = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={
+            "hostname": "vm-1", "machine_identity": "i-1",
+            "provider": "manual", "provider_metadata": {"reverse_tunnel": True},
+        },
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 400
+    fake_db.register_client.assert_not_called()
+
+
+def test_response_omits_tunnel_fields_when_not_a_tunnel_client(reg_client):
+    client, _ = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": "vm-1", "machine_identity": "i-1"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert "tunnel_url" not in r.get_json()
+
+
+@pytest.mark.parametrize("bad", [
+    "vm-1\nrestrictions:", "../../etc/passwd", "vm 1", "-leading-dash", "",
+])
+def test_register_rejects_a_malformed_hostname(reg_client, bad):
+    client, fake_db = reg_client
+    r = client.post(
+        "/api/v1/clients/register",
+        json={"hostname": bad, "machine_identity": "i-1"},
+        headers={"Authorization": "Bearer tk_test_register"},
+    )
+    assert r.status_code == 400
+    fake_db.register_client.assert_not_called()

--- a/packages/allocator/tests/test_reverse_tunnel_connectivity.py
+++ b/packages/allocator/tests/test_reverse_tunnel_connectivity.py
@@ -1,0 +1,138 @@
+import uuid
+from unittest.mock import patch
+
+import pytest
+
+from lablink_allocator_service.providers.protocol import (
+    BrowserSessionTarget,
+    ClientConnectivity,
+    ClientJoinMaterial,
+)
+
+
+def test_satisfies_protocol_and_flags():
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        ReverseTunnelClientConnectivity,
+    )
+
+    c = ReverseTunnelClientConnectivity()
+    assert isinstance(c, ClientConnectivity)
+    assert c.name == "reverse_tunnel"
+    assert c.requires_tailscale_check is False
+    assert c.requires_tunnel_check is True
+
+
+def test_registry_resolves_the_strategy():
+    from lablink_allocator_service.providers.registry import get_provider
+
+    prov = get_provider(
+        "manual", region=None, terraform_dir=None, connectivity="reverse_tunnel"
+    )
+    assert prov.client_connectivity.name == "reverse_tunnel"
+
+
+def test_validator_accepts_the_connectivity_value():
+    from lablink_allocator_service.validate_config import VALID_CONNECTIVITY
+
+    assert "reverse_tunnel" in VALID_CONNECTIVITY
+
+
+def test_delegates_to_client_session_with_tunnel_alias_fallback():
+    """prepare_browser_session delegates to client_session.prepare_browser_session
+    and injects the tunnel-alias resolver via the fallback_fn kwarg — the same
+    extension point MeshOverlayClientConnectivity uses for its overlay-hostname
+    fallback."""
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        ReverseTunnelClientConnectivity,
+        _resolve_tunnel_alias,
+    )
+
+    sentinel = BrowserSessionTarget(ws_url="proxy/tok", browser_credential=None)
+    sid = uuid.uuid4()
+    with patch(
+        "lablink_allocator_service.providers.connectivity.reverse_tunnel."
+        "prepare_browser_session",
+        return_value=sentinel,
+    ) as m:
+        conn = ReverseTunnelClientConnectivity()
+        out = conn.prepare_browser_session(
+            database="DB",
+            hostname="vm-1",
+            session_id=sid,
+            browser_token="tok",
+            agent_token="api",
+        )
+    assert out is sentinel
+    m.assert_called_once_with(
+        database="DB",
+        hostname="vm-1",
+        session_id=sid,
+        browser_token="tok",
+        agent_token="api",
+        fallback_fn=_resolve_tunnel_alias,
+    )
+
+
+def test_resolve_tunnel_alias_builds_loopback_address():
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        _resolve_tunnel_alias,
+    )
+
+    mock_db = type(
+        "DB", (), {"get_tunnel_alias": staticmethod(lambda hostname: 12)}
+    )()
+    with patch(
+        "lablink_allocator_service.providers.connectivity.reverse_tunnel._db",
+        return_value=mock_db,
+    ):
+        result = _resolve_tunnel_alias("vm-1")
+    assert result == "127.0.0.12"
+
+
+def test_resolve_tunnel_alias_raises_when_not_registered():
+    from lablink_allocator_service.client_session import RotationFailed
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        _resolve_tunnel_alias,
+    )
+
+    mock_db = type(
+        "DB", (), {"get_tunnel_alias": staticmethod(lambda hostname: None)}
+    )()
+    with patch(
+        "lablink_allocator_service.providers.connectivity.reverse_tunnel._db",
+        return_value=mock_db,
+    ):
+        with pytest.raises(RotationFailed, match="vm-1"):
+            _resolve_tunnel_alias("vm-1")
+
+
+def test_make_join_material_returns_reverse_tunnel():
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        ReverseTunnelClientConnectivity,
+    )
+
+    c = ReverseTunnelClientConnectivity()
+    m = c.make_join_material(
+        allocator_url="http://a:5000",
+        client_image="img:1",
+        register_token="tk_1",
+    )
+    assert isinstance(m, ClientJoinMaterial)
+    assert m.connectivity == "reverse_tunnel"
+    assert m.allocator_url == "http://a:5000"
+    assert m.client_image == "img:1"
+    assert m.register_token == "tk_1"
+
+
+def test_cleanup_client_identity_revokes_tunnel_client():
+    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
+        ReverseTunnelClientConnectivity,
+    )
+
+    with patch(
+        "lablink_allocator_service.providers.connectivity.reverse_tunnel."
+        "tunnel_manager.revoke_client"
+    ) as m:
+        c = ReverseTunnelClientConnectivity()
+        c.cleanup_client_identity(hostname="vm-1")
+    m.assert_called_once_with("vm-1")

--- a/packages/allocator/tests/test_reverse_tunnel_connectivity.py
+++ b/packages/allocator/tests/test_reverse_tunnel_connectivity.py
@@ -31,12 +31,6 @@ def test_registry_resolves_the_strategy():
     assert prov.client_connectivity.name == "reverse_tunnel"
 
 
-def test_validator_accepts_the_connectivity_value():
-    from lablink_allocator_service.validate_config import VALID_CONNECTIVITY
-
-    assert "reverse_tunnel" in VALID_CONNECTIVITY
-
-
 def test_delegates_to_client_session_with_tunnel_alias_fallback():
     """prepare_browser_session delegates to client_session.prepare_browser_session
     and injects the tunnel-alias resolver via the fallback_fn kwarg — the same
@@ -106,33 +100,17 @@ def test_resolve_tunnel_alias_raises_when_not_registered():
             _resolve_tunnel_alias("vm-1")
 
 
-def test_make_join_material_returns_reverse_tunnel():
+def test_make_join_material_reports_the_connectivity_name():
+    """Only the connectivity field carries logic; the rest is pass-through.
+    cleanup_client_identity has no unit test here on purpose — it's a
+    one-line delegation, driven for real by test_registration_api.py's
+    test_unregister_revokes_a_reverse_tunnel_clients_restrictions_rule."""
     from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
         ReverseTunnelClientConnectivity,
     )
 
-    c = ReverseTunnelClientConnectivity()
-    m = c.make_join_material(
-        allocator_url="http://a:5000",
-        client_image="img:1",
-        register_token="tk_1",
+    m = ReverseTunnelClientConnectivity().make_join_material(
+        allocator_url="http://a:5000", client_image="img:1", register_token="tk_1",
     )
     assert isinstance(m, ClientJoinMaterial)
     assert m.connectivity == "reverse_tunnel"
-    assert m.allocator_url == "http://a:5000"
-    assert m.client_image == "img:1"
-    assert m.register_token == "tk_1"
-
-
-def test_cleanup_client_identity_revokes_tunnel_client():
-    from lablink_allocator_service.providers.connectivity.reverse_tunnel import (
-        ReverseTunnelClientConnectivity,
-    )
-
-    with patch(
-        "lablink_allocator_service.providers.connectivity.reverse_tunnel."
-        "tunnel_manager.revoke_client"
-    ) as m:
-        c = ReverseTunnelClientConnectivity()
-        c.cleanup_client_identity(hostname="vm-1")
-    m.assert_called_once_with("vm-1")

--- a/packages/allocator/tests/test_start_sh_tunnel.py
+++ b/packages/allocator/tests/test_start_sh_tunnel.py
@@ -32,9 +32,18 @@ def test_mode_is_read_from_the_mounted_config_not_an_env_var(script_text):
     """Nothing sets CONNECTIVITY_MODE in the container environment, and
     nothing should: this mode adds no env and no port to the compose stack
     (Task 14 pins that). The config file the allocator already mounts is the
-    only source of truth."""
+    only source of truth.
+
+    Must be the resolved "$CONFIG_DIR/$CONFIG_NAME" rather than a hardcoded
+    /config/config.yaml too: both are overridable env knobs, and if this read
+    and Flask disagree the tunnel server never starts while Flask still
+    reports reverse_tunnel, so /api/health 503s forever."""
     assert "CONNECTIVITY_MODE=$(" in script_text
-    assert "/config/config.yaml" in script_text
+    mode_line = next(
+        ln for ln in script_text.splitlines() if ln.startswith("CONNECTIVITY_MODE=$(")
+    )
+    assert "$CONFIG_DIR/$CONFIG_NAME" in mode_line
+    assert "/config/config.yaml" not in mode_line
 
 
 def test_binds_loopback_only(block):
@@ -53,11 +62,8 @@ def test_idle_timeout_is_short(block):
     assert int(m.group(1)) <= 30
 
 
-def test_uses_the_restrictions_file(block):
-    assert "--restrict-config /tmp/lablink-tunnel/restrictions.yaml" in block
-
-
-def test_restrictions_file_exists_before_the_server_starts(block):
+def test_uses_a_restrictions_file_that_exists_before_the_server_starts(block):
     """wstunnel refuses to start if --restrict-config points at a missing
     file, and the first client registers only after Flask is up."""
+    assert "--restrict-config /tmp/lablink-tunnel/restrictions.yaml" in block
     assert "restrictions:" in block  # seeds an empty document

--- a/packages/allocator/tests/test_start_sh_tunnel.py
+++ b/packages/allocator/tests/test_start_sh_tunnel.py
@@ -1,0 +1,63 @@
+"""Structural tests for start.sh's tunnel block — text assertions rather
+than execution, for the same reason as test_start_sh_status.py: start.sh
+launches long-running services and isn't sourceable."""
+from pathlib import Path
+
+import pytest
+
+START_SH = Path(__file__).resolve().parents[1] / "start.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return START_SH.read_text()
+
+
+@pytest.fixture(scope="module")
+def block() -> str:
+    lines = START_SH.read_text().splitlines()
+    start = next(
+        i for i, ln in enumerate(lines)
+        if ln.startswith('if [ "$CONNECTIVITY_MODE" = "reverse_tunnel" ]')
+    )
+    end = next(i for i, ln in enumerate(lines[start:], start) if ln == "fi")
+    return "\n".join(lines[start:end + 1])
+
+
+def test_gated_on_connectivity_mode(block):
+    assert 'if [ "$CONNECTIVITY_MODE" = "reverse_tunnel" ]' in block
+
+
+def test_mode_is_read_from_the_mounted_config_not_an_env_var(script_text):
+    """Nothing sets CONNECTIVITY_MODE in the container environment, and
+    nothing should: this mode adds no env and no port to the compose stack
+    (Task 14 pins that). The config file the allocator already mounts is the
+    only source of truth."""
+    assert "CONNECTIVITY_MODE=$(" in script_text
+    assert "/config/config.yaml" in script_text
+
+
+def test_binds_loopback_only(block):
+    """The tunnel server must never be reachable except through nginx."""
+    assert "ws://127.0.0.1:8080" in block
+    assert "0.0.0.0" not in block
+
+
+def test_idle_timeout_is_short(block):
+    """Default is 3 minutes, during which an orphaned listener accepts
+    connections and hangs. Anything above ~30s reintroduces that window."""
+    import re
+
+    m = re.search(r"--remote-to-local-server-idle-timeout\s+(\d+)s", block)
+    assert m, "idle timeout not set"
+    assert int(m.group(1)) <= 30
+
+
+def test_uses_the_restrictions_file(block):
+    assert "--restrict-config /tmp/lablink-tunnel/restrictions.yaml" in block
+
+
+def test_restrictions_file_exists_before_the_server_starts(block):
+    """wstunnel refuses to start if --restrict-config points at a missing
+    file, and the first client registers only after Flask is up."""
+    assert "restrictions:" in block  # seeds an empty document

--- a/packages/allocator/tests/test_tunnel_auth.py
+++ b/packages/allocator/tests/test_tunnel_auth.py
@@ -1,0 +1,91 @@
+"""Tests for GET/POST /internal/tunnel_auth -- the nginx auth_request gate
+for the reverse-tunnel WebSocket attach point.
+
+Security model under test: the URL path prefix identifies which client is
+attaching; the bearer token authenticates it. Both must agree -- a client
+must not be able to attach under another client's prefix even holding a
+valid secret of its own. Missing header, unknown prefix, or mismatched
+secret must all fail closed (401) before any per-client state is touched.
+"""
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture
+def tunnel_auth_client(app, monkeypatch):
+    """Flask test client wired for /internal/tunnel_auth, with a MagicMock
+    database. Returns (test_client, fake_db, secret) -- mirrors reg_client
+    in conftest.py."""
+    from lablink_allocator_service import main
+    from lablink_allocator_service.secret_hash import hash_secret
+
+    secret = "real-client-secret"
+    fake_db = MagicMock()
+    fake_db.get_client_secret_hash.return_value = hash_secret(secret)
+    monkeypatch.setattr(main, "database", fake_db, raising=False)
+    return app.test_client(), fake_db, secret
+
+
+def test_valid_secret_for_that_prefix_is_authorized(tunnel_auth_client):
+    client, fake_db, secret = tunnel_auth_client
+    prefix = "vm-1-" + "a" * 16
+    fake_db.get_tunnel_path_prefix.return_value = ("vm-1", prefix)
+    r = client.get(
+        "/internal/tunnel_auth",
+        headers={"X-Original-URI": f"/tunnel/{prefix}", "X-Tunnel-Auth": f"Bearer {secret}"},
+    )
+    assert r.status_code == 200
+
+
+def test_wrong_secret_is_rejected(tunnel_auth_client):
+    client, fake_db, _ = tunnel_auth_client
+    prefix = "vm-1-" + "a" * 16
+    fake_db.get_tunnel_path_prefix.return_value = ("vm-1", prefix)
+    r = client.get(
+        "/internal/tunnel_auth",
+        headers={"X-Original-URI": f"/tunnel/{prefix}", "X-Tunnel-Auth": "Bearer nope"},
+    )
+    assert r.status_code == 401
+
+
+def test_unknown_prefix_is_rejected(tunnel_auth_client):
+    client, fake_db, secret = tunnel_auth_client
+    fake_db.get_tunnel_path_prefix.return_value = None
+    r = client.get(
+        "/internal/tunnel_auth",
+        headers={"X-Original-URI": "/tunnel/not-a-client", "X-Tunnel-Auth": f"Bearer {secret}"},
+    )
+    assert r.status_code == 401
+
+
+def test_missing_header_is_rejected(tunnel_auth_client):
+    client, *_ = tunnel_auth_client
+    r = client.get("/internal/tunnel_auth", headers={"X-Original-URI": "/tunnel/x"})
+    assert r.status_code == 401
+
+
+def test_mismatched_prefix_and_secret_is_rejected(tunnel_auth_client):
+    """A client holding a *valid* secret of its own must not be able to
+    attach under a different client's prefix. get_tunnel_path_prefix maps
+    the requested prefix to "other-vm", whose stored hash is for a
+    different secret -- so verify_secret_cached must fail even though the
+    token presented is a real, well-formed secret (just not that client's)."""
+    from lablink_allocator_service.secret_hash import hash_secret
+
+    client, fake_db, secret = tunnel_auth_client
+    other_prefix = "other-vm-" + "b" * 16
+    fake_db.get_tunnel_path_prefix.return_value = ("other-vm", other_prefix)
+    fake_db.get_client_secret_hash.side_effect = lambda client_id: (
+        hash_secret("other-vms-own-secret")
+        if client_id == "other-vm"
+        else hash_secret(secret)
+    )
+    r = client.get(
+        "/internal/tunnel_auth",
+        headers={
+            "X-Original-URI": f"/tunnel/{other_prefix}",
+            "X-Tunnel-Auth": f"Bearer {secret}",
+        },
+    )
+    assert r.status_code == 401

--- a/packages/allocator/tests/test_tunnel_auth.py
+++ b/packages/allocator/tests/test_tunnel_auth.py
@@ -1,11 +1,20 @@
 """Tests for GET/POST /internal/tunnel_auth -- the nginx auth_request gate
 for the reverse-tunnel WebSocket attach point.
 
-Security model under test: the URL path prefix identifies which client is
-attaching; the bearer token authenticates it. Both must agree -- a client
-must not be able to attach under another client's prefix even holding a
-valid secret of its own. Missing header, unknown prefix, or mismatched
-secret must all fail closed (401) before any per-client state is touched.
+Security model under test: nginx captures the client's prefix from the
+FIRST path segment and hands it to this endpoint as its own header
+(X-Tunnel-Prefix) -- the endpoint must not re-derive identity from the
+URI itself, since the client's real request path is /<prefix>/events and
+last-segment extraction would read "events" and 401 every legitimate
+attach. The bearer token authenticates the identity nginx already
+resolved. Missing header, unknown prefix, absent secret hash, a
+scheme-less token, or a mismatched secret must all fail closed (401)
+before any per-client state is touched.
+
+Tests pin WHICH identity was resolved and whose hash was checked
+(assert_called_once_with), not just the final status code -- a MagicMock
+that ignores its arguments would otherwise hide an extraction bug like
+the one that made this endpoint 401 every real attach.
 """
 from unittest.mock import MagicMock
 
@@ -29,22 +38,28 @@ def tunnel_auth_client(app, monkeypatch):
 
 def test_valid_secret_for_that_prefix_is_authorized(tunnel_auth_client):
     client, fake_db, secret = tunnel_auth_client
-    prefix = "vm-1-" + "a" * 16
+    prefix = "tun-vm-1-" + "a" * 16
     fake_db.get_tunnel_path_prefix.return_value = ("vm-1", prefix)
     r = client.get(
         "/internal/tunnel_auth",
-        headers={"X-Original-URI": f"/tunnel/{prefix}", "X-Tunnel-Auth": f"Bearer {secret}"},
+        headers={"X-Tunnel-Prefix": prefix, "X-Tunnel-Auth": f"Bearer {secret}"},
     )
     assert r.status_code == 200
+    # Pin WHICH identity was resolved and whose hash was checked. Without
+    # these, a mock that ignores its arguments hides every extraction and
+    # identity-confusion bug -- including the one that made this endpoint 401
+    # every real attach.
+    fake_db.get_tunnel_path_prefix.assert_called_once_with(prefix)
+    fake_db.get_client_secret_hash.assert_called_once_with("vm-1")
 
 
 def test_wrong_secret_is_rejected(tunnel_auth_client):
     client, fake_db, _ = tunnel_auth_client
-    prefix = "vm-1-" + "a" * 16
+    prefix = "tun-vm-1-" + "a" * 16
     fake_db.get_tunnel_path_prefix.return_value = ("vm-1", prefix)
     r = client.get(
         "/internal/tunnel_auth",
-        headers={"X-Original-URI": f"/tunnel/{prefix}", "X-Tunnel-Auth": "Bearer nope"},
+        headers={"X-Tunnel-Prefix": prefix, "X-Tunnel-Auth": "Bearer nope"},
     )
     assert r.status_code == 401
 
@@ -54,38 +69,37 @@ def test_unknown_prefix_is_rejected(tunnel_auth_client):
     fake_db.get_tunnel_path_prefix.return_value = None
     r = client.get(
         "/internal/tunnel_auth",
-        headers={"X-Original-URI": "/tunnel/not-a-client", "X-Tunnel-Auth": f"Bearer {secret}"},
+        headers={"X-Tunnel-Prefix": "tun-not-a-client", "X-Tunnel-Auth": f"Bearer {secret}"},
+    )
+    assert r.status_code == 401
+
+
+def test_client_row_without_a_secret_hash_is_rejected(tunnel_auth_client):
+    client, fake_db, secret = tunnel_auth_client
+    prefix = "tun-vm-1-" + "a" * 16
+    fake_db.get_tunnel_path_prefix.return_value = ("vm-1", prefix)
+    fake_db.get_client_secret_hash.return_value = None
+    r = client.get(
+        "/internal/tunnel_auth",
+        headers={"X-Tunnel-Prefix": prefix, "X-Tunnel-Auth": f"Bearer {secret}"},
+    )
+    assert r.status_code == 401
+
+
+def test_a_bare_token_without_the_bearer_scheme_is_rejected(tunnel_auth_client):
+    """House idiom across this codebase is startswith("Bearer ") then reject;
+    accepting a scheme-less token would diverge from every other endpoint."""
+    client, fake_db, secret = tunnel_auth_client
+    prefix = "tun-vm-1-" + "a" * 16
+    fake_db.get_tunnel_path_prefix.return_value = ("vm-1", prefix)
+    r = client.get(
+        "/internal/tunnel_auth",
+        headers={"X-Tunnel-Prefix": prefix, "X-Tunnel-Auth": secret},
     )
     assert r.status_code == 401
 
 
 def test_missing_header_is_rejected(tunnel_auth_client):
     client, *_ = tunnel_auth_client
-    r = client.get("/internal/tunnel_auth", headers={"X-Original-URI": "/tunnel/x"})
-    assert r.status_code == 401
-
-
-def test_mismatched_prefix_and_secret_is_rejected(tunnel_auth_client):
-    """A client holding a *valid* secret of its own must not be able to
-    attach under a different client's prefix. get_tunnel_path_prefix maps
-    the requested prefix to "other-vm", whose stored hash is for a
-    different secret -- so verify_secret_cached must fail even though the
-    token presented is a real, well-formed secret (just not that client's)."""
-    from lablink_allocator_service.secret_hash import hash_secret
-
-    client, fake_db, secret = tunnel_auth_client
-    other_prefix = "other-vm-" + "b" * 16
-    fake_db.get_tunnel_path_prefix.return_value = ("other-vm", other_prefix)
-    fake_db.get_client_secret_hash.side_effect = lambda client_id: (
-        hash_secret("other-vms-own-secret")
-        if client_id == "other-vm"
-        else hash_secret(secret)
-    )
-    r = client.get(
-        "/internal/tunnel_auth",
-        headers={
-            "X-Original-URI": f"/tunnel/{other_prefix}",
-            "X-Tunnel-Auth": f"Bearer {secret}",
-        },
-    )
+    r = client.get("/internal/tunnel_auth", headers={"X-Tunnel-Prefix": "tun-x"})
     assert r.status_code == 401

--- a/packages/allocator/tests/test_tunnel_manager.py
+++ b/packages/allocator/tests/test_tunnel_manager.py
@@ -1,6 +1,7 @@
 """Tests for the reverse-tunnel connectivity mode's server-side bookkeeping:
 the per-client restrictions file and the attached-client check."""
 import pytest
+import yaml
 
 
 @pytest.fixture
@@ -50,6 +51,49 @@ def test_revoke_removes_only_that_client(tm):
 
 def test_revoke_unknown_client_is_a_noop(tm):
     tm.revoke_client("never-registered")  # must not raise
+
+
+def test_authorize_rejects_unsafe_client_id(tm):
+    # client_id is the DB hostname: attacker-controlled via registration,
+    # not validated upstream. A newline would let it forge a second
+    # top-level YAML restriction (see the module docstring) if it ever
+    # reached the renderer -- authorize_client must refuse it outright.
+    with pytest.raises(ValueError):
+        tm.authorize_client(
+            client_id="vm-evil\nrestrictions:\n  - name: pwn",
+            alias_octet=10,
+            prefix="vm-evil-abc",
+        )
+    assert not tm.RESTRICTIONS_PATH.exists()
+
+
+def test_authorize_rejects_unsafe_prefix(tm):
+    with pytest.raises(ValueError):
+        tm.authorize_client(
+            client_id="vm-1", alias_octet=10, prefix="vm-1\nrestrictions:"
+        )
+    assert not tm.RESTRICTIONS_PATH.exists()
+
+
+def test_authorize_rejects_out_of_range_alias_octet(tm):
+    with pytest.raises(ValueError):
+        tm.authorize_client(client_id="vm-1", alias_octet=255, prefix="vm-1-abc")
+    with pytest.raises(ValueError):
+        tm.authorize_client(client_id="vm-1", alias_octet=0, prefix="vm-1-abc")
+    assert not tm.RESTRICTIONS_PATH.exists()
+
+
+def test_render_cannot_be_forced_into_a_second_top_level_entry(tm):
+    # Defense in depth, independent of authorize_client's validation: even
+    # if a malicious value reached the module-level dict directly, the
+    # yaml.safe_dump-based renderer must not let it forge extra YAML
+    # structure. Pokes the private dict the same way the `tm` fixture does.
+    evil_client_id = "vm-evil\nrestrictions:\n  - name: pwn\n    match: [!Any]"
+    tm._restrictions[evil_client_id] = (10, "whatever")
+    tm._write()
+    parsed = yaml.safe_load(tm.RESTRICTIONS_PATH.read_text())
+    assert len(parsed["restrictions"]) == 1
+    assert parsed["restrictions"][0]["name"] == evil_client_id
 
 
 def test_restrictions_file_is_owner_only(tm):

--- a/packages/allocator/tests/test_tunnel_manager.py
+++ b/packages/allocator/tests/test_tunnel_manager.py
@@ -67,51 +67,22 @@ def test_revoke_unknown_client_is_a_noop(tm):
     tm.revoke_client("never-registered")  # must not raise
 
 
-def test_authorize_rejects_unsafe_client_id(tm):
-    # client_id is the DB hostname: attacker-controlled via registration,
-    # not validated upstream. A newline would let it forge a second
-    # top-level YAML restriction (see the module docstring) if it ever
-    # reached the renderer -- authorize_client must refuse it outright.
+@pytest.mark.parametrize("client_id,octet,prefix", [
+    # A newline could forge a second top-level YAML restriction if it ever
+    # reached the renderer; client_id is the DB hostname, so it arrives from
+    # registration input. Trailing-newline cases specifically: `.match()` with
+    # a `$`-anchored pattern still accepts them (Python's `$` matches before a
+    # trailing newline), so fullmatch is what actually closes it.
+    ("vm-evil\nrestrictions:\n  - name: pwn", 10, "tun-vm-evil-abc"),
+    ("vm-1", 10, "vm-1\nrestrictions:"),
+    ("vm-1\n", 10, "tun-vm-1-abc"),
+    ("vm-1", 10, "tun-vm-1-abc\n"),
+    ("vm-1", 255, "tun-vm-1-abc"),   # octet range: above
+    ("vm-1", 0, "tun-vm-1-abc"),     # ...and below
+])
+def test_authorize_rejects_unsafe_input(tm, client_id, octet, prefix):
     with pytest.raises(ValueError):
-        tm.authorize_client(
-            client_id="vm-evil\nrestrictions:\n  - name: pwn",
-            alias_octet=10,
-            prefix="tun-vm-evil-abc",
-        )
-    assert not tm.RESTRICTIONS_PATH.exists()
-
-
-def test_authorize_rejects_unsafe_prefix(tm):
-    with pytest.raises(ValueError):
-        tm.authorize_client(
-            client_id="vm-1", alias_octet=10, prefix="vm-1\nrestrictions:"
-        )
-    assert not tm.RESTRICTIONS_PATH.exists()
-
-
-def test_authorize_rejects_out_of_range_alias_octet(tm):
-    with pytest.raises(ValueError):
-        tm.authorize_client(client_id="vm-1", alias_octet=255, prefix="tun-vm-1-abc")
-    with pytest.raises(ValueError):
-        tm.authorize_client(client_id="vm-1", alias_octet=0, prefix="tun-vm-1-abc")
-    assert not tm.RESTRICTIONS_PATH.exists()
-
-
-def test_authorize_rejects_a_trailing_newline_client_id(tm):
-    # `.match()` + a `$`-anchored pattern still accepts a single trailing
-    # newline (Python's `$` matches just before a trailing newline, not
-    # only end-of-string) -- fullmatch is what actually closes this.
-    # safe_dump blocks the real YAML-injection exploit either way, but
-    # the module docstring claims this check stops a trailing newline,
-    # so it must.
-    with pytest.raises(ValueError):
-        tm.authorize_client(client_id="vm-1\n", alias_octet=10, prefix="tun-vm-1-abc")
-    assert not tm.RESTRICTIONS_PATH.exists()
-
-
-def test_authorize_rejects_a_trailing_newline_prefix(tm):
-    with pytest.raises(ValueError):
-        tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc\n")
+        tm.authorize_client(client_id=client_id, alias_octet=octet, prefix=prefix)
     assert not tm.RESTRICTIONS_PATH.exists()
 
 
@@ -167,12 +138,6 @@ def test_revoke_after_restart_finds_the_stale_entry(tm):
 
     text = tm.RESTRICTIONS_PATH.read_text()
     assert "tun-vm-1-abc" not in text
-
-
-def test_hydrate_tolerates_a_missing_file(tm):
-    assert not tm.RESTRICTIONS_PATH.exists()
-    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
-    assert "tun-vm-1-abc" in tm.RESTRICTIONS_PATH.read_text()
 
 
 def test_hydrate_tolerates_a_malformed_file(tm):

--- a/packages/allocator/tests/test_tunnel_manager.py
+++ b/packages/allocator/tests/test_tunnel_manager.py
@@ -1,0 +1,76 @@
+"""Tests for the reverse-tunnel connectivity mode's server-side bookkeeping:
+the per-client restrictions file and the attached-client check."""
+import pytest
+
+
+@pytest.fixture
+def tm(tmp_path, monkeypatch):
+    from lablink_allocator_service import tunnel_manager
+
+    monkeypatch.setattr(
+        tunnel_manager, "RESTRICTIONS_PATH", tmp_path / "restrictions.yaml"
+    )
+    monkeypatch.setattr(tunnel_manager, "_restrictions", {})
+    return tunnel_manager
+
+
+def test_path_prefix_is_stable_and_client_specific(tm):
+    a = tm.path_prefix("vm-1", "secret-a")
+    assert a == tm.path_prefix("vm-1", "secret-a")
+    assert a != tm.path_prefix("vm-2", "secret-a")
+    assert a != tm.path_prefix("vm-1", "secret-b")
+    assert a.startswith("vm-1-")
+
+
+def test_authorize_writes_a_rule_scoped_to_one_alias(tm):
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="vm-1-abc")
+    text = tm.RESTRICTIONS_PATH.read_text()
+    assert "vm-1-abc" in text
+    assert "127.0.0.10/32" in text
+    assert "6080" in text and "7070" in text
+    # The whole point: no other alias may appear in this client's rule.
+    assert "127.0.0.11" not in text
+
+
+def test_second_client_does_not_clobber_the_first(tm):
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="vm-1-abc")
+    tm.authorize_client(client_id="vm-2", alias_octet=11, prefix="vm-2-def")
+    text = tm.RESTRICTIONS_PATH.read_text()
+    assert "vm-1-abc" in text and "vm-2-def" in text
+
+
+def test_revoke_removes_only_that_client(tm):
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="vm-1-abc")
+    tm.authorize_client(client_id="vm-2", alias_octet=11, prefix="vm-2-def")
+    tm.revoke_client("vm-1")
+    text = tm.RESTRICTIONS_PATH.read_text()
+    assert "vm-1-abc" not in text
+    assert "vm-2-def" in text
+
+
+def test_revoke_unknown_client_is_a_noop(tm):
+    tm.revoke_client("never-registered")  # must not raise
+
+
+def test_restrictions_file_is_owner_only(tm):
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="vm-1-abc")
+    assert tm.RESTRICTIONS_PATH.stat().st_mode & 0o777 == 0o600
+
+
+def test_attached_aliases_reads_listening_sockets(tm, monkeypatch):
+    # 0A00007F:17C0 == 127.0.0.10:6080 in /proc/net/tcp's byte order.
+    monkeypatch.setattr(
+        tm, "_proc_net_tcp",
+        lambda: "sl local_address rem_address st\n"
+                " 0: 0A00007F:17C0 00000000:0000 0A\n",
+    )
+    assert tm.attached_aliases() == {10}
+
+
+def test_attached_aliases_ignores_non_listening_rows(tm, monkeypatch):
+    monkeypatch.setattr(
+        tm, "_proc_net_tcp",
+        lambda: "sl local_address rem_address st\n"
+                " 0: 0A00007F:17C0 01020304:1F90 01\n",
+    )
+    assert tm.attached_aliases() == set()

--- a/packages/allocator/tests/test_tunnel_manager.py
+++ b/packages/allocator/tests/test_tunnel_manager.py
@@ -20,33 +20,46 @@ def test_path_prefix_is_stable_and_client_specific(tm):
     assert a == tm.path_prefix("vm-1", "secret-a")
     assert a != tm.path_prefix("vm-2", "secret-a")
     assert a != tm.path_prefix("vm-1", "secret-b")
-    assert a.startswith("vm-1-")
+    assert a.startswith("tun-vm-1-")
 
 
 def test_authorize_writes_a_rule_scoped_to_one_alias(tm):
-    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="vm-1-abc")
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
     text = tm.RESTRICTIONS_PATH.read_text()
-    assert "vm-1-abc" in text
+    assert "tun-vm-1-abc" in text
     assert "127.0.0.10/32" in text
     assert "6080" in text and "7070" in text
     # The whole point: no other alias may appear in this client's rule.
     assert "127.0.0.11" not in text
 
 
+def test_match_value_has_no_path_separator(tm):
+    # !PathPrefix matches only the client's first path segment (measured
+    # against wstunnel 10.6.2). A match value with a "/" in it can never
+    # fire -- and the failure mode is a silent deny-all for that client,
+    # not an error, which is exactly how this went unnoticed the first
+    # time. The rendered match must be the bare prefix.
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
+    parsed = yaml.safe_load(tm.RESTRICTIONS_PATH.read_text())
+    match_value = parsed["restrictions"][0]["match"][0]
+    assert "/" not in match_value
+    assert match_value == "tun-vm-1-abc"
+
+
 def test_second_client_does_not_clobber_the_first(tm):
-    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="vm-1-abc")
-    tm.authorize_client(client_id="vm-2", alias_octet=11, prefix="vm-2-def")
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
+    tm.authorize_client(client_id="vm-2", alias_octet=11, prefix="tun-vm-2-def")
     text = tm.RESTRICTIONS_PATH.read_text()
-    assert "vm-1-abc" in text and "vm-2-def" in text
+    assert "tun-vm-1-abc" in text and "tun-vm-2-def" in text
 
 
 def test_revoke_removes_only_that_client(tm):
-    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="vm-1-abc")
-    tm.authorize_client(client_id="vm-2", alias_octet=11, prefix="vm-2-def")
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
+    tm.authorize_client(client_id="vm-2", alias_octet=11, prefix="tun-vm-2-def")
     tm.revoke_client("vm-1")
     text = tm.RESTRICTIONS_PATH.read_text()
-    assert "vm-1-abc" not in text
-    assert "vm-2-def" in text
+    assert "tun-vm-1-abc" not in text
+    assert "tun-vm-2-def" in text
 
 
 def test_revoke_unknown_client_is_a_noop(tm):
@@ -62,7 +75,7 @@ def test_authorize_rejects_unsafe_client_id(tm):
         tm.authorize_client(
             client_id="vm-evil\nrestrictions:\n  - name: pwn",
             alias_octet=10,
-            prefix="vm-evil-abc",
+            prefix="tun-vm-evil-abc",
         )
     assert not tm.RESTRICTIONS_PATH.exists()
 
@@ -77,9 +90,9 @@ def test_authorize_rejects_unsafe_prefix(tm):
 
 def test_authorize_rejects_out_of_range_alias_octet(tm):
     with pytest.raises(ValueError):
-        tm.authorize_client(client_id="vm-1", alias_octet=255, prefix="vm-1-abc")
+        tm.authorize_client(client_id="vm-1", alias_octet=255, prefix="tun-vm-1-abc")
     with pytest.raises(ValueError):
-        tm.authorize_client(client_id="vm-1", alias_octet=0, prefix="vm-1-abc")
+        tm.authorize_client(client_id="vm-1", alias_octet=0, prefix="tun-vm-1-abc")
     assert not tm.RESTRICTIONS_PATH.exists()
 
 
@@ -97,7 +110,7 @@ def test_render_cannot_be_forced_into_a_second_top_level_entry(tm):
 
 
 def test_restrictions_file_is_owner_only(tm):
-    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="vm-1-abc")
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
     assert tm.RESTRICTIONS_PATH.stat().st_mode & 0o777 == 0o600
 
 

--- a/packages/allocator/tests/test_tunnel_manager.py
+++ b/packages/allocator/tests/test_tunnel_manager.py
@@ -12,6 +12,7 @@ def tm(tmp_path, monkeypatch):
         tunnel_manager, "RESTRICTIONS_PATH", tmp_path / "restrictions.yaml"
     )
     monkeypatch.setattr(tunnel_manager, "_restrictions", {})
+    monkeypatch.setattr(tunnel_manager, "_hydrated", False)
     return tunnel_manager
 
 
@@ -130,6 +131,75 @@ def test_render_cannot_be_forced_into_a_second_top_level_entry(tm):
 def test_restrictions_file_is_owner_only(tm):
     tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
     assert tm.RESTRICTIONS_PATH.stat().st_mode & 0o777 == 0o600
+
+
+def test_authorize_after_restart_does_not_drop_other_clients(tm):
+    """A bare allocator restart wipes the in-process _restrictions dict
+    (module-level, not persisted) but leaves the restrictions file on
+    disk. Without rehydration, the next authorize_client() renders the
+    WHOLE file from the empty dict, silently revoking every other
+    client's tunnel."""
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
+    tm.authorize_client(client_id="vm-2", alias_octet=11, prefix="tun-vm-2-def")
+
+    # Simulate a process restart: the dict and the hydration flag are
+    # gone; the file (RESTRICTIONS_PATH, patched by the fixture) survives.
+    tm._restrictions.clear()
+    tm._hydrated = False
+
+    tm.authorize_client(client_id="vm-3", alias_octet=12, prefix="tun-vm-3-ghi")
+
+    text = tm.RESTRICTIONS_PATH.read_text()
+    assert "tun-vm-1-abc" in text
+    assert "tun-vm-2-def" in text
+    assert "tun-vm-3-ghi" in text
+
+
+def test_revoke_after_restart_finds_the_stale_entry(tm):
+    """revoke_client must also rehydrate: otherwise a revoke issued right
+    after a restart (before any authorize_client call) is a no-op against
+    the empty in-memory dict, leaving the stale rule live forever."""
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
+    tm._restrictions.clear()
+    tm._hydrated = False
+
+    tm.revoke_client("vm-1")
+
+    text = tm.RESTRICTIONS_PATH.read_text()
+    assert "tun-vm-1-abc" not in text
+
+
+def test_hydrate_tolerates_a_missing_file(tm):
+    assert not tm.RESTRICTIONS_PATH.exists()
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
+    assert "tun-vm-1-abc" in tm.RESTRICTIONS_PATH.read_text()
+
+
+def test_hydrate_tolerates_a_malformed_file(tm):
+    tm.RESTRICTIONS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tm.RESTRICTIONS_PATH.write_text("not: [valid")  # unterminated flow sequence
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
+    text = tm.RESTRICTIONS_PATH.read_text()
+    assert "tun-vm-1-abc" in text
+    assert "not:" not in text
+
+
+def test_hydrate_only_reads_the_file_once_per_process(tm):
+    """A second hydrate call in the same process must be a no-op -- once
+    _hydrated is set, an external rewrite of the file (another process, a
+    human edit) must not get silently picked up mid-run."""
+    tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc")
+    tm.RESTRICTIONS_PATH.write_text(
+        "restrictions:\n"
+        "- name: vm-9\n"
+        "  match: [tun-vm-9-xyz]\n"
+        "  allow:\n"
+        "  - port: ['6080', '7070']\n"
+        "    cidr: ['127.0.0.9/32']\n"
+    )
+    tm._hydrate_from_disk()
+    assert "vm-9" not in tm._restrictions
+    assert "vm-1" in tm._restrictions
 
 
 def test_attached_aliases_reads_listening_sockets(tm, monkeypatch):

--- a/packages/allocator/tests/test_tunnel_manager.py
+++ b/packages/allocator/tests/test_tunnel_manager.py
@@ -96,6 +96,24 @@ def test_authorize_rejects_out_of_range_alias_octet(tm):
     assert not tm.RESTRICTIONS_PATH.exists()
 
 
+def test_authorize_rejects_a_trailing_newline_client_id(tm):
+    # `.match()` + a `$`-anchored pattern still accepts a single trailing
+    # newline (Python's `$` matches just before a trailing newline, not
+    # only end-of-string) -- fullmatch is what actually closes this.
+    # safe_dump blocks the real YAML-injection exploit either way, but
+    # the module docstring claims this check stops a trailing newline,
+    # so it must.
+    with pytest.raises(ValueError):
+        tm.authorize_client(client_id="vm-1\n", alias_octet=10, prefix="tun-vm-1-abc")
+    assert not tm.RESTRICTIONS_PATH.exists()
+
+
+def test_authorize_rejects_a_trailing_newline_prefix(tm):
+    with pytest.raises(ValueError):
+        tm.authorize_client(client_id="vm-1", alias_octet=10, prefix="tun-vm-1-abc\n")
+    assert not tm.RESTRICTIONS_PATH.exists()
+
+
 def test_render_cannot_be_forced_into_a_second_top_level_entry(tm):
     # Defense in depth, independent of authorize_client's validation: even
     # if a malicious value reached the module-level dict directly, the

--- a/packages/cli/src/lablink_cli/api.py
+++ b/packages/cli/src/lablink_cli/api.py
@@ -320,19 +320,28 @@ class RegistrationClient:
         gpu_model: str | None,
         lan_ip: str | None = None,
         overlay_hostname: str | None = None,
+        reverse_tunnel: bool = False,
     ) -> dict:
         """POST /api/v1/clients/register; return parsed JSON.
 
-        Exactly one of ``lan_ip`` (real BYO box, LAN-direct connectivity)
-        or ``overlay_hostname`` (mesh-overlay connectivity, e.g. a
-        Run:AI-hosted workload) is expected — enforced by the caller
+        Exactly one of ``lan_ip`` (real BYO box, LAN-direct connectivity),
+        ``overlay_hostname`` (mesh-overlay connectivity, e.g. a
+        Run:AI-hosted workload), or ``reverse_tunnel=True`` (reverse-tunnel
+        connectivity — the client dials out, so it has no address for the
+        allocator to reach) is expected — enforced by the caller
         (``run_register``), not here.
 
         Raises AllocatorAuthError on 401, AllocatorConflictError on 409,
         AllocatorUnavailableError on connection failure, AllocatorError
         on other HTTP error codes / malformed response.
         """
-        if overlay_hostname is not None:
+        if reverse_tunnel:
+            # The sentinel the allocator validates against its configured
+            # connectivity. No endpoint_url: a tunnel client has no address
+            # the allocator can dial -- the tunnel is the path.
+            provider_metadata = {"reverse_tunnel": True}
+            endpoint_url = None
+        elif overlay_hostname is not None:
             provider_metadata = {"overlay_hostname": overlay_hostname}
             endpoint_url = None
         else:

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -435,7 +435,7 @@ def register(
     ),
     tunnel: bool = typer.Option(
         False,
-        "--tunnel/--no-tunnel",
+        "--tunnel",
         help="Register a tunnel client: instead of the allocator dialling "
         "this box, the box dials OUT to the allocator and holds one "
         "connection open. For networks that won't carry Tailscale and "

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -433,6 +433,17 @@ def register(
         "workload submission — for registering ahead of time, from "
         "somewhere other than the workload itself.",
     ),
+    tunnel: bool = typer.Option(
+        False,
+        "--tunnel/--no-tunnel",
+        help="Register a tunnel client: instead of the allocator dialling "
+        "this box, the box dials OUT to the allocator and holds one "
+        "connection open. For networks that won't carry Tailscale and "
+        "boxes that can't accept inbound connections. Takes no arguments — "
+        "the allocator mints every value needed. Defaults to "
+        "docker-running the client here; pass --no-run-locally to print "
+        "secrets for a separate workload submission instead.",
+    ),
     force: bool = typer.Option(
         False,
         "--force",
@@ -476,6 +487,7 @@ def register(
         overlay_hostname=overlay_hostname,
         tailscale_authkey=tailscale_authkey,
         run_locally=run_locally,
+        reverse_tunnel=tunnel,
     )
 
 

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -724,18 +724,23 @@ def _print_summary(
     # Only substitute when we actually have the real URL — funnel_active
     # can be True while funnel_url is None (enable succeeded but the
     # status lookup didn't match), and a guessed fallback here would be
-    # exactly the wrong URL this function used to print.
-    funnel_url_used = mesh_overlay and funnel_active and bool(funnel_url)
+    # exactly the wrong URL this function used to print. Gated on off_lan,
+    # not just mesh_overlay: a reverse_tunnel client behind a NAT'd/
+    # firewalled box is just as unreachable at the LAN address, and Funnel
+    # (participant_exposure: tailscale_funnel) is the only way an off-LAN
+    # tunnel client reaches this deployment at all.
+    funnel_url_used = off_lan and funnel_active and bool(funnel_url)
+    # Hoisted above the mesh_overlay/reverse_tunnel branch so both off-LAN
+    # modes get the substitution — lan_direct clients genuinely are on the
+    # LAN, so their own hint below keeps using register_url as-is.
+    if funnel_url_used:
+        register_url = funnel_url
     if mesh_overlay:
         # A mesh-overlay client (e.g. a Run:AI-hosted workload) isn't on
         # the allocator's LAN at all — the LAN URL above is unreachable
         # from it regardless of whether we detected one. When Funnel is
         # live, its public URL actually IS reachable from anywhere with
-        # internet access, so prefer it here specifically — but only for
-        # this mesh-overlay hint; lan_direct clients genuinely are on the
-        # LAN, so their own hint below keeps using register_url as-is.
-        if funnel_url_used:
-            register_url = funnel_url
+        # internet access, so prefer it here specifically.
         console.print(
             "\n[bold]Next step:[/bold] for each mesh-overlay client "
             "(e.g. a Run:AI-hosted workload), open a terminal inside "

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -716,6 +716,11 @@ def _print_summary(
     # insert a hard newline mid-command — that would break the
     # operator's copy-paste.
     mesh_overlay = cfg.manual.connectivity == "mesh_overlay"
+    reverse_tunnel = cfg.manual.connectivity == "reverse_tunnel"
+    # Both connectivity modes below mean the client isn't reachable on the
+    # allocator's own LAN — mesh_overlay via a Tailscale tailnet,
+    # reverse_tunnel by dialing out instead of accepting inbound at all.
+    off_lan = mesh_overlay or reverse_tunnel
     # Only substitute when we actually have the real URL — funnel_active
     # can be True while funnel_url is None (enable succeeded but the
     # status lookup didn't match), and a guessed fallback here would be
@@ -742,6 +747,18 @@ def _print_summary(
             f"--register-token {register_token or '<token>'} "
             "--overlay-hostname <name> --tailscale-authkey <key>"
         )
+    elif reverse_tunnel:
+        console.print(
+            "\n[bold]Next step:[/bold] for each tunnel client (a box or "
+            "workload that can't accept inbound connections), open a "
+            "terminal inside it and run (hostname/machine-identity/GPU are "
+            "auto-detected; the tunnel's values are minted by the "
+            "allocator, so --tunnel takes no arguments):"
+        )
+        register_cmd = (
+            f"  lablink client register --allocator-url {register_url} "
+            f"--register-token {register_token or '<token>'} --tunnel"
+        )
     else:
         console.print("\n[bold]Next step:[/bold] on each BYO box on the same LAN, run")
         register_cmd = (
@@ -749,7 +766,7 @@ def _print_summary(
             f"--register-token {register_token or '<token>'}"
         )
     console.print(register_cmd, soft_wrap=True, highlight=False)
-    if mesh_overlay:
+    if off_lan:
         console.print(
             "  [dim]Registering ahead of time from elsewhere instead? "
             "Add --no-run-locally to print secrets for your own "

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -475,15 +475,23 @@ def _write_env_file(
     # is already written above and is what start.sh gates on, so a missing
     # value fails loudly there instead of silently skipping the tunnel.
     if resp.get("tunnel_url"):
-        # Always wss://: the allocator reports its canonical URL, which may
-        # be http:// behind an ingress that terminates TLS, and a ws:// dial
-        # would then be downgraded or refused.
-        tunnel_url = resp["tunnel_url"].replace("https://", "wss://", 1)
+        # resp["tunnel_url"] is only the SIGNAL that this is a tunnel
+        # client; the URL VALUE comes from resolved_url (same reasoning as
+        # ALLOCATOR_URL above, lablink#396): resp["tunnel_url"] is
+        # canonical_base_url(request), which can't detect HTTPS on a manual
+        # deployment (ssl.provider: none keeps the X-Forwarded-Proto gate
+        # shut — see that function's own docstring). Behind the operator's
+        # own reverse proxy (which the rendered compose explicitly
+        # recommends), that means it reports http:// even when the
+        # allocator is only reachable over HTTPS, and a ws:// dial against
+        # that host simply doesn't work. resolved_url is what the caller
+        # proved reachable to get this far.
+        tunnel_url = resolved_url.replace("https://", "wss://", 1)
         tunnel_url = tunnel_url.replace("http://", "ws://", 1)
         lines.append(f"TUNNEL_URL={tunnel_url}")
         lines.append(f"TUNNEL_PATH_PREFIX={resp['tunnel_path_prefix']}")
         lines.append(f"TUNNEL_BIND_ADDR={resp['tunnel_bind_addr']}")
-        # frpc/wstunnel dial localhost inside the container; keep KasmVNC
+        # wstunnel dials localhost inside the container; keep KasmVNC
         # off the client's own LAN interface too.
         lines.append("KASMVNC_LISTEN=127.0.0.1")
     if overlay_hostname is not None:

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -133,6 +133,12 @@ def run_register(
             "— a tunnel client joins no tailnet."
         )
         raise SystemExit(1)
+    if reverse_tunnel and lan_ip is not None:
+        console.print(
+            "[red]--lan-ip does not apply with --tunnel[/red] "
+            "— a tunnel client dials out; the allocator never dials its LAN address."
+        )
+        raise SystemExit(1)
 
     remote_mode = overlay_hostname is not None or reverse_tunnel
 

--- a/packages/cli/src/lablink_cli/commands/register.py
+++ b/packages/cli/src/lablink_cli/commands/register.py
@@ -92,10 +92,11 @@ def run_register(
     overlay_hostname: str | None = None,
     tailscale_authkey: str | None = None,
     run_locally: bool = True,
+    reverse_tunnel: bool = False,
 ) -> None:
     """Orchestrate registration. Exits non-zero on any user-facing error.
 
-    Three shapes:
+    Four shapes:
     - Real BYO box (default): auto-detects hostname/LAN IP/machine
       identity/GPU, then docker-runs the client container after
       persisting secrets.
@@ -111,19 +112,39 @@ def run_register(
       machine's own facts); ``--hostname``/``--machine-identity`` are
       required. No docker run — instead prints the secrets for the
       admin to paste into their own workload submission.
+    - Reverse-tunnel (``reverse_tunnel=True``, i.e. ``--tunnel``): the
+      client dials out to the allocator instead of being dialled, so it
+      needs none of overlay's Tailscale plumbing — no ``--tailscale-
+      authkey``, no LAN IP, no published ports. Otherwise follows the
+      same run-locally/hand-off shape as mesh-overlay.
     """
     console = Console()
     env_file = env_file or DEFAULT_ENV_FILE
 
-    if overlay_hostname is None:
+    if reverse_tunnel and overlay_hostname is not None:
+        console.print(
+            "[red]--tunnel and --overlay-hostname are different "
+            "connectivity modes; pass only one.[/red]"
+        )
+        raise SystemExit(1)
+    if reverse_tunnel and tailscale_authkey:
+        console.print(
+            "[red]--tailscale-authkey does not apply with --tunnel[/red] "
+            "— a tunnel client joins no tailnet."
+        )
+        raise SystemExit(1)
+
+    remote_mode = overlay_hostname is not None or reverse_tunnel
+
+    if not remote_mode:
         if not run_locally:
             console.print(
                 "[red]--no-run-locally only applies with "
-                "--overlay-hostname.[/red]"
+                "--overlay-hostname or --tunnel.[/red]"
             )
             raise SystemExit(1)
     else:
-        if not tailscale_authkey:
+        if overlay_hostname is not None and not tailscale_authkey:
             console.print(
                 "[red]--tailscale-authkey is required with "
                 "--overlay-hostname.[/red]"
@@ -132,34 +153,37 @@ def run_register(
         if not run_locally:
             if not hostname:
                 console.print(
-                    "[red]--hostname is required with --overlay-hostname "
-                    "--no-run-locally.[/red] Auto-detection would report "
-                    "this machine's own hostname, not the future "
+                    "[red]--hostname is required with --overlay-hostname/"
+                    "--tunnel --no-run-locally.[/red] Auto-detection would "
+                    "report this machine's own hostname, not the future "
                     "client's — the client doesn't exist yet."
                 )
                 raise SystemExit(1)
             if not machine_identity:
                 console.print(
                     "[red]--machine-identity is required with "
-                    "--overlay-hostname --no-run-locally.[/red] "
+                    "--overlay-hostname/--tunnel --no-run-locally.[/red] "
                     "Auto-detection would report this machine's own "
                     "identity, not the future client's."
                 )
                 raise SystemExit(1)
 
-    # Step 1: idempotency / resume. Skipped only for the mesh-overlay
-    # hand-off case (overlay_hostname set, run_locally false) — that
+    # Step 1: idempotency / resume. Skipped only for the hand-off case
+    # (overlay_hostname or reverse_tunnel set, run_locally false) — that
     # case has no local container/env-file lifecycle to resume.
     if (
-        (overlay_hostname is None or run_locally)
+        (not remote_mode or run_locally)
         and env_file.exists()
         and not force
     ):
         _resume(env_file, console)
         return
 
-    if overlay_hostname is not None:
-        console.print(f"Registering overlay hostname: {overlay_hostname}")
+    if remote_mode:
+        if overlay_hostname is not None:
+            console.print(f"Registering overlay hostname: {overlay_hostname}")
+        else:
+            console.print("Registering a reverse-tunnel client...")
         if run_locally:
             resolved_hostname = _detect_hostname(hostname, console)
             resolved_machine_identity = _detect_machine_identity(
@@ -208,6 +232,14 @@ def run_register(
                 gpu_present=resolved_gpu_present,
                 gpu_model=resolved_gpu_model,
             )
+        elif reverse_tunnel:
+            response = client.register(
+                hostname=resolved_hostname,
+                machine_identity=resolved_machine_identity,
+                reverse_tunnel=True,
+                gpu_present=resolved_gpu_present,
+                gpu_model=resolved_gpu_model,
+            )
         else:
             response = client.register(
                 hostname=resolved_hostname,
@@ -229,11 +261,26 @@ def run_register(
         console.print(f"[red]{e}[/red]")
         raise SystemExit(1) from e
 
+    if reverse_tunnel and response.get("connectivity") != "reverse_tunnel":
+        # A version-skewed allocator that predates the sentinel may have
+        # silently ignored it and registered some other connectivity —
+        # this docker run will omit --publish (LOCAL flag says tunnel) and
+        # start.sh will never open one (CONNECTIVITY says otherwise), so
+        # the client would be unreachable by both paths while reporting
+        # healthy. Fail loudly instead of shipping that.
+        console.print(
+            "[red]--tunnel was requested but the allocator registered this "
+            f"client as connectivity={response.get('connectivity')!r} "
+            "instead of reverse_tunnel. The allocator likely predates "
+            "reverse-tunnel support and ignored the request.[/red]"
+        )
+        raise SystemExit(1)
+
     # Step 5: persist env file (0600)
     _write_env_file(
         env_file,
-        allocator_url,
         response,
+        allocator_url=allocator_url,
         overlay_hostname=overlay_hostname,
         tailscale_authkey=tailscale_authkey,
     )
@@ -241,21 +288,23 @@ def run_register(
         f"[green]Secrets saved to {env_file} (mode 0600)[/green]"
     )
 
-    if overlay_hostname is not None and not run_locally:
-        # No host for the CLI to act on — the Run:AI workload doesn't
-        # exist yet. Print everything the admin needs to paste into
-        # their own workload submission instead of docker-running
-        # anything. The loop below already emits OVERLAY_HOSTNAME/
-        # TAILSCALE_AUTHKEY since _write_env_file now includes them.
+    if remote_mode and not run_locally:
+        # No host for the CLI to act on — the box doesn't exist yet.
+        # Print everything the admin needs to paste into their own
+        # workload submission instead of docker-running anything. The
+        # loop below already emits OVERLAY_HOSTNAME/TAILSCALE_AUTHKEY or
+        # TUNNEL_* since _write_env_file writes whichever apply.
         console.print(
             "\n[bold]No local container will be started[/bold] — this "
             "box doesn't exist yet. Paste the following into your "
-            "Run:AI workload's environment variables:\n"
+            "own workload submission's environment variables:\n"
         )
         for line in env_file.read_text().splitlines():
             if line.startswith("#"):
                 continue
             print(line)
+        if overlay_hostname is None:
+            return
         # There is no docker run for us to add `-v` to on this path, so the
         # operator has to arrange persistence themselves. Without it every
         # workload restart joins the tailnet as a brand-new node and
@@ -280,7 +329,7 @@ def run_register(
     startup_script_path = _write_startup_script(response)
     cmd = _build_docker_run(
         env_file, response, resolved_gpu_present, startup_script_path,
-        overlay_hostname,
+        overlay_hostname, reverse_tunnel=reverse_tunnel,
     )
     console.print(
         f"[green]Registered as client #{response['client_id']}[/green]"
@@ -291,6 +340,11 @@ def run_register(
             "[dim]This container joins Tailscale as "
             f"{overlay_hostname} on start — confirm with "
             "`docker logs lablink-client`.[/dim]"
+        )
+    elif reverse_tunnel:
+        console.print(
+            "[dim]This container opens a tunnel to the allocator on "
+            "start — confirm with `docker logs lablink-client`.[/dim]"
         )
     _start_log_shipper(env_file, console)
 
@@ -361,9 +415,9 @@ def _resume(env_file: Path, console: Console) -> None:
 
 def _write_env_file(
     env_file: Path,
-    allocator_url: str,
     resp: dict,
     *,
+    allocator_url: str,
     overlay_hostname: str | None = None,
     tailscale_authkey: str | None = None,
 ) -> None:
@@ -416,6 +470,22 @@ def _write_env_file(
         lines.append(f"TUTORIAL_REPO_TO_CLONE={resp['repository']}")
     if resp.get("subject_software"):
         lines.append(f"SUBJECT_SOFTWARE={resp['subject_software']}")
+    # The allocator-minted tunnel values, detected from the response rather
+    # than passed in: both are response fields. CONNECTIVITY=reverse_tunnel
+    # is already written above and is what start.sh gates on, so a missing
+    # value fails loudly there instead of silently skipping the tunnel.
+    if resp.get("tunnel_url"):
+        # Always wss://: the allocator reports its canonical URL, which may
+        # be http:// behind an ingress that terminates TLS, and a ws:// dial
+        # would then be downgraded or refused.
+        tunnel_url = resp["tunnel_url"].replace("https://", "wss://", 1)
+        tunnel_url = tunnel_url.replace("http://", "ws://", 1)
+        lines.append(f"TUNNEL_URL={tunnel_url}")
+        lines.append(f"TUNNEL_PATH_PREFIX={resp['tunnel_path_prefix']}")
+        lines.append(f"TUNNEL_BIND_ADDR={resp['tunnel_bind_addr']}")
+        # frpc/wstunnel dial localhost inside the container; keep KasmVNC
+        # off the client's own LAN interface too.
+        lines.append("KASMVNC_LISTEN=127.0.0.1")
     if overlay_hostname is not None:
         # Written so a nested `docker run --env-file` (the run_locally
         # path) carries these into the container automatically —
@@ -453,6 +523,7 @@ def _build_docker_run(
     gpu_present: bool,
     startup_script: Path | None,
     overlay_hostname: str | None,
+    reverse_tunnel: bool = False,
 ) -> list[str]:
     cmd = [
         "docker", "run", "-d",
@@ -465,6 +536,10 @@ def _build_docker_run(
         # bits forever. Costs one HEAD per register; layers that haven't
         # changed are not re-downloaded.
         "--pull", "always",
+        # The client image is published amd64-only, so an arm64 host (Apple
+        # Silicon) otherwise fails with "no matching manifest for
+        # linux/arm64/v8". No-op on native amd64.
+        "--platform", "linux/amd64",
     ]
     if gpu_present:
         cmd += ["--gpus", "all"]
@@ -520,9 +595,17 @@ def _build_docker_run(
     # host's, leaving the ports unreachable from the LAN — the
     # allocator's password rotation just times out at the container's
     # :7070. Explicit `--publish` behaves the same on every platform.
+    #
+    # Reverse-tunnel clients publish neither: the allocator reaches this
+    # container through the tunnel it dials out, and publishing would
+    # expose KasmVNC/the agent on the LAN this mode exists to avoid
+    # trusting.
+    if not reverse_tunnel:
+        cmd += [
+            "--publish", "7070:7070",
+            "--publish", "6080:6080",
+        ]
     cmd += [
-        "--publish", "7070:7070",
-        "--publish", "6080:6080",
         "--env-file", str(env_file),
         resp["client_image"],
     ]

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -309,7 +309,9 @@ class ManualConnectivityScreen(Screen):
                 "How the student's browser reaches a client's KasmVNC desktop.\n"
                 "lan_direct: the client is on the allocator's own LAN (default).\n"
                 "mesh_overlay: the client isn't on the allocator's LAN (e.g. a\n"
-                "Run:AI-hosted workload) — reached over a Tailscale tailnet instead.",
+                "Run:AI-hosted workload) — reached over a Tailscale tailnet instead.\n"
+                "reverse_tunnel: the client can't accept inbound connections at\n"
+                "all — it dials out and holds a tunnel open instead.",
                 classes="step-description",
             )
 
@@ -324,6 +326,11 @@ class ManualConnectivityScreen(Screen):
                     "mesh_overlay — client reached over Tailscale",
                     value=(current == "mesh_overlay"),
                     id="connectivity-mesh-overlay",
+                )
+                yield RadioButton(
+                    "reverse_tunnel — client dials out and holds a tunnel",
+                    value=(current == "reverse_tunnel"),
+                    id="connectivity-reverse-tunnel",
                 )
 
             yield Label(
@@ -383,9 +390,10 @@ class ManualConnectivityScreen(Screen):
     def _next(self) -> None:
         cfg = self.app.config
         rb = self.query_one("#connectivity-select", RadioSet)
-        chosen = "lan_direct"
-        if rb.pressed_button and rb.pressed_button.id == "connectivity-mesh-overlay":
-            chosen = "mesh_overlay"
+        chosen = {
+            "connectivity-mesh-overlay": "mesh_overlay",
+            "connectivity-reverse-tunnel": "reverse_tunnel",
+        }.get(rb.pressed_button and rb.pressed_button.id, "lan_direct")
         cfg.manual.connectivity = chosen
         cfg.manual.overlay_tailnet = self.query_one(
             "#overlay-tailnet", Input

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -273,6 +273,17 @@ class ManualMachineScreen(Screen):
         self.app.push_screen(ManualConnectivityScreen())
 
 
+def _tailnet_needed(connectivity: str, participant_exposure: str) -> bool:
+    """True when something in this config actually reads overlay_tailnet.
+
+    Mirrors the validator's rule (see get_config_errors): the tailnet is
+    required by mesh_overlay connectivity *or* by tailscale_funnel exposure,
+    and by nothing else. Keep the two in step — if they disagree, the wizard
+    either blocks on a field it disabled or offers one nothing consumes.
+    """
+    return connectivity == "mesh_overlay" or participant_exposure == "tailscale_funnel"
+
+
 # ---------------------------------------------------------------------------
 # Screen 4 (Manual path only): Client connectivity
 # ---------------------------------------------------------------------------
@@ -334,14 +345,22 @@ class ManualConnectivityScreen(Screen):
                 )
 
             yield Label(
-                "Tailscale tailnet domain (used by mesh_overlay and/or "
-                "participant exposure below, e.g. example.ts.net)",
+                "Tailscale tailnet domain — needed only by mesh_overlay or by\n"
+                "tailscale_funnel exposure below (e.g. example.ts.net)",
                 classes="field-label",
+                id="overlay-tailnet-label",
             )
+            # Disabled when neither of the two things that consume it is
+            # selected, rather than hidden: DnsScreen already uses `disabled`
+            # for fields a mode doesn't apply to, and Textual leaves disabled
+            # widgets out of the Tab order, so an operator can see the field
+            # exists and why without being able to type into a value nothing
+            # would read. reverse_tunnel needs no address of its own.
             yield Input(
                 value=cfg.manual.overlay_tailnet or "",
                 placeholder="example.ts.net",
                 id="overlay-tailnet",
+                disabled=not _tailnet_needed(current, current_exposure),
             )
 
             yield Label(
@@ -381,6 +400,33 @@ class ManualConnectivityScreen(Screen):
 
     def on_mount(self) -> None:
         self.query_one("#connectivity-error").display = False
+
+    def _pressed(self, selector: str) -> str:
+        rb = self.query_one(selector, RadioSet)
+        return (rb.pressed_button.id or "") if rb.pressed_button else ""
+
+    @on(RadioSet.Changed)
+    def _sync_tailnet_field(self, event: RadioSet.Changed) -> None:
+        """Enable the tailnet field only for the modes that consume it.
+
+        Driven by BOTH radio sets, not just connectivity: the tailnet is
+        required by mesh_overlay *and* by tailscale_funnel exposure, so a
+        reverse_tunnel deployment that also publishes itself via Funnel
+        still needs one. reverse_tunnel on its own needs no address.
+        """
+        connectivity = {
+            "connectivity-mesh-overlay": "mesh_overlay",
+            "connectivity-reverse-tunnel": "reverse_tunnel",
+        }.get(self._pressed("#connectivity-select"), "lan_direct")
+        exposure = (
+            "tailscale_funnel"
+            if self._pressed("#participant-exposure-select")
+            == "participant-exposure-funnel"
+            else "none"
+        )
+        self.query_one("#overlay-tailnet", Input).disabled = not _tailnet_needed(
+            connectivity, exposure
+        )
 
     @on(Button.Pressed, "#back")
     def _back(self) -> None:

--- a/packages/cli/tests/test_app.py
+++ b/packages/cli/tests/test_app.py
@@ -514,6 +514,31 @@ class TestDeployDispatch:
 # client register command
 # ------------------------------------------------------------------
 class TestClientRegisterCommand:
+    def test_cli_exposes_tunnel_flag(self):
+        import inspect
+        from lablink_cli.commands.register import run_register
+
+        assert "reverse_tunnel" in inspect.signature(run_register).parameters
+
+        result = CliRunner().invoke(app, ["client", "register", "--help"])
+        assert result.exit_code == 0
+        # _plain, not result.output: Typer renders help through Rich and CI
+        # has colour enabled, which breaks the flag name up with ANSI codes.
+        plain = _plain(result.output)
+        assert "--tunnel" in plain
+        assert "--no-tunnel" in plain
+
+    def test_passes_tunnel_flag_through(self):
+        runner = CliRunner()
+        with patch("lablink_cli.commands.register.run_register") as mock_run:
+            result = runner.invoke(app, [
+                "client", "register",
+                "--allocator-url", "https://a.example.com",
+                "--register-token", "rtok", "--tunnel",
+            ])
+        assert result.exit_code == 0, result.output
+        assert mock_run.call_args.kwargs["reverse_tunnel"] is True
+
     def test_passes_overlay_flags_through(self):
         runner = CliRunner()
         with patch("lablink_cli.commands.register.run_register") as mock_run:

--- a/packages/cli/tests/test_app.py
+++ b/packages/cli/tests/test_app.py
@@ -515,18 +515,11 @@ class TestDeployDispatch:
 # ------------------------------------------------------------------
 class TestClientRegisterCommand:
     def test_cli_exposes_tunnel_flag(self):
-        import inspect
-        from lablink_cli.commands.register import run_register
-
-        assert "reverse_tunnel" in inspect.signature(run_register).parameters
-
         result = CliRunner().invoke(app, ["client", "register", "--help"])
         assert result.exit_code == 0
         # _plain, not result.output: Typer renders help through Rich and CI
         # has colour enabled, which breaks the flag name up with ANSI codes.
-        plain = _plain(result.output)
-        assert "--tunnel" in plain
-        assert "--no-tunnel" in plain
+        assert "--tunnel" in _plain(result.output)
 
     def test_passes_tunnel_flag_through(self):
         runner = CliRunner()

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2025,19 +2025,6 @@ class TestReverseTunnelDeploy:
 
     @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
     @patch("lablink_cli.commands.deploy_compose._extract_register_token")
-    def test_summary_shows_the_valueless_flag(self, mock_extract, mock_lan, capsys):
-        from lablink_cli.commands.deploy_compose import _print_summary
-
-        mock_extract.return_value = "tok123456789012345678901"
-        mock_lan.return_value = "192.168.1.42"
-        _print_summary(_manual_cfg(connectivity="reverse_tunnel"))
-        out = capsys.readouterr().out
-        assert "--tunnel" in out
-        assert "on the same LAN" not in out
-        assert "--no-run-locally" in out
-
-    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
-    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
     def test_register_hint_uses_public_url_when_funnel_active(
         self, mock_extract, mock_lan, capsys
     ):
@@ -2066,3 +2053,6 @@ class TestReverseTunnelDeploy:
             f"--allocator-url {real_url} --register-token {token} --tunnel" in out
         )
         assert "--allocator-url http://192.168.1.42" not in out
+        # ...and the hint is the off-LAN one, not the BYO-box one.
+        assert "on the same LAN" not in out
+        assert "--no-run-locally" in out

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2035,3 +2035,34 @@ class TestReverseTunnelDeploy:
         assert "--tunnel" in out
         assert "on the same LAN" not in out
         assert "--no-run-locally" in out
+
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_register_hint_uses_public_url_when_funnel_active(
+        self, mock_extract, mock_lan, capsys
+    ):
+        """Regression: a reverse_tunnel client is behind a NAT/firewall that
+        can't accept inbound connections at all — participant_exposure:
+        tailscale_funnel is the only way an off-LAN one reaches this
+        deployment, exactly like mesh_overlay. Before this fix,
+        funnel_url_used (and the register_url substitution) were gated on
+        mesh_overlay only, so this printed an unreachable LAN address even
+        with Funnel live."""
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        token = "abc123def456ghi789jklmnop"
+        mock_extract.return_value = token
+        mock_lan.return_value = "192.168.1.42"
+        real_url = "https://lablink-allocator-testlab.example.ts.net"
+
+        _print_summary(
+            _manual_cfg(connectivity="reverse_tunnel"),
+            funnel_active=True,
+            funnel_url=real_url,
+        )
+
+        out = capsys.readouterr().out
+        assert (
+            f"--allocator-url {real_url} --register-token {token} --tunnel" in out
+        )
+        assert "--allocator-url http://192.168.1.42" not in out

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2004,3 +2004,34 @@ class TestCanonicalUrlFile:
             cfg, yes=True, workdir_root=tmp_path, tailscale_authkey="tskey-abc"
         )
         assert "https://known.example.ts.net" in (target / "allocator-url").read_text()
+
+
+class TestReverseTunnelDeploy:
+    def test_renders_no_extra_port_or_env(self, tmp_path):
+        """The mode needs no inbound port and no secrets in .env. If this
+        fails, the transport has regressed toward frp's shape."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(connectivity="reverse_tunnel")
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        env = (target / ".env").read_text()
+        assert "TUNNEL" not in env and "TOKEN" not in env
+        compose = (target / "docker-compose.yml").read_text()
+        assert compose.count("ports:") == 1
+        assert ":8080" not in compose
+        assert not (target / "docker-compose.override.yml").exists()
+
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_summary_shows_the_valueless_flag(self, mock_extract, mock_lan, capsys):
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        mock_extract.return_value = "tok123456789012345678901"
+        mock_lan.return_value = "192.168.1.42"
+        _print_summary(_manual_cfg(connectivity="reverse_tunnel"))
+        out = capsys.readouterr().out
+        assert "--tunnel" in out
+        assert "on the same LAN" not in out
+        assert "--no-run-locally" in out

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -1672,15 +1672,8 @@ class TestReverseTunnelRegister:
             {"client_image": "img"}, False, None, None, reverse_tunnel=True,
         )
         assert "--publish" not in cmd
-
-    def test_docker_run_pins_amd64(self):
-        from lablink_cli.commands.register import _build_docker_run
-        from pathlib import Path
-
-        cmd = _build_docker_run(
-            Path("/tmp/client.env"),
-            {"client_image": "img"}, False, None, None, reverse_tunnel=True,
-        )
+        # The client image is published amd64-only, so an arm64 host needs
+        # the platform pin or docker run fails on the manifest.
         assert "--platform" in cmd and "linux/amd64" in cmd
 
     def test_tunnel_and_overlay_hostname_are_mutually_exclusive(self, tmp_path):

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -1695,6 +1695,22 @@ class TestReverseTunnelRegister:
                 insecure=False, overlay_hostname="host", reverse_tunnel=True,
             )
 
+    def test_tunnel_and_lan_ip_are_mutually_exclusive(self, tmp_path):
+        """A tunnel client dials out; the allocator never dials its LAN
+        address, so --lan-ip is meaningless here and must be rejected
+        the same way --overlay-hostname/--tailscale-authkey already are,
+        rather than silently ignored."""
+        from lablink_cli.commands.register import run_register
+        import pytest
+
+        with pytest.raises(SystemExit):
+            run_register(
+                allocator_url="https://a", register_token="t", hostname=None,
+                lan_ip="192.168.1.5", machine_identity=None, gpu_present=None,
+                gpu_model=None, force=True, env_file=tmp_path / "e",
+                insecure=False, reverse_tunnel=True,
+            )
+
     def test_version_skew_is_caught(self, tmp_path, monkeypatch, capsys):
         """An allocator too old to know the sentinel may ignore it and
         register some other connectivity. This docker run already omits

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -1470,8 +1470,9 @@ class TestWriteEnvFile:
         from lablink_cli.commands.register import _write_env_file
 
         _write_env_file(
-            tmp_env_file, "https://lablink.example.com",
+            tmp_env_file,
             self._resp_with_monitoring(),
+            allocator_url="https://lablink.example.com",
         )
 
         text = tmp_env_file.read_text()
@@ -1494,8 +1495,9 @@ class TestWriteEnvFile:
         from lablink_cli.commands.register import _write_env_file
 
         _write_env_file(
-            tmp_env_file, "https://lablink.example.com",
+            tmp_env_file,
             self._resp_with_monitoring(),
+            allocator_url="https://lablink.example.com",
         )
         text = tmp_env_file.read_text()
         assert "CLIENT_SECRET=s3cret" in text
@@ -1506,8 +1508,9 @@ class TestWriteEnvFile:
         from lablink_cli.commands.register import _write_env_file
 
         _write_env_file(
-            tmp_env_file, "https://lablink.example.com",
+            tmp_env_file,
             self._resp_with_monitoring(),
+            allocator_url="https://lablink.example.com",
             overlay_hostname="classroom-gpu-3",
             tailscale_authkey="tskey-abc",
         )
@@ -1520,8 +1523,9 @@ class TestWriteEnvFile:
         from lablink_cli.commands.register import _write_env_file
 
         _write_env_file(
-            tmp_env_file, "https://lablink.example.com",
+            tmp_env_file,
             self._resp_with_monitoring(),
+            allocator_url="https://lablink.example.com",
         )
 
         content = tmp_env_file.read_text()
@@ -1545,8 +1549,8 @@ class TestWriteEnvFile:
 
         _write_env_file(
             tmp_env_file,
-            "https://lablink-allocator.example.ts.net",
             resp,
+            allocator_url="https://lablink-allocator.example.ts.net",
         )
 
         content = tmp_env_file.read_text()
@@ -1559,7 +1563,7 @@ class TestWriteEnvFile:
         from lablink_cli.commands.register import _write_env_file
 
         _write_env_file(
-            tmp_env_file, "", self._resp_with_monitoring(),
+            tmp_env_file, self._resp_with_monitoring(), allocator_url="",
         )
 
         content = tmp_env_file.read_text()
@@ -1598,3 +1602,89 @@ def test_non_overlay_run_has_no_tailscale_volume():
     cmd = _build_docker_run(Path("/tmp/env"), resp, False, None, None)
 
     assert not any("/var/lib/tailscale" in part for part in cmd)
+
+
+class TestReverseTunnelRegister:
+    def test_env_file_carries_tunnel_values(self, tmp_path):
+        from lablink_cli.commands.register import _write_env_file
+
+        env = tmp_path / "client.env"
+        _write_env_file(
+            env,
+            {
+                "client_id": "vm-1", "client_secret": "cs", "agent_token": "at",
+                "register_token": "rt", "connectivity": "reverse_tunnel",
+                "client_image": "img", "allocator_url": "https://a.example.com",
+                "tunnel_url": "https://a.example.com",
+                "tunnel_path_prefix": "tun-vm-1-abc",
+                "tunnel_bind_addr": "127.0.0.12",
+            },
+            allocator_url="https://a.example.com",
+            overlay_hostname=None, tailscale_authkey=None,
+        )
+        text = env.read_text()
+        assert "TUNNEL_URL=wss://a.example.com" in text
+        assert "TUNNEL_PATH_PREFIX=tun-vm-1-abc" in text
+        assert "TUNNEL_BIND_ADDR=127.0.0.12" in text
+        # frpc dialed localhost inside the container; so does wstunnel, so
+        # keep KasmVNC off the client's own LAN.
+        assert "KASMVNC_LISTEN=127.0.0.1" in text
+        assert env.stat().st_mode & 0o777 == 0o600
+
+    def test_docker_run_publishes_no_host_ports(self):
+        from lablink_cli.commands.register import _build_docker_run
+        from pathlib import Path
+
+        cmd = _build_docker_run(
+            Path("/tmp/client.env"),
+            {"client_image": "img"}, False, None, None, reverse_tunnel=True,
+        )
+        assert "--publish" not in cmd
+
+    def test_docker_run_pins_amd64(self):
+        from lablink_cli.commands.register import _build_docker_run
+        from pathlib import Path
+
+        cmd = _build_docker_run(
+            Path("/tmp/client.env"),
+            {"client_image": "img"}, False, None, None, reverse_tunnel=True,
+        )
+        assert "--platform" in cmd and "linux/amd64" in cmd
+
+    def test_tunnel_and_overlay_hostname_are_mutually_exclusive(self, tmp_path):
+        from lablink_cli.commands.register import run_register
+        import pytest
+
+        with pytest.raises(SystemExit):
+            run_register(
+                allocator_url="https://a", register_token="t", hostname=None,
+                lan_ip=None, machine_identity=None, gpu_present=None,
+                gpu_model=None, force=True, env_file=tmp_path / "e",
+                insecure=False, overlay_hostname="host", reverse_tunnel=True,
+            )
+
+    def test_version_skew_is_caught(self, tmp_path, monkeypatch, capsys):
+        """An allocator too old to know the sentinel may ignore it and
+        register some other connectivity. This docker run already omits
+        --publish because the LOCAL flag says tunnel, and start.sh would
+        never open one because CONNECTIVITY says otherwise -- unreachable by
+        both paths while reporting healthy. Fail loudly instead."""
+        import pytest
+        from lablink_cli.commands import register as reg
+
+        monkeypatch.setattr(
+            reg.RegistrationClient, "register",
+            lambda self, **kw: {
+                "client_id": "vm-1", "client_secret": "cs", "agent_token": "at",
+                "register_token": "rt", "connectivity": "lan_direct",
+                "client_image": "img",
+            },
+        )
+        with pytest.raises(SystemExit):
+            reg.run_register(
+                allocator_url="https://a", register_token="t", hostname="h",
+                lan_ip=None, machine_identity="m", gpu_present=False,
+                gpu_model=None, force=True, env_file=tmp_path / "e",
+                insecure=False, reverse_tunnel=True,
+            )
+        assert "reverse_tunnel" in capsys.readouterr().out

--- a/packages/cli/tests/test_register.py
+++ b/packages/cli/tests/test_register.py
@@ -1626,10 +1626,42 @@ class TestReverseTunnelRegister:
         assert "TUNNEL_URL=wss://a.example.com" in text
         assert "TUNNEL_PATH_PREFIX=tun-vm-1-abc" in text
         assert "TUNNEL_BIND_ADDR=127.0.0.12" in text
-        # frpc dialed localhost inside the container; so does wstunnel, so
-        # keep KasmVNC off the client's own LAN.
+        # wstunnel dials localhost inside the container; keep KasmVNC
+        # off the client's own LAN.
         assert "KASMVNC_LISTEN=127.0.0.1" in text
         assert env.stat().st_mode & 0o777 == 0o600
+
+    def test_tunnel_url_prefers_caller_url_over_the_response_value(self, tmp_path):
+        """Same bug class as lablink#396 (see
+        test_prefers_caller_url_over_downgraded_response_url above):
+        resp["tunnel_url"] is canonical_base_url(request), which cannot
+        detect HTTPS on a manual deployment (ssl.provider: none keeps the
+        X-Forwarded-Proto gate shut) — so behind the operator's own
+        reverse proxy it reports http:// even when the allocator is only
+        reachable over HTTPS, and a ws:// dial against that host just
+        doesn't work. resp["tunnel_url"] must be used only as the SIGNAL
+        that this is a tunnel client; the URL value must come from the
+        caller's own (proven-reachable) allocator_url."""
+        from lablink_cli.commands.register import _write_env_file
+
+        env = tmp_path / "client.env"
+        _write_env_file(
+            env,
+            {
+                "client_id": "vm-1", "client_secret": "cs", "agent_token": "at",
+                "register_token": "rt", "connectivity": "reverse_tunnel",
+                "client_image": "img",
+                "allocator_url": "http://a.example.com",
+                "tunnel_url": "http://a.example.com",
+                "tunnel_path_prefix": "tun-vm-1-abc",
+                "tunnel_bind_addr": "127.0.0.12",
+            },
+            allocator_url="https://a.example.com",
+            overlay_hostname=None, tailscale_authkey=None,
+        )
+        text = env.read_text()
+        assert "TUNNEL_URL=wss://a.example.com" in text
+        assert "TUNNEL_URL=ws://a.example.com" not in text
 
     def test_docker_run_publishes_no_host_ports(self):
         from lablink_cli.commands.register import _build_docker_run

--- a/packages/cli/tests/test_registration_client.py
+++ b/packages/cli/tests/test_registration_client.py
@@ -141,11 +141,6 @@ class TestRegister:
 
     @patch("lablink_cli.api.urlopen")
     def test_register_sends_the_tunnel_sentinel(self, mock_urlopen):
-        """The brief's own test mocks `lablink_cli.api.requests.post`, but
-        this module has no `requests` import at all — it POSTs via
-        urllib's `urlopen` (see every other test in this class). Adapted
-        to the actual transport; the assertions (sentinel shape,
-        endpoint_url=None) are unchanged from the brief's intent."""
         response = {"client_id": "vm-1"}
         mock_resp = MagicMock()
         mock_resp.read.return_value = json.dumps(response).encode()

--- a/packages/cli/tests/test_registration_client.py
+++ b/packages/cli/tests/test_registration_client.py
@@ -140,6 +140,30 @@ class TestRegister:
         assert body["provider"] == "manual"
 
     @patch("lablink_cli.api.urlopen")
+    def test_register_sends_the_tunnel_sentinel(self, mock_urlopen):
+        """The brief's own test mocks `lablink_cli.api.requests.post`, but
+        this module has no `requests` import at all — it POSTs via
+        urllib's `urlopen` (see every other test in this class). Adapted
+        to the actual transport; the assertions (sentinel shape,
+        endpoint_url=None) are unchanged from the brief's intent."""
+        response = {"client_id": "vm-1"}
+        mock_resp = MagicMock()
+        mock_resp.read.return_value = json.dumps(response).encode()
+        mock_resp.__enter__ = lambda s: s
+        mock_resp.__exit__ = MagicMock(return_value=False)
+        mock_urlopen.return_value = mock_resp
+
+        _make_client().register(
+            hostname="vm-1", machine_identity="i-1",
+            gpu_present=False, gpu_model=None, reverse_tunnel=True,
+        )
+
+        sent_req = mock_urlopen.call_args[0][0]
+        body = json.loads(sent_req.data.decode())
+        assert body["provider_metadata"] == {"reverse_tunnel": True}
+        assert body.get("endpoint_url") is None
+
+    @patch("lablink_cli.api.urlopen")
     def test_lan_ip_shape_unchanged(self, mock_urlopen):
         """Existing lan_ip callers must see byte-identical body shape."""
         response = {"client_id": 1}

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -495,6 +495,7 @@ def _drive_connectivity_screen(
     choose_mesh_overlay: bool,
     overlay_tailnet: str = "",
     choose_funnel: bool = False,
+    choose_reverse_tunnel: bool = False,
 ):
     """Push ManualConnectivityScreen directly, drive it, return
     (cfg.manual.connectivity, cfg.manual.overlay_tailnet,
@@ -521,6 +522,11 @@ def _drive_connectivity_screen(
                     if btn.id == "connectivity-mesh-overlay":
                         btn.value = True
                 screen.query_one("#overlay-tailnet", Input).value = overlay_tailnet
+            if choose_reverse_tunnel:
+                radio_set = screen.query_one("#connectivity-select", RadioSet)
+                for btn in radio_set.query(RadioButton):
+                    if btn.id == "connectivity-reverse-tunnel":
+                        btn.value = True
             if choose_funnel:
                 exposure_set = screen.query_one(
                     "#participant-exposure-select", RadioSet
@@ -571,6 +577,24 @@ def test_connectivity_screen_blocks_next_when_tailnet_missing():
     )
     assert connectivity == "mesh_overlay"
     assert stack_delta == 0, "invalid submission must not push DnsScreen"
+
+
+def test_connectivity_screen_writes_reverse_tunnel():
+    connectivity, tailnet, exposure, stack_delta = _drive_connectivity_screen(
+        choose_mesh_overlay=False, choose_reverse_tunnel=True
+    )
+    assert connectivity == "reverse_tunnel"
+    assert stack_delta == 1, "valid submission should push DnsScreen"
+
+
+def test_reverse_tunnel_needs_no_extra_fields():
+    """The mode's whole point: nothing for the operator to supply. If this
+    ever needs a config value, the design has regressed."""
+    connectivity, tailnet, exposure, stack_delta = _drive_connectivity_screen(
+        choose_mesh_overlay=False, choose_reverse_tunnel=True
+    )
+    assert tailnet == ""
+    assert stack_delta == 1
 
 
 def _drive_startup_retry_fields(

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -126,6 +126,20 @@ RUN for f in /usr/share/kasmvnc/www/assets/ui-*.js; do \
             || { echo "ERROR: sed did not remove the clobber from $f"; exit 1; }; \
     done
 
+# wstunnel -- reverse-tunnel connectivity's client side. Dials OUT to the
+# allocator's HTTPS address and asks it to expose this container's KasmVNC
+# (:6080) and agent (:7070) on the allocator's loopback. Only the client half
+# is needed here; the server half is the allocator image's business. Must stay
+# in lockstep with Dockerfile.dev. Harmless when unused -- start.sh only runs
+# it when CONNECTIVITY=reverse_tunnel.
+ARG WSTUNNEL_VERSION=10.6.2
+RUN curl -L -o /tmp/wstunnel.tar.gz \
+      "https://github.com/erebe/wstunnel/releases/download/v${WSTUNNEL_VERSION}/wstunnel_${WSTUNNEL_VERSION}_linux_amd64.tar.gz" && \
+    tar -xzf /tmp/wstunnel.tar.gz -C /tmp && \
+    mv /tmp/wstunnel /usr/local/bin/wstunnel && \
+    chmod +x /usr/local/bin/wstunnel && \
+    rm -f /tmp/wstunnel.tar.gz
+
 EXPOSE 6080 7070
 
 # lightdm conflicts with headless VNC; disable it so KasmVNC can own the session.

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -112,6 +112,20 @@ RUN for f in /usr/share/kasmvnc/www/assets/ui-*.js; do \
             || { echo "ERROR: sed did not remove the clobber from $f"; exit 1; }; \
     done
 
+# wstunnel -- reverse-tunnel connectivity's client side. Dials OUT to the
+# allocator's HTTPS address and asks it to expose this container's KasmVNC
+# (:6080) and agent (:7070) on the allocator's loopback. Only the client half
+# is needed here; the server half is the allocator image's business. Must stay
+# in lockstep with Dockerfile.dev. Harmless when unused -- start.sh only runs
+# it when CONNECTIVITY=reverse_tunnel.
+ARG WSTUNNEL_VERSION=10.6.2
+RUN curl -L -o /tmp/wstunnel.tar.gz \
+      "https://github.com/erebe/wstunnel/releases/download/v${WSTUNNEL_VERSION}/wstunnel_${WSTUNNEL_VERSION}_linux_amd64.tar.gz" && \
+    tar -xzf /tmp/wstunnel.tar.gz -C /tmp && \
+    mv /tmp/wstunnel /usr/local/bin/wstunnel && \
+    chmod +x /usr/local/bin/wstunnel && \
+    rm -f /tmp/wstunnel.tar.gz
+
 EXPOSE 6080 7070
 
 # lightdm conflicts with headless VNC; disable it so KasmVNC can own the session.

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -199,11 +199,17 @@ if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
   # proves reachability. Gating on 2xx deadlocked startup (observed live
   # 2026-07-31): the client waited for a green health check that could only go
   # green once the client's tunnel was up, which this check was blocking.
+  #
+  # Deliberately -k, same reason: this must not be stricter than the tunnel it
+  # gates. wstunnel v10.6.2's --tls-verify-certificate help reads "Disabled by
+  # default. The client will happily connect to any server with self-signed
+  # certificate." and this branch sets no such flag -- so without -k a
+  # self-signed or staging cert aborts a client whose tunnel connects fine.
   TUNNEL_PROBE_URL="$(printf '%s' "$TUNNEL_URL" \
     | sed -e 's|^wss://|https://|' -e 's|^ws://|http://|')/api/health"
   TUNNEL_REACHABLE=""
   for attempt in 1 2 3 4 5; do
-    if curl -s --max-time 5 -o /dev/null "$TUNNEL_PROBE_URL"; then
+    if curl -sk --max-time 5 -o /dev/null "$TUNNEL_PROBE_URL"; then
       TUNNEL_REACHABLE=yes
       break
     else
@@ -217,7 +223,15 @@ if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
     sleep 3
   done
   if [ -z "$TUNNEL_REACHABLE" ]; then
-    tunnel_abort "cannot reach the allocator at $TUNNEL_PROBE_URL -- the tunnel cannot come up. Check DNS and routing from inside this container: a hostname that resolves to an address this container cannot route to fails exactly here (curl exit 6 = DNS, 7 = no route, 28 = timeout, 35/60 = TLS)."
+    # A TLS failure that survives -k isn't trust, so don't send them to DNS.
+    case "$probe_rc" in
+      35|60)
+        tunnel_abort "TLS handshake with the allocator at $TUNNEL_PROBE_URL failed (curl exit $probe_rc) -- the tunnel cannot come up. Not a trust problem (nothing here verifies certs): check TUNNEL_URL's scheme and port."
+        ;;
+      *)
+        tunnel_abort "cannot reach the allocator at $TUNNEL_PROBE_URL (curl exit $probe_rc) -- the tunnel cannot come up. Check DNS and routing from inside this container (curl 6 = DNS, 7 = no route / refused, 28 = timeout)."
+        ;;
+    esac
   fi
 
   echo "Opening tunnel to $TUNNEL_URL..."
@@ -251,48 +265,44 @@ if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
     tunnel_abort "$1"
   }
 
-  # Distinct failures, and only the first kills the process on its own:
+  # Two fatal conditions, checked now and again after the grace window:
   #  - process died (bad binary, bad flag)
-  #  - handshake rejected. wstunnel does NOT exit on this -- it logs
+  #  - 401/403. wstunnel does NOT exit on a rejected handshake -- it logs
   #    "Invalid status code: NNN" and RETRIES FOREVER, so a kill -0 check
-  #    alone would report healthy while the client is unreachable -- the
-  #    exact failure this feature has shipped three times before. Verified
-  #    in a spike: nginx returns 401 at the upgrade and the client loops.
-  sleep 5
-  if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
-    tunnel_fail "tunnel process exited -- see [tunnel] output above"
-  fi
-
-  # 401/403 mean the allocator rejected our credentials/URL outright --
-  # retrying can never fix that -- so fail immediately rather than waiting
-  # out the grace window below, which exists for errors that CAN self-heal.
-  if grep -qE "Invalid status code: 40[13]" "$TUNNEL_LOG"; then
-    tunnel_fail "tunnel handshake rejected (401/403) by the allocator -- see [tunnel] output"
-  fi
-
-  # Any OTHER non-101 upgrade response (e.g. a 503 while the allocator's
-  # proxy is still warming up) or a generic handshake-failure line is not
-  # necessarily permanent: wstunnel's own backoff can succeed on the very
-  # next attempt, inside the same window we just waited out. A single
-  # point-in-time grep can't tell a permanent failure from one that already
-  # recovered, so check whether failures are STILL accumulating rather than
-  # whether one ever appeared: snapshot the count, wait a short second
-  # window, and only fail if it grew (or the process died in the meantime).
-  # ponytail: fixed 3s window -- if wstunnel's backoff ever exceeds this
-  # between attempts, a persistently-failing non-401 tunnel could take an
-  # extra cycle to be caught. Widen this (or read wstunnel's own backoff
-  # config) if that's ever observed in practice.
-  FAILURES=$(grep -cE "Invalid status code|failed to do websocket handshake|cannot connect to remote server" "$TUNNEL_LOG")
-  if [ "$FAILURES" -gt 0 ]; then
-    sleep 3
+  #    alone would report healthy while the client is unreachable, the exact
+  #    failure this feature has shipped three times. Neither can be fixed by
+  #    retrying, so they are fatal immediately rather than folded into the
+  #    grace window, which exists for errors that CAN self-heal.
+  tunnel_check_fatal() {
     if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
       tunnel_fail "tunnel process exited -- see [tunnel] output above"
     fi
     if grep -qE "Invalid status code: 40[13]" "$TUNNEL_LOG"; then
       tunnel_fail "tunnel handshake rejected (401/403) by the allocator -- see [tunnel] output"
     fi
-    FAILURES_AFTER=$(grep -cE "Invalid status code|failed to do websocket handshake|cannot connect to remote server" "$TUNNEL_LOG")
-    if [ "$FAILURES_AFTER" -gt "$FAILURES" ]; then
+  }
+  tunnel_count_failures() {
+    grep -cE "Invalid status code|failed to do websocket handshake|cannot connect to remote server" "$TUNNEL_LOG"
+  }
+
+  sleep 5
+  tunnel_check_fatal
+
+  # Any OTHER non-101 upgrade response (e.g. a 503 while the allocator's
+  # proxy is still warming up) may be transient: wstunnel's own backoff can
+  # succeed on the very next attempt, inside the window we just waited out.
+  # A point-in-time grep can't tell a permanent failure from one that already
+  # recovered, so ask whether failures are STILL accumulating -- snapshot the
+  # count, wait a short second window, fail only if it grew.
+  # ponytail: fixed 3s window -- if wstunnel's backoff ever exceeds this
+  # between attempts, a persistently-failing non-401 tunnel could take an
+  # extra cycle to be caught. Widen this (or read wstunnel's own backoff
+  # config) if that's ever observed in practice.
+  FAILURES=$(tunnel_count_failures)
+  if [ "$FAILURES" -gt 0 ]; then
+    sleep 3
+    tunnel_check_fatal
+    if [ "$(tunnel_count_failures)" -gt "$FAILURES" ]; then
       tunnel_fail "tunnel handshake still failing after the grace window -- see [tunnel] output"
     fi
   fi

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -192,19 +192,32 @@ if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
   # reports-healthy-while-unreachable failure this block exists to prevent.
   # So probe positively here rather than inferring health from the absence of
   # a failure line. Retries because a just-started allocator can need a moment.
+  #
+  # Deliberately NO -f: this asks "can I reach that host at all", not "is the
+  # allocator ready". Any HTTP answer -- including the 503 the readiness
+  # endpoint returns while THIS client's own tunnel is still unattached --
+  # proves reachability. Gating on 2xx deadlocked startup (observed live
+  # 2026-07-31): the client waited for a green health check that could only go
+  # green once the client's tunnel was up, which this check was blocking.
   TUNNEL_PROBE_URL="$(printf '%s' "$TUNNEL_URL" \
     | sed -e 's|^wss://|https://|' -e 's|^ws://|http://|')/api/health"
   TUNNEL_REACHABLE=""
   for attempt in 1 2 3 4 5; do
-    if curl -sf --max-time 5 -o /dev/null "$TUNNEL_PROBE_URL"; then
+    if curl -s --max-time 5 -o /dev/null "$TUNNEL_PROBE_URL"; then
       TUNNEL_REACHABLE=yes
       break
+    else
+      # $? must be read here, inside the else: after `fi` it is the *if
+      # statement's* status, which is 0 when the condition failed and no else
+      # ran. curl's code is the diagnosis: 6 = DNS, 7 = no route / refused,
+      # 28 = timeout, 35/60 = TLS. Without it this line names a symptom only.
+      probe_rc=$?
+      echo "allocator not reachable yet at $TUNNEL_PROBE_URL (attempt $attempt/5, curl exit $probe_rc)"
     fi
-    echo "allocator not reachable yet at $TUNNEL_PROBE_URL (attempt $attempt/5)"
     sleep 3
   done
   if [ -z "$TUNNEL_REACHABLE" ]; then
-    tunnel_abort "cannot reach the allocator at $TUNNEL_PROBE_URL -- the tunnel cannot come up. Check DNS and routing from inside this container: a hostname that resolves to an address this container cannot route to fails exactly here."
+    tunnel_abort "cannot reach the allocator at $TUNNEL_PROBE_URL -- the tunnel cannot come up. Check DNS and routing from inside this container: a hostname that resolves to an address this container cannot route to fails exactly here (curl exit 6 = DNS, 7 = no route, 28 = timeout, 35/60 = TLS)."
   fi
 
   echo "Opening tunnel to $TUNNEL_URL..."

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -192,28 +192,62 @@ if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
     "$TUNNEL_URL" > >(sed -u 's/^/[tunnel] /' | tee -a "$TUNNEL_LOG" >&5) 2>&1 &
   TUNNEL_PID=$!
 
-  # Two distinct failures, and only the first kills the process:
-  #  - process died (bad binary, bad flag)
-  #  - handshake rejected (wrong secret, wrong URL, allocator not configured
-  #    for this mode). wstunnel logs "Invalid status code: 401" and RETRIES
-  #    FOREVER, so a kill -0 check alone would report healthy while the
-  #    client is unreachable -- the exact failure this feature has shipped
-  #    three times before. Verified in a spike: nginx returns 401 at the
-  #    upgrade and the client loops.
-  sleep 5
-  if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
-    echo "tunnel process exited -- see [tunnel] output above" >&2
-    touch "$STATUS_SUPERSEDED_FILE"
-    send_status "error" || echo ">> WARNING: failed to report status=error"
-    exit 1
-  fi
-  if grep -qE "Invalid status code|failed to do websocket handshake" "$TUNNEL_LOG"; then
-    echo "tunnel handshake rejected by the allocator -- see [tunnel] output" >&2
+  # Kills the tunnel and reports status=error. Shared by every failure
+  # branch below so each one stays a one-liner.
+  tunnel_fail() {
+    echo "$1" >&2
     kill "$TUNNEL_PID" 2>/dev/null
     touch "$STATUS_SUPERSEDED_FILE"
     send_status "error" || echo ">> WARNING: failed to report status=error"
     exit 1
+  }
+
+  # Distinct failures, and only the first kills the process on its own:
+  #  - process died (bad binary, bad flag)
+  #  - handshake rejected. wstunnel does NOT exit on this -- it logs
+  #    "Invalid status code: NNN" and RETRIES FOREVER, so a kill -0 check
+  #    alone would report healthy while the client is unreachable -- the
+  #    exact failure this feature has shipped three times before. Verified
+  #    in a spike: nginx returns 401 at the upgrade and the client loops.
+  sleep 5
+  if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
+    tunnel_fail "tunnel process exited -- see [tunnel] output above"
   fi
+
+  # 401/403 mean the allocator rejected our credentials/URL outright --
+  # retrying can never fix that -- so fail immediately rather than waiting
+  # out the grace window below, which exists for errors that CAN self-heal.
+  if grep -qE "Invalid status code: 40[13]" "$TUNNEL_LOG"; then
+    tunnel_fail "tunnel handshake rejected (401/403) by the allocator -- see [tunnel] output"
+  fi
+
+  # Any OTHER non-101 upgrade response (e.g. a 503 while the allocator's
+  # proxy is still warming up) or a generic handshake-failure line is not
+  # necessarily permanent: wstunnel's own backoff can succeed on the very
+  # next attempt, inside the same window we just waited out. A single
+  # point-in-time grep can't tell a permanent failure from one that already
+  # recovered, so check whether failures are STILL accumulating rather than
+  # whether one ever appeared: snapshot the count, wait a short second
+  # window, and only fail if it grew (or the process died in the meantime).
+  # ponytail: fixed 3s window -- if wstunnel's backoff ever exceeds this
+  # between attempts, a persistently-failing non-401 tunnel could take an
+  # extra cycle to be caught. Widen this (or read wstunnel's own backoff
+  # config) if that's ever observed in practice.
+  FAILURES=$(grep -cE "Invalid status code|failed to do websocket handshake" "$TUNNEL_LOG")
+  if [ "$FAILURES" -gt 0 ]; then
+    sleep 3
+    if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
+      tunnel_fail "tunnel process exited -- see [tunnel] output above"
+    fi
+    if grep -qE "Invalid status code: 40[13]" "$TUNNEL_LOG"; then
+      tunnel_fail "tunnel handshake rejected (401/403) by the allocator -- see [tunnel] output"
+    fi
+    FAILURES_AFTER=$(grep -cE "Invalid status code|failed to do websocket handshake" "$TUNNEL_LOG")
+    if [ "$FAILURES_AFTER" -gt "$FAILURES" ]; then
+      tunnel_fail "tunnel handshake still failing after the grace window -- see [tunnel] output"
+    fi
+  fi
+
   echo "Tunnel process running (pid $TUNNEL_PID)"
 fi
 

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -154,6 +154,69 @@ if [ -n "$TAILSCALE_AUTHKEY" ]; then
   fi
 fi
 
+# Reverse-tunnel connectivity: dial OUT to the allocator and hold one
+# WebSocket open, asking it to expose this container's KasmVNC (:6080) and
+# agent (:7070) on the loopback alias it assigned us. Gated on CONNECTIVITY
+# rather than on a secret's presence: an absent or misspelled value must be a
+# loud failure, not a silent no-tunnel.
+#
+# Unlike the tailscale join this does NOT need to run first -- the tunnel is
+# inbound-only (allocator -> client) and this container reaches the
+# allocator's HTTP API directly regardless. It does need to be up before a
+# session is assigned, hence ahead of the custom startup script.
+if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
+  for v in TUNNEL_URL TUNNEL_PATH_PREFIX TUNNEL_BIND_ADDR CLIENT_SECRET; do
+    # ${!v} indirect expansion, not eval -- this script is #!/bin/bash.
+    if [ -z "${!v}" ]; then
+      echo "CONNECTIVITY=reverse_tunnel but $v is unset" >&2
+      touch "$STATUS_SUPERSEDED_FILE"
+      send_status "error" || echo ">> WARNING: failed to report status=error"
+      exit 1
+    fi
+  done
+
+  echo "Opening tunnel to $TUNNEL_URL..."
+  # Tee to a file as well as the log stream: the liveness check below has to
+  # READ this output, because a rejected upgrade does not kill the process.
+  TUNNEL_LOG=/tmp/lablink-tunnel-client.log
+  # Process substitution, NOT a `| sed ... &` pipeline: after a pipeline $!
+  # is the PID of the last stage (sed), which stays alive whether or not the
+  # tunnel did, making the liveness check below vacuous.
+  # -P is mandatory: without it the client ignores the URL's path entirely
+  # and requests /v1/events, which no tunnel location matches (measured).
+  wstunnel client \
+    -P "$TUNNEL_PATH_PREFIX" \
+    -H "Authorization: Bearer $CLIENT_SECRET" \
+    -R tcp://$TUNNEL_BIND_ADDR:6080:127.0.0.1:6080 \
+    -R tcp://$TUNNEL_BIND_ADDR:7070:127.0.0.1:7070 \
+    "$TUNNEL_URL" > >(sed -u 's/^/[tunnel] /' | tee -a "$TUNNEL_LOG" >&5) 2>&1 &
+  TUNNEL_PID=$!
+
+  # Two distinct failures, and only the first kills the process:
+  #  - process died (bad binary, bad flag)
+  #  - handshake rejected (wrong secret, wrong URL, allocator not configured
+  #    for this mode). wstunnel logs "Invalid status code: 401" and RETRIES
+  #    FOREVER, so a kill -0 check alone would report healthy while the
+  #    client is unreachable -- the exact failure this feature has shipped
+  #    three times before. Verified in a spike: nginx returns 401 at the
+  #    upgrade and the client loops.
+  sleep 5
+  if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
+    echo "tunnel process exited -- see [tunnel] output above" >&2
+    touch "$STATUS_SUPERSEDED_FILE"
+    send_status "error" || echo ">> WARNING: failed to report status=error"
+    exit 1
+  fi
+  if grep -qE "Invalid status code|failed to do websocket handshake" "$TUNNEL_LOG"; then
+    echo "tunnel handshake rejected by the allocator -- see [tunnel] output" >&2
+    kill "$TUNNEL_PID" 2>/dev/null
+    touch "$STATUS_SUPERSEDED_FILE"
+    send_status "error" || echo ">> WARNING: failed to report status=error"
+    exit 1
+  fi
+  echo "Tunnel process running (pid $TUNNEL_PID)"
+fi
+
 # Report 'initializing' as soon as the overlay (if any) is up. On cold
 # reboot this is redundant with user_data.sh's earlier post, but on warm
 # reboot user_data.sh's guard may exit before reaching its send_status —

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -179,6 +179,13 @@ if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
   # Tee to a file as well as the log stream: the liveness check below has to
   # READ this output, because a rejected upgrade does not kill the process.
   TUNNEL_LOG=/tmp/lablink-tunnel-client.log
+  # Per-run state, same reason as STATUS_SUPERSEDED_FILE above: `docker
+  # restart` re-runs this script against the SAME filesystem, and the tee
+  # below is append-only. Without truncating here, a 401/403 logged on ANY
+  # earlier boot (e.g. the allocator's DB not yet ready) would survive to
+  # kill an already-healthy tunnel on every later boot -- permanently and
+  # silently, since the detection below only ever checks this file.
+  : > "$TUNNEL_LOG"
   # Process substitution, NOT a `| sed ... &` pipeline: after a pipeline $!
   # is the PID of the last stage (sed), which stays alive whether or not the
   # tunnel did, making the liveness check below vacuous.

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -165,15 +165,47 @@ fi
 # allocator's HTTP API directly regardless. It does need to be up before a
 # session is assigned, hence ahead of the custom startup script.
 if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
+  # Report status=error and stop. Used by every pre-launch failure below;
+  # tunnel_fail() further down is this plus killing the running tunnel.
+  tunnel_abort() {
+    echo "$1" >&2
+    touch "$STATUS_SUPERSEDED_FILE"
+    send_status "error" || echo ">> WARNING: failed to report status=error"
+    exit 1
+  }
+
   for v in TUNNEL_URL TUNNEL_PATH_PREFIX TUNNEL_BIND_ADDR CLIENT_SECRET; do
     # ${!v} indirect expansion, not eval -- this script is #!/bin/bash.
     if [ -z "${!v}" ]; then
-      echo "CONNECTIVITY=reverse_tunnel but $v is unset" >&2
-      touch "$STATUS_SUPERSEDED_FILE"
-      send_status "error" || echo ">> WARNING: failed to report status=error"
-      exit 1
+      tunnel_abort "CONNECTIVITY=reverse_tunnel but $v is unset"
     fi
   done
+
+  # Preflight: can this container reach the allocator at all? The tunnel dials
+  # the host in TUNNEL_URL, so if ordinary HTTPS to that host fails, the tunnel
+  # cannot come up either -- and wstunnel's output will NOT say so. On a
+  # connect-level failure (a name resolving to an unroutable address, no route,
+  # a blocked port) it logs only "Opening TCP connection" per retry, at INFO,
+  # with no error line for the checks below to match. Observed live 2026-07-31:
+  # a client whose DNS resolved the allocator to a tailnet address it had no
+  # route to printed "Tunnel process running" and carried on, exactly the
+  # reports-healthy-while-unreachable failure this block exists to prevent.
+  # So probe positively here rather than inferring health from the absence of
+  # a failure line. Retries because a just-started allocator can need a moment.
+  TUNNEL_PROBE_URL="$(printf '%s' "$TUNNEL_URL" \
+    | sed -e 's|^wss://|https://|' -e 's|^ws://|http://|')/api/health"
+  TUNNEL_REACHABLE=""
+  for attempt in 1 2 3 4 5; do
+    if curl -sf --max-time 5 -o /dev/null "$TUNNEL_PROBE_URL"; then
+      TUNNEL_REACHABLE=yes
+      break
+    fi
+    echo "allocator not reachable yet at $TUNNEL_PROBE_URL (attempt $attempt/5)"
+    sleep 3
+  done
+  if [ -z "$TUNNEL_REACHABLE" ]; then
+    tunnel_abort "cannot reach the allocator at $TUNNEL_PROBE_URL -- the tunnel cannot come up. Check DNS and routing from inside this container: a hostname that resolves to an address this container cannot route to fails exactly here."
+  fi
 
   echo "Opening tunnel to $TUNNEL_URL..."
   # Tee to a file as well as the log stream: the liveness check below has to
@@ -202,11 +234,8 @@ if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
   # Kills the tunnel and reports status=error. Shared by every failure
   # branch below so each one stays a one-liner.
   tunnel_fail() {
-    echo "$1" >&2
     kill "$TUNNEL_PID" 2>/dev/null
-    touch "$STATUS_SUPERSEDED_FILE"
-    send_status "error" || echo ">> WARNING: failed to report status=error"
-    exit 1
+    tunnel_abort "$1"
   }
 
   # Distinct failures, and only the first kills the process on its own:
@@ -240,7 +269,7 @@ if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
   # between attempts, a persistently-failing non-401 tunnel could take an
   # extra cycle to be caught. Widen this (or read wstunnel's own backoff
   # config) if that's ever observed in practice.
-  FAILURES=$(grep -cE "Invalid status code|failed to do websocket handshake" "$TUNNEL_LOG")
+  FAILURES=$(grep -cE "Invalid status code|failed to do websocket handshake|cannot connect to remote server" "$TUNNEL_LOG")
   if [ "$FAILURES" -gt 0 ]; then
     sleep 3
     if ! kill -0 "$TUNNEL_PID" 2>/dev/null; then
@@ -249,7 +278,7 @@ if [ "$CONNECTIVITY" = "reverse_tunnel" ]; then
     if grep -qE "Invalid status code: 40[13]" "$TUNNEL_LOG"; then
       tunnel_fail "tunnel handshake rejected (401/403) by the allocator -- see [tunnel] output"
     fi
-    FAILURES_AFTER=$(grep -cE "Invalid status code|failed to do websocket handshake" "$TUNNEL_LOG")
+    FAILURES_AFTER=$(grep -cE "Invalid status code|failed to do websocket handshake|cannot connect to remote server" "$TUNNEL_LOG")
     if [ "$FAILURES_AFTER" -gt "$FAILURES" ]; then
       tunnel_fail "tunnel handshake still failing after the grace window -- see [tunnel] output"
     fi

--- a/packages/client/tests/test_start_sh_reverse_tunnel.py
+++ b/packages/client/tests/test_start_sh_reverse_tunnel.py
@@ -99,6 +99,38 @@ def test_liveness_check_uses_process_substitution_not_a_pipeline(block):
     assert "> >(sed" in block
 
 
+def test_log_is_truncated_before_reuse():
+    """docker restart re-runs this script against the SAME filesystem (see
+    the STATUS_SUPERSEDED_FILE comment above this block for the identical
+    hazard). TUNNEL_LOG is opened with `tee -a`, so a rejected-handshake
+    line logged on ANY earlier boot must not survive to poison detection
+    on a later, healthy boot. Extracts just the lines between the
+    TUNNEL_LOG assignment and the wstunnel launch (truncation must happen
+    before the tee starts appending), substitutes a tmp path for the
+    hardcoded one, pre-seeds stale content, and confirms it's gone."""
+    lines = START_SH.read_text().splitlines()
+    start = next(
+        i for i, ln in enumerate(lines) if ln.strip().startswith("TUNNEL_LOG=")
+    )
+    end = next(i for i in range(start, len(lines)) if "wstunnel client" in lines[i])
+    snippet = "\n".join(lines[start:end])
+    assert ': > "$TUNNEL_LOG"' in snippet, (
+        "expected TUNNEL_LOG to be truncated before wstunnel launch"
+    )
+
+    with tempfile.TemporaryDirectory() as d:
+        log_path = Path(d) / "lablink-tunnel-client.log"
+        log_path.write_text("[tunnel] Invalid status code: 401\n")
+        harness = snippet.replace("/tmp/lablink-tunnel-client.log", str(log_path))
+
+        result = subprocess.run(
+            ["bash", "-c", harness], capture_output=True, text=True, timeout=5,
+        )
+
+        assert result.returncode == 0, result.stderr
+        assert log_path.read_text() == ""
+
+
 def test_precedes_the_custom_startup_script(block):
     text = START_SH.read_text().splitlines()
     tunnel_at = next(

--- a/packages/client/tests/test_start_sh_reverse_tunnel.py
+++ b/packages/client/tests/test_start_sh_reverse_tunnel.py
@@ -268,7 +268,12 @@ class TestReachabilityPreflight:
         end = script_text.index('  echo "Opening tunnel to')
         return re.sub(r"sleep 3\b", "sleep 0.05", script_text[start:end])
 
-    def _run(self, curl_rc: int) -> subprocess.CompletedProcess:
+    def _run(
+        self, curl_rc: int = 0, curl_body: str | None = None
+    ) -> subprocess.CompletedProcess:
+        """curl_body overrides the stub for tests that need the probe's
+        *flags* to decide the outcome rather than a fixed exit code."""
+        stub = curl_body if curl_body is not None else f"return {curl_rc}"
         snippet = self._extract_preflight(START_SH.read_text())
         with tempfile.TemporaryDirectory() as d:
             harness = f"""
@@ -279,7 +284,7 @@ TUNNEL_PATH_PREFIX="tun-vm-1-abc"
 TUNNEL_BIND_ADDR="127.0.0.10"
 CLIENT_SECRET="cs"
 send_status() {{ echo "STATUS_CALLED:$1"; return 0; }}
-curl() {{ return {curl_rc}; }}
+curl() {{ {stub}; }}
 {snippet}
 echo "REACHED_LAUNCH"
 """
@@ -304,3 +309,27 @@ echo "REACHED_LAUNCH"
         result = self._run(curl_rc=0)
         assert "STATUS_CALLED:error" not in result.stdout, result.stdout
         assert "REACHED_LAUNCH" in result.stdout, result.stdout
+
+    def test_readiness_503_still_counts_as_reachable(self):
+        """The deadlock this probe caused, observed live 2026-07-31:
+        /api/health answers 503 while THIS client's own tunnel is unattached,
+        so a probe demanding 2xx could only pass once the tunnel was up --
+        which the probe itself was blocking. Any HTTP answer proves
+        reachability, which is all this check is entitled to ask.
+
+        The stub fails exactly the way curl does when -f meets a 503 (exit 22)
+        and succeeds otherwise, so this passes only if the probe drops -f."""
+        result = self._run(
+            curl_body='for a in "$@"; do case "$a" in -*f*) return 22;; esac; '
+            "done; return 0"
+        )
+        assert "REACHED_LAUNCH" in result.stdout, result.stdout
+        assert "STATUS_CALLED:error" not in result.stdout, result.stdout
+
+    def test_failure_message_carries_curls_exit_code(self):
+        """The live failure log said only "not reachable", which is a symptom.
+        curl's exit code separates DNS (6) from no-route (7) from timeout (28)
+        -- and `$?` read after `fi` would report the if statement's 0 instead,
+        so this asserts the real code reaches the log."""
+        result = self._run(curl_rc=6)
+        assert "curl exit 6" in result.stdout, result.stdout

--- a/packages/client/tests/test_start_sh_reverse_tunnel.py
+++ b/packages/client/tests/test_start_sh_reverse_tunnel.py
@@ -61,10 +61,12 @@ def test_passes_the_path_prefix_explicitly(block):
     assert '-P "$TUNNEL_PATH_PREFIX"' in block
 
 
-def test_missing_input_reports_error_status(validation_loop):
-    assert "STATUS_SUPERSEDED_FILE" in validation_loop
-    assert 'send_status "error"' in validation_loop
-    assert "exit 1" in validation_loop
+def test_missing_input_reports_error_status(validation_loop, block):
+    """The loop delegates to tunnel_abort, which is what reports the status
+    and stops -- assert both halves so neither can drift away."""
+    assert "tunnel_abort" in validation_loop
+    assert 'send_status "error"' in block
+    assert "exit 1" in block
 
 
 def test_binds_the_allocator_assigned_alias_for_both_ports(block):
@@ -197,7 +199,18 @@ class TestDetectionLogicBehavior:
 set -u
 TUNNEL_LOG="{log_path}"
 STATUS_SUPERSEDED_FILE="{superseded}"
+TUNNEL_URL="wss://allocator.example.com"
+TUNNEL_PATH_PREFIX="tun-vm-1-abc"
+TUNNEL_BIND_ADDR="127.0.0.10"
+CLIENT_SECRET="cs"
 send_status() {{ echo "STATUS_CALLED:$1"; return 0; }}
+# Defined above the extracted snippet in start.sh, so stand it in here.
+tunnel_abort() {{
+  echo "$1" >&2
+  touch "$STATUS_SUPERSEDED_FILE"
+  send_status "error"
+  exit 1
+}}
 # Redirected so this stand-in process doesn't hold the harness's own
 # stdout pipe open after the harness itself exits.
 sleep 100 </dev/null >/dev/null 2>&1 &
@@ -241,3 +254,53 @@ echo "REACHED_END"
         )
         assert "STATUS_CALLED:error" in result.stdout, result.stdout
         assert "REACHED_END" not in result.stdout, result.stdout
+
+
+class TestReachabilityPreflight:
+    """Runs the real preflight (from `tunnel_abort() {` through the line that
+    announces the tunnel) in a bash subprocess with `curl` stubbed, so the
+    probe's decision is what is under test rather than whether an allocator
+    happens to be listening on this machine."""
+
+    @staticmethod
+    def _extract_preflight(script_text: str) -> str:
+        start = script_text.index("  tunnel_abort() {")
+        end = script_text.index('  echo "Opening tunnel to')
+        return re.sub(r"sleep 3\b", "sleep 0.05", script_text[start:end])
+
+    def _run(self, curl_rc: int) -> subprocess.CompletedProcess:
+        snippet = self._extract_preflight(START_SH.read_text())
+        with tempfile.TemporaryDirectory() as d:
+            harness = f"""
+set -u
+STATUS_SUPERSEDED_FILE="{Path(d) / 'superseded'}"
+TUNNEL_URL="wss://allocator.example.com"
+TUNNEL_PATH_PREFIX="tun-vm-1-abc"
+TUNNEL_BIND_ADDR="127.0.0.10"
+CLIENT_SECRET="cs"
+send_status() {{ echo "STATUS_CALLED:$1"; return 0; }}
+curl() {{ return {curl_rc}; }}
+{snippet}
+echo "REACHED_LAUNCH"
+"""
+            return subprocess.run(
+                ["bash", "-c", harness], capture_output=True, text=True, timeout=30
+            )
+
+    def test_unreachable_allocator_fails_instead_of_declaring_a_live_tunnel(self):
+        """The bug this preflight exists for, observed live 2026-07-31: with
+        the allocator unreachable (a hostname resolving to an address this
+        container cannot route to), wstunnel logs only "Opening TCP
+        connection" per retry -- at INFO, no error line -- so every log-based
+        check passes and the client announced a healthy tunnel that had never
+        connected. Only a positive probe catches it."""
+        result = self._run(curl_rc=7)  # curl(7): couldn't connect, as observed
+        assert "STATUS_CALLED:error" in result.stdout, result.stdout
+        assert "REACHED_LAUNCH" not in result.stdout, result.stdout
+        assert "cannot reach the allocator" in result.stderr, result.stderr
+
+    def test_reachable_allocator_proceeds_to_launch(self):
+        """The probe must not become a new way to strand a healthy client."""
+        result = self._run(curl_rc=0)
+        assert "STATUS_CALLED:error" not in result.stdout, result.stdout
+        assert "REACHED_LAUNCH" in result.stdout, result.stdout

--- a/packages/client/tests/test_start_sh_reverse_tunnel.py
+++ b/packages/client/tests/test_start_sh_reverse_tunnel.py
@@ -1,0 +1,84 @@
+"""Structural tests for start.sh's reverse-tunnel block. Text assertions
+rather than execution (start.sh launches long-running services). Each one
+guards a failure mode that produces no error message on its own."""
+from pathlib import Path
+
+import pytest
+
+START_SH = Path(__file__).resolve().parents[1] / "start.sh"
+
+
+@pytest.fixture(scope="module")
+def block() -> str:
+    lines = START_SH.read_text().splitlines()
+    start = next(
+        i for i, ln in enumerate(lines)
+        if ln.startswith('if [ "$CONNECTIVITY" = "reverse_tunnel" ]')
+    )
+    end = next(i for i, ln in enumerate(lines[start:], start) if ln == "fi")
+    return "\n".join(lines[start:end + 1])
+
+
+def test_gated_on_connectivity_not_on_secret_presence(block):
+    """Gating on a secret's presence would make a missing value a silent
+    no-tunnel; the allocator already told us the mode."""
+    assert 'if [ "$CONNECTIVITY" = "reverse_tunnel" ]' in block
+
+
+def test_requires_its_inputs(block):
+    required = "for v in TUNNEL_URL TUNNEL_PATH_PREFIX TUNNEL_BIND_ADDR CLIENT_SECRET"
+    assert required in block
+
+
+def test_passes_the_path_prefix_explicitly(block):
+    """Without -P the client ignores the URL path and requests /v1/events,
+    which matches no tunnel location — measured against the real client."""
+    assert '-P "$TUNNEL_PATH_PREFIX"' in block
+
+
+def test_missing_input_reports_error_status(block):
+    assert "STATUS_SUPERSEDED_FILE" in block
+    assert 'send_status "error"' in block
+    assert "exit 1" in block
+
+
+def test_binds_the_allocator_assigned_alias_for_both_ports(block):
+    assert '-R tcp://$TUNNEL_BIND_ADDR:6080:127.0.0.1:6080' in block
+    assert '-R tcp://$TUNNEL_BIND_ADDR:7070:127.0.0.1:7070' in block
+
+
+def test_authenticates_with_the_client_secret(block):
+    assert 'Authorization: Bearer $CLIENT_SECRET' in block
+
+
+def test_verifies_the_tunnel_survived_attaching(block):
+    """wstunnel retries a rejected upgrade forever, so a wrong secret would
+    otherwise leave the client reporting healthy while unreachable."""
+    assert 'kill -0 "$TUNNEL_PID"' in block
+
+
+def test_detects_a_rejected_upgrade_not_just_a_dead_process(block):
+    """The load-bearing check. wstunnel does NOT exit on a rejected
+    handshake -- it logs `Invalid status code: 401` and retries forever, so
+    a process-liveness check alone reports healthy while the client is
+    unreachable. That is precisely the failure class this feature has
+    shipped three times. Scan the tunnel's own output for a failed
+    handshake during the wait window."""
+    assert "Invalid status code" in block or "handshake" in block
+    assert "TUNNEL_LOG" in block
+
+
+def test_liveness_check_uses_process_substitution_not_a_pipeline(block):
+    """After a pipeline, $! is the PID of the LAST stage (sed), which
+    survives whether or not the tunnel did -- making the check vacuous."""
+    assert "> >(sed" in block
+
+
+def test_precedes_the_custom_startup_script(block):
+    text = START_SH.read_text().splitlines()
+    tunnel_at = next(
+        i for i, ln in enumerate(text)
+        if ln.startswith('if [ "$CONNECTIVITY" = "reverse_tunnel" ]')
+    )
+    script_at = next(i for i, ln in enumerate(text) if "custom-startup.sh" in ln)
+    assert tunnel_at < script_at

--- a/packages/client/tests/test_start_sh_reverse_tunnel.py
+++ b/packages/client/tests/test_start_sh_reverse_tunnel.py
@@ -29,44 +29,27 @@ def block() -> str:
     return "\n".join(lines[start:end + 1])
 
 
-@pytest.fixture(scope="module")
-def validation_loop(block) -> str:
-    """The `for v in ...; do ... done` input-validation loop, scoped tightly
-    so its assertions can't be satisfied by an unrelated failure branch
-    elsewhere in the block (e.g. tunnel_fail, added for the grace-window
-    fix, also contains `send_status "error"` and `exit 1`)."""
-    lines = block.splitlines()
-    start = next(
-        i for i, ln in enumerate(lines)
-        if ln.strip().startswith("for v in TUNNEL_URL")
-    )
-    end = next(i for i in range(start, len(lines)) if lines[i].strip() == "done")
-    return "\n".join(lines[start:end + 1])
-
-
 def test_gated_on_connectivity_not_on_secret_presence(block):
     """Gating on a secret's presence would make a missing value a silent
     no-tunnel; the allocator already told us the mode."""
     assert 'if [ "$CONNECTIVITY" = "reverse_tunnel" ]' in block
 
 
-def test_requires_its_inputs(validation_loop):
-    required = "for v in TUNNEL_URL TUNNEL_PATH_PREFIX TUNNEL_BIND_ADDR CLIENT_SECRET"
-    assert required in validation_loop
+def test_requires_its_inputs_and_aborts_when_one_is_missing(block):
+    """Scoped to the validation loop's own lines, not the whole block:
+    tunnel_fail and tunnel_check_fatal also contain send_status/exit, so a
+    block-wide `in` check would pass even if this loop stopped aborting."""
+    loop = next(ln for ln in block.splitlines() if "for v in TUNNEL_URL" in ln)
+    assert "TUNNEL_URL TUNNEL_PATH_PREFIX TUNNEL_BIND_ADDR CLIENT_SECRET" in loop
+    assert "tunnel_abort" in block
+    assert 'send_status "error"' in block
+    assert "exit 1" in block
 
 
 def test_passes_the_path_prefix_explicitly(block):
     """Without -P the client ignores the URL path and requests /v1/events,
     which matches no tunnel location — measured against the real client."""
     assert '-P "$TUNNEL_PATH_PREFIX"' in block
-
-
-def test_missing_input_reports_error_status(validation_loop, block):
-    """The loop delegates to tunnel_abort, which is what reports the status
-    and stops -- assert both halves so neither can drift away."""
-    assert "tunnel_abort" in validation_loop
-    assert 'send_status "error"' in block
-    assert "exit 1" in block
 
 
 def test_binds_the_allocator_assigned_alias_for_both_ports(block):
@@ -79,20 +62,11 @@ def test_authenticates_with_the_client_secret(block):
 
 
 def test_verifies_the_tunnel_survived_attaching(block):
-    """wstunnel retries a rejected upgrade forever, so a wrong secret would
-    otherwise leave the client reporting healthy while unreachable."""
+    """The dead-process branch has no behavioral test (the bash harnesses
+    below stand in a live PID), so this text check is its only guard.
+    Rejected-upgrade detection IS covered behaviorally — see
+    TestDetectionLogicBehavior."""
     assert 'kill -0 "$TUNNEL_PID"' in block
-
-
-def test_detects_a_rejected_upgrade_not_just_a_dead_process(block):
-    """The load-bearing check. wstunnel does NOT exit on a rejected
-    handshake -- it logs `Invalid status code: 401` and retries forever, so
-    a process-liveness check alone reports healthy while the client is
-    unreachable. That is precisely the failure class this feature has
-    shipped three times. Scan the tunnel's own output for a failed
-    handshake during the wait window."""
-    assert "Invalid status code" in block or "handshake" in block
-    assert "TUNNEL_LOG" in block
 
 
 def test_liveness_check_uses_process_substitution_not_a_pipeline(block):
@@ -141,22 +115,6 @@ def test_precedes_the_custom_startup_script(block):
     )
     script_at = next(i for i, ln in enumerate(text) if "custom-startup.sh" in ln)
     assert tunnel_at < script_at
-
-
-def test_401_403_fail_fast_without_a_grace_window(block):
-    """A wrong secret (401) or forbidden prefix (403) will never succeed on
-    retry, so it must be checked -- and be fatal -- before the grace window
-    that exists for potentially-transient errors, not folded into it."""
-    assert 'grep -qE "Invalid status code: 40[13]"' in block
-
-
-def test_other_failures_get_a_grace_window_before_failing(block):
-    """A non-101 upgrade response that isn't 401/403 (e.g. a 503 while the
-    allocator's proxy is still warming up) may be transient -- wstunnel's own
-    backoff can succeed on the next attempt. The fix must not fail on a
-    single point-in-time grep; it must check whether failures are still
-    accumulating after a second, shorter wait."""
-    assert block.count("grep -cE") == 2, "expected a before/after failure count"
 
 
 class TestDetectionLogicBehavior:
@@ -333,3 +291,38 @@ echo "REACHED_LAUNCH"
         so this asserts the real code reaches the log."""
         result = self._run(curl_rc=6)
         assert "curl exit 6" in result.stdout, result.stdout
+        # ...and a connectivity failure must keep pointing at DNS/routing —
+        # the TLS branch below must not swallow this class.
+        assert "cannot reach the allocator" in result.stderr, result.stderr
+        assert "TLS handshake" not in result.stderr, result.stderr
+
+    def test_self_signed_cert_still_counts_as_reachable(self):
+        """The probe must not be stricter than the tunnel it gates.
+
+        wstunnel does not verify server certificates -- v10.6.2's
+        --tls-verify-certificate help: "Disabled by default. The client will
+        happily connect to any server with self-signed certificate." -- and
+        this branch passes no such flag. So an allocator on a self-signed or
+        staging cert (ssl.staging, or the operator's own reverse proxy) must
+        not abort a client whose tunnel would connect fine.
+
+        The stub fails with curl's real cert-rejection code (60) unless -k is
+        present, so this passes only if the probe actually sends -k.
+        """
+        result = self._run(
+            curl_body='for a in "$@"; do case "$a" in -*k*) return 0;; esac; '
+            "done; return 60"
+        )
+        assert "REACHED_LAUNCH" in result.stdout, result.stdout
+        assert "STATUS_CALLED:error" not in result.stdout, result.stdout
+
+    @pytest.mark.parametrize("rc", [35, 60])
+    def test_tls_failure_is_not_diagnosed_as_dns(self, rc):
+        """A TLS failure that survives -k is not a trust problem, so the
+        abort must not send the operator to DNS and routing -- which is what
+        the single catch-all message used to do for every exit code."""
+        result = self._run(curl_rc=rc)
+        assert "STATUS_CALLED:error" in result.stdout, result.stdout
+        assert "TLS handshake" in result.stderr, result.stderr
+        assert f"curl exit {rc}" in result.stderr, result.stderr
+        assert "Check DNS and routing" not in result.stderr, result.stderr

--- a/packages/client/tests/test_start_sh_reverse_tunnel.py
+++ b/packages/client/tests/test_start_sh_reverse_tunnel.py
@@ -1,6 +1,16 @@
 """Structural tests for start.sh's reverse-tunnel block. Text assertions
 rather than execution (start.sh launches long-running services). Each one
-guards a failure mode that produces no error message on its own."""
+guards a failure mode that produces no error message on its own.
+
+The detection logic (grace window that distinguishes a transient non-101
+upgrade response from a permanent one) is behavioral, not just structural,
+so it is also exercised for real: `_run_detection_logic` extracts that
+logic verbatim from start.sh and runs it in a bash subprocess against a
+fixture log and a stubbed background process, with the real sleeps shortened
+so the test stays fast."""
+import re
+import subprocess
+import tempfile
 from pathlib import Path
 
 import pytest
@@ -19,15 +29,30 @@ def block() -> str:
     return "\n".join(lines[start:end + 1])
 
 
+@pytest.fixture(scope="module")
+def validation_loop(block) -> str:
+    """The `for v in ...; do ... done` input-validation loop, scoped tightly
+    so its assertions can't be satisfied by an unrelated failure branch
+    elsewhere in the block (e.g. tunnel_fail, added for the grace-window
+    fix, also contains `send_status "error"` and `exit 1`)."""
+    lines = block.splitlines()
+    start = next(
+        i for i, ln in enumerate(lines)
+        if ln.strip().startswith("for v in TUNNEL_URL")
+    )
+    end = next(i for i in range(start, len(lines)) if lines[i].strip() == "done")
+    return "\n".join(lines[start:end + 1])
+
+
 def test_gated_on_connectivity_not_on_secret_presence(block):
     """Gating on a secret's presence would make a missing value a silent
     no-tunnel; the allocator already told us the mode."""
     assert 'if [ "$CONNECTIVITY" = "reverse_tunnel" ]' in block
 
 
-def test_requires_its_inputs(block):
+def test_requires_its_inputs(validation_loop):
     required = "for v in TUNNEL_URL TUNNEL_PATH_PREFIX TUNNEL_BIND_ADDR CLIENT_SECRET"
-    assert required in block
+    assert required in validation_loop
 
 
 def test_passes_the_path_prefix_explicitly(block):
@@ -36,10 +61,10 @@ def test_passes_the_path_prefix_explicitly(block):
     assert '-P "$TUNNEL_PATH_PREFIX"' in block
 
 
-def test_missing_input_reports_error_status(block):
-    assert "STATUS_SUPERSEDED_FILE" in block
-    assert 'send_status "error"' in block
-    assert "exit 1" in block
+def test_missing_input_reports_error_status(validation_loop):
+    assert "STATUS_SUPERSEDED_FILE" in validation_loop
+    assert 'send_status "error"' in validation_loop
+    assert "exit 1" in validation_loop
 
 
 def test_binds_the_allocator_assigned_alias_for_both_ports(block):
@@ -82,3 +107,105 @@ def test_precedes_the_custom_startup_script(block):
     )
     script_at = next(i for i, ln in enumerate(text) if "custom-startup.sh" in ln)
     assert tunnel_at < script_at
+
+
+def test_401_403_fail_fast_without_a_grace_window(block):
+    """A wrong secret (401) or forbidden prefix (403) will never succeed on
+    retry, so it must be checked -- and be fatal -- before the grace window
+    that exists for potentially-transient errors, not folded into it."""
+    assert 'grep -qE "Invalid status code: 40[13]"' in block
+
+
+def test_other_failures_get_a_grace_window_before_failing(block):
+    """A non-101 upgrade response that isn't 401/403 (e.g. a 503 while the
+    allocator's proxy is still warming up) may be transient -- wstunnel's own
+    backoff can succeed on the next attempt. The fix must not fail on a
+    single point-in-time grep; it must check whether failures are still
+    accumulating after a second, shorter wait."""
+    assert block.count("grep -cE") == 2, "expected a before/after failure count"
+
+
+class TestDetectionLogicBehavior:
+    """Runs the actual post-launch detection logic from start.sh (from
+    `tunnel_fail() {` through the final `echo "Tunnel process running"`) in
+    a real bash subprocess, against a fixture TUNNEL_LOG and a stand-in
+    background process -- not just asserting the text exists, but that it
+    produces the right exit behavior. `sleep 5`/`sleep 3` are shortened so
+    each run takes a fraction of a second instead of ~8s."""
+
+    @staticmethod
+    def _extract_detection_snippet(script_text: str) -> str:
+        start = script_text.index("  tunnel_fail() {")
+        end = script_text.index('echo "Tunnel process running')
+        snippet = script_text[start:end]
+        # Same logic, faster clock -- durations aren't what's under test.
+        snippet = re.sub(r"sleep 5\b", "sleep 0.2", snippet)
+        snippet = re.sub(r"sleep 3\b", "sleep 0.2", snippet)
+        return snippet
+
+    def _run(
+        self, log_lines, append_after: str | None = None
+    ) -> subprocess.CompletedProcess:
+        snippet = self._extract_detection_snippet(START_SH.read_text())
+        with tempfile.TemporaryDirectory() as d:
+            log_path = Path(d) / "tunnel.log"
+            log_path.write_text("\n".join(log_lines) + "\n")
+            superseded = Path(d) / "superseded"
+
+            # A real background process this harness controls stands in for
+            # wstunnel, so `kill -0 "$TUNNEL_PID"` behaves like it would for
+            # a genuinely-alive tunnel. `send_status` is stubbed to report
+            # what it was called with instead of hitting the network.
+            append_cmd = (
+                f'(sleep 0.25; echo "{append_after}" >> "{log_path}") '
+                f"</dev/null >/dev/null 2>&1 &\n"
+                if append_after else ""
+            )
+            harness = f"""
+set -u
+TUNNEL_LOG="{log_path}"
+STATUS_SUPERSEDED_FILE="{superseded}"
+send_status() {{ echo "STATUS_CALLED:$1"; return 0; }}
+# Redirected so this stand-in process doesn't hold the harness's own
+# stdout pipe open after the harness itself exits.
+sleep 100 </dev/null >/dev/null 2>&1 &
+TUNNEL_PID=$!
+{append_cmd}{snippet}
+echo "REACHED_END"
+"""
+            return subprocess.run(
+                ["bash", "-c", harness], capture_output=True, text=True, timeout=10
+            )
+
+    def test_transient_failure_that_recovers_does_not_strand_the_tunnel(self):
+        """A 503 logged once (allocator proxy still warming up) followed by
+        a successful connect must NOT be treated as fatal."""
+        result = self._run([
+            "[tunnel] Connecting to wss://allocator.example.com/prefix/",
+            "[tunnel] Invalid status code: 503",
+            "[tunnel] Connected, tunnel established",
+        ])
+        assert "STATUS_CALLED:error" not in result.stdout, result.stdout
+        assert "REACHED_END" in result.stdout, result.stdout
+
+    def test_persistent_401_fails_fast_without_waiting_out_the_grace_window(self):
+        """A wrong secret must still fail fast -- this is the property the
+        fix must not trade away."""
+        result = self._run([
+            "[tunnel] Connecting to wss://allocator.example.com/prefix/",
+            "[tunnel] Invalid status code: 401",
+        ])
+        assert "STATUS_CALLED:error" in result.stdout, result.stdout
+        assert "REACHED_END" not in result.stdout, result.stdout
+
+    def test_persistent_non_auth_failure_still_fails_after_the_grace_window(self):
+        """A repeated (but not 401/403) failure that is STILL happening when
+        the grace window ends must not be waved through just because no
+        single grep caught it -- the log keeps growing across the window."""
+        result = self._run(
+            ["[tunnel] Connecting to wss://allocator.example.com/prefix/",
+             "[tunnel] Invalid status code: 503"],
+            append_after="[tunnel] Invalid status code: 503",
+        )
+        assert "STATUS_CALLED:error" in result.stdout, result.stdout
+        assert "REACHED_END" not in result.stdout, result.stdout


### PR DESCRIPTION
**Draft: the acceptance gate has not been run.** See "Outstanding" below before reviewing depth-first — the code is complete and reviewed, but the one test that proves the feature works end to end needs a second machine on another network.

## The problem

LabLink can only show a student a desktop if the **allocator can start a connection to the client** — it POSTs a rotated VNC password to the client's `:7070`, and its nginx opens a WebSocket to the client's `:6080`. That works for a client on the allocator's LAN (`lan_direct`) or on a Tailscale tailnet (`mesh_overlay`).

It does not work for the case we actually keep hitting: a GPU workload in a cluster or on a laptop elsewhere on campus, which has internet access but cannot accept inbound connections, and often cannot run Tailscale because the platform won't grant the privileges its network device needs.

## The approach

The client dials **out** to the allocator's existing public HTTPS address and holds one WebSocket open (`wstunnel`, reverse mode). The allocator exposes that client's `:6080`/`:7070` on a per-client loopback alias `127.0.0.<octet>`, and `X-Upstream` points nginx at that alias — so nginx, `auth_request`, the session token scheme and password rotation are all unchanged. The tunnel is a transport swapped in beneath an existing seam.

The property that makes it worth having: **deploying this mode adds nothing.** No new config field, no new `.env` entry, no new published port, no compose override. The reviewer verified that by rendering both compose variants rather than trusting the test that asserts it.

## Changes

- **Allocator**: `reverse_tunnel` connectivity strategy; `tunnel_manager` (per-client authorization + attachment checks); alias allocation; `wstunnel` server bound to loopback only, launched from `start.sh` when the config says so; nginx `^/(tun-…)` location gated by an `auth_request` endpoint that authenticates with `client_secret`; registration mints the alias and path prefix; health reports per-client *attachment*.
- **Client**: `wstunnel` in both images; a `start.sh` block that opens the tunnel, and fails loudly — reporting `status=error` — on both a dead process and a rejected handshake.
- **CLI**: `lablink client register --tunnel` (valueless — the allocator mints every value), env-file plumbing, no published host ports for a tunnel client, a version-skew guard, and the `reverse_tunnel` option in `lablink configure`.
- Rides along: `--platform linux/amd64` on the client docker run, which fixes local registration on Apple Silicon for **every** connectivity mode (it currently fails with `no matching manifest for linux/arm64/v8`).

## Testing

`allocator 833 passed / 20 skipped` · `client 153 passed` · `CLI 689 passed` · `ruff` clean in all three.

Note for anyone running these locally: with `FORCE_COLOR` set, about six pre-existing CLI tests fail because they assert plain substrings against Rich output. They fail on `main` too. Run with `env -u FORCE_COLOR`.

## Outstanding — the acceptance gate

Task 15 of the plan has **not** been run, because it needs a client on a different network. Unproven until it does:

1. A real cross-LAN desktop session.
2. Round-trip latency against the frp experiment's measured 0.036–0.31 s baseline.
3. Re-registration leaving exactly one restrictions rule, naming the new alias only.
4. A killed tunnel surfacing as `"N client(s) not attached"` on `/api/health`.

What **does** have evidence is the security gate: a client presenting another client's alias was refused by the tunnel server with `Rejecting connection with not allowed destination`, measured during development.

Three assumptions to confirm in that same run:

- Whether `wstunnel` 10.6.2 hot-reloads `--restrict-config` for a rule added **after** the server starts. The entire first-client flow depends on it; development proved a client attaches, but never measured a rule added later.
- Whether `!PathPrefix` is an exact first-segment compare or a regex. A `.` is legal in a hostname and is a regex metacharacter. No practical exploit was found — every cross-match needs another client's 64-bit digest, and the `allow` side stays pinned to the attacker's own octet — but it is an unverified assumption inside a security-critical matcher.
- `nginx -t` and `wstunnel --version` were verified during development but not in the final review pass.

## First live run: one bug found and fixed

The mode was exercised against a real client for the first time on 2026-07-31, and it found a defect of the exact class this feature keeps producing — **the client announced a healthy tunnel that had never connected.**

The client's DNS resolved the allocator to an address it had no route to, so `wstunnel` retried forever. The startup check passed anyway: it recognises handshake rejection (`Invalid status code`, `failed to do websocket handshake`), and a connect-level failure produces neither, so the failure count stayed `0`, the grace-window check was skipped, and `kill -0` passed because the process was alive in its retry loop. Worse, `wstunnel` logged **no error line at all** for this failure mode — only `Opening TCP connection` per retry, at INFO — so no pattern could have matched. Replaying the observed log through the detection logic alone confirms it: no error reported, success declared.

Fixed in `e86a15a6` by replacing inference-from-absence with a **positive probe**: before launching the tunnel, the client checks that ordinary HTTPS to the host in `TUNNEL_URL` answers. If it doesn't, the tunnel cannot come up, and the client reports `status=error` naming DNS/routing instead of proceeding. The client's own repeated `curl: (7)` lines show that signal was available and unused.

That makes four instances of *reports-healthy-while-unreachable* in this feature's history, every one found by running it rather than by a test. Reviewers should weight that when judging the remaining unverified items below.

## Known operational caveats

Both of these are properties of using **Tailscale Funnel** as the allocator's ingress, not defects in this mode — and between them they cost two test attempts, so they are worth knowing before deploying:

1. **A client with Tailscale installed but logged out or stopped cannot resolve the allocator's `ts.net` name.** Tailscale registers itself as the resolver for the tailnet's domain, and when the daemon isn't running those lookups fail instead of falling through to public DNS. `lablink client register` then fails before sending a packet, with a DNS error that looks nothing like a connectivity or auth problem. A machine with *no* Tailscale resolves the name fine.
2. **A client container on a host that is running Tailscale inherits MagicDNS and resolves the allocator to its `100.x` tailnet address**, which the container cannot route to — the failure above. Symptom is `[Errno 101] Network is unreachable` while the same container reaches the rest of the internet normally. Workaround for a same-host test: run the client with `--dns 8.8.8.8` so it resolves publicly and goes out through the real Funnel path.

3. **A client that cannot resolve the allocator also cannot report that it failed.** `send_status "error"` needs the same DNS that just failed, so the abort path's status POST fails too (six `curl: (6)` lines in the observed run) and the allocator keeps whatever status the client last had. With `--restart unless-stopped` the container then crash-loops invisibly — from the allocator's side it looks idle, and a student can be assigned a VM that is not running. This is pre-existing and not specific to this mode (any DNS failure has always had this shape), and there is no second channel to report over, so nothing here fixes it; it is listed because the reverse-tunnel preflight makes the crash-loop *likely* enough to matter, and because "reports nothing" is a distinct failure from the reports-healthy-while-unreachable class above.

An allocator behind an ordinary reverse proxy with a normal DNS name has neither failure mode, which is a real argument for that option in production.

## Design decisions worth knowing while reviewing

- **The path prefix must be the URL's first segment.** Measured: `!PathPrefix` only inspects that segment, so a `/tunnel/<prefix>` scheme is unexpressible — it is either deny-all or grants every client every alias. Hence `tun-<client>-<digest>` at the root, with the client passing `-P` explicitly (it ignores any path in the URL it dials).
- **The auth endpoint is the only secret-to-identity binding.** The restrictions file is keyed *by path*, so it constrains a client to one alias but does not prove who it is.
- **Auth is `client_secret`** — per-client and revoked when the row is deleted — rather than a new deployment-wide token.
- **Health observes the pairing, not the process.** A bound port is not evidence of an attached client: the tunnel server keeps a listener bound for its idle timeout after a client leaves, and connections to an orphan hang rather than fail.
- **The client's failure check reads the tunnel's output, not just its PID.** The tunnel does not exit on a rejected handshake; it retries forever. A liveness-only check would report a healthy client that can never be reached — the failure mode this feature's predecessor shipped three times.

## Relationship to #416 / #417 / #418

Those three implement the same capability over `frp` (Experiment 1) and are still open. This branch is Experiment 2 and starts from `main`, depending on none of them. They work, but their topology needs a publicly reachable rendezvous — either an inbound port on the allocator or a host you run — which is what motivated this alternative. Both shouldn't land; that's a decision for the meeting, not this PR.

## Reviewer hint

This was built task-by-task with a review after each, and **the plan was the defect source rather than the implementations** — nine plan errors were caught, mostly by reviews that ran the real binary rather than reading code. The four late findings were all lifecycle bugs invisible to any single task: a restart wiping other clients' authorizations, a stale log entry killing healthy tunnels on reboot, `ws://` on the exact topology this mode targets, and an unreachable register URL for the Funnel case. Cross-file lifecycle is where the remaining risk lives, not in any one module.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

