### PR TITLE
feat: publish the allocator at an admin-chosen hostname via Cloudflare Tunnel

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -459,6 +459,103 @@ monitoring:
 
 **Viewing.** With `monitoring.enabled: true`, the admin UI exposes a **Session Metrics** button on the admin landing page; the page shows a cohort summary, funnel, per-VM table, and CSV/JSON download buttons. From the CLI, run `lablink stats` for the same summary in your terminal or `lablink export-metrics --client` to download CSV/JSON.
 
+### Manual Provider Options (`manual`)
+
+Applies only when `provider: manual` (bring-your-own clients, deployed with
+`lablink deploy` onto a machine you already have). Ignored by the AWS provider.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `connectivity` | string | `lan_direct` | How a participant's browser reaches a client's KasmVNC desktop: `lan_direct` (client is on the allocator's own LAN) or `mesh_overlay` (client is reached over a Tailscale tailnet and proxied through the allocator's nginx). |
+| `overlay_tailnet` | string | `""` | The tailnet's MagicDNS suffix (e.g. `example.ts.net`). Required for `connectivity: mesh_overlay` and for `participant_exposure: tailscale_funnel`. |
+| `participant_exposure` | string | `none` | How **participants** reach the allocator itself: `none` (LAN-only), `tailscale_funnel`, or `cloudflare_tunnel`. Independent of `connectivity`. |
+| `public_hostname` | string | `""` | The hostname participants open, e.g. `lab.smithlab.org`. Required when `participant_exposure: cloudflare_tunnel`; ignored otherwise. |
+
+`participant_exposure` is not the same axis as `connectivity`: the first is about
+publishing the allocator, the second about reaching clients. Any exposure mode
+other than `none` requires `connectivity: mesh_overlay` — `lan_direct` sends the
+browser straight to a client's LAN IP over `ws://`, which is unreachable off-LAN
+and blocked as mixed content from an HTTPS page. Both `lablink configure` and
+`lablink deploy` reject that combination.
+
+#### Exposure mode: `tailscale_funnel`
+
+Publishes the allocator at `<machine>.<tailnet>.ts.net` using the same Tailscale
+sidecar `mesh_overlay` already provisions. No domain required, but the hostname
+is not yours to choose — Tailscale Funnel supports no custom domains.
+
+#### Exposure mode: `cloudflare_tunnel`
+
+Publishes the allocator at a hostname you choose, through a Cloudflare Tunnel in
+your own Cloudflare account. `cloudflared` ships inside the allocator image and
+is started only when this mode is set; LabLink makes no Cloudflare API calls.
+
+!!! warning "Requires a domain whose nameservers point at Cloudflare"
+    A custom hostname needs Cloudflare's free-plan **full setup** — the domain's
+    nameservers must be delegated to Cloudflare. Cloudflare's partial (CNAME)
+    setup is Business-tier and subdomain zones are Enterprise-tier, so an
+    institutional domain such as `salk.edu` **cannot** be used on the free plan.
+    Register a domain you control instead (typically ~$10/yr), or use
+    `tailscale_funnel`, which needs no domain at all.
+
+**One-time setup** (done once per deployment host; the tunnel and its DNS record
+live in your Cloudflare account, so the URL is stable across every
+`lablink deploy` and `lablink destroy`):
+
+1. Sign up at [cloudflare.com](https://cloudflare.com) (free).
+2. **Add a site** → enter your domain → choose the Free plan.
+3. At your domain's registrar, replace the nameservers with the two Cloudflare shows.
+4. Wait for activation (usually minutes).
+5. Open the **Zero Trust** dashboard; pick a team name and the Free plan.
+6. **Networks → Tunnels → Create a tunnel** → connector `cloudflared` → name it.
+7. Copy the **token** from the Docker install command it shows (`eyJhIjoiN…`).
+8. On the **Public hostname** tab: subdomain `lab`, your domain, type `HTTP`, URL
+   `http://localhost:5000`. Cloudflare creates the DNS record for you.
+
+Cloudflare's Zero Trust onboarding sometimes asks for a payment method even
+though the plan is free.
+
+**Configuration:**
+
+```yaml
+provider: manual
+deployment_name: smith-lab
+ssl:
+  provider: none        # Cloudflare supplies the public certificate
+manual:
+  connectivity: mesh_overlay   # lan_direct is rejected with any exposure mode
+  overlay_tailnet: example.ts.net
+  participant_exposure: cloudflare_tunnel
+  public_hostname: lab.smithlab.org
+```
+
+**Deploy:**
+
+```bash
+lablink deploy \
+  --tailscale-authkey tskey-auth-... \
+  --cloudflare-tunnel-token eyJhIjoiN...
+```
+
+The token is stored only in the deployment's `.env` (mode `0600`), never in
+`config.yaml`, and is carried forward on redeploys — pass
+`--cloudflare-tunnel-token` on the first deploy, or again to rotate it. If the
+mode is set and no token is available, both `lablink deploy` and the container's
+`start.sh` fail loudly rather than starting an allocator that looks healthy but
+is unreachable.
+
+After `docker compose up`, `lablink deploy` requests `https://<public_hostname>/api/health`
+for up to 30 seconds. A miss is a warning, not a failure — a freshly created DNS
+record may still be propagating.
+
+##### Cloudflare can read your traffic
+
+Cloudflare Tunnel terminates TLS at Cloudflare's edge, so admin logins, session
+cookies and participant desktop streams are all decrypted there. Tailscale
+Funnel does not do this — its relays forward encrypted bytes and TLS terminates
+on your own machine. If your data cannot transit a third party in cleartext, use
+`tailscale_funnel` and accept its `.ts.net` hostname.
+
 ## Validating Configuration
 
 After modifying configuration, validate it:

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -544,9 +544,10 @@ mode is set and no token is available, both `lablink deploy` and the container's
 `start.sh` fail loudly rather than starting an allocator that looks healthy but
 is unreachable.
 
-After `docker compose up`, `lablink deploy` requests `https://<public_hostname>/api/health`
-for up to 30 seconds. A miss is a warning, not a failure — a freshly created DNS
-record may still be propagating.
+After `docker compose up`, `lablink deploy` makes one request to
+`https://<public_hostname>/api/health`. A miss is a warning, not a failure — a
+freshly created DNS record may still be propagating, in which case retry the URL
+in your browser in a few minutes.
 
 ##### Cloudflare can read your traffic
 

--- a/packages/allocator/Dockerfile
+++ b/packages/allocator/Dockerfile
@@ -39,6 +39,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm /tmp/kasmvncserver.deb && \
     rm -rf /var/lib/apt/lists/*
 
+# cloudflared -- the connector for manual.participant_exposure=cloudflare_tunnel.
+# A single static binary (not a tarball, not a .deb), so no unpack step. Harmless
+# when unused: start.sh only launches it when the mode is set. Pinned rather than
+# floating, and paired with --no-autoupdate at runtime, so what ships is what was
+# tested. Must stay in lockstep with Dockerfile.dev.
+ARG CLOUDFLARED_VERSION=2026.7.3
+RUN curl -L -o /usr/local/bin/cloudflared \
+      "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64" && \
+    chmod +x /usr/local/bin/cloudflared
+
 # Fix the bundled noVNC viewer's RFB VncAuth handshake. nginx (above)
 # serves /static/novnc/ from /usr/share/kasmvnc/www/ on THIS container,
 # so the browser-loaded bundle is the allocator's, not the client's.

--- a/packages/allocator/Dockerfile.dev
+++ b/packages/allocator/Dockerfile.dev
@@ -35,6 +35,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm /tmp/kasmvncserver.deb && \
     rm -rf /var/lib/apt/lists/*
 
+# cloudflared -- the connector for manual.participant_exposure=cloudflare_tunnel.
+# A single static binary (not a tarball, not a .deb), so no unpack step. Harmless
+# when unused: start.sh only launches it when the mode is set. Pinned rather than
+# floating, and paired with --no-autoupdate at runtime, so what ships is what was
+# tested. Must stay in lockstep with Dockerfile.
+ARG CLOUDFLARED_VERSION=2026.7.3
+RUN curl -L -o /usr/local/bin/cloudflared \
+      "https://github.com/cloudflare/cloudflared/releases/download/${CLOUDFLARED_VERSION}/cloudflared-linux-amd64" && \
+    chmod +x /usr/local/bin/cloudflared
+
 # Fix the bundled noVNC viewer's RFB VncAuth handshake. nginx (above)
 # serves /static/novnc/ from /usr/share/kasmvnc/www/ on THIS container,
 # so the browser-loaded bundle is the allocator's, not the client's.

--- a/packages/allocator/src/lablink_allocator_service/conf/structured_config.py
+++ b/packages/allocator/src/lablink_allocator_service/conf/structured_config.py
@@ -207,11 +207,26 @@ class ManualConfig:
               public internet via the tailnet named by overlay_tailnet,
               using the same tailscale sidecar connectivity="mesh_overlay"
               already provisions (reused, not a second sidecar).
+            - "cloudflare_tunnel": publish the allocator at
+              public_hostname via a Cloudflare Tunnel the admin created in
+              their own Cloudflare account. Requires a domain whose
+              nameservers point at Cloudflare (free-plan "full setup" —
+              partial/CNAME setup is Business-tier, subdomain zones are
+              Enterprise, so an institutional domain cannot be used).
+              NOTE: unlike Funnel, which terminates TLS on this machine,
+              Cloudflare decrypts all traffic at its edge — admin logins
+              and participant desktop streams included.
+        public_hostname (str): The public hostname participants open, e.g.
+            "lab.smithlab.org". Required when participant_exposure is
+            "cloudflare_tunnel"; ignored otherwise. Deliberately generic:
+            any future exposure mode with an admin-chosen hostname reuses
+            this field rather than adding a vendor-named one.
     """
 
     connectivity: str = field(default="lan_direct")
     overlay_tailnet: str = field(default="")
     participant_exposure: str = field(default="none")
+    public_hostname: str = field(default="")
 
 
 @dataclass

--- a/packages/allocator/src/lablink_allocator_service/validate_config.py
+++ b/packages/allocator/src/lablink_allocator_service/validate_config.py
@@ -7,6 +7,7 @@ validation during CI/CD pipelines.
 
 import argparse
 import logging
+import re
 import sys
 from pathlib import Path
 from typing import Tuple
@@ -57,6 +58,39 @@ WEAK_ADMIN_PASSWORDS = frozenset(
     {"123456", "admin", "password", "changeme", "placeholder_admin_password", ""}
 )
 MIN_ADMIN_PASSWORD_LENGTH = 12
+
+# manual.public_hostname is interpolated straight into "https://{host}" — both
+# for the canonical-URL file the allocator hands to registering clients and for
+# the CLI's post-deploy reachability check. Anything but a bare DNS name
+# therefore produces a silently broken URL rather than an error: the most
+# likely mistake is pasting the scheme ("https://lab.example.org", which the
+# docs and wizard both display in URL form), yielding
+# "https://https://lab.example.org" that canonical_base_url happily accepts
+# because it still startswith("https://"). A newline would append a second
+# line to that file, which is read with a whole-file read().strip().
+#
+# Deliberately stricter than validate_domain_format (which only rejects
+# leading/trailing dots): a dot is required, since a Cloudflare public
+# hostname is always a FQDN under a zone the admin controls.
+PUBLIC_HOSTNAME_RE = re.compile(
+    r"^(?=.{1,253}$)"
+    r"[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?"
+    r"(\.[A-Za-z0-9]([A-Za-z0-9-]{0,61}[A-Za-z0-9])?)+$"
+)
+
+PUBLIC_HOSTNAME_HINT = (
+    "must be a bare hostname such as 'lab.smithlab.org' — no scheme "
+    "(drop the https://), port, path, or whitespace"
+)
+
+
+def is_valid_public_hostname(hostname: str) -> bool:
+    """True if *hostname* is a bare FQDN safe to interpolate into a URL.
+
+    Empty is *not* accepted here; callers report that separately, because
+    "you left it blank" and "you typed a URL" need different guidance.
+    """
+    return bool(PUBLIC_HOSTNAME_RE.match(hostname))
 
 
 def is_weak_admin_password(password: str) -> bool:
@@ -161,15 +195,20 @@ def get_config_errors(cfg) -> list:
         # cloudflare_tunnel publishes at an admin-chosen hostname, so that
         # hostname is not optional. The tunnel token is checked at deploy
         # time instead (it lives in .env, never in config.yaml).
-        if participant_exposure == "cloudflare_tunnel" and not getattr(
-            manual_cfg, "public_hostname", ""
-        ):
-            errors.append(
-                "manual.participant_exposure is 'cloudflare_tunnel' but "
-                "manual.public_hostname is empty — set it to the hostname "
-                "configured as the tunnel's public hostname in Cloudflare "
-                "(e.g. lab.smithlab.org)."
-            )
+        if participant_exposure == "cloudflare_tunnel":
+            public_hostname = getattr(manual_cfg, "public_hostname", "")
+            if not public_hostname:
+                errors.append(
+                    "manual.participant_exposure is 'cloudflare_tunnel' but "
+                    "manual.public_hostname is empty — set it to the hostname "
+                    "configured as the tunnel's public hostname in Cloudflare "
+                    "(e.g. lab.smithlab.org)."
+                )
+            elif not is_valid_public_hostname(public_hostname):
+                errors.append(
+                    f"manual.public_hostname {PUBLIC_HOSTNAME_HINT} "
+                    f"(got '{public_hostname}')"
+                )
 
         needs_tailnet = (
             connectivity == "mesh_overlay" or participant_exposure == "tailscale_funnel"

--- a/packages/allocator/src/lablink_allocator_service/validate_config.py
+++ b/packages/allocator/src/lablink_allocator_service/validate_config.py
@@ -32,10 +32,14 @@ VALID_PROVIDERS = ("aws", "manual")
 VALID_CONNECTIVITY = ("lan_direct", "mesh_overlay")
 
 # manual.participant_exposure — how participants (not clients) reach the
-# allocator when it isn't on their LAN. Independent of connectivity above;
-# "tailscale_funnel" reuses the same tailnet, just for a different purpose
-# (publishing the allocator's own HTTP port, not reaching a client).
-VALID_PARTICIPANT_EXPOSURE = ("none", "tailscale_funnel")
+# allocator when it isn't on their LAN. Independent of connectivity above.
+# "tailscale_funnel" reuses the mesh_overlay tailnet to publish the
+# allocator's own HTTP port; "cloudflare_tunnel" publishes it at
+# manual.public_hostname through a Cloudflare Tunnel the admin owns.
+# Must stay in sync with the wizard's exposure radio set and with
+# deploy_compose's preflights, which key on "not none" rather than on any
+# single value.
+VALID_PARTICIPANT_EXPOSURE = ("none", "tailscale_funnel", "cloudflare_tunnel")
 
 # Deployment-example / commonly-typed weak values a Funnel-exposed admin
 # panel must never ship with — CT-log scanning finds a newly-published
@@ -135,18 +139,34 @@ def get_config_errors(cfg) -> list:
         # lan_direct sends the participant's browser straight to a client's
         # LAN IP (ws://<client-ip>:6080 — see LANDirectClientConnectivity),
         # bypassing the allocator entirely. That's unreachable off-LAN and,
-        # once the allocator itself is Funnel-exposed, actively blocked as
+        # once the allocator itself is publicly exposed, actively blocked as
         # mixed content by the browser (ws:// from an https:// page).
         # mesh_overlay doesn't have this problem — it proxies sessions
-        # through the allocator's own nginx, which Funnel already exposes.
-        if participant_exposure == "tailscale_funnel" and connectivity == "lan_direct":
+        # through the allocator's own nginx, which any exposure mode
+        # publishes. Keyed on "any exposure" rather than on Funnel
+        # specifically: the reasoning is about being publicly reachable,
+        # not about which tunnel does the publishing.
+        if participant_exposure != "none" and connectivity == "lan_direct":
             errors.append(
-                "manual.participant_exposure is 'tailscale_funnel' but "
+                f"manual.participant_exposure is '{participant_exposure}' but "
                 "manual.connectivity is 'lan_direct' — participant sessions "
                 "would connect directly to a client's LAN IP, which is "
                 "unreachable off-LAN and blocked as mixed content from the "
-                "HTTPS Funnel page. Use manual.connectivity: mesh_overlay "
+                "HTTPS page. Use manual.connectivity: mesh_overlay "
                 "instead, which proxies sessions through the allocator."
+            )
+
+        # cloudflare_tunnel publishes at an admin-chosen hostname, so that
+        # hostname is not optional. The tunnel token is checked at deploy
+        # time instead (it lives in .env, never in config.yaml).
+        if participant_exposure == "cloudflare_tunnel" and not getattr(
+            manual_cfg, "public_hostname", ""
+        ):
+            errors.append(
+                "manual.participant_exposure is 'cloudflare_tunnel' but "
+                "manual.public_hostname is empty — set it to the hostname "
+                "configured as the tunnel's public hostname in Cloudflare "
+                "(e.g. lab.smithlab.org)."
             )
 
         needs_tailnet = (

--- a/packages/allocator/start.sh
+++ b/packages/allocator/start.sh
@@ -130,10 +130,19 @@ if [ "$PARTICIPANT_EXPOSURE" = "cloudflare_tunnel" ]; then
   # The origin is configured in Cloudflare, not here; logging it keeps the
   # docs' "type http://localhost:5000" instruction traceable to the code.
   echo "Starting Cloudflare Tunnel connector (expected origin: http://localhost:5000)..."
+  # cloudflared dumps its entire environment at INFO on startup, so leaving
+  # the token exported writes it verbatim into `docker logs` -- persisted,
+  # greppable by anyone with docker access, and shipped to whatever collects
+  # container logs. Hand it over as an argument and drop it from the
+  # environment first, so the dump has nothing to find. (The argument is
+  # still visible in the container's process list; cloudflared accepts no
+  # file-based token, so that exposure is unavoidable here.)
+  _cf_token="$CLOUDFLARE_TUNNEL_TOKEN"
+  unset CLOUDFLARE_TUNNEL_TOKEN
   # Backgrounded: nginx must reach the exec below to keep the container
   # alive. cloudflared dials Cloudflare first and retries the origin, so
   # starting a second or two before nginx listens is fine.
-  cloudflared tunnel --no-autoupdate run --token "$CLOUDFLARE_TUNNEL_TOKEN" &
+  cloudflared tunnel --no-autoupdate run --token "$_cf_token" &
 fi
 
 # Foreground nginx; this keeps the container alive.

--- a/packages/allocator/start.sh
+++ b/packages/allocator/start.sh
@@ -86,6 +86,27 @@ done
 # Validate nginx config; refuse to start if broken.
 nginx -t
 
+# Cloudflare Tunnel exposure: connect Cloudflare's edge to this container's
+# own nginx (:5000, the port the admin enters as the tunnel's public-hostname
+# service URL). The tunnel's ingress config lives in Cloudflare, not here, so
+# there is nothing to render locally and nothing to persist -- cloudflared
+# pulls it on every start. Gated on the mode so lan_direct/tailscale_funnel
+# deployments never start a connector.
+if [ "$PARTICIPANT_EXPOSURE" = "cloudflare_tunnel" ]; then
+  if [ -z "$CLOUDFLARE_TUNNEL_TOKEN" ]; then
+    echo "participant_exposure is 'cloudflare_tunnel' but CLOUDFLARE_TUNNEL_TOKEN is empty." >&2
+    echo "Re-run: lablink deploy --cloudflare-tunnel-token <token>" >&2
+    exit 1
+  fi
+  # The origin is configured in Cloudflare, not here; logging it keeps the
+  # docs' "type http://localhost:5000" instruction traceable to the code.
+  echo "Starting Cloudflare Tunnel connector (expected origin: http://localhost:5000)..."
+  # Backgrounded: nginx must reach the exec below to keep the container
+  # alive. cloudflared dials Cloudflare first and retries the origin, so
+  # starting a second or two before nginx listens is fine.
+  cloudflared tunnel --no-autoupdate run --token "$CLOUDFLARE_TUNNEL_TOKEN" &
+fi
+
 # Foreground nginx; this keeps the container alive.
 echo "Starting nginx on :5000..."
 exec nginx -g 'daemon off;'

--- a/packages/allocator/tests/test_start_sh_cloudflared.py
+++ b/packages/allocator/tests/test_start_sh_cloudflared.py
@@ -1,0 +1,84 @@
+"""Structural tests for start.sh's Cloudflare Tunnel connector block.
+
+start.sh launches long-running services and `exec`s nginx, so it isn't
+sourceable — these assert against the script text rather than executing it,
+the same approach as the client package's test_start_sh_status.py. The
+connector's runtime behaviour is verified by hand against a real tunnel.
+"""
+
+from pathlib import Path
+
+import pytest
+
+START_SH = Path(__file__).resolve().parents[1] / "start.sh"
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return START_SH.read_text()
+
+
+@pytest.fixture(scope="module")
+def block(script_text: str) -> str:
+    lines = script_text.splitlines()
+    start = next(
+        i
+        for i, ln in enumerate(lines)
+        if ln.startswith('if [ "$PARTICIPANT_EXPOSURE" = "cloudflare_tunnel" ]')
+    )
+    end = next(i for i in range(start, len(lines)) if lines[i] == "fi")
+    return "\n".join(lines[start : end + 1])
+
+
+def test_gated_on_the_exposure_mode(block):
+    """lan_direct/funnel deployments must never start a connector."""
+    assert 'if [ "$PARTICIPANT_EXPOSURE" = "cloudflare_tunnel" ]' in block
+
+
+def test_empty_token_exits_nonzero(block):
+    """A mode set with no token must fail loudly. Silently skipping the
+    connector produces an allocator that looks healthy and is unreachable
+    — the exact failure class that shipped three times in this subsystem."""
+    assert '-z "$CLOUDFLARE_TUNNEL_TOKEN"' in block
+    assert "exit 1" in block
+
+
+def test_targets_the_containers_own_nginx_port(block):
+    """The connector reaches nginx on :5000 inside this container. It is
+    NOT told the origin here — the ingress config lives in Cloudflare —
+    but the port must appear in a comment so the docs' instruction to type
+    http://localhost:5000 stays traceable to the code."""
+    assert "5000" in block
+
+
+def test_runs_with_the_token_and_no_autoupdate(block):
+    assert "--token" in block
+    assert '"$CLOUDFLARE_TUNNEL_TOKEN"' in block
+    # The version is pinned in the Dockerfile; letting the binary update
+    # itself at runtime would silently un-pin it.
+    assert "--no-autoupdate" in block
+
+
+def test_backgrounded_so_nginx_still_execs(block):
+    assert block.rstrip().endswith("fi")
+    assert "&" in block
+
+
+def test_connector_block_precedes_the_nginx_exec(script_text):
+    lines = script_text.splitlines()
+    connector = next(
+        i for i, ln in enumerate(lines) if "cloudflared" in ln and "--token" in ln
+    )
+    nginx = next(i for i, ln in enumerate(lines) if ln.startswith("exec nginx"))
+    assert connector < nginx, "exec nginx replaces the shell; nothing after it runs"
+
+
+def test_version_is_pinned_in_both_dockerfiles():
+    """A floating tag would change what ships without a code change, and
+    the two files must not drift apart."""
+    root = START_SH.parent
+    for name in ("Dockerfile", "Dockerfile.dev"):
+        text = (root / name).read_text()
+        assert "ARG CLOUDFLARED_VERSION=2026.7.3" in text, name
+        assert "cloudflared-linux-amd64" in text, name
+        assert "cloudflared:latest" not in text, name

--- a/packages/allocator/tests/test_start_sh_cloudflared.py
+++ b/packages/allocator/tests/test_start_sh_cloudflared.py
@@ -59,6 +59,23 @@ def test_runs_with_the_token_and_no_autoupdate(block):
     assert "--no-autoupdate" in block
 
 
+def test_token_is_dropped_from_the_environment_before_launching(block):
+    """cloudflared logs its entire environment at INFO on startup, so an
+    exported token lands in `docker logs` verbatim — persisted and readable
+    by anyone with docker access. It must be copied to a local variable and
+    unset before the connector starts."""
+    lines = block.splitlines()
+    unset = next(
+        i for i, ln in enumerate(lines) if "unset CLOUDFLARE_TUNNEL_TOKEN" in ln
+    )
+    launch = next(
+        i for i, ln in enumerate(lines) if "cloudflared" in ln and "--token" in ln
+    )
+    assert unset < launch, "the unset must precede the connector launch"
+    # ...and the launch must not reach for the exported name again.
+    assert "$CLOUDFLARE_TUNNEL_TOKEN" not in lines[launch]
+
+
 def test_backgrounded_so_nginx_still_execs(block):
     assert block.rstrip().endswith("fi")
     assert "&" in block

--- a/packages/allocator/tests/test_validate_config.py
+++ b/packages/allocator/tests/test_validate_config.py
@@ -439,7 +439,9 @@ class TestParticipantExposureField:
     def test_rejects_unknown_value(self):
         from lablink_allocator_service.validate_config import get_config_errors
 
-        cfg = self._make_cfg(participant_exposure="cloudflare_tunnel")
+        # Was "cloudflare_tunnel" until that became a real mode; any value
+        # outside VALID_PARTICIPANT_EXPOSURE serves the same purpose.
+        cfg = self._make_cfg(participant_exposure="ngrok")
         errors = get_config_errors(cfg)
         assert any("manual.participant_exposure must be one of" in e for e in errors)
 
@@ -643,3 +645,87 @@ class TestParticipantExposureWeakPasswordGate:
         assert cfg.app.admin_password == MISSING_SECRET
         errors = get_config_errors(cfg)
         assert not any("admin_password" in e for e in errors)
+
+
+class TestCloudflareTunnelExposure:
+    def _cfg(self, *, connectivity="mesh_overlay", public_hostname="lab.example.org"):
+        from lablink_allocator_service.conf.structured_config import Config
+
+        cfg = Config()
+        cfg.provider = "manual"
+        cfg.manual.connectivity = connectivity
+        cfg.manual.overlay_tailnet = "example.ts.net"
+        cfg.manual.participant_exposure = "cloudflare_tunnel"
+        cfg.manual.public_hostname = public_hostname
+        cfg.app.admin_user = "admin"
+        cfg.app.admin_password = "a-strong-password-1"
+        return cfg
+
+    def test_value_is_accepted(self):
+        from lablink_allocator_service.validate_config import (
+            VALID_PARTICIPANT_EXPOSURE,
+        )
+
+        assert "cloudflare_tunnel" in VALID_PARTICIPANT_EXPOSURE
+
+    def test_valid_config_has_no_exposure_errors(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._cfg())
+        assert not [e for e in errors if "participant_exposure" in e]
+
+    def test_missing_public_hostname_is_rejected(self):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._cfg(public_hostname=""))
+        matching = [e for e in errors if "public_hostname" in e]
+        assert matching, f"expected a public_hostname error, got {errors}"
+        # The wizard filters on both substrings; see Task 6.
+        assert "participant_exposure" in matching[0]
+
+    def test_lan_direct_is_rejected_for_cloudflare_too(self):
+        """The lan_direct rejection was written for Funnel but argues about
+        public exposure in general: lan_direct points the browser at a
+        client's LAN IP, unreachable off-LAN and mixed-content-blocked from
+        any HTTPS page."""
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._cfg(connectivity="lan_direct"))
+        matching = [e for e in errors if "lan_direct" in e]
+        assert matching, f"expected a lan_direct error, got {errors}"
+        assert "cloudflare_tunnel" in matching[0], (
+            "the message must name the mode that triggered it, not Funnel"
+        )
+
+    def test_cloudflare_does_not_require_a_tailnet_by_itself(self):
+        """overlay_tailnet is needed for mesh_overlay clients, not for this
+        exposure mode. lan_direct is rejected above, so this uses the one
+        combination that isolates the question."""
+        from lablink_allocator_service.conf.structured_config import Config
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        cfg = Config()
+        cfg.provider = "manual"
+        cfg.manual.connectivity = "mesh_overlay"
+        cfg.manual.overlay_tailnet = "example.ts.net"
+        cfg.manual.participant_exposure = "cloudflare_tunnel"
+        cfg.manual.public_hostname = "lab.example.org"
+        cfg.app.admin_user = "admin"
+        cfg.app.admin_password = "a-strong-password-1"
+        assert not [e for e in get_config_errors(cfg) if "overlay_tailnet" in e]
+
+
+def test_funnel_lan_direct_error_still_fires():
+    """Regression guard: generalizing the check must not drop the case it
+    was written for."""
+    from lablink_allocator_service.conf.structured_config import Config
+    from lablink_allocator_service.validate_config import get_config_errors
+
+    cfg = Config()
+    cfg.provider = "manual"
+    cfg.manual.connectivity = "lan_direct"
+    cfg.manual.overlay_tailnet = "example.ts.net"
+    cfg.manual.participant_exposure = "tailscale_funnel"
+    cfg.app.admin_user = "admin"
+    cfg.app.admin_password = "a-strong-password-1"
+    assert [e for e in get_config_errors(cfg) if "lan_direct" in e]

--- a/packages/allocator/tests/test_validate_config.py
+++ b/packages/allocator/tests/test_validate_config.py
@@ -1,3 +1,5 @@
+import pytest
+
 import lablink_allocator_service.validate_config as vc_module
 from lablink_allocator_service.validate_config import validate_config
 
@@ -682,6 +684,71 @@ class TestCloudflareTunnelExposure:
         assert matching, f"expected a public_hostname error, got {errors}"
         # The wizard filters on both substrings; see Task 6.
         assert "participant_exposure" in matching[0]
+
+    @pytest.mark.parametrize(
+        "hostname",
+        [
+            "https://lab.example.org",  # the likely paste — docs show URL form
+            "http://lab.example.org",
+            "lab.example.org/",
+            "lab.example.org/path",
+            "lab.example.org:5000",
+            "lab example.org",
+            "lab.example.org\nevil.example",  # injects a 2nd allocator-url line
+            "localhost",  # no dot: a Cloudflare public hostname is a FQDN
+            ".lab.example.org",
+            "lab.example.org.",
+            "-lab.example.org",
+            "lab..example.org",
+        ],
+    )
+    def test_malformed_public_hostname_is_rejected(self, hostname):
+        """The value is interpolated into "https://{host}" for the canonical-URL
+        file clients are handed, and canonical_base_url accepts anything that
+        merely startswith("https://") — so without this check a pasted scheme
+        yields "https://https://host" that breaks silently."""
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._cfg(public_hostname=hostname))
+        assert [e for e in errors if "public_hostname" in e], (
+            f"{hostname!r} should have been rejected, got {errors}"
+        )
+
+    @pytest.mark.parametrize(
+        "hostname",
+        [
+            "lab.smithlab.org",
+            "lablink-testing.com",
+            "a.b.c.example.org",
+            "lab-1.example.org",
+            "xn--80ak6aa92e.com",  # IDN punycode
+            "LAB.Example.ORG",  # DNS is case-insensitive
+        ],
+    )
+    def test_wellformed_public_hostname_is_accepted(self, hostname):
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        errors = get_config_errors(self._cfg(public_hostname=hostname))
+        assert not [e for e in errors if "public_hostname" in e], (
+            f"{hostname!r} should have been accepted, got {errors}"
+        )
+
+    def test_blank_and_malformed_give_different_guidance(self):
+        """"You left it blank" and "you typed a URL" need different fixes;
+        a single generic message would send the operator the wrong way."""
+        from lablink_allocator_service.validate_config import get_config_errors
+
+        blank = [
+            e for e in get_config_errors(self._cfg(public_hostname="")) if "public_hostname" in e
+        ][0]
+        malformed = [
+            e
+            for e in get_config_errors(self._cfg(public_hostname="https://lab.example.org"))
+            if "public_hostname" in e
+        ][0]
+        assert blank != malformed
+        assert "empty" in blank
+        assert "https://" in malformed
 
     def test_lan_direct_is_rejected_for_cloudflare_too(self):
         """The lan_direct rejection was written for Funnel but argues about

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -191,13 +191,27 @@ def deploy(
         "'tailscale_funnel'; optional on redeploys (the previous value is "
         "carried forward). Manual provider only.",
     ),
+    cloudflare_tunnel_token: str = typer.Option(
+        None,
+        "--cloudflare-tunnel-token",
+        help="Cloudflare Tunnel token for publishing the allocator at "
+        "manual.public_hostname. Required on the first deploy when "
+        "manual.participant_exposure is 'cloudflare_tunnel'; optional on "
+        "redeploys (the previous value is carried forward). Supply it again "
+        "to rotate. Manual provider only.",
+    ),
 ) -> None:
     """Deploy LabLink infrastructure (AWS Terraform or docker-compose)."""
     cfg = _load_cfg(config)
     if cfg.provider == "manual":
         from lablink_cli.commands.deploy_compose import run_deploy_compose
 
-        run_deploy_compose(cfg, yes=yes, tailscale_authkey=tailscale_authkey)
+        run_deploy_compose(
+            cfg,
+            yes=yes,
+            tailscale_authkey=tailscale_authkey,
+            cloudflare_tunnel_token=cloudflare_tunnel_token,
+        )
         return
 
     from lablink_cli.commands.deploy import run_deploy

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -772,24 +772,30 @@ def _print_summary(
     # we could detect one.
     register_url = lan_url or local_url
 
+    # The deployment's one internet-reachable URL, or None. Funnel's has to
+    # be read back out of the sidecar and can be missing even when enabled;
+    # Cloudflare's is just config the admin typed. Everything downstream only
+    # cares whether such a URL exists, so both collapse into one value here
+    # rather than each exposure mode growing its own branch.
+    if funnel_active and funnel_url:
+        public_url = funnel_url
+    elif cfg.manual.participant_exposure == "cloudflare_tunnel":
+        public_url = f"https://{cfg.manual.public_hostname}"
+    else:
+        public_url = None
+
     console.print("\n[bold green]Deployment complete.[/bold green]")
-    if funnel_active:
-        public_url = funnel_url or (
-            "(enabled, but the URL could not be determined — run "
-            f"`docker exec {TAILSCALE_SIDECAR_CONTAINER_NAME} tailscale "
-            "funnel status` to see it)"
-        )
+    if funnel_active and not funnel_url:
         console.print(
-            f"  Allocator URL (public): {public_url}",
+            "  Allocator URL (public): (enabled, but the URL could not be "
+            f"determined — run `docker exec {TAILSCALE_SIDECAR_CONTAINER_NAME} "
+            "tailscale funnel status` to see it)",
             soft_wrap=True,
             highlight=False,
         )
-    # Derived here rather than passed in: unlike Funnel's URL, which has to
-    # be read back out of the sidecar and has an "enabled but unknown"
-    # state, this one is just config the admin typed.
-    if cfg.manual.participant_exposure == "cloudflare_tunnel":
+    elif public_url:
         console.print(
-            f"  Allocator URL (public): https://{cfg.manual.public_hostname}",
+            f"  Allocator URL (public): {public_url}",
             soft_wrap=True,
             highlight=False,
         )
@@ -834,26 +840,27 @@ def _print_summary(
     # allocator's own LAN — mesh_overlay via a Tailscale tailnet,
     # reverse_tunnel by dialing out instead of accepting inbound at all.
     off_lan = mesh_overlay or reverse_tunnel
-    # Only substitute when we actually have the real URL — funnel_active
-    # can be True while funnel_url is None (enable succeeded but the
-    # status lookup didn't match), and a guessed fallback here would be
-    # exactly the wrong URL this function used to print. Gated on off_lan,
-    # not just mesh_overlay: a reverse_tunnel client behind a NAT'd/
-    # firewalled box is just as unreachable at the LAN address, and Funnel
-    # (participant_exposure: tailscale_funnel) is the only way an off-LAN
-    # tunnel client reaches this deployment at all.
-    funnel_url_used = off_lan and funnel_active and bool(funnel_url)
+    # Substitute only when a real public URL exists — funnel_active can be
+    # True while funnel_url is None (enable succeeded but the status lookup
+    # didn't match), and a guessed fallback here would be exactly the wrong
+    # URL this function used to print. Gated on off_lan, not just
+    # mesh_overlay: a reverse_tunnel client behind a NAT'd/firewalled box is
+    # just as unreachable at the LAN address. Gated on public_url rather
+    # than on Funnel specifically, because an off-LAN client cannot reach
+    # the LAN address no matter which exposure mode publishes the
+    # allocator — printing one is how this hint was wrong before.
+    public_url_used = off_lan and bool(public_url)
     # Hoisted above the mesh_overlay/reverse_tunnel branch so both off-LAN
     # modes get the substitution — lan_direct clients genuinely are on the
     # LAN, so their own hint below keeps using register_url as-is.
-    if funnel_url_used:
-        register_url = funnel_url
+    if public_url_used:
+        register_url = public_url
     if mesh_overlay:
         # A mesh-overlay client (e.g. a Run:AI-hosted workload) isn't on
         # the allocator's LAN at all — the LAN URL above is unreachable
-        # from it regardless of whether we detected one. When Funnel is
-        # live, its public URL actually IS reachable from anywhere with
-        # internet access, so prefer it here specifically.
+        # from it regardless of whether we detected one. Whichever exposure
+        # mode is live, its public URL IS reachable from anywhere with
+        # internet access, so prefer that here.
         console.print(
             "\n[bold]Next step:[/bold] for each mesh-overlay client "
             "(e.g. a Run:AI-hosted workload), open a terminal inside "
@@ -891,12 +898,12 @@ def _print_summary(
             "workload submission instead of running here, along with "
             "--hostname/--machine-identity.[/dim]"
         )
-    if not lan_url and not funnel_url_used:
+    if not lan_url and not public_url_used:
         # If we fell back to localhost, the printed command only works
         # for a BYO client *on the operator host*. Call that out so the
         # operator doesn't blindly hand it to a remote teammate. Doesn't
-        # apply when the mesh-overlay hint above already substituted the
-        # Funnel URL instead of falling back to localhost.
+        # apply when the off-LAN hint above already substituted a public
+        # URL instead of falling back to localhost.
         console.print(
             "  [yellow]Note:[/yellow] the URL above is localhost — only "
             "valid for a BYO client running on this same machine. For "

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -340,6 +340,23 @@ def run_deploy_compose(
                 "public hostname in Cloudflare (e.g. lab.smithlab.org)."
             )
             raise SystemExit(1)
+        from lablink_allocator_service.validate_config import (
+            PUBLIC_HOSTNAME_HINT,
+            is_valid_public_hostname,
+        )
+
+        # The value is interpolated into "https://{host}" for the canonical-URL
+        # file clients are handed, and canonical_base_url accepts anything that
+        # merely startswith("https://") — so a pasted scheme yields
+        # "https://https://host" that fails silently rather than loudly.
+        if not is_valid_public_hostname(cfg.manual.public_hostname):
+            console.print(
+                "[red]manual.public_hostname is not a bare hostname.[/red]\n"
+                f"It {PUBLIC_HOSTNAME_HINT}.",
+                highlight=False,
+            )
+            console.print(f"  got: {cfg.manual.public_hostname!r}", highlight=False)
+            raise SystemExit(1)
         previous_cf_token = _read_env_value(target / ".env", "CLOUDFLARE_TUNNEL_TOKEN")
         if not cloudflare_tunnel_token and not previous_cf_token:
             console.print(

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -32,10 +32,6 @@ from lablink_cli.config.schema import Config, save_config
 DEFAULT_COMPOSE_DIR = Path.home() / ".lablink" / "compose"
 DEFAULT_HTTP_PORT = "80"
 HEALTH_POLL_TIMEOUT_SECONDS = 300
-# Shorter than the health poll above on purpose: the stack is already
-# confirmed healthy locally by then, so this only waits on DNS/edge
-# propagation, and a miss is a warning rather than a failure.
-PUBLIC_HOSTNAME_VERIFY_TIMEOUT_SECONDS = 30
 ALLOCATOR_IMAGE_BASE = "ghcr.io/talmolab/lablink-allocator-image"
 # Only ssl=none is supported by the manual-provider compose stack today:
 # the allocator image has no TLS terminator (Caddy is part of the AWS
@@ -490,13 +486,11 @@ def run_deploy_compose(
             _write_canonical_url(target, funnel_url)
     funnel_active = cfg.manual.participant_exposure == "tailscale_funnel" and funnel_ok
 
-    cloudflare_url = None
     if cfg.manual.participant_exposure == "cloudflare_tunnel":
-        cloudflare_url = f"https://{cfg.manual.public_hostname}"
         if not _verify_public_hostname(cfg.manual.public_hostname):
             console.print(
-                f"[yellow]{cloudflare_url} did not answer within "
-                f"{PUBLIC_HOSTNAME_VERIFY_TIMEOUT_SECONDS}s.[/yellow]\n"
+                f"[yellow]https://{cfg.manual.public_hostname} did not "
+                "answer.[/yellow]\n"
                 "The stack is up locally. Common causes: the DNS record is "
                 "still propagating (retry in a few minutes), or the tunnel's "
                 "public hostname in Cloudflare does not point at "
@@ -504,12 +498,7 @@ def run_deploy_compose(
             )
             _print_last_log_lines()
 
-    _print_summary(
-        cfg,
-        funnel_active=funnel_active,
-        funnel_url=funnel_url,
-        cloudflare_url=cloudflare_url,
-    )
+    _print_summary(cfg, funnel_active=funnel_active, funnel_url=funnel_url)
 
     if not funnel_ok:
         raise SystemExit(1)
@@ -522,27 +511,22 @@ def _verify_public_hostname(hostname: str) -> bool:
     Cloudflare edge, the tunnel, nginx and Flask together — checking that
     cloudflared is alive says nothing about whether the edge found it.
 
-    Deliberately advisory. A proxied CNAME created minutes earlier can
-    still be propagating, and the deployment itself is correct in that
-    case — the caller warns rather than failing.
+    Advisory, and deliberately a single attempt rather than a poll: by this
+    point the stack is already confirmed healthy locally, so a failure here
+    is either a still-propagating DNS record or a wrong origin in the
+    Cloudflare dashboard. Neither is something waiting fixes, and the
+    caller only warns — so retrying would just delay the same message.
     """
     url = f"https://{hostname}"
-    console.print(
-        f"[bold]Verifying public hostname {url}/api/health "
-        f"(up to {PUBLIC_HOSTNAME_VERIFY_TIMEOUT_SECONDS}s) …[/bold]"
-    )
-    deadline = time.monotonic() + PUBLIC_HOSTNAME_VERIFY_TIMEOUT_SECONDS
-    while time.monotonic() < deadline:
-        try:
-            if check_health_endpoint(url).get("healthy"):
-                console.print(f"[green]Public hostname is live: {url}[/green]")
-                return True
-        except OSError:
-            # Unresolvable name / refused connection while the record
-            # propagates. Indistinguishable from "not ready yet" here.
-            pass
-        time.sleep(3)
-    return False
+    console.print(f"[bold]Verifying public hostname {url}/api/health …[/bold]")
+    try:
+        healthy = bool(check_health_endpoint(url).get("healthy"))
+    except OSError:
+        # Unresolvable name / refused connection while the record propagates.
+        healthy = False
+    if healthy:
+        console.print(f"[green]Public hostname is live: {url}[/green]")
+    return healthy
 
 
 def _compose_up(target: Path) -> None:
@@ -775,11 +759,7 @@ def _print_last_log_lines(lines: int = 30) -> None:
 
 
 def _print_summary(
-    cfg: Config,
-    *,
-    funnel_active: bool = False,
-    funnel_url: str | None = None,
-    cloudflare_url: str | None = None,
+    cfg: Config, *, funnel_active: bool = False, funnel_url: str | None = None
 ) -> None:
     register_token = _extract_register_token()
     # Manual provider is HTTP-only; preflight rejects anything else.
@@ -804,13 +784,12 @@ def _print_summary(
             soft_wrap=True,
             highlight=False,
         )
-    # Separate from funnel_url rather than folded into it: Funnel has an
-    # "enabled but URL unknown" state (it has to be read back out of the
-    # sidecar) that a Cloudflare hostname, being config the admin typed,
-    # can never be in.
-    if cloudflare_url:
+    # Derived here rather than passed in: unlike Funnel's URL, which has to
+    # be read back out of the sidecar and has an "enabled but unknown"
+    # state, this one is just config the admin typed.
+    if cfg.manual.participant_exposure == "cloudflare_tunnel":
         console.print(
-            f"  Allocator URL (public): {cloudflare_url}",
+            f"  Allocator URL (public): https://{cfg.manual.public_hostname}",
             soft_wrap=True,
             highlight=False,
         )

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -32,6 +32,10 @@ from lablink_cli.config.schema import Config, save_config
 DEFAULT_COMPOSE_DIR = Path.home() / ".lablink" / "compose"
 DEFAULT_HTTP_PORT = "80"
 HEALTH_POLL_TIMEOUT_SECONDS = 300
+# Shorter than the health poll above on purpose: the stack is already
+# confirmed healthy locally by then, so this only waits on DNS/edge
+# propagation, and a miss is a warning rather than a failure.
+PUBLIC_HOSTNAME_VERIFY_TIMEOUT_SECONDS = 30
 ALLOCATOR_IMAGE_BASE = "ghcr.io/talmolab/lablink-allocator-image"
 # Only ssl=none is supported by the manual-provider compose stack today:
 # the allocator image has no TLS terminator (Caddy is part of the AWS
@@ -122,7 +126,11 @@ def _tailscale_state_volume_exists(target: Path) -> bool:
 
 
 def render_compose_dir(
-    cfg: Config, target: Path, *, tailscale_authkey: str | None = None
+    cfg: Config,
+    target: Path,
+    *,
+    tailscale_authkey: str | None = None,
+    cloudflare_tunnel_token: str | None = None,
 ) -> None:
     """Render docker-compose.yml + .env + config.yaml into target.
 
@@ -145,6 +153,11 @@ def render_compose_dir(
     is not persisted in config.yaml (unlike admin/DB creds) — only into
     this deployment's .env, and only for as long as the sidecar needs it
     to join for the first time.
+
+    `cloudflare_tunnel_token` is only meaningful when
+    `cfg.manual.participant_exposure == "cloudflare_tunnel"`, and follows
+    the same rules as `tailscale_authkey`: .env only, carried forward on a
+    redeploy that omits it, overridden when supplied again (rotation).
     """
     target.mkdir(parents=True, exist_ok=True)
     needs_sidecar = _needs_tailscale_sidecar(cfg)
@@ -164,12 +177,25 @@ def render_compose_dir(
     #    instead of blanking out an already-joined sidecar's key.
     env_path = target / ".env"
     previous_authkey = _read_env_value(env_path, "TS_AUTHKEY")
+    previous_cf_token = _read_env_value(env_path, "CLOUDFLARE_TUNNEL_TOKEN")
 
     allocator_image = _allocator_image(cfg)
     env_lines = [
         f"ALLOCATOR_IMAGE={allocator_image}",
         f"HTTP_PORT={DEFAULT_HTTP_PORT}",
+        # Always declared: the compose templates substitute it
+        # unconditionally, and an unset variable makes `docker compose up`
+        # warn on every deploy.
+        f"PARTICIPANT_EXPOSURE={cfg.manual.participant_exposure}",
     ]
+    if cfg.manual.participant_exposure == "cloudflare_tunnel":
+        # Same carry-forward rule as TS_AUTHKEY: a redeploy that omits the
+        # flag keeps the working token, while an explicitly supplied one
+        # wins (that is the rotation path).
+        env_lines.append(
+            f"CLOUDFLARE_TUNNEL_TOKEN="
+            f"{cloudflare_tunnel_token or previous_cf_token or ''}"
+        )
     if needs_sidecar:
         resolved_authkey = tailscale_authkey or previous_authkey or ""
         env_lines.append(f"TS_AUTHKEY={resolved_authkey}")
@@ -207,6 +233,10 @@ def render_compose_dir(
             canonical_target.read_text() if canonical_target.exists() else ""
         )
         canonical_target.write_text(previous_url)
+    elif cfg.manual.participant_exposure == "cloudflare_tunnel":
+        # Known up front — the admin typed it. No after-the-fact write, and
+        # no window where the allocator reports the wrong URL.
+        canonical_target.write_text(f"https://{cfg.manual.public_hostname}")
     else:
         canonical_target.write_text("")
 
@@ -245,6 +275,7 @@ def run_deploy_compose(
     yes: bool = False,
     workdir_root: Path | None = None,
     tailscale_authkey: str | None = None,
+    cloudflare_tunnel_token: str | None = None,
 ) -> None:
     """Bring up the allocator stack via docker-compose.
 
@@ -265,6 +296,11 @@ def run_deploy_compose(
     `lablink destroy`, which wipes the working directory — including
     `.env` — but keeps that volume specifically so this doesn't force a
     needless re-auth).
+    `cloudflare_tunnel_token` is required when
+    `cfg.manual.participant_exposure == "cloudflare_tunnel"`, unless a
+    value is already on record in this deployment's existing `.env`. There
+    is no state-volume equivalent here: the tunnel's identity lives in
+    Cloudflare's account, and the token is the only local copy.
     """
     target = compose_workdir(cfg, workdir_root)
 
@@ -292,6 +328,35 @@ def run_deploy_compose(
                 "and re-run with --tailscale-authkey <key>."
             )
             raise SystemExit(1)
+
+    # Preflight: cloudflare_tunnel needs a hostname and a token. The
+    # hostname is also checked by get_config_errors(), but `lablink deploy`
+    # never calls that validator for the manual provider — this is the
+    # actual enforcement point for a hand-edited config.yaml. Modeled on
+    # the TS_AUTHKEY check above, minus the state-volume clause: there is
+    # no volume here, so "on record in .env" is the whole condition.
+    if cfg.manual.participant_exposure == "cloudflare_tunnel":
+        if not cfg.manual.public_hostname:
+            console.print(
+                "[red]manual.participant_exposure is 'cloudflare_tunnel' but "
+                "manual.public_hostname is empty.[/red]\n"
+                "Set it to the hostname you configured as the tunnel's "
+                "public hostname in Cloudflare (e.g. lab.smithlab.org)."
+            )
+            raise SystemExit(1)
+        previous_cf_token = _read_env_value(target / ".env", "CLOUDFLARE_TUNNEL_TOKEN")
+        if not cloudflare_tunnel_token and not previous_cf_token:
+            console.print(
+                "[red]manual.participant_exposure is 'cloudflare_tunnel' but "
+                "no --cloudflare-tunnel-token was given, and no previous "
+                "value is on record for this deployment.[/red]\n"
+                "Create a tunnel in Cloudflare's Zero Trust dashboard "
+                "(Networks > Tunnels), copy the token from its Docker "
+                "install command, and re-run with "
+                "--cloudflare-tunnel-token <token>."
+            )
+            raise SystemExit(1)
+
     # Preflight: SSL provider must be one the compose template supports.
     # The allocator image has no TLS terminator, so only ssl=none works
     # out of the box. Operators who need TLS run their own reverse proxy
@@ -306,29 +371,29 @@ def run_deploy_compose(
         )
         raise SystemExit(1)
 
-    # Preflight: lan_direct + tailscale_funnel is not a supported
+    # Preflight: lan_direct + any public exposure is not a supported
     # combination. lan_direct sends the participant's browser straight to
     # a client's LAN IP (ws://<client-ip>:6080 — see
     # LANDirectClientConnectivity), bypassing the allocator entirely —
     # unreachable off-LAN and blocked as mixed content once the allocator
-    # itself is Funnel-exposed. mesh_overlay proxies sessions through the
-    # allocator's own nginx instead, which Funnel already exposes.
+    # itself is publicly exposed. mesh_overlay proxies sessions through the
+    # allocator's own nginx instead, which any exposure mode publishes.
     # get_config_errors() also rejects this (catches it in the wizard/
     # `show-config`/`doctor`), but `lablink deploy` never calls that
     # validator for the manual provider — this is the actual enforcement
     # point for a hand-edited config.yaml deployed directly.
     if (
-        cfg.manual.participant_exposure == "tailscale_funnel"
+        cfg.manual.participant_exposure != "none"
         and cfg.manual.connectivity == "lan_direct"
     ):
         console.print(
-            "[red]manual.participant_exposure is 'tailscale_funnel' but "
-            "manual.connectivity is 'lan_direct'.[/red]\n"
+            f"[red]manual.participant_exposure is "
+            f"'{cfg.manual.participant_exposure}' but manual.connectivity is "
+            f"'lan_direct'.[/red]\n"
             "Participant sessions would connect directly to a client's LAN "
             "IP, which is unreachable off-LAN and blocked as mixed content "
-            "from the HTTPS Funnel page. Use manual.connectivity: "
-            "mesh_overlay instead, which proxies sessions through the "
-            "allocator."
+            "from the HTTPS page. Use manual.connectivity: mesh_overlay "
+            "instead, which proxies sessions through the allocator."
         )
         raise SystemExit(1)
 
@@ -349,22 +414,23 @@ def run_deploy_compose(
     cfg.app.admin_user = admin_user
     cfg.app.admin_password = admin_pw
 
-    # Preflight: a Funnel-exposed allocator is scanned by bots within
+    # Preflight: a publicly exposed allocator is scanned by bots within
     # minutes of publication (empirically confirmed 2026-07-22) — refuse
     # to ship a weak/example admin password once that's the case. Placed
     # after resolve_admin_credentials so a value resolved interactively
     # is what actually gets checked, not whatever (possibly empty) value
     # cfg.app.admin_password held before resolution.
-    if cfg.manual.participant_exposure == "tailscale_funnel":
+    if cfg.manual.participant_exposure != "none":
         from lablink_allocator_service.validate_config import is_weak_admin_password
 
         if is_weak_admin_password(admin_pw):
             console.print(
-                "[red]manual.participant_exposure is 'tailscale_funnel' "
-                "but the resolved admin password is empty, a known "
-                "example value, or shorter than 12 characters.[/red]\n"
-                "A Funnel-exposed allocator is reachable from the public "
-                "internet and gets scanned within minutes — set a strong "
+                f"[red]manual.participant_exposure is "
+                f"'{cfg.manual.participant_exposure}' but the resolved admin "
+                "password is empty, a known example value, or shorter than "
+                "12 characters.[/red]\n"
+                "A publicly exposed allocator is reachable from the internet "
+                "and gets scanned within minutes — set a strong "
                 "admin_password (12+ characters, not a common default) "
                 "before deploying."
             )
@@ -382,7 +448,12 @@ def run_deploy_compose(
             console.print("Aborted.")
             raise SystemExit(1)
 
-    render_compose_dir(cfg, target, tailscale_authkey=tailscale_authkey)
+    render_compose_dir(
+        cfg,
+        target,
+        tailscale_authkey=tailscale_authkey,
+        cloudflare_tunnel_token=cloudflare_tunnel_token,
+    )
     console.print(f"[green]Rendered {target}[/green]")
 
     # Explicitly disable Funnel *before* _compose_up, whenever the new
@@ -419,10 +490,59 @@ def run_deploy_compose(
             _write_canonical_url(target, funnel_url)
     funnel_active = cfg.manual.participant_exposure == "tailscale_funnel" and funnel_ok
 
-    _print_summary(cfg, funnel_active=funnel_active, funnel_url=funnel_url)
+    cloudflare_url = None
+    if cfg.manual.participant_exposure == "cloudflare_tunnel":
+        cloudflare_url = f"https://{cfg.manual.public_hostname}"
+        if not _verify_public_hostname(cfg.manual.public_hostname):
+            console.print(
+                f"[yellow]{cloudflare_url} did not answer within "
+                f"{PUBLIC_HOSTNAME_VERIFY_TIMEOUT_SECONDS}s.[/yellow]\n"
+                "The stack is up locally. Common causes: the DNS record is "
+                "still propagating (retry in a few minutes), or the tunnel's "
+                "public hostname in Cloudflare does not point at "
+                "http://localhost:5000."
+            )
+            _print_last_log_lines()
+
+    _print_summary(
+        cfg,
+        funnel_active=funnel_active,
+        funnel_url=funnel_url,
+        cloudflare_url=cloudflare_url,
+    )
 
     if not funnel_ok:
         raise SystemExit(1)
+
+
+def _verify_public_hostname(hostname: str) -> bool:
+    """True if the allocator answers on its public hostname.
+
+    One request over the real public URL proves DNS resolution, the
+    Cloudflare edge, the tunnel, nginx and Flask together — checking that
+    cloudflared is alive says nothing about whether the edge found it.
+
+    Deliberately advisory. A proxied CNAME created minutes earlier can
+    still be propagating, and the deployment itself is correct in that
+    case — the caller warns rather than failing.
+    """
+    url = f"https://{hostname}"
+    console.print(
+        f"[bold]Verifying public hostname {url}/api/health "
+        f"(up to {PUBLIC_HOSTNAME_VERIFY_TIMEOUT_SECONDS}s) …[/bold]"
+    )
+    deadline = time.monotonic() + PUBLIC_HOSTNAME_VERIFY_TIMEOUT_SECONDS
+    while time.monotonic() < deadline:
+        try:
+            if check_health_endpoint(url).get("healthy"):
+                console.print(f"[green]Public hostname is live: {url}[/green]")
+                return True
+        except OSError:
+            # Unresolvable name / refused connection while the record
+            # propagates. Indistinguishable from "not ready yet" here.
+            pass
+        time.sleep(3)
+    return False
 
 
 def _compose_up(target: Path) -> None:
@@ -655,7 +775,11 @@ def _print_last_log_lines(lines: int = 30) -> None:
 
 
 def _print_summary(
-    cfg: Config, *, funnel_active: bool = False, funnel_url: str | None = None
+    cfg: Config,
+    *,
+    funnel_active: bool = False,
+    funnel_url: str | None = None,
+    cloudflare_url: str | None = None,
 ) -> None:
     register_token = _extract_register_token()
     # Manual provider is HTTP-only; preflight rejects anything else.
@@ -677,6 +801,16 @@ def _print_summary(
         )
         console.print(
             f"  Allocator URL (public): {public_url}",
+            soft_wrap=True,
+            highlight=False,
+        )
+    # Separate from funnel_url rather than folded into it: Funnel has an
+    # "enabled but URL unknown" state (it has to be read back out of the
+    # sidecar) that a Cloudflare hostname, being config the admin typed,
+    # can never be in.
+    if cloudflare_url:
+        console.print(
+            f"  Allocator URL (public): {cloudflare_url}",
             soft_wrap=True,
             highlight=False,
         )

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -746,16 +746,40 @@ def _health_poll() -> None:
     raise SystemExit(1)
 
 
+def _redact_secrets(text: str) -> str:
+    """Blank out credential values in container output before printing it.
+
+    Keyed on the variable *name*, not the value's shape: a Cloudflare token
+    is base64-ish and a tailnet auth key is `tskey-`-prefixed, but both are
+    the vendor's to change, whereas the names are ours.
+
+    Needed because `cloudflared` logs its whole environment at INFO on
+    startup. `start.sh` unsets the token before launching it, so a current
+    image never logs it — this is the second layer, covering images built
+    before that change and any other path that echoes a secret.
+    """
+    return re.sub(
+        r"((?:CLOUDFLARE_TUNNEL_TOKEN|TS_AUTHKEY)[=:]|--token[= ])\S+",
+        r"\1<redacted>",
+        text,
+    )
+
+
 def _print_last_log_lines(lines: int = 30) -> None:
     result = subprocess.run(
         ["docker", "logs", "--tail", str(lines), ALLOCATOR_CONTAINER_NAME],
-        capture_output=True,
+        # Merge stderr: the allocator's Python logging goes there (see
+        # _extract_register_token), so capturing the streams separately and
+        # printing only stdout hid the very tracebacks this dump exists to
+        # surface. Merging is also why the redaction above is load-bearing.
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
         text=True,
         check=False,
     )
     if result.stdout:
         console.print("[dim]Last allocator log lines:[/dim]")
-        console.print(result.stdout)
+        console.print(_redact_secrets(result.stdout))
 
 
 def _print_summary(

--- a/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
+++ b/packages/cli/src/lablink_cli/templates/docker-compose-mesh-overlay.yml
@@ -45,6 +45,18 @@ services:
       # Funnel-exposed; the allocator falls back to the request host then.
       - ./allocator-url:/config/allocator-url:ro
       - allocator_pgdata:/var/lib/postgresql
+    environment:
+      # Which participant-exposure mode start.sh should act on. Always
+      # present (compose has no conditionals; an unset variable makes
+      # `docker compose up` warn). The other two modes leave start.sh's
+      # connector block untouched.
+      - PARTICIPANT_EXPOSURE=${PARTICIPANT_EXPOSURE:-none}
+      # Cloudflare Tunnel token, for participant_exposure=cloudflare_tunnel.
+      # Comes from .env (written by `lablink deploy
+      # --cloudflare-tunnel-token`), never from config.yaml — it is a
+      # credential. start.sh exits non-zero if the mode is set and this is
+      # empty, rather than starting an unexposed allocator that looks fine.
+      - CLOUDFLARE_TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN:-}
     ports:
       # The container's nginx listens on :5000 (see lablink-nginx.conf in
       # the allocator package). It is the only listener — there is no TLS

--- a/packages/cli/src/lablink_cli/templates/docker-compose.yml
+++ b/packages/cli/src/lablink_cli/templates/docker-compose.yml
@@ -40,6 +40,18 @@ services:
       # the allocator an identical /config layout.
       - ./allocator-url:/config/allocator-url:ro
       - allocator_pgdata:/var/lib/postgresql
+    environment:
+      # Which participant-exposure mode start.sh should act on. Always
+      # present (compose has no conditionals; an unset variable makes
+      # `docker compose up` warn). The other two modes leave start.sh's
+      # connector block untouched.
+      - PARTICIPANT_EXPOSURE=${PARTICIPANT_EXPOSURE:-none}
+      # Cloudflare Tunnel token, for participant_exposure=cloudflare_tunnel.
+      # Comes from .env (written by `lablink deploy
+      # --cloudflare-tunnel-token`), never from config.yaml — it is a
+      # credential. start.sh exits non-zero if the mode is set and this is
+      # empty, rather than starting an unexposed allocator that looks fine.
+      - CLOUDFLARE_TUNNEL_TOKEN=${CLOUDFLARE_TUNNEL_TOKEN:-}
     ports:
       # The container's nginx listens on :5000 (see lablink-nginx.conf in
       # the allocator package). It is the only listener — there is no TLS

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -290,6 +290,7 @@ class ManualConnectivityScreen(Screen):
         current_exposure = (
             getattr(cfg.manual, "participant_exposure", "none") or "none"
         )
+        current_hostname = getattr(cfg.manual, "public_hostname", "") or ""
 
         yield Header()
         with VerticalScroll():
@@ -343,13 +344,16 @@ class ManualConnectivityScreen(Screen):
             )
             yield Label(
                 "How participants (not clients) reach the allocator when it\n"
-                "isn't on their LAN. Independent of connectivity above — you\n"
-                "can combine either connectivity option with either exposure\n"
-                "option.\n"
+                "isn't on their LAN. Independent of connectivity above.\n"
                 "none: allocator stays LAN-only, as today (default).\n"
-                "tailscale_funnel: publish the allocator itself to\n"
-                "participants over the public internet via Tailscale Funnel —\n"
-                "no Tailscale install needed on their side.",
+                "tailscale_funnel: published at <machine>.<tailnet>.ts.net —\n"
+                "no domain needed, but the hostname is not yours to choose.\n"
+                "cloudflare_tunnel: published at a hostname you choose.\n"
+                "Needs a domain whose nameservers point at Cloudflare, plus a\n"
+                "tunnel token from Cloudflare's Zero Trust dashboard. Note\n"
+                "that Cloudflare decrypts all traffic at its edge, including\n"
+                "admin logins and participant desktop streams; Funnel does\n"
+                "not. See docs/configuration.md for the one-time setup.",
                 classes="step-description",
             )
             with RadioSet(id="participant-exposure-select"):
@@ -364,6 +368,26 @@ class ManualConnectivityScreen(Screen):
                     value=(current_exposure == "tailscale_funnel"),
                     id="participant-exposure-funnel",
                 )
+                yield RadioButton(
+                    "cloudflare_tunnel — publish at a hostname you choose",
+                    value=(current_exposure == "cloudflare_tunnel"),
+                    id="participant-exposure-cloudflare",
+                )
+
+            # Hard-wrapped: .field-label doesn't wrap, so a single long line
+            # widens this screen's virtual width past an 80-column terminal
+            # (the overflow class of bug #399 fixed).
+            yield Label(
+                "Public hostname (cloudflare_tunnel only — the hostname\n"
+                "you configured as the tunnel's public hostname in\n"
+                "Cloudflare, e.g. lab.smithlab.org)",
+                classes="field-label",
+            )
+            yield Input(
+                value=current_hostname,
+                placeholder="lab.smithlab.org",
+                id="public-hostname",
+            )
 
             yield Label("", id="connectivity-error", classes="error")
         with Center():
@@ -393,12 +417,15 @@ class ManualConnectivityScreen(Screen):
 
         rb_exposure = self.query_one("#participant-exposure-select", RadioSet)
         chosen_exposure = "none"
-        if (
-            rb_exposure.pressed_button
-            and rb_exposure.pressed_button.id == "participant-exposure-funnel"
-        ):
+        pressed = rb_exposure.pressed_button
+        if pressed and pressed.id == "participant-exposure-funnel":
             chosen_exposure = "tailscale_funnel"
+        elif pressed and pressed.id == "participant-exposure-cloudflare":
+            chosen_exposure = "cloudflare_tunnel"
         cfg.manual.participant_exposure = chosen_exposure
+        cfg.manual.public_hostname = self.query_one(
+            "#public-hostname", Input
+        ).value.strip()
 
         errors = [
             e for e in validate_config(cfg)
@@ -406,6 +433,9 @@ class ManualConnectivityScreen(Screen):
                 "connectivity" in e
                 or "overlay_tailnet" in e
                 or "participant_exposure" in e
+                # The cloudflare_tunnel hostname error names this field;
+                # omitting it here would let an invalid config through.
+                or "public_hostname" in e
             )
             # admin_password isn't collected until deploy time (resolve_admin_
             # credentials runs in deploy_compose.py, not the wizard) — the

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -504,7 +504,21 @@ class ManualConnectivityScreen(Screen):
             return
         error_label.display = False
 
-        self.app.push_screen(DnsScreen())
+        # The manual path skips DnsScreen: the compose stack reads neither
+        # cfg.dns nor cfg.eip, and reads cfg.ssl.provider only to reject
+        # anything but "none" (SUPPORTED_SSL_FOR_MANUAL in deploy_compose).
+        # Asking for DNS and a TLS provider that the deploy then refuses is
+        # a trap, not a choice.
+        #
+        # Pinning both here is mandatory, not tidiness: SSLConfig.provider
+        # defaults to "letsencrypt", and DnsScreen is the only place the
+        # wizard ever writes cfg.ssl.provider. Skipping it without this
+        # would leave every manual config failing that preflight — and an
+        # inherited AWS config would carry a real domain through too.
+        cfg.ssl.provider = "none"
+        cfg.dns.enabled = False
+
+        self.app.push_screen(StartupScreen())
 
 
 # ---------------------------------------------------------------------------

--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -413,6 +413,10 @@ class ManualConnectivityScreen(Screen):
                 value=current_hostname,
                 placeholder="lab.smithlab.org",
                 id="public-hostname",
+                # Mirrors #overlay-tailnet: the initial state has to be right
+                # before any RadioSet.Changed fires, since re-entering the
+                # wizard on an existing config never touches the radios.
+                disabled=current_exposure != "cloudflare_tunnel",
             )
 
             yield Label("", id="connectivity-error", classes="error")
@@ -430,26 +434,36 @@ class ManualConnectivityScreen(Screen):
         return (rb.pressed_button.id or "") if rb.pressed_button else ""
 
     @on(RadioSet.Changed)
-    def _sync_tailnet_field(self, event: RadioSet.Changed) -> None:
-        """Enable the tailnet field only for the modes that consume it.
+    def _sync_conditional_fields(self, event: RadioSet.Changed) -> None:
+        """Enable each address field only for the modes that consume it.
 
         Driven by BOTH radio sets, not just connectivity: the tailnet is
         required by mesh_overlay *and* by tailscale_funnel exposure, so a
         reverse_tunnel deployment that also publishes itself via Funnel
         still needs one. reverse_tunnel on its own needs no address.
+
+        The two fields are mutually exclusive in practice — Funnel's
+        hostname is Tailscale's to assign and Cloudflare's needs no tailnet
+        — so leaving both editable invites filling in the one that will be
+        ignored. Neither field is *cleared* on switching away: a value the
+        operator already typed is preserved for switching back, and an
+        ignored `public_hostname` is documented as harmless.
         """
         connectivity = {
             "connectivity-mesh-overlay": "mesh_overlay",
             "connectivity-reverse-tunnel": "reverse_tunnel",
         }.get(self._pressed("#connectivity-select"), "lan_direct")
+        pressed_exposure = self._pressed("#participant-exposure-select")
         exposure = (
             "tailscale_funnel"
-            if self._pressed("#participant-exposure-select")
-            == "participant-exposure-funnel"
+            if pressed_exposure == "participant-exposure-funnel"
             else "none"
         )
         self.query_one("#overlay-tailnet", Input).disabled = not _tailnet_needed(
             connectivity, exposure
+        )
+        self.query_one("#public-hostname", Input).disabled = (
+            pressed_exposure != "participant-exposure-cloudflare"
         )
 
     @on(Button.Pressed, "#back")

--- a/packages/cli/tests/test_app.py
+++ b/packages/cli/tests/test_app.py
@@ -534,3 +534,10 @@ class TestClientRegisterCommand:
         kwargs = mock_run.call_args.kwargs
         assert kwargs["overlay_hostname"] == "classroom-gpu-3"
         assert kwargs["tailscale_authkey"] == "tskey-abc"
+
+
+def test_deploy_help_documents_the_cloudflare_token_flag():
+    """CI renders Typer help with ANSI escapes; _plain() strips them."""
+    result = runner.invoke(app, ["deploy", "--help"])
+    assert result.exit_code == 0
+    assert "--cloudflare-tunnel-token" in _plain(result.output)

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2223,6 +2223,44 @@ class TestCloudflareTunnelPreflights:
                 cloudflare_tunnel_token="eyJhIjoiTOKEN",
             )
 
+    @pytest.mark.parametrize(
+        "hostname",
+        [
+            "https://lab.example.org",
+            "lab.example.org/",
+            "lab.example.org:5000",
+            "lab.example.org\nevil.example",
+            "localhost",
+        ],
+    )
+    # Everything downstream of the preflight is patched, including
+    # _health_poll: if this check ever regresses, run_deploy_compose would
+    # otherwise fall through to a real 300s health poll and this test would
+    # hang for five minutes per case instead of failing immediately.
+    @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_malformed_public_hostname_is_rejected(
+        self, mock_up, mock_poll, mock_summary, mock_verify, tmp_path, hostname
+    ):
+        """`lablink deploy` never calls get_config_errors() for the manual
+        provider, so this is the only gate a hand-edited config.yaml passes
+        through. Without it a pasted scheme reaches the allocator-url file as
+        "https://https://host" and every client is handed that."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        with pytest.raises(SystemExit):
+            run_deploy_compose(
+                self._cf_cfg(public_hostname=hostname),
+                yes=True,
+                workdir_root=tmp_path,
+                tailscale_authkey="tskey-abc",
+                cloudflare_tunnel_token="eyJhIjoiTOKEN",
+            )
+        # Rejected before anything starts, not after a half-built stack.
+        mock_up.assert_not_called()
+
     @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
     @patch("lablink_cli.commands.deploy_compose._print_summary")
     @patch("lablink_cli.commands.deploy_compose._health_poll")

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2357,6 +2357,49 @@ class TestVerifyPublicHostname:
         assert _verify_public_hostname("lab.example.org") is False
 
 
+class TestRedactSecretsInLogDump:
+    def test_redacts_token_and_authkey_by_name(self):
+        """cloudflared logs its whole environment at INFO, so the log dump
+        can carry credentials. Keyed on the variable name, since the value
+        formats are the vendors' to change."""
+        from lablink_cli.commands.deploy_compose import _redact_secrets
+
+        raw = (
+            "INF Environmental variables "
+            "map[CLOUDFLARE_TUNNEL_TOKEN:eyJhIjoiZGVhZGJlZWY]\n"
+            "TS_AUTHKEY=tskey-auth-kSecret123\n"
+            "cloudflared tunnel run --token eyJhIjoiZGVhZGJlZWY\n"
+            "ordinary log line, must survive\n"
+        )
+        out = _redact_secrets(raw)
+
+        assert "eyJhIjoiZGVhZGJlZWY" not in out
+        assert "tskey-auth-kSecret123" not in out
+        assert out.count("<redacted>") == 3
+        assert "ordinary log line, must survive" in out
+
+    @patch("lablink_cli.commands.deploy_compose.subprocess.run")
+    def test_dump_merges_stderr_and_redacts(self, mock_run, capsys):
+        """The allocator's Python logging goes to stderr, so the dump has to
+        merge it — which is what makes the redaction load-bearing."""
+        import subprocess
+
+        from lablink_cli.commands.deploy_compose import _print_last_log_lines
+
+        mock_run.return_value = MagicMock(
+            stdout="CLOUDFLARE_TUNNEL_TOKEN:eyJhIjoiLEAKED\nTraceback here\n",
+            returncode=0,
+        )
+        _print_last_log_lines()
+
+        assert mock_run.call_args.kwargs["stderr"] is subprocess.STDOUT
+        out = capsys.readouterr().out
+        assert "eyJhIjoiLEAKED" not in out
+        assert "<redacted>" in out
+        # The whole point of merging stderr: tracebacks must still show.
+        assert "Traceback here" in out
+
+
 class TestVerificationIsAWarningNotAFailure:
     def _cf_cfg(self):
         return _manual_cfg(

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2474,3 +2474,58 @@ class TestReverseTunnelDeploy:
         # ...and the hint is the off-LAN one, not the BYO-box one.
         assert "on the same LAN" not in out
         assert "--no-run-locally" in out
+
+    @pytest.mark.parametrize("connectivity", ["mesh_overlay", "reverse_tunnel"])
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_register_hint_uses_public_url_when_cloudflare_active(
+        self, mock_extract, mock_lan, capsys, connectivity
+    ):
+        """Regression: the substitution above was gated on Funnel, so a
+        cloudflare_tunnel deployment printed the LAN address that an off-LAN
+        client cannot reach — despite a verified public HTTPS URL existing.
+        Both off-LAN connectivity modes are affected; mesh_overlay +
+        cloudflare_tunnel is this feature's own documented example."""
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        token = "abc123def456ghi789jklmnop"
+        mock_extract.return_value = token
+        mock_lan.return_value = "192.168.1.42"
+
+        _print_summary(
+            _manual_cfg(
+                connectivity=connectivity,
+                overlay_tailnet="example.ts.net",
+                participant_exposure="cloudflare_tunnel",
+                public_hostname="lab.example.org",
+            )
+        )
+
+        out = capsys.readouterr().out
+        assert (
+            f"--allocator-url https://lab.example.org --register-token {token}" in out
+        )
+        assert "--allocator-url http://192.168.1.42" not in out
+
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_lan_direct_hint_keeps_the_lan_url(self, mock_extract, mock_lan, capsys):
+        """The substitution must stay scoped to off-LAN clients: a lan_direct
+        BYO box genuinely is on the LAN, so it keeps the LAN address. (This
+        config is preflight-rejected at deploy time; _print_summary is
+        checked directly to pin the branch.)"""
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        mock_extract.return_value = "abc123def456ghi789jklmnop"
+        mock_lan.return_value = "192.168.1.42"
+
+        _print_summary(
+            _manual_cfg(
+                participant_exposure="cloudflare_tunnel",
+                public_hostname="lab.example.org",
+            )
+        )
+
+        out = capsys.readouterr().out
+        assert "--allocator-url http://192.168.1.42" in out
+        assert "--allocator-url https://lab.example.org" not in out

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2337,20 +2337,20 @@ class TestVerifyPublicHostname:
         # One check proves DNS + Cloudflare edge + tunnel + nginx + Flask.
         assert mock_check.call_args[0][0] == "https://lab.example.org"
 
-    @patch("lablink_cli.commands.deploy_compose.time.sleep")
     @patch("lablink_cli.commands.deploy_compose.check_health_endpoint")
-    def test_returns_false_after_the_timeout(self, mock_check, mock_sleep):
+    def test_returns_false_on_a_miss_without_retrying(self, mock_check):
+        """A single attempt: the caller only warns, so retrying would delay
+        the same message rather than change it."""
         from lablink_cli.commands.deploy_compose import _verify_public_hostname
 
         mock_check.return_value = {"healthy": False}
         assert _verify_public_hostname("lab.example.org") is False
-        assert mock_check.call_count > 1, "must retry, not give up on one miss"
+        assert mock_check.call_count == 1
 
-    @patch("lablink_cli.commands.deploy_compose.time.sleep")
     @patch("lablink_cli.commands.deploy_compose.check_health_endpoint")
-    def test_survives_a_raising_check(self, mock_check, mock_sleep):
+    def test_survives_a_raising_check(self, mock_check):
         """DNS for a brand-new record may not resolve yet; a raised
-        exception must be a retry, not a crashed deploy."""
+        exception must be a warning, not a crashed deploy."""
         from lablink_cli.commands.deploy_compose import _verify_public_hostname
 
         mock_check.side_effect = OSError("name or service not known")
@@ -2388,27 +2388,25 @@ class TestVerificationIsAWarningNotAFailure:
         )
         mock_summary.assert_called_once()
 
-    @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
-    @patch("lablink_cli.commands.deploy_compose._print_summary")
-    @patch("lablink_cli.commands.deploy_compose._health_poll")
-    @patch("lablink_cli.commands.deploy_compose._compose_up")
-    def test_summary_receives_the_public_url(
-        self, mock_up, mock_poll, mock_summary, mock_verify, tmp_path
-    ):
-        from lablink_cli.commands.deploy_compose import run_deploy_compose
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_summary_prints_the_public_url(self, mock_extract, mock_lan, capsys):
+        """The URL is derived from cfg inside _print_summary rather than
+        threaded in as a parameter, so the summary is what pins it down."""
+        from lablink_cli.commands.deploy_compose import _print_summary
 
-        mock_verify.return_value = True
-        run_deploy_compose(
-            self._cf_cfg(),
-            yes=True,
-            workdir_root=tmp_path,
-            tailscale_authkey="tskey-abc",
-            cloudflare_tunnel_token="eyJhIjoiTOKEN",
-        )
+        mock_extract.return_value = "abc123def456ghi789jklmnop"
+        mock_lan.return_value = "192.168.1.42"
+
+        _print_summary(self._cf_cfg())
         assert (
-            mock_summary.call_args.kwargs["cloudflare_url"]
-            == "https://lab.example.org"
+            "Allocator URL (public): https://lab.example.org"
+            in capsys.readouterr().out
         )
+
+        # ...and only for this mode.
+        _print_summary(_manual_cfg(participant_exposure="none"))
+        assert "URL (public)" not in capsys.readouterr().out
 
     @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
     @patch("lablink_cli.commands.deploy_compose._print_summary")

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -19,6 +19,7 @@ def _manual_cfg(
     connectivity="lan_direct",
     overlay_tailnet="",
     participant_exposure="none",
+    public_hostname="",
 ):
     cfg = Config()
     cfg.provider = "manual"
@@ -30,6 +31,7 @@ def _manual_cfg(
     cfg.manual.connectivity = connectivity
     cfg.manual.overlay_tailnet = overlay_tailnet
     cfg.manual.participant_exposure = participant_exposure
+    cfg.manual.public_hostname = public_hostname
     return cfg
 
 
@@ -485,11 +487,11 @@ class TestDeployComposeParticipantExposurePreflight:
     @patch("lablink_cli.commands.deploy_compose._print_summary")
     @patch("lablink_cli.commands.deploy_compose._health_poll")
     @patch("lablink_cli.commands.deploy_compose._compose_up")
-    def test_weak_password_irrelevant_when_funnel_disabled(
+    def test_weak_password_irrelevant_when_exposure_is_none(
         self, mock_up, mock_poll, mock_summary, tmp_path
     ):
-        """The password gate is scoped to tailscale_funnel — an ordinary
-        lan_direct deployment must not be newly blocked by it."""
+        """The password gate is scoped to any public exposure, not to one
+        tunnel — an unexposed lan_direct deployment must not be blocked."""
         from lablink_cli.commands.deploy_compose import run_deploy_compose
 
         cfg = _manual_cfg(connectivity="lan_direct", admin_password="123456")
@@ -2004,3 +2006,422 @@ class TestCanonicalUrlFile:
             cfg, yes=True, workdir_root=tmp_path, tailscale_authkey="tskey-abc"
         )
         assert "https://known.example.ts.net" in (target / "allocator-url").read_text()
+
+
+class TestRenderComposeDirCloudflareTunnel:
+    def test_env_carries_mode_and_token(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            overlay_tailnet="example.ts.net",
+            participant_exposure="cloudflare_tunnel",
+            public_hostname="lab.example.org",
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(
+            cfg,
+            target,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiTOKEN",
+        )
+
+        env_content = (target / ".env").read_text()
+        assert "PARTICIPANT_EXPOSURE=cloudflare_tunnel" in env_content
+        assert "CLOUDFLARE_TUNNEL_TOKEN=eyJhIjoiTOKEN" in env_content
+
+    def test_env_always_declares_the_mode(self, tmp_path):
+        """Compose templates have no conditionals, so the key must exist on
+        every render or `docker compose up` warns about an unset variable."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(participant_exposure="none")
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target)
+
+        env_content = (target / ".env").read_text()
+        assert "PARTICIPANT_EXPOSURE=none" in env_content
+        assert "CLOUDFLARE_TUNNEL_TOKEN" not in env_content
+
+    def test_token_is_carried_forward_when_flag_omitted(self, tmp_path):
+        """Mirrors TS_AUTHKEY: a redeploy without the flag must not blank
+        out a working token."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            overlay_tailnet="example.ts.net",
+            participant_exposure="cloudflare_tunnel",
+            public_hostname="lab.example.org",
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(
+            cfg,
+            target,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiFIRST",
+        )
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-abc")
+
+        assert "CLOUDFLARE_TUNNEL_TOKEN=eyJhIjoiFIRST" in (target / ".env").read_text()
+
+    def test_new_token_overrides_the_carried_one(self, tmp_path):
+        """Rotation path: an explicitly supplied token must win."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            overlay_tailnet="example.ts.net",
+            participant_exposure="cloudflare_tunnel",
+            public_hostname="lab.example.org",
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(
+            cfg,
+            target,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiOLD",
+        )
+        render_compose_dir(
+            cfg,
+            target,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiNEW",
+        )
+
+        env_content = (target / ".env").read_text()
+        assert "CLOUDFLARE_TUNNEL_TOKEN=eyJhIjoiNEW" in env_content
+        assert "eyJhIjoiOLD" not in env_content
+
+    def test_canonical_url_written_at_render_time(self, tmp_path):
+        """Unlike Funnel, the hostname is known before anything starts, so
+        there is no after-the-fact write."""
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            render_compose_dir,
+        )
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            overlay_tailnet="example.ts.net",
+            participant_exposure="cloudflare_tunnel",
+            public_hostname="lab.example.org",
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(
+            cfg,
+            target,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiTOKEN",
+        )
+
+        assert (
+            target / CANONICAL_URL_FILENAME
+        ).read_text() == "https://lab.example.org"
+
+    def test_switching_away_clears_the_canonical_url(self, tmp_path):
+        """A stale public URL handed to clients is worse than none."""
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            render_compose_dir,
+        )
+
+        target = tmp_path / "compose"
+        render_compose_dir(
+            _manual_cfg(
+                connectivity="mesh_overlay",
+                overlay_tailnet="example.ts.net",
+                participant_exposure="cloudflare_tunnel",
+                public_hostname="lab.example.org",
+            ),
+            target,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiTOKEN",
+        )
+        render_compose_dir(_manual_cfg(participant_exposure="none"), target)
+
+        assert (target / CANONICAL_URL_FILENAME).read_text() == ""
+
+    def test_no_extra_compose_service_is_rendered(self, tmp_path):
+        """The connector runs inside the allocator container, so the
+        template count stays at two and no sidecar appears."""
+        from lablink_cli.commands.deploy_compose import render_compose_dir
+
+        cfg = _manual_cfg(
+            connectivity="lan_direct",
+            participant_exposure="cloudflare_tunnel",
+            public_hostname="lab.example.org",
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target, cloudflare_tunnel_token="eyJhIjoiTOKEN")
+
+        compose_yaml = (target / "docker-compose.yml").read_text()
+        assert "cloudflared:" not in compose_yaml
+        assert "PARTICIPANT_EXPOSURE" in compose_yaml
+        assert "CLOUDFLARE_TUNNEL_TOKEN" in compose_yaml
+
+
+class TestFunnelCanonicalUrlUnchanged:
+    def test_funnel_still_preserves_the_previous_url(self, tmp_path):
+        """Regression guard: Funnel's URL is unknown until _enable_funnel
+        runs, so render must preserve whatever is already there."""
+        from lablink_cli.commands.deploy_compose import (
+            CANONICAL_URL_FILENAME,
+            render_compose_dir,
+        )
+
+        cfg = _manual_cfg(
+            connectivity="mesh_overlay",
+            overlay_tailnet="example.ts.net",
+            participant_exposure="tailscale_funnel",
+        )
+        target = tmp_path / "compose"
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-abc")
+        (target / CANONICAL_URL_FILENAME).write_text("https://box.example.ts.net")
+        render_compose_dir(cfg, target, tailscale_authkey="tskey-abc")
+
+        assert (
+            target / CANONICAL_URL_FILENAME
+        ).read_text() == "https://box.example.ts.net"
+
+
+class TestCloudflareTunnelPreflights:
+    def _cf_cfg(self, **kw):
+        return _manual_cfg(
+            connectivity="mesh_overlay",
+            overlay_tailnet="example.ts.net",
+            participant_exposure="cloudflare_tunnel",
+            public_hostname=kw.pop("public_hostname", "lab.example.org"),
+            # _manual_cfg's default ("pw") is weak, and the exposure
+            # password gate would then be what raises in every test here.
+            admin_password=kw.pop("admin_password", "a-strong-password-1"),
+            **kw,
+        )
+
+    def test_first_deploy_without_token_is_rejected(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        with pytest.raises(SystemExit):
+            run_deploy_compose(
+                self._cf_cfg(),
+                yes=True,
+                workdir_root=tmp_path,
+                # Supplied so the sidecar's own authkey preflight can't be
+                # what raises — this test is about the tunnel token.
+                tailscale_authkey="tskey-abc",
+            )
+
+    def test_empty_public_hostname_is_rejected(self, tmp_path):
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        with pytest.raises(SystemExit):
+            run_deploy_compose(
+                self._cf_cfg(public_hostname=""),
+                yes=True,
+                workdir_root=tmp_path,
+                tailscale_authkey="tskey-abc",
+                cloudflare_tunnel_token="eyJhIjoiTOKEN",
+            )
+
+    @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_first_deploy_with_token_proceeds(
+        self, mock_up, mock_poll, mock_summary, mock_verify, tmp_path
+    ):
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        mock_verify.return_value = True
+        run_deploy_compose(
+            self._cf_cfg(),
+            yes=True,
+            workdir_root=tmp_path,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiTOKEN",
+        )
+        mock_up.assert_called_once()
+
+    @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_redeploy_without_token_uses_the_recorded_one(
+        self, mock_up, mock_poll, mock_summary, mock_verify, tmp_path
+    ):
+        """The token is on record in .env from the first deploy, so the
+        preflight must not demand it again."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        mock_verify.return_value = True
+        run_deploy_compose(
+            self._cf_cfg(),
+            yes=True,
+            workdir_root=tmp_path,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiTOKEN",
+        )
+        run_deploy_compose(
+            self._cf_cfg(),
+            yes=True,
+            workdir_root=tmp_path,
+            tailscale_authkey="tskey-abc",
+        )
+        assert mock_up.call_count == 2
+
+    def test_lan_direct_is_rejected(self, tmp_path):
+        """Same reasoning as lan_direct + Funnel: participant sessions would
+        point at a client's LAN IP, mixed-content-blocked from HTTPS."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cfg = _manual_cfg(
+            connectivity="lan_direct",
+            participant_exposure="cloudflare_tunnel",
+            public_hostname="lab.example.org",
+        )
+        with pytest.raises(SystemExit):
+            run_deploy_compose(
+                cfg,
+                yes=True,
+                workdir_root=tmp_path,
+                cloudflare_tunnel_token="eyJhIjoiTOKEN",
+            )
+
+    def test_weak_admin_password_is_rejected(self, tmp_path):
+        """A publicly exposed allocator is bot-scanned within minutes,
+        whichever tunnel publishes it."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cfg = self._cf_cfg(admin_password="123456")
+        with pytest.raises(SystemExit):
+            run_deploy_compose(
+                cfg,
+                yes=True,
+                workdir_root=tmp_path,
+                tailscale_authkey="tskey-abc",
+                cloudflare_tunnel_token="eyJhIjoiTOKEN",
+            )
+
+    @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    @patch("lablink_cli.commands.deploy_compose._disable_funnel")
+    def test_no_funnel_disable_dance_for_this_mode(
+        self, mock_disable, mock_up, mock_poll, mock_summary, mock_verify, tmp_path
+    ):
+        """_disable_funnel is still called (exposure isn't tailscale_funnel),
+        which is correct — it clears any Funnel state left in a preserved
+        sidecar volume. What must NOT happen is _enable_funnel running."""
+        from lablink_cli.commands import deploy_compose
+
+        mock_verify.return_value = True
+        with patch.object(deploy_compose, "_enable_funnel") as mock_enable:
+            deploy_compose.run_deploy_compose(
+                self._cf_cfg(),
+                yes=True,
+                workdir_root=tmp_path,
+                tailscale_authkey="tskey-abc",
+                cloudflare_tunnel_token="eyJhIjoiTOKEN",
+            )
+        mock_enable.assert_not_called()
+
+
+class TestVerifyPublicHostname:
+    @patch("lablink_cli.commands.deploy_compose.check_health_endpoint")
+    def test_returns_true_when_the_hostname_answers(self, mock_check):
+        from lablink_cli.commands.deploy_compose import _verify_public_hostname
+
+        mock_check.return_value = {"healthy": True}
+        assert _verify_public_hostname("lab.example.org") is True
+        # One check proves DNS + Cloudflare edge + tunnel + nginx + Flask.
+        assert mock_check.call_args[0][0] == "https://lab.example.org"
+
+    @patch("lablink_cli.commands.deploy_compose.time.sleep")
+    @patch("lablink_cli.commands.deploy_compose.check_health_endpoint")
+    def test_returns_false_after_the_timeout(self, mock_check, mock_sleep):
+        from lablink_cli.commands.deploy_compose import _verify_public_hostname
+
+        mock_check.return_value = {"healthy": False}
+        assert _verify_public_hostname("lab.example.org") is False
+        assert mock_check.call_count > 1, "must retry, not give up on one miss"
+
+    @patch("lablink_cli.commands.deploy_compose.time.sleep")
+    @patch("lablink_cli.commands.deploy_compose.check_health_endpoint")
+    def test_survives_a_raising_check(self, mock_check, mock_sleep):
+        """DNS for a brand-new record may not resolve yet; a raised
+        exception must be a retry, not a crashed deploy."""
+        from lablink_cli.commands.deploy_compose import _verify_public_hostname
+
+        mock_check.side_effect = OSError("name or service not known")
+        assert _verify_public_hostname("lab.example.org") is False
+
+
+class TestVerificationIsAWarningNotAFailure:
+    def _cf_cfg(self):
+        return _manual_cfg(
+            connectivity="mesh_overlay",
+            overlay_tailnet="example.ts.net",
+            participant_exposure="cloudflare_tunnel",
+            public_hostname="lab.example.org",
+            admin_password="a-strong-password-1",
+        )
+
+    @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_unreachable_hostname_does_not_exit_nonzero(
+        self, mock_up, mock_poll, mock_summary, mock_verify, tmp_path
+    ):
+        """A fresh proxied CNAME can still be propagating. The stack is up
+        and correct; warn, don't fail."""
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        mock_verify.return_value = False
+        run_deploy_compose(
+            self._cf_cfg(),
+            yes=True,
+            workdir_root=tmp_path,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiTOKEN",
+        )
+        mock_summary.assert_called_once()
+
+    @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_summary_receives_the_public_url(
+        self, mock_up, mock_poll, mock_summary, mock_verify, tmp_path
+    ):
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        mock_verify.return_value = True
+        run_deploy_compose(
+            self._cf_cfg(),
+            yes=True,
+            workdir_root=tmp_path,
+            tailscale_authkey="tskey-abc",
+            cloudflare_tunnel_token="eyJhIjoiTOKEN",
+        )
+        assert (
+            mock_summary.call_args.kwargs["cloudflare_url"]
+            == "https://lab.example.org"
+        )
+
+    @patch("lablink_cli.commands.deploy_compose._verify_public_hostname")
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_not_called_for_other_exposure_modes(
+        self, mock_up, mock_poll, mock_summary, mock_verify, tmp_path
+    ):
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        run_deploy_compose(
+            _manual_cfg(participant_exposure="none"),
+            yes=True,
+            workdir_root=tmp_path,
+        )
+        mock_verify.assert_not_called()

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import asyncio
 
+import pytest
+
 
 def _drive_monitoring_toggle(initial_enabled: bool, click_enabled: bool) -> bool:
     """Drive MonitoringScreen, return cfg.monitoring.enabled after Next.
@@ -768,6 +770,103 @@ def test_connectivity_screen_blocks_cloudflare_without_hostname():
     )
     assert cfg.manual.participant_exposure == "cloudflare_tunnel"
     assert stack_delta == 0, "invalid submission must not push the next screen"
+
+
+def _hostname_field_disabled(*, select_exposure=None, preset_exposure="none"):
+    """Return #public-hostname's disabled state on ManualConnectivityScreen.
+
+    `preset_exposure` seeds the config (re-entering the wizard on an existing
+    config, where no radio is ever touched); `select_exposure` presses a radio
+    button id instead, exercising the RadioSet.Changed handler.
+    """
+    import asyncio
+    from textual.widgets import Input, RadioButton, RadioSet
+
+    cfg, app = _build_cfg_and_app()
+    cfg.provider = "manual"
+    cfg.manual.participant_exposure = preset_exposure
+
+    async def _run():
+        from lablink_cli.tui.wizard import ManualConnectivityScreen
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = ManualConnectivityScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            if select_exposure is not None:
+                for btn in screen.query_one(
+                    "#participant-exposure-select", RadioSet
+                ).query(RadioButton):
+                    if btn.id == select_exposure:
+                        btn.value = True
+                await pilot.pause()
+            return screen.query_one("#public-hostname", Input).disabled
+
+    return asyncio.run(_run())
+
+
+@pytest.mark.parametrize(
+    "radio_id,expected_disabled",
+    [
+        ("participant-exposure-none", True),
+        ("participant-exposure-funnel", True),
+        ("participant-exposure-cloudflare", False),
+    ],
+)
+def test_public_hostname_enabled_only_for_cloudflare(radio_id, expected_disabled):
+    """Funnel's hostname is Tailscale's to assign, so an editable
+    public_hostname there invites filling in a field that is then ignored."""
+    assert _hostname_field_disabled(select_exposure=radio_id) is expected_disabled
+
+
+@pytest.mark.parametrize(
+    "preset,expected_disabled",
+    [("none", True), ("tailscale_funnel", True), ("cloudflare_tunnel", False)],
+)
+def test_public_hostname_initial_state_matches_existing_config(
+    preset, expected_disabled
+):
+    """Re-entering `lablink configure` on an existing config never touches a
+    radio, so RadioSet.Changed never fires — compose() has to get it right."""
+    assert _hostname_field_disabled(preset_exposure=preset) is expected_disabled
+
+
+def test_switching_exposure_preserves_a_typed_hostname():
+    """Disabling must not clear: an operator who mis-clicks Funnel and comes
+    back shouldn't have to retype the hostname."""
+    import asyncio
+    from textual.widgets import Input, RadioButton, RadioSet
+
+    cfg, app = _build_cfg_and_app()
+    cfg.provider = "manual"
+
+    async def _run():
+        from lablink_cli.tui.wizard import ManualConnectivityScreen
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = ManualConnectivityScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            field = screen.query_one("#public-hostname", Input)
+            radios = screen.query_one("#participant-exposure-select", RadioSet)
+
+            def press(target):
+                for btn in radios.query(RadioButton):
+                    if btn.id == target:
+                        btn.value = True
+
+            press("participant-exposure-cloudflare")
+            await pilot.pause()
+            field.value = "lab.example.org"
+            press("participant-exposure-funnel")
+            await pilot.pause()
+            return field.disabled, field.value
+
+    disabled, value = asyncio.run(_run())
+    assert disabled is True
+    assert value == "lab.example.org"
 
 
 # ---------------------------------------------------------------------------

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -582,7 +582,7 @@ def test_connectivity_screen_defaults_to_lan_direct():
     )
     assert connectivity == "lan_direct"
     assert exposure == "none"
-    assert stack_delta == 1, "valid submission should push DnsScreen"
+    assert stack_delta == 1, "valid submission should push the next screen"
 
 
 def test_connectivity_screen_writes_mesh_overlay_and_tailnet():
@@ -592,7 +592,7 @@ def test_connectivity_screen_writes_mesh_overlay_and_tailnet():
     assert connectivity == "mesh_overlay"
     assert tailnet == "example.ts.net"
     assert exposure == "none"
-    assert stack_delta == 1, "valid submission should push DnsScreen"
+    assert stack_delta == 1, "valid submission should push the next screen"
 
 
 def test_connectivity_screen_blocks_next_when_tailnet_missing():
@@ -609,7 +609,7 @@ def test_connectivity_screen_writes_reverse_tunnel():
         choose_mesh_overlay=False, choose_reverse_tunnel=True
     )
     assert connectivity == "reverse_tunnel"
-    assert stack_delta == 1, "valid submission should push DnsScreen"
+    assert stack_delta == 1, "valid submission should push the next screen"
 
 
 def test_reverse_tunnel_needs_no_extra_fields():
@@ -700,7 +700,7 @@ def test_connectivity_screen_writes_tailscale_funnel_independent_of_connectivity
     assert connectivity == "mesh_overlay"
     assert exposure == "tailscale_funnel"
     assert tailnet == "example.ts.net"
-    assert stack_delta == 1, "valid submission should push DnsScreen"
+    assert stack_delta == 1, "valid submission should push the next screen"
 
 
 def test_connectivity_screen_blocks_lan_direct_with_funnel():
@@ -753,7 +753,7 @@ def test_connectivity_screen_writes_cloudflare_tunnel_and_hostname():
     )
     assert cfg.manual.participant_exposure == "cloudflare_tunnel"
     assert cfg.manual.public_hostname == "lab.example.org"
-    assert stack_delta == 1, "valid submission should push DnsScreen"
+    assert stack_delta == 1, "valid submission should push the next screen"
 
 
 def test_connectivity_screen_blocks_cloudflare_without_hostname():
@@ -767,7 +767,90 @@ def test_connectivity_screen_blocks_cloudflare_without_hostname():
         public_hostname="",
     )
     assert cfg.manual.participant_exposure == "cloudflare_tunnel"
-    assert stack_delta == 0, "invalid submission must not push DnsScreen"
+    assert stack_delta == 0, "invalid submission must not push the next screen"
+
+
+# ---------------------------------------------------------------------------
+# The manual path skips DNS/SSL
+# ---------------------------------------------------------------------------
+def _advance_past_connectivity(preset_ssl=None, preset_dns_enabled=None):
+    """Submit a valid ManualConnectivityScreen, return (top screen name, cfg).
+
+    Optional presets simulate a config carried over from the AWS path, where
+    ssl/dns were really configured.
+    """
+    import asyncio
+
+    cfg, app = _build_cfg_and_app()
+    cfg.provider = "manual"
+    if preset_ssl is not None:
+        cfg.ssl.provider = preset_ssl
+    if preset_dns_enabled is not None:
+        cfg.dns.enabled = preset_dns_enabled
+
+    async def _run():
+        from lablink_cli.tui.wizard import ManualConnectivityScreen
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.push_screen(ManualConnectivityScreen())
+            await pilot.pause()
+            app.screen_stack[-1]._next()
+            await pilot.pause()
+            return type(app.screen_stack[-1]).__name__, cfg
+
+    return asyncio.run(_run())
+
+
+def test_manual_path_skips_the_dns_ssl_screen():
+    """Nothing in the compose stack reads cfg.dns or cfg.eip, and
+    cfg.ssl.provider is read only to reject anything but 'none'. Offering
+    those choices to a manual operator is a trap, not a configuration."""
+    top, _ = _advance_past_connectivity()
+    assert top == "StartupScreen", f"manual path should skip DnsScreen, got {top}"
+
+
+def test_manual_path_pins_ssl_none_and_disables_dns():
+    """Mandatory, not cosmetic: SSLConfig.provider defaults to 'letsencrypt'
+    and DnsScreen is the only place the wizard writes cfg.ssl.provider, so
+    skipping that screen without pinning here leaves every manual config
+    failing deploy_compose's SUPPORTED_SSL_FOR_MANUAL preflight."""
+    _, cfg = _advance_past_connectivity()
+    assert cfg.ssl.provider == "none"
+    assert cfg.dns.enabled is False
+
+
+def test_manual_path_overrides_an_inherited_aws_dns_config():
+    """Switching an existing AWS config to manual must not carry its real
+    TLS provider and domain through — there is no longer a screen on which
+    to turn them off."""
+    _, cfg = _advance_past_connectivity(
+        preset_ssl="letsencrypt", preset_dns_enabled=True
+    )
+    assert cfg.ssl.provider == "none"
+    assert cfg.dns.enabled is False
+
+
+def test_aws_path_still_reaches_the_dns_ssl_screen():
+    """Regression guard: the skip above must be scoped to the manual path.
+    The AWS path genuinely provisions DNS and TLS via Terraform."""
+    import asyncio
+
+    cfg, app = _build_cfg_and_app()
+    cfg.provider = "aws"
+
+    async def _run():
+        from lablink_cli.tui.wizard import MachineScreen
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            app.push_screen(MachineScreen())
+            await pilot.pause()
+            app.screen_stack[-1]._next()
+            await pilot.pause()
+            return type(app.screen_stack[-1]).__name__
+
+    assert asyncio.run(_run()) == "DnsScreen"
 
 
 def test_connectivity_screen_blocks_lan_direct_with_cloudflare():

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -490,22 +490,26 @@ def test_dns_advanced_eip_radio_is_scrollable_into_view():
 # ---------------------------------------------------------------------------
 # ManualConnectivityScreen
 # ---------------------------------------------------------------------------
-def _drive_connectivity_screen(
+def _drive_connectivity_screen_cfg(
     *,
     choose_mesh_overlay: bool,
     overlay_tailnet: str = "",
     choose_funnel: bool = False,
+    choose_cloudflare: bool = False,
+    public_hostname: str = "",
 ):
-    """Push ManualConnectivityScreen directly, drive it, return
-    (cfg.manual.connectivity, cfg.manual.overlay_tailnet,
-    cfg.manual.participant_exposure, screen_stack_grew)."""
+    """Push ManualConnectivityScreen, drive it, return (cfg, stack_delta).
+
+    The 4-tuple wrapper below predates the third exposure mode; new cases
+    read fields off cfg directly instead of growing the tuple.
+    """
     import asyncio
     from textual.widgets import Input, RadioButton, RadioSet
 
     cfg, app = _build_cfg_and_app()
     cfg.provider = "manual"
 
-    async def _run() -> tuple[str, str, str, int]:
+    async def _run():
         from lablink_cli.tui.wizard import ManualConnectivityScreen
 
         async with app.run_test() as pilot:
@@ -520,29 +524,45 @@ def _drive_connectivity_screen(
                 for btn in radio_set.query(RadioButton):
                     if btn.id == "connectivity-mesh-overlay":
                         btn.value = True
-                screen.query_one("#overlay-tailnet", Input).value = overlay_tailnet
+            screen.query_one("#overlay-tailnet", Input).value = overlay_tailnet
+
+            target_id = None
             if choose_funnel:
+                target_id = "participant-exposure-funnel"
+            elif choose_cloudflare:
+                target_id = "participant-exposure-cloudflare"
+            if target_id:
                 exposure_set = screen.query_one(
                     "#participant-exposure-select", RadioSet
                 )
                 for btn in exposure_set.query(RadioButton):
-                    if btn.id == "participant-exposure-funnel":
+                    if btn.id == target_id:
                         btn.value = True
-                if not choose_mesh_overlay:
-                    screen.query_one(
-                        "#overlay-tailnet", Input
-                    ).value = overlay_tailnet
+            if choose_cloudflare:
+                screen.query_one("#public-hostname", Input).value = public_hostname
+
             await pilot.pause()
             screen._next()
             await pilot.pause()
-            return (
-                cfg.manual.connectivity,
-                cfg.manual.overlay_tailnet,
-                cfg.manual.participant_exposure,
-                len(app.screen_stack) - stack_before,
-            )
+            return cfg, len(app.screen_stack) - stack_before
 
     return asyncio.run(_run())
+
+
+def _drive_connectivity_screen(
+    *, choose_mesh_overlay: bool, overlay_tailnet: str = "", choose_funnel: bool = False
+):
+    cfg, delta = _drive_connectivity_screen_cfg(
+        choose_mesh_overlay=choose_mesh_overlay,
+        overlay_tailnet=overlay_tailnet,
+        choose_funnel=choose_funnel,
+    )
+    return (
+        cfg.manual.connectivity,
+        cfg.manual.overlay_tailnet,
+        cfg.manual.participant_exposure,
+        delta,
+    )
 
 
 def test_connectivity_screen_defaults_to_lan_direct():
@@ -693,3 +713,51 @@ def test_connectivity_screen_funnel_does_not_block_on_unset_admin_password():
         "a real requirement (tailnet) blocks progression; an unset "
         "admin_password (not yet collected at this wizard stage) must not"
     )
+
+
+def test_connectivity_screen_writes_cloudflare_tunnel_and_hostname():
+    cfg, stack_delta = _drive_connectivity_screen_cfg(
+        choose_mesh_overlay=True,
+        overlay_tailnet="example.ts.net",
+        choose_cloudflare=True,
+        public_hostname="lab.example.org",
+    )
+    assert cfg.manual.participant_exposure == "cloudflare_tunnel"
+    assert cfg.manual.public_hostname == "lab.example.org"
+    assert stack_delta == 1, "valid submission should push DnsScreen"
+
+
+def test_connectivity_screen_blocks_cloudflare_without_hostname():
+    """The hostname is the whole point of this mode; an empty one must not
+    get past the screen. Requires the error-substring filter in _next() to
+    include 'public_hostname'."""
+    cfg, stack_delta = _drive_connectivity_screen_cfg(
+        choose_mesh_overlay=True,
+        overlay_tailnet="example.ts.net",
+        choose_cloudflare=True,
+        public_hostname="",
+    )
+    assert cfg.manual.participant_exposure == "cloudflare_tunnel"
+    assert stack_delta == 0, "invalid submission must not push DnsScreen"
+
+
+def test_connectivity_screen_blocks_lan_direct_with_cloudflare():
+    """Same rejection lan_direct + Funnel gets, now generalized."""
+    cfg, stack_delta = _drive_connectivity_screen_cfg(
+        choose_mesh_overlay=False,
+        overlay_tailnet="example.ts.net",
+        choose_cloudflare=True,
+        public_hostname="lab.example.org",
+    )
+    assert cfg.manual.connectivity == "lan_direct"
+    assert stack_delta == 0
+
+
+def test_connectivity_screen_cloudflare_hostname_is_stripped():
+    cfg, _ = _drive_connectivity_screen_cfg(
+        choose_mesh_overlay=True,
+        overlay_tailnet="example.ts.net",
+        choose_cloudflare=True,
+        public_hostname="  lab.example.org  ",
+    )
+    assert cfg.manual.public_hostname == "lab.example.org"


### PR DESCRIPTION
## Summary

Adds a third `manual.participant_exposure` mode, `cloudflare_tunnel`, so a self-hosted allocator is published at a hostname the admin chose (`https://lab.smithlab.org`) instead of Tailscale Funnel's fixed `<machine>.<tailnet>.ts.net`. Tailscale supports no custom domains on Funnel at all, so this is the only way to get a lab's own hostname.

The admin creates the tunnel once in Cloudflare's dashboard and pastes its token into `lablink deploy`. **LabLink makes zero Cloudflare API calls** — no tunnel creation, no DNS records, no teardown.

Additive: `tailscale_funnel` and `none` are untouched, and no existing config changes meaning.

## Changes Made

**Allocator**
- `conf/structured_config.py` — new `manual.public_hostname` field.
- `validate_config.py` — `cloudflare_tunnel` added to `VALID_PARTICIPANT_EXPOSURE`; preflights requiring `public_hostname` to be present *and* well-formed when the mode is set.
- `Dockerfile` / `Dockerfile.dev` — `cloudflared` pinned at `ARG CLOUDFLARED_VERSION=2026.7.3`.
- `start.sh` — connector block, gated on the mode, backgrounded before `exec nginx`.

**CLI**
- `app.py` — `--cloudflare-tunnel-token`.
- `commands/deploy_compose.py` — token into `.env` (mode `0600`), preflights, canonical-URL file written at render time.
- `templates/docker-compose.yml` + `templates/docker-compose-mesh-overlay.yml` — pass the mode and token through.
- `tui/wizard.py` — third exposure radio plus the hostname input; the manual path skips the DNS/SSL screen, and the hostname input is disabled unless `cloudflare_tunnel` is selected.

**Docs** — `docs/configuration.md`, a new section covering setup, the TLS trade-off, and the zone-setup constraint.

## How it works

- `cloudflared` is installed **in the allocator image** and launched by `start.sh` only when the mode is set, connecting Cloudflare's edge to the container's own nginx on `:5000`. Not a compose sidecar: that would turn two compose templates into four, and compose `profiles:` aren't removed by the bare `docker compose down` that `lablink destroy` runs.
- The token lives only in the deployment's `.env`, never in `config.yaml`, and follows `TS_AUTHKEY`'s carry-forward rule — pass `--cloudflare-tunnel-token` on the first deploy, or again to rotate.
- Because the hostname is known before anything starts, the existing `allocator-url` canonical-URL file is written at render time. Funnel's whole `_enable_funnel`/`_disable_funnel` dance has no counterpart here.
- `ssl.provider` stays `none` — Cloudflare supplies the public certificate.

## Design Decisions

**Trade-off, disclosed in three places.** Cloudflare Tunnel **terminates TLS at Cloudflare's edge** — admin logins, session cookies and participant desktop streams are all decrypted there. Funnel does not: its relays forward encrypted bytes and TLS terminates on the operator's own machine. Disclosed in the wizard, the `ManualConfig` docstring, and `docs/configuration.md`, because it's a lab policy decision rather than an implementation detail. `tailscale_funnel` therefore stays — it's also the option for an admin with no domain.

**The constraint that decides whether this is usable.** A custom hostname on Cloudflare's free plan requires **full zone setup**: the domain's nameservers must point at Cloudflare. Partial/CNAME setup is Business-tier and subdomain zones are Enterprise-tier, so `salk.edu` or any institutional domain **cannot** be used. Admins must bring a domain they can repoint nameservers for (typically a ~\$10/yr personal one). This is documented as the feature's premise, not a footnote.

**Preflight generalizations (not new behavior).** Three gates that keyed on `== "tailscale_funnel"` now key on `!= "none"`. Their reasoning was always about being publicly reachable, not about which tunnel does the publishing:

| Gate | Location |
|---|---|
| `lan_direct` + any exposure is rejected | `deploy_compose.py` |
| weak-admin-password is rejected | `deploy_compose.py` |
| `lan_direct` + any exposure is rejected | `get_config_errors()` |

Regression guards keep the Funnel cases they were written for.

One asymmetry remains on purpose-of-least-change grounds and is worth a reviewer's eye: `get_config_errors()`'s *weak-password* gate still keys on `== "tailscale_funnel"`, so `lablink configure`'s ReviewScreen won't warn a Cloudflare admin about a weak password. It is not a hole — `deploy_compose.py`'s `!= "none"` gate is what actually blocks a deploy, and `TestCloudflareTunnelPreflights::test_weak_admin_password_is_rejected` covers exactly that. Say the word and I'll make the two symmetrical.

## Interaction with `reverse_tunnel` (from the `main` merge), and the bug it surfaced

`main` landed `reverse_tunnel` connectivity (#419) after this branch was cut. Because the preflights above key on `!= "none"` rather than on Funnel, `reverse_tunnel` + `cloudflare_tunnel` is permitted by construction, and it's coherent — like `mesh_overlay`, `reverse_tunnel` proxies participant sessions through the allocator's own nginx, which any exposure mode publishes.

Checking that pair turned up a real bug on this feature's **main** path. `_print_summary` substituted the public URL into the copy-paste register command only when Funnel was live:

```python
funnel_url_used = off_lan and funnel_active and bool(funnel_url)
```

`funnel_active` is `False` for `cloudflare_tunnel`, so `register_url` stayed the LAN address — which an off-LAN client, the only kind either mode has, cannot reach. The operator saw a correct public URL two lines above a command using the wrong one:

```
Allocator URL (public): https://lab.example.org       ← correct
lablink client register --allocator-url http://192.168.1.42 …   ← unreachable
```

This hit `mesh_overlay` + `cloudflare_tunnel` as well — the configuration in this PR's own `docs/configuration.md` example. Third instance of the class: #419 fixed it for Funnel × `reverse_tunnel`, and the Funnel 302-redirect version broke every `mesh_overlay` client in July.

Fixed at the shared point rather than per-branch: both exposure modes collapse into one `public_url`, and the substitution keys on that URL existing rather than on which tunnel publishes it — so the displayed URL and the substituted one can no longer disagree. Funnel's "enabled but URL unknown" state stays its own display branch, since there's no real URL to substitute there. The container side was already correct — `render_compose_dir` writes `https://<public_hostname>` into the mounted `allocator-url` file, so the register *response* always carried the right URL; only the printed hint was wrong.

Regression tests are parametrized over both off-LAN modes, and were verified failing with the old gating restored before being accepted. `test_lan_direct_hint_keeps_the_lan_url` pins that the substitution stays scoped — a `lan_direct` BYO box genuinely is on the LAN.

The merge itself needed two test-file conflict resolutions (the wizard helper that both branches restructured, and two test classes appended at the same point) — see the merge commit for the reasoning.

## Credential handling: `cloudflared` logs its own token

Found against a live deployment. `cloudflared` dumps its entire environment at INFO on startup, so the exported token went into `docker logs` verbatim:

```
INF Environmental variables map[CLOUDFLARE_TUNNEL_TOKEN:eyJhIjoi…]
```

We store it `0600` and keep it out of `config.yaml`, and then a dependency writes it to a log that persists, greps, and ships to whatever collects container output.

`start.sh` now copies the token to a shell local and `unset`s the exported name before launching the connector, so the environment dump has nothing to find. That's the fix that matters — it covers `docker logs` for every reader, not only callers that come through the CLI. **The token is still visible in the container's process list**; `cloudflared` accepts no file-based token, so that exposure is unavoidable and is called out in the code.

`_print_last_log_lines` also gained a redaction pass keyed on the variable *name* (`CLOUDFLARE_TUNNEL_TOKEN`, `TS_AUTHKEY`, `--token`) rather than the value's shape, since the shapes belong to Cloudflare and Tailscale.

That function had a second, unrelated bug: it used `capture_output=True` and printed `.stdout` only, but the allocator's Python logging goes to **stderr** — so the dump that exists to explain a failed deploy was hiding every traceback. It now merges stderr, which is also what makes the redaction load-bearing rather than dead code.

## `public_hostname` format validation

The field was checked only for non-emptiness, but it is interpolated straight into `https://{host}` twice — into the canonical-URL file the allocator hands every registering client, and into the CLI's post-deploy reachability check. Anything other than a bare DNS name produced a silently broken URL rather than an error. Confirmed by execution before fixing:

| input | validation | resulting `allocator-url` |
|---|---|---|
| `https://lab.example.org` | **no errors** | `https://https://lab.example.org` |
| `lab.example.org\nevil.example` | **no errors** | a two-line file |

The first is the likely mistake — both the docs and the wizard display this value in URL form — and `canonical_base_url` accepts the result because it still `startswith("https://")`. The second survives because that file is read with a whole-file `read().strip()`.

`is_valid_public_hostname()` lives in the allocator's `validate_config` and is imported by the CLI, the same sharing already used for `is_weak_admin_password`. `validate_domain_format` was **not** reused: it only rejects leading/trailing dots, so it catches none of these. Wired into `get_config_errors()` and into `deploy_compose`'s own preflight, since `lablink deploy` never calls that validator for the manual provider. The wizard needed no change — its existing `public_hostname` substring filter picks the message up.

## Wizard: two behaviour changes on the manual path

**The DNS/SSL screen is skipped.** The compose stack reads neither `cfg.dns` nor `cfg.eip`, and reads `cfg.ssl.provider` only to reject anything but `none`. Offering a manual operator a DNS setup that is ignored and a TLS provider that makes deploy exit 1 is a trap, not a choice. The AWS path keeps the screen, where Terraform really does provision both — guarded by a regression test.

Pinning `ssl.provider="none"` and `dns.enabled=False` on the way past is **mandatory, not tidiness**: `SSLConfig.provider` defaults to `letsencrypt`, and `DnsScreen` was the only place the wizard ever wrote `cfg.ssl.provider`. Manual configs were deployable purely because the operator passed through that screen and picked "no DNS", so removing it without pinning would have broken every manual deploy.

**The public-hostname field is disabled unless `cloudflare_tunnel` is selected**, extending the `RadioSet.Changed` handler that already governs `#overlay-tailnet`. Disabling does not clear the value, so a mis-click and return doesn't lose typing. Layout checked by hand at 80×24: identical geometry in all three modes (74×3 at y=15, virtual width 78, no horizontal overflow).

## Post-review simplification

An over-engineering pass cut three things (net -23 lines) after the feature was working:

- `_verify_public_hostname` polled for 30s with a `monotonic()` deadline and `sleep(3)`, duplicating `_health_poll`'s loop. But the caller only warns, and by then the stack is already confirmed healthy locally — so a miss is either propagating DNS or a wrong origin in the dashboard, neither of which waiting fixes. Now **one** request. `docs/configuration.md` was corrected to match.
- `PUBLIC_HOSTNAME_VERIFY_TIMEOUT_SECONDS` went with it.
- `_print_summary`'s `cloudflare_url` kwarg carried zero information (the function already receives `cfg`); derived inline instead. This is what made the bug above a one-line fix rather than a three-branch one.

`_health_poll` itself is untouched — that loop is fatal and waits on a container actually starting.

## Testing

| Check | Result |
|---|---|
| allocator `pytest tests --ignore=tests/terraform` | 867 passed, 20 skipped |
| allocator, replicated **image layout** (no Dockerfiles present) | 841 passed, 26 skipped |
| allocator `ruff check src tests` | All checks passed |
| CLI `pytest tests` | 734 passed, 1 deselected |
| CLI `ruff check src tests` | All checks passed |
| client `pytest tests` | 156 passed |
| client `ruff check src tests` | All checks passed |
| `cloudflared --version` in the built dev image | `2026.7.3` |
| `sh -n /app/start.sh` in the image | parses |
| both compose templates | parse; `environment:` present on `allocator` |
| wizard at 80×24 (Pilot geometry) | three exposure radios each on their own line (h=1, no wrap/collapse); hostname input reachable by scrolling; no added horizontal overflow |

New tests: 7 structural tests for the `start.sh` connector block (`test_start_sh_cloudflared.py`), plus `TestRenderComposeDirCloudflareTunnel` / `TestCloudflareTunnelPreflights` in `test_deploy_compose.py`, wizard cases in `test_wizard.py`, and validator cases in `test_validate_config.py`.

**Verify Allocator Image CI fix.** That job runs `pytest tests` *inside* the built image, which copies `start.sh` but not the Dockerfiles, so the new Dockerfile-drift guard failed on `FileNotFoundError: /app/lablink-allocator/Dockerfile`. It now skips when the Dockerfile is absent — the convention already used by `test_no_api_token_refs.py`. Verified against a replica of the image layout (`start.sh` + `tests/` + `src/` + `terraform/`, no Dockerfiles): the whole suite, not just that file, is clean at 841 passed / 26 skipped.

`mkdocs build --strict` aborts on 6 pre-existing griffe annotation warnings, none from the new section; CI runs plain `mkdocs build`, which passes.

## Related Issues

None — this implements the design approved 2026-07-30. No issue was filed.

## Still to do before merge

**No local image build is needed.** `lablink-images.yml:111` appends `.dev` to the Dockerfile path for pull requests, so the `-test` tags are built from `Dockerfile.dev` **with this branch's source**. (The PyPI path — `uv add lablink-allocator-service==${PACKAGE_VERSION}` — applies only to a manual `workflow_dispatch` with `environment: prod`.) So just point the config at CI's build:

```yaml
allocator:
  image_tag: linux-amd64-latest-test
```

Do **not** try to build `Dockerfile.dev` locally and tag it into the `ghcr.io/...` name: both compose templates set `pull_policy: always`, so `docker compose up` pulls regardless of what is present locally and fails with `manifest unknown` on a tag that exists only on your machine.

**No Cloudflare account needed** — verified 2026-08-03 against a real stack on `reverse_tunnel` + `cloudflare_tunnel` with a junk token, using CI's `linux-amd64-latest-test` image:

- [x] mode set with no token → non-zero exit, no stack — exit 1, no traceback, 0 containers created
- [x] empty `public_hostname` → non-zero exit, no traceback — exit 1
- [x] `connectivity: lan_direct` → rejected — exit 1, message names both fields
- [x] weak `admin_password` → rejected (this gate now fires for Cloudflare, not just Funnel) — exit 1
- [x] malformed `public_hostname` → rejected — exit 1, `got: 'https://lab.example.org'`
- [x] rendered `.env` carries `PARTICIPANT_EXPOSURE` + `CLOUDFLARE_TUNNEL_TOKEN`; `allocator-url` holds `https://<hostname>` — `.env` at mode `600`
- [x] container gate on an empty token → crash-loops under `restart: unless-stopped` (restarts 5→7, gate message once per attempt) and `/api/health` stays unreachable, so it never serves. *A bare `docker run` cannot test this — the connector block sits after the Flask-readiness wait, so without a database the container dies earlier for an unrelated reason.*
- [x] switch to `participant_exposure: none` → no connector runs, `allocator-url` 0 bytes, no token line in `.env`, health 200
- [x] the printed register command uses the `https://` hostname, not the LAN IP — printed `--allocator-url https://lab.example.org` while the LAN IP `http://10.20.3.58` was detected and shown on its own line. This is the bug fixed above, confirmed live on the `reverse_tunnel` pair.
- [x] `docker logs` contains no token after the `unset` fix — **0 occurrences**, and 0 mentions of the variable name at all

Also observed: a rejected connector (`Provided Tunnel token is not valid`) leaves nginx running with 9 processes, so the backgrounding does what it claims — a dead connector does not take the container down with it.

**Needs a real Cloudflare account and a domain whose nameservers can be repointed** (an institutional domain cannot be used — see the constraint above):

- [x] the connector registers with Cloudflare's edge — **done 2026-08-03**: 4 QUIC connections (lax01/05/11), `"tunnel":"ok"` on local `/api/health`, running `reverse_tunnel` + `cloudflare_tunnel` with no Tailscale sidecar
- [x] `https://<hostname>` loads from an unrelated network with a valid certificate
- [x] a full participant session over the public hostname — confirm the KasmVNC **WebSocket** carries the desktop, not just the landing page
- [x] the register response's `allocator_url` is the `https://` hostname (no redirect)
- [x] `lablink destroy` then `lablink deploy` with no token flag → same URL back, no dashboard visit
- [x] an unchanged `tailscale_funnel` config → no regression
- [x] **`connectivity: reverse_tunnel` + `cloudflare_tunnel`** — a client registers and serves a session. Legal by construction and now unit-covered, but whether wstunnel's WebSocket survives Cloudflare's edge is the one thing no static check settles.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

