### PR TITLE
fix(allocator): branch BYO onboarding command on manual.connectivity

### DIFF
--- a/packages/allocator/src/lablink_allocator_service/routes/admin_pages.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/admin_pages.py
@@ -48,14 +48,23 @@ def byo_onboarding():
     The register token rotates on each allocator restart, so this page is
     dynamic — re-render to get the current token. Behind admin Basic auth
     (same gate as the rest of /admin); no new privilege boundary.
+
+    The rendered flags depend on the configured connectivity, because
+    ``register_client`` rejects a shape that doesn't match it with a 400 (see
+    its ``expects_overlay``/``expects_tunnel`` checks) — a single lan_direct
+    command would be guaranteed-broken copy-paste on the other two modes.
+    Read off ``client_connectivity.name`` rather than
+    ``cfg.manual.connectivity`` so this page and that check can never disagree.
     """
     from lablink_allocator_service import main
 
+    provider = current_app.config["LABLINK_PROVIDER"]
     return render_template(
         "byo-onboarding.html",
         allocator_url=canonical_base_url(request),
         register_token=main.REGISTER_TOKEN,
         show_insecure=is_self_signed_ssl(main.cfg),
+        connectivity=provider.client_connectivity.name,
     )
 
 

--- a/packages/allocator/src/lablink_allocator_service/templates/byo-onboarding.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/byo-onboarding.html
@@ -88,17 +88,41 @@
   <body>
     <div class="panel">
       <h2>BYO Client Onboarding</h2>
+      {% if connectivity == "mesh_overlay" %}
       <p>
-        Run this command on a Linux GPU box to register it as a manual client
-        with this allocator. The command is pre-populated with this
+        This allocator uses <strong>mesh_overlay</strong> connectivity, so a
+        client reaches it over a Tailscale tailnet rather than the LAN. Open a
+        terminal inside each client (e.g. a Run:AI-hosted workload) and run the
+        command below — hostname, machine identity and GPU are auto-detected.
+        Choose any <code>&lt;name&gt;</code> as that client's Tailscale
+        hostname, and mint <code>&lt;key&gt;</code> in your Tailscale admin
+        console.
+      </p>
+      {% elif connectivity == "reverse_tunnel" %}
+      <p>
+        This allocator uses <strong>reverse_tunnel</strong> connectivity: the
+        client dials out to this allocator instead of accepting inbound
+        connections. Open a terminal inside each client box and run the command
+        below — hostname, machine identity and GPU are auto-detected, and
+        <code>--tunnel</code> takes no arguments because the allocator mints
+        every value the tunnel needs.
+      </p>
+      {% else %}
+      <p>
+        Run this command on a Linux GPU box on this allocator's LAN to register
+        it as a manual client. The command is pre-populated with this
         deployment's URL and current bootstrap token.
       </p>
+      {% endif %}
 
       <div class="cmd-wrap">
         <button class="copy-btn" id="copyBtn" onclick="copyCmd()">Copy</button>
         <pre id="cmd">lablink client register \
   --allocator-url {{ allocator_url }} \
-  --register-token {{ register_token }}{% if show_insecure %} \
+  --register-token {{ register_token }}{% if connectivity == "mesh_overlay" %} \
+  --overlay-hostname &lt;name&gt; \
+  --tailscale-authkey &lt;key&gt;{% elif connectivity == "reverse_tunnel" %} \
+  --tunnel{% endif %}{% if show_insecure %} \
   --insecure{% endif %}</pre>
       </div>
 
@@ -107,6 +131,17 @@
         restart. If a BYO operator's <code>lablink client register</code> fails with
         an auth error, refresh this page to copy the current token.
       </div>
+
+      {% if connectivity in ("mesh_overlay", "reverse_tunnel") %}
+      <p style="font-size: 14px; color: #666;">
+        Registering ahead of time, from somewhere other than the client itself?
+        Add <code>--no-run-locally</code> to print the secrets for your own
+        workload submission instead of starting a container here. That also
+        requires <code>--hostname</code> and <code>--machine-identity</code>,
+        since auto-detection would report this machine's facts, not the future
+        client's.
+      </p>
+      {% endif %}
 
       <p style="font-size: 14px; color: #666;">
         Prerequisites on the BYO box: Docker + nvidia-container-toolkit (for

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -69,6 +69,47 @@ def test_byo_onboarding_shows_insecure_for_self_signed(client, admin_headers, mo
     assert "--insecure" in html
 
 
+def _onboarding_html(app, client, admin_headers, connectivity):
+    """Render the onboarding page as if the deployment used *connectivity*."""
+    app.config["LABLINK_PROVIDER"] = SimpleNamespace(
+        client_connectivity=SimpleNamespace(name=connectivity)
+    )
+    response = client.get("/admin/byo-onboarding", headers=admin_headers)
+    assert response.status_code == 200
+    return response.data.decode()
+
+
+def test_byo_onboarding_mesh_overlay_flags(app, client, admin_headers):
+    """register_client 400s a mesh_overlay registration that arrives without
+    --overlay-hostname/--tailscale-authkey, so the copyable command must carry
+    both — otherwise the page hands the admin a guaranteed-broken command."""
+    html = _onboarding_html(app, client, admin_headers, "mesh_overlay")
+    assert "--overlay-hostname" in html
+    assert "--tailscale-authkey" in html
+    assert "--tunnel" not in html
+    # Hand-off variant's extra requirements are stated, not just implied.
+    assert "--no-run-locally" in html
+    assert "--machine-identity" in html
+
+
+def test_byo_onboarding_reverse_tunnel_flags(app, client, admin_headers):
+    """--tunnel takes no arguments, and overlay's Tailscale flags are rejected
+    outright by run_register in this mode."""
+    html = _onboarding_html(app, client, admin_headers, "reverse_tunnel")
+    assert "--tunnel" in html
+    assert "--overlay-hostname" not in html
+    assert "--tailscale-authkey" not in html
+
+
+def test_byo_onboarding_lan_direct_has_no_off_lan_flags(app, client, admin_headers):
+    """lan_direct is the one mode where the bare command is correct; the
+    off-LAN flags would be rejected as not applicable."""
+    html = _onboarding_html(app, client, admin_headers, "lan_direct")
+    assert "--overlay-hostname" not in html
+    assert "--tunnel" not in html
+    assert "--no-run-locally" not in html
+
+
 @patch("lablink_allocator_service.main.database")
 def test_admin_instances(mock_database, client, admin_headers):
     """Test the admin instances endpoint without any instances."""


### PR DESCRIPTION
## Problem

`/admin/byo-onboarding` rendered exactly one command shape — the `lan_direct` one:

```
lablink client register --allocator-url <url> --register-token <tok> [--insecure]
```

But `admin.html` shows that button for every `not can_provision_hosts` provider, i.e. all three valid `manual.connectivity` values, and `register_client` rejects a mismatched shape with a 400:

- `mesh_overlay` → *"register with --overlay-hostname and --tailscale-authkey"*
- `reverse_tunnel` → *"register with --tunnel"*

So on two of the three modes, the admin was handed a copy-paste command guaranteed to fail. The page dates from the lan_direct-only era (PR D2/D3) and was never updated when mesh_overlay and reverse_tunnel landed.

## Change

Branch three ways, mirroring the split `deploy_compose.py` already prints for the same purpose:

| `manual.connectivity` | Rendered flags |
|---|---|
| `lan_direct` | `--allocator-url`, `--register-token` |
| `mesh_overlay` | + `--overlay-hostname <name>` `--tailscale-authkey <key>` |
| `reverse_tunnel` | + `--tunnel` |

Both off-LAN modes also get a note about the hand-off variant (`--no-run-locally`, which additionally requires `--hostname` and `--machine-identity`), and mode-specific intro text — "open a terminal inside the workload" rather than "on a Linux GPU box on this allocator's LAN".

Keyed on `provider.client_connectivity.name` rather than `cfg.manual.connectivity`, so this page and `register_client`'s `expects_overlay`/`expects_tunnel` checks read the same value and cannot drift.

`--insecure` gating is unchanged (`self_signed` only).

## Verification

- 3 new tests in `test_pages.py`, one per mode, asserting both presence and absence of the mode-specific flags.
- Allocator: 870 passed, 20 skipped (`--ignore=tests/terraform`).
- CLI: 734 passed, 1 deselected.
- `ruff check packages/allocator packages/client packages/cli`: clean.
- Rendered all three commands via Jinja directly to confirm the line continuations and that the escaped `&lt;name&gt;`/`&lt;key&gt;` placeholders come back as `<name>`/`<key>` through the copy button's `innerText`:

```
lablink client register \
  --allocator-url http://192.168.1.9:5000 \
  --register-token tk_abc123 \
  --overlay-hostname <name> \
  --tailscale-authkey <key>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)
