### PR TITLE
feat(allocator): serve the allocator's own logs at /admin/allocator-logs

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -515,3 +515,33 @@ Retrieves reboot tracking information for a specific VM.
 - **Code:** `404 Not Found` if the VM is not found.
 - **Code:** `503 Service Unavailable` if the logs are not yet available because the VM's log shipper has not started reporting yet.
 - **Code:** `500 Internal Server Error` on failure.
+
+### Get the Allocator's Own Logs
+
+**Endpoint:** `GET /api/allocator-logs`
+
+**Description:** Returns a redacted tail (last 2000 lines) of the allocator's own container output, read from the file `start.sh` writes at `/var/log/lablink/allocator.log`. Backs the `/admin/allocator-logs` page. Values of `PASSWORD`/`TOKEN`/`SECRET`/`KEY` assignments are masked before the response leaves the process.
+
+**Authentication:** Admin HTTP Basic
+
+**URL Parameters:** None
+
+**Request Body:** None
+
+**Success Response:**
+
+- **Code:** `200 OK`
+- **Content:**
+  ```json
+  {
+    "cloud_init_logs": null,
+    "docker_logs": "2026-08-03 12:00:00 - Starting nginx on :5000...",
+    "error": null
+  }
+  ```
+
+`cloud_init_logs` is always `null`: the allocator host's cloud-init output lives outside the container and is out of scope. When no log file exists, `docker_logs` is `null` and `error` explains why — the response is still `200`.
+
+**Error Response:**
+
+- **Code:** `401 Unauthorized` without admin credentials.

--- a/packages/allocator/Dockerfile
+++ b/packages/allocator/Dockerfile
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     postgresql postgresql-contrib \
     rsync \
     openssh-client \
+    apache2-utils \
     libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/packages/allocator/Dockerfile.dev
+++ b/packages/allocator/Dockerfile.dev
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     postgresql postgresql-contrib \
     rsync \
     openssh-client \
+    apache2-utils \
     libpq-dev && \
     rm -rf /var/lib/apt/lists/*
 

--- a/packages/allocator/src/lablink_allocator_service/main.py
+++ b/packages/allocator/src/lablink_allocator_service/main.py
@@ -27,6 +27,9 @@ from lablink_allocator_service.routes.admin_pages import bp as admin_pages_bp
 from lablink_allocator_service.routes.admin_sessions import (
     bp as admin_sessions_bp,
 )
+from lablink_allocator_service.routes.allocator_logs import (
+    bp as allocator_logs_bp,
+)
 from lablink_allocator_service.routes.desktop import bp as desktop_bp
 from lablink_allocator_service.routes.health import bp as health_bp
 from lablink_allocator_service.routes.internal_proxy_auth import (
@@ -86,6 +89,7 @@ app.wsgi_app = _ProxyFixWhenTrusted(
 )
 app.register_blueprint(admin_pages_bp)
 app.register_blueprint(admin_sessions_bp)
+app.register_blueprint(allocator_logs_bp)
 app.register_blueprint(desktop_bp)
 app.register_blueprint(health_bp)
 app.register_blueprint(internal_proxy_auth_bp)

--- a/packages/allocator/src/lablink_allocator_service/routes/admin_pages.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/admin_pages.py
@@ -106,8 +106,10 @@ def get_vm_logs(hostname):
     # template hides that section when provider != "aws".
     return render_template(
         "instance-logs.html",
-        hostname=hostname,
-        provider=main.cfg.provider,
+        log_title=f"VM Logs - {hostname}",
+        log_endpoint=f"/api/vm-logs/{hostname}",
+        download_slug=hostname,
+        show_cloud_init=(main.cfg.provider or "aws") == "aws",
     )
 
 

--- a/packages/allocator/src/lablink_allocator_service/routes/admin_pages.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/admin_pages.py
@@ -110,6 +110,8 @@ def get_vm_logs(hostname):
         log_endpoint=f"/api/vm-logs/{hostname}",
         download_slug=hostname,
         show_cloud_init=(main.cfg.provider or "aws") == "aws",
+        # Opened in a new tab from the instances page, so it can close itself.
+        show_close=True,
     )
 
 

--- a/packages/allocator/src/lablink_allocator_service/routes/allocator_logs.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/allocator_logs.py
@@ -1,0 +1,57 @@
+"""The allocator's own logs: a JSON tail plus the admin page that shows it.
+
+Its own blueprint rather than part of admin_pages because this is the one
+log source that comes off the local filesystem instead of the database --
+start.sh writes it, since nothing mounts docker.sock and the allocator
+therefore cannot run `docker logs` on itself.
+"""
+import logging
+
+from flask import Blueprint, jsonify, render_template
+
+from lablink_allocator_service.auth import auth
+from lablink_allocator_service.utils.log_tail import read_allocator_log
+
+bp = Blueprint("allocator_logs", __name__)
+
+logger = logging.getLogger(__name__)
+
+_MISSING_LOG_MSG = (
+    "No allocator log file found under /var/log/lablink. This page reads "
+    "the file start.sh writes inside the container, so it is empty when "
+    "the allocator runs outside its container or from an image predating "
+    "this feature. Run `lablink logs` instead."
+)
+
+
+@bp.route("/api/allocator-logs", methods=["GET"])
+@auth.login_required
+def allocator_logs_api():
+    """Return a redacted tail of the allocator's own log file.
+
+    Mirrors /api/vm-logs/<hostname>'s response keys so the shared logs
+    template's JavaScript works unchanged. cloud_init_logs is always None:
+    the allocator's cloud-init output lives on the EC2 host, outside this
+    container, and is deliberately out of scope.
+    """
+    logs = read_allocator_log()
+    return jsonify(
+        {
+            "cloud_init_logs": None,
+            "docker_logs": logs,
+            "error": None if logs else _MISSING_LOG_MSG,
+        }
+    )
+
+
+@bp.route("/admin/allocator-logs", methods=["GET"])
+@auth.login_required
+def allocator_logs_page():
+    """Render the shared logs page pointed at this blueprint's API."""
+    return render_template(
+        "instance-logs.html",
+        log_title="Allocator Logs",
+        log_endpoint="/api/allocator-logs",
+        download_slug="allocator",
+        show_cloud_init=False,
+    )

--- a/packages/allocator/src/lablink_allocator_service/routes/allocator_logs.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/allocator_logs.py
@@ -17,10 +17,8 @@ bp = Blueprint("allocator_logs", __name__)
 logger = logging.getLogger(__name__)
 
 _MISSING_LOG_MSG = (
-    "No allocator log file found under /var/log/lablink. This page reads "
-    "the file start.sh writes inside the container, so it is empty when "
-    "the allocator runs outside its container or from an image predating "
-    "this feature. Run `lablink logs` instead."
+    "No log file under /var/log/lablink -- start.sh writes it, so it is "
+    "absent outside the container. Run `lablink logs` instead."
 )
 
 

--- a/packages/allocator/src/lablink_allocator_service/routes/allocator_logs.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/allocator_logs.py
@@ -54,4 +54,6 @@ def allocator_logs_page():
         log_endpoint="/api/allocator-logs",
         download_slug="allocator",
         show_cloud_init=False,
+        # Reached via same-tab navigation from /admin, so window.close() is a no-op.
+        show_close=False,
     )

--- a/packages/allocator/src/lablink_allocator_service/templates/admin.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/admin.html
@@ -118,6 +118,9 @@
           Session Metrics
         </button>
         {% endif %}
+        <button onclick="location.href='/admin/allocator-logs'">
+          Allocator Logs
+        </button>
       </div>
     </div>
   </body>

--- a/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
@@ -276,11 +276,14 @@
         </div>
 
         <!-- Navigation -->
+        {# Only pages opened in their own tab can close themselves. #}
+        {% if show_close %}
         <div style="text-align: center;">
             <button class="back-button" onclick="handleClose()">
                 <i class="bi bi-x-lg me-2"></i>Close Tab
             </button>
         </div>
+        {% endif %}
     </div>
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>

--- a/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
@@ -3,7 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>VM Logs - {{ hostname }}</title>
+    <title>{{ log_title }}</title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet">
     <link href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.11.0/font/bootstrap-icons.css" rel="stylesheet">
     <style>
@@ -205,7 +205,7 @@
         <div class="header-card">
             <h2 style="margin: 0; color: #333;">
                 <span class="status-indicator"></span>
-                VM Logs - {{ hostname }}
+                {{ log_title }}
             </h2>
         </div>
 
@@ -236,7 +236,7 @@
             </div>
 
             <!-- Log type tabs -->
-            {% set has_cloud_init = (provider or 'aws') == 'aws' %}
+            {% set has_cloud_init = show_cloud_init %}
             <ul class="nav nav-tabs mb-0" id="logTabs" role="tablist">
                 {% if has_cloud_init %}
                 <li class="nav-item" role="presentation">
@@ -285,7 +285,8 @@
 
     <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/js/bootstrap.bundle.min.js"></script>
     <script>
-        const hostname = "{{ hostname }}";
+        const logEndpoint = "{{ log_endpoint }}";
+        const downloadSlug = "{{ download_slug }}";
         const hasCloudInit = {{ 'true' if has_cloud_init else 'false' }};
         let autoRefreshInterval = null;
         let isAutoRefreshing = false;
@@ -306,7 +307,7 @@
             try {
                 const shouldFollowTail = document.getElementById("followTail").checked;
 
-                const res = await fetch(`/api/vm-logs/${hostname}`, { credentials : 'include' });
+                const res = await fetch(logEndpoint, { credentials : 'include' });
                 if (res.ok) {
                     const data = await res.json();
                     const cloudInitLogs = data.cloud_init_logs || "No logs available.";
@@ -375,7 +376,7 @@
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;
-            a.download = `${hostname}_logs_${new Date().toISOString().replace(/[:.]/g, '-')}.txt`;
+            a.download = `${downloadSlug}_logs_${new Date().toISOString().replace(/[:.]/g, '-')}.txt`;
             document.body.appendChild(a);
             a.click();
             document.body.removeChild(a);

--- a/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
@@ -314,7 +314,7 @@
                 if (res.ok) {
                     const data = await res.json();
                     const cloudInitLogs = data.cloud_init_logs || "No logs available.";
-                    const dockerLogs = data.docker_logs || "No logs available.";
+                    const dockerLogs = data.docker_logs || data.error || "No logs available.";
 
                     setBoxText("cloudInitLogBox", cloudInitLogs);
                     setBoxText("dockerLogBox", dockerLogs);

--- a/packages/allocator/src/lablink_allocator_service/utils/log_tail.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/log_tail.py
@@ -16,11 +16,9 @@ from pathlib import Path
 from lablink_allocator_service.utils.ansi import strip_ansi
 
 LOG_DIR = Path("/var/log/lablink")
-LOG_BASENAME = "allocator.log"
 
-# Matches what `rotatelogs -n 2` produces: the base name plus its circular
-# sibling (allocator.log, allocator.log.1).
-_ROTATION_GLOB = f"{LOG_BASENAME}*"
+# Matches what `rotatelogs -n 2` produces: allocator.log, allocator.log.1.
+_ROTATION_GLOB = "allocator.log*"
 
 # Matches the CLI's _MANUAL_ALLOCATOR_TAIL so the web page and `lablink
 # logs` show the same depth of history.
@@ -56,16 +54,7 @@ def _rotation_files(log_dir: Path) -> list[Path]:
     the concatenation chronological either way.
     """
     try:
-        files = [p for p in log_dir.glob(_ROTATION_GLOB) if p.is_file()]
-        # Build (mtime, path) pairs inside the guard, skipping entries
-        # whose stat fails (e.g., file disappears between glob and here).
-        pairs = []
-        for p in files:
-            try:
-                pairs.append((p.stat().st_mtime, p))
-            except OSError:
-                continue
-        return [p for _, p in sorted(pairs)]
+        return sorted(log_dir.glob(_ROTATION_GLOB), key=lambda p: p.stat().st_mtime)
     except OSError:
         return []
 
@@ -74,8 +63,7 @@ def _tail_bytes(path: Path, window: int) -> str:
     """Read at most `window` bytes from the end of `path`."""
     with path.open("rb") as fh:
         fh.seek(0, os.SEEK_END)
-        size = fh.tell()
-        fh.seek(max(0, size - window))
+        fh.seek(max(0, fh.tell() - window))
         return fh.read().decode("utf-8", errors="replace")
 
 

--- a/packages/allocator/src/lablink_allocator_service/utils/log_tail.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/log_tail.py
@@ -33,7 +33,7 @@ _TAIL_WINDOW_BYTES = 2 * 1024 * 1024
 # The log page makes that stream readable to anyone holding the admin
 # password, so mask before it leaves the process.
 _SECRET_RE = re.compile(
-    r"((?:PASSWORD|TOKEN|SECRET|KEY)\s*[=:]\s*)(\S+)",
+    r"((?:\w*(?:PASSWORD|TOKEN|SECRET|KEY)\w*)\s*[=:]\s*)(\S+)",
     re.IGNORECASE,
 )
 
@@ -55,9 +55,17 @@ def _rotation_files(log_dir: Path) -> list[Path]:
     """
     try:
         files = [p for p in log_dir.glob(_ROTATION_GLOB) if p.is_file()]
+        # Build (mtime, path) pairs inside the guard, skipping entries
+        # whose stat fails (e.g., file disappears between glob and here).
+        pairs = []
+        for p in files:
+            try:
+                pairs.append((p.stat().st_mtime, p))
+            except OSError:
+                continue
+        return [p for _, p in sorted(pairs)]
     except OSError:
         return []
-    return sorted(files, key=lambda p: p.stat().st_mtime)
 
 
 def _tail_bytes(path: Path, window: int) -> str:

--- a/packages/allocator/src/lablink_allocator_service/utils/log_tail.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/log_tail.py
@@ -13,6 +13,8 @@ import os
 import re
 from pathlib import Path
 
+from lablink_allocator_service.utils.ansi import strip_ansi
+
 LOG_DIR = Path("/var/log/lablink")
 LOG_BASENAME = "allocator.log"
 
@@ -81,7 +83,7 @@ def read_allocator_log(
     log_dir: Path = LOG_DIR,
     max_lines: int = DEFAULT_MAX_LINES,
 ) -> str | None:
-    """Last `max_lines` lines across the rotation set, redacted.
+    """Last `max_lines` lines across the rotation set, cleaned and redacted.
 
     Returns None when there is no log file to read at all -- the caller
     turns that into a user-facing explanation rather than an error.
@@ -99,4 +101,8 @@ def read_allocator_log(
     # line. Harmless: _TAIL_WINDOW_BYTES holds far more than max_lines of
     # ordinary output, so the slice below almost always discards it.
     lines = "".join(chunks).splitlines()[-max_lines:]
-    return redact_secrets("\n".join(lines)) or None
+    # Werkzeug colorizes non-2xx request lines, so this stream carries ANSI
+    # escapes that the log box would render as literal junk. Client VM logs
+    # reach the same template already clean -- vm_telemetry strips them at
+    # ingestion -- so strip here to match.
+    return redact_secrets(strip_ansi("\n".join(lines))) or None

--- a/packages/allocator/src/lablink_allocator_service/utils/log_tail.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/log_tail.py
@@ -1,0 +1,94 @@
+"""Bounded reads of the allocator's own log file.
+
+start.sh tees this container's entire stdout/stderr through `rotatelogs`
+into LOG_DIR, and this module is the only way the allocator can show that
+output: nothing mounts docker.sock, so it cannot run `docker logs` on
+itself.
+
+Flask-free on purpose -- the tailing and redaction logic is the part worth
+testing, and keeping it out of the route module lets it test against
+tmp_path with no app fixture.
+"""
+import os
+import re
+from pathlib import Path
+
+LOG_DIR = Path("/var/log/lablink")
+LOG_BASENAME = "allocator.log"
+
+# Matches what `rotatelogs -n 2` produces: the base name plus its circular
+# sibling (allocator.log, allocator.log.1).
+_ROTATION_GLOB = f"{LOG_BASENAME}*"
+
+# Matches the CLI's _MANUAL_ALLOCATOR_TAIL so the web page and `lablink
+# logs` show the same depth of history.
+DEFAULT_MAX_LINES = 2000
+
+# Enough bytes to cover DEFAULT_MAX_LINES of ordinary log output without
+# reading a 64 MB file on every 5-second poll from the log page.
+_TAIL_WINDOW_BYTES = 2 * 1024 * 1024
+
+# cloudflared dumps its entire environment at INFO on startup (see
+# start.sh), which puts the Postgres and admin passwords into this stream.
+# The log page makes that stream readable to anyone holding the admin
+# password, so mask before it leaves the process.
+_SECRET_RE = re.compile(
+    r"((?:PASSWORD|TOKEN|SECRET|KEY)\s*[=:]\s*)(\S+)",
+    re.IGNORECASE,
+)
+
+_REDACTED = "***REDACTED***"
+
+
+def redact_secrets(text: str) -> str:
+    """Mask the values of secret-looking assignments, keeping the keys."""
+    return _SECRET_RE.sub(rf"\1{_REDACTED}", text)
+
+
+def _rotation_files(log_dir: Path) -> list[Path]:
+    """Existing log files, oldest first.
+
+    `rotatelogs -n` cycles a fixed list of names rather than shifting
+    them, so the numeric suffix does not indicate age -- right after a
+    rotation `allocator.log` is the *newer* file. Sorting by mtime keeps
+    the concatenation chronological either way.
+    """
+    try:
+        files = [p for p in log_dir.glob(_ROTATION_GLOB) if p.is_file()]
+    except OSError:
+        return []
+    return sorted(files, key=lambda p: p.stat().st_mtime)
+
+
+def _tail_bytes(path: Path, window: int) -> str:
+    """Read at most `window` bytes from the end of `path`."""
+    with path.open("rb") as fh:
+        fh.seek(0, os.SEEK_END)
+        size = fh.tell()
+        fh.seek(max(0, size - window))
+        return fh.read().decode("utf-8", errors="replace")
+
+
+def read_allocator_log(
+    log_dir: Path = LOG_DIR,
+    max_lines: int = DEFAULT_MAX_LINES,
+) -> str | None:
+    """Last `max_lines` lines across the rotation set, redacted.
+
+    Returns None when there is no log file to read at all -- the caller
+    turns that into a user-facing explanation rather than an error.
+    """
+    chunks = []
+    for path in _rotation_files(log_dir):
+        try:
+            chunks.append(_tail_bytes(path, _TAIL_WINDOW_BYTES))
+        except OSError:
+            continue
+    if not chunks:
+        return None
+
+    # The byte window can slice mid-line, leaving a fragmentary first
+    # line. Harmless: _TAIL_WINDOW_BYTES holds far more than max_lines of
+    # ordinary output, so the slice below almost always discards it.
+    lines = "".join(chunks).splitlines()[-max_lines:]
+    return redact_secrets("\n".join(lines)) or None

--- a/packages/allocator/start.sh
+++ b/packages/allocator/start.sh
@@ -1,22 +1,10 @@
 #!/bin/bash
 
-# Capture this container's entire stdout/stderr so the allocator can serve its
-# own logs at /admin/allocator-logs. Nothing mounts docker.sock (deliberately --
-# it would hand this internet-exposed container root on the Docker host), so the
-# allocator cannot run `docker logs` on itself; a file it writes is the only
-# option.
-#
-# `tee` is load-bearing. rotatelogs writes ONLY to its file, so redirecting
-# straight into it would silence the container's stdout and make `docker logs`
-# return nothing -- breaking `lablink logs` for both providers and the very
-# fallback this page relies on for boot-failure diagnosis. tee's own stdout
-# keeps feeding the container's stdout while its second descriptor feeds
-# rotatelogs.
-#
-# rotatelogs -n 2 cycles two fixed filenames (allocator.log, allocator.log.1),
-# capping disk at ~128 MB with no cron and no logrotate config. Plain `tee -a`
-# to a file would grow without limit inside a single long run, which is the
-# failure mode that matters for a BYO allocator left up for weeks.
+# Capture stdout/stderr to a file so /admin/allocator-logs has something to
+# read: nothing mounts docker.sock, so the allocator cannot `docker logs`
+# itself. `tee` is load-bearing -- rotatelogs writes only to its file, so
+# piping straight into it would leave `docker logs` (and `lablink logs`)
+# empty. `-n 2` cycles two files, capping disk at ~128 MB without logrotate.
 mkdir -p /var/log/lablink
 exec > >(tee >(rotatelogs -n 2 /var/log/lablink/allocator.log 64M)) 2>&1
 

--- a/packages/allocator/start.sh
+++ b/packages/allocator/start.sh
@@ -1,5 +1,25 @@
 #!/bin/bash
 
+# Capture this container's entire stdout/stderr so the allocator can serve its
+# own logs at /admin/allocator-logs. Nothing mounts docker.sock (deliberately --
+# it would hand this internet-exposed container root on the Docker host), so the
+# allocator cannot run `docker logs` on itself; a file it writes is the only
+# option.
+#
+# `tee` is load-bearing. rotatelogs writes ONLY to its file, so redirecting
+# straight into it would silence the container's stdout and make `docker logs`
+# return nothing -- breaking `lablink logs` for both providers and the very
+# fallback this page relies on for boot-failure diagnosis. tee's own stdout
+# keeps feeding the container's stdout while its second descriptor feeds
+# rotatelogs.
+#
+# rotatelogs -n 2 cycles two fixed filenames (allocator.log, allocator.log.1),
+# capping disk at ~128 MB with no cron and no logrotate config. Plain `tee -a`
+# to a file would grow without limit inside a single long run, which is the
+# failure mode that matters for a BYO allocator left up for weeks.
+mkdir -p /var/log/lablink
+exec > >(tee >(rotatelogs -n 2 /var/log/lablink/allocator.log 64M)) 2>&1
+
 export POSTGRES_HOST_AUTH_METHOD=trust
 
 

--- a/packages/allocator/tests/test_allocator_logs.py
+++ b/packages/allocator/tests/test_allocator_logs.py
@@ -1,0 +1,50 @@
+"""The allocator's own log endpoint and admin page."""
+
+
+def test_api_requires_auth(client):
+    assert client.get("/api/allocator-logs").status_code == 401
+
+
+def test_page_requires_auth(client):
+    assert client.get("/admin/allocator-logs").status_code == 401
+
+
+def test_api_returns_logs(client, admin_headers, monkeypatch):
+    monkeypatch.setattr(
+        "lablink_allocator_service.routes.allocator_logs.read_allocator_log",
+        lambda: "Starting nginx on :5000...",
+    )
+    body = client.get("/api/allocator-logs", headers=admin_headers).get_json()
+    assert body["docker_logs"] == "Starting nginx on :5000..."
+    assert body["cloud_init_logs"] is None
+    assert body["error"] is None
+
+
+def test_api_explains_a_missing_log_file(client, admin_headers, monkeypatch):
+    """A missing file is a user-facing explanation, not a 500."""
+    monkeypatch.setattr(
+        "lablink_allocator_service.routes.allocator_logs.read_allocator_log",
+        lambda: None,
+    )
+    resp = client.get("/api/allocator-logs", headers=admin_headers)
+    assert resp.status_code == 200
+    body = resp.get_json()
+    assert body["docker_logs"] is None
+    assert "lablink logs" in body["error"]
+
+
+def test_page_renders_single_docker_tab(client, admin_headers):
+    """Cloud-init is out of scope for the allocator, so only one tab."""
+    html = client.get(
+        "/admin/allocator-logs", headers=admin_headers
+    ).data.decode()
+    assert "Allocator Logs" in html
+    assert 'id="cloudInitTab"' not in html
+    assert 'id="dockerTab"' in html
+    assert 'id="dockerLogBox"' in html
+    assert '"/api/allocator-logs"' in html
+
+
+def test_admin_dashboard_links_to_the_page(client, admin_headers):
+    html = client.get("/admin", headers=admin_headers).data.decode()
+    assert "/admin/allocator-logs" in html

--- a/packages/allocator/tests/test_allocator_logs.py
+++ b/packages/allocator/tests/test_allocator_logs.py
@@ -45,6 +45,12 @@ def test_page_renders_single_docker_tab(client, admin_headers):
     assert '"/api/allocator-logs"' in html
 
 
+def test_page_has_no_close_button(client, admin_headers):
+    """Same-tab navigation from /admin means window.close() would do nothing."""
+    html = client.get("/admin/allocator-logs", headers=admin_headers).data.decode()
+    assert "Close Tab" not in html
+
+
 def test_admin_dashboard_links_to_the_page(client, admin_headers):
     html = client.get("/admin", headers=admin_headers).data.decode()
     assert "/admin/allocator-logs" in html

--- a/packages/allocator/tests/test_log_tail.py
+++ b/packages/allocator/tests/test_log_tail.py
@@ -37,19 +37,42 @@ def test_empty_log_dir_returns_none(tmp_path):
     assert read_allocator_log(log_dir=tmp_path) is None
 
 
+def test_window_trims_from_the_end(tmp_path, monkeypatch):
+    """The seek window reads only the tail, and a mid-line slice does not
+    corrupt the lines that survive."""
+    monkeypatch.setattr(
+        "lablink_allocator_service.utils.log_tail._TAIL_WINDOW_BYTES", 40
+    )
+    (tmp_path / "allocator.log").write_text(
+        "".join(f"line {i:03d}\n" for i in range(100))
+    )
+    out = read_allocator_log(log_dir=tmp_path, max_lines=1000)
+    # Only the last ~40 bytes are read, so early lines must be absent...
+    assert "line 000" not in out
+    # ...the final line must survive intact...
+    assert out.splitlines()[-1] == "line 099"
+    # ...and every surviving line must be whole, not a fragment.
+    for line in out.splitlines()[1:]:
+        assert line.startswith("line ")
+
+
 def test_redacts_secret_assignments():
     text = (
         "POSTGRES_PASSWORD=hunter2\n"
         "CLOUDFLARE_TUNNEL_TOKEN=eyJhIjoiYWJj\n"
         "admin_password: s3cret\n"
+        "AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE\n"
+        "API_TOKEN_V2=abc123\n"
         "Starting nginx on :5000...\n"
     )
     out = redact_secrets(text)
     assert "hunter2" not in out
     assert "eyJhIjoiYWJj" not in out
     assert "s3cret" not in out
+    assert "AKIAIOSFODNN7EXAMPLE" not in out
+    assert "abc123" not in out
     assert "Starting nginx on :5000..." in out
-    assert out.count("***REDACTED***") == 3
+    assert out.count("***REDACTED***") == 5
 
 
 def test_redaction_applies_through_read(tmp_path):

--- a/packages/allocator/tests/test_log_tail.py
+++ b/packages/allocator/tests/test_log_tail.py
@@ -1,0 +1,59 @@
+"""Bounded reads of the allocator's own log file."""
+import os
+
+from lablink_allocator_service.utils.log_tail import (
+    read_allocator_log,
+    redact_secrets,
+)
+
+
+def test_tail_returns_last_n_lines(tmp_path):
+    (tmp_path / "allocator.log").write_text(
+        "\n".join(f"line {i}" for i in range(100)) + "\n"
+    )
+    out = read_allocator_log(log_dir=tmp_path, max_lines=10)
+    assert out.splitlines() == [f"line {i}" for i in range(90, 100)]
+
+
+def test_tail_spans_rotation_files_oldest_first(tmp_path):
+    """`rotatelogs -n` cycles filenames, so the suffix does not indicate
+    age -- ordering must come from mtime."""
+    older = tmp_path / "allocator.log"
+    newer = tmp_path / "allocator.log.1"
+    older.write_text("from the older file\n")
+    newer.write_text("from the newer file\n")
+    os.utime(older, (1_000, 1_000))
+    os.utime(newer, (2_000, 2_000))
+
+    out = read_allocator_log(log_dir=tmp_path, max_lines=10)
+    assert out.splitlines() == ["from the older file", "from the newer file"]
+
+
+def test_missing_log_dir_returns_none(tmp_path):
+    assert read_allocator_log(log_dir=tmp_path / "nope") is None
+
+
+def test_empty_log_dir_returns_none(tmp_path):
+    assert read_allocator_log(log_dir=tmp_path) is None
+
+
+def test_redacts_secret_assignments():
+    text = (
+        "POSTGRES_PASSWORD=hunter2\n"
+        "CLOUDFLARE_TUNNEL_TOKEN=eyJhIjoiYWJj\n"
+        "admin_password: s3cret\n"
+        "Starting nginx on :5000...\n"
+    )
+    out = redact_secrets(text)
+    assert "hunter2" not in out
+    assert "eyJhIjoiYWJj" not in out
+    assert "s3cret" not in out
+    assert "Starting nginx on :5000..." in out
+    assert out.count("***REDACTED***") == 3
+
+
+def test_redaction_applies_through_read(tmp_path):
+    (tmp_path / "allocator.log").write_text("DB_PASSWORD=letmein\n")
+    out = read_allocator_log(log_dir=tmp_path)
+    assert "letmein" not in out
+    assert "***REDACTED***" in out

--- a/packages/allocator/tests/test_log_tail.py
+++ b/packages/allocator/tests/test_log_tail.py
@@ -75,6 +75,16 @@ def test_redacts_secret_assignments():
     assert out.count("***REDACTED***") == 5
 
 
+def test_strips_ansi_escapes(tmp_path):
+    """Werkzeug colorizes non-2xx request lines; the log box would render
+    the escapes as literal junk."""
+    (tmp_path / "allocator.log").write_text(
+        '\x1b[31m\x1b[1mGET /admin HTTP/1.1\x1b[0m" 401\n'
+    )
+    out = read_allocator_log(log_dir=tmp_path)
+    assert out == 'GET /admin HTTP/1.1" 401'
+
+
 def test_redaction_applies_through_read(tmp_path):
     (tmp_path / "allocator.log").write_text("DB_PASSWORD=letmein\n")
     out = read_allocator_log(log_dir=tmp_path)

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -207,6 +207,27 @@ def test_log_page_vm_not_found(client, admin_headers, monkeypatch):
     assert "VM not found." in response.data.decode()
 
 
+def test_log_page_hides_cloud_init_for_manual_provider(
+    client, admin_headers, monkeypatch
+):
+    """Non-AWS providers have no cloud-init concept, so that tab must not
+    render. Guards the template's show_cloud_init parameterization."""
+    fake_db = MagicMock()
+    fake_db.vm_exists.return_value = True
+    monkeypatch.setattr("lablink_allocator_service.main.database", fake_db)
+    # The view reads only cfg.provider off cfg for this page.
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.cfg",
+        SimpleNamespace(provider="manual"),
+    )
+
+    html = client.get("/admin/logs/vm-1", headers=admin_headers).data.decode()
+    assert 'id="cloudInitTab"' not in html
+    assert 'id="dockerTab"' in html
+    assert "VM Logs - vm-1" in html
+    assert '"/api/vm-logs/vm-1"' in html
+
+
 @patch("lablink_allocator_service.main.database")
 def test_view_instances_vnc_actions_by_state(mock_database, client, admin_headers):
     """Each VM state shows the right VNC action in the actions cell."""

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -226,6 +226,8 @@ def test_log_page_hides_cloud_init_for_manual_provider(
     assert 'id="dockerTab"' in html
     assert "VM Logs - vm-1" in html
     assert '"/api/vm-logs/vm-1"' in html
+    # Opened in its own tab from the instances page, so Close Tab works here.
+    assert "Close Tab" in html
 
 
 @patch("lablink_allocator_service.main.database")


### PR DESCRIPTION
## Summary

- Adds `/admin/allocator-logs`, an admin page showing the allocator's **own** container output, working identically on AWS and manual/BYO deployments.
- `start.sh` tees the container's entire stdout/stderr through `rotatelogs` into `/var/log/lablink/allocator.log`; a Flask-free helper tails and redacts it; a thin blueprint serves it as JSON.
- Reuses the existing `instance-logs.html` (parameterized, not cloned), so both log pages share one template.

`lablink logs` already showed allocator logs for both providers, so this is not a missing capability — it's a missing **access path**. The TUI needs the admin's laptop with AWS credentials / SSH reachability or local Docker; this page needs a browser and the admin password. For BYO especially, whoever debugs a deployment is often not whoever ran `lablink deploy`.

## Changes Made

**Capture** (`start.sh`, both Dockerfiles)
- `exec > >(tee >(rotatelogs -n 2 /var/log/lablink/allocator.log 64M)) 2>&1` at the top of `start.sh`, before anything can emit output. PID 1 is bash, so every subprocess (Postgres, Flask, `nginx -t`, `cloudflared`) inherits it.
- `apache2-utils` added to the apt block in `Dockerfile` and `Dockerfile.dev`, for `rotatelogs`.

**Read** (`utils/log_tail.py`, new)
- Tails the last 2000 lines (matching the CLI's `_MANUAL_ALLOCATOR_TAIL`) by seeking a bounded window back from EOF, not by reading a 64 MB file on every 5-second poll.
- Concatenates both rotation files **oldest-first by mtime** — `rotatelogs -n` cycles a fixed list of names, so the `.1` suffix does not indicate age.
- Masks `PASSWORD`/`TOKEN`/`SECRET`/`KEY` values, and strips ANSI escapes.
- A missing log file returns `None`, never raises.

**Serve** (`routes/allocator_logs.py`, new)
- `GET /api/allocator-logs` → `{"cloud_init_logs": null, "docker_logs": str|null, "error": str|null}`. Keys deliberately mirror `/api/vm-logs/<hostname>` so the shared template's JS needs no changes.
- `GET /admin/allocator-logs` → renders the shared template. Both routes `@auth.login_required`.
- A missing log file is a 200 with an `error` string explaining it, not a 500.

**Page** (`instance-logs.html`, `admin.html`, `admin_pages.py`)
- The template now takes `log_title` / `log_endpoint` / `download_slug` / `show_cloud_init` from its caller instead of deriving them from `hostname` and `provider`. No behaviour change to the client-VM page.
- One unconditional **Allocator Logs** button on the admin dashboard.

## Testing

`885 passed, 20 skipped` (`--ignore=tests/terraform`), `ruff` clean. New: `tests/test_log_tail.py` (8 tests, `tmp_path` only, no fixtures), `tests/test_allocator_logs.py` (6), plus one added to `test_pages.py` guarding the template parameterization on a non-AWS provider.

Hand-tested against `lablink-allocator:dev` with a manual-provider config:

| Check | Result |
|---|---|
| **`docker logs` after the redirect** | 157 lines, identical to the file — the `tee` regression check |
| Log file present, non-empty | Postgres startup lines at head |
| Survives `docker restart` | pre-restart lines still served |
| Both routes unauthenticated | 401 / 401 |
| Redaction end-to-end | `..._PASSWORD=hunter2` → `***REDACTED***`, no leak |
| ANSI | 3 escapes in the raw file → 0 in the response |
| Page | single Docker tab (badge 165), no cloud-init tab, Lines/Last Updated populated |
| Auto-refresh, download | toggles; filename `allocator_logs_<ts>.txt` |
| Client-VM page unregressed | `VM Logs - <host>`, fetches `/api/vm-logs/<host>` |

Hand-testing caught one bug the unit tests could not: werkzeug colorizes non-2xx request lines, so the page rendered `^[[31m^[[1mGET /admin/allocator-logs`. Client VM logs arrive clean because `vm_telemetry` strips ANSI at ingestion; the fix reuses that same `strip_ansi` helper.

## Design Decisions

- **No `docker.sock` mount.** The allocator cannot run `docker logs` on itself, and mounting the socket would hand this internet-exposed container root on the Docker host. A file the container writes itself is the only option.
- **`tee` is load-bearing.** `rotatelogs` writes only to its file, so redirecting straight into it would silence the container's stdout and break `lablink logs` for both providers, `logs_viewer.py`'s direct-`docker logs` path, and hand-typed `docker logs`. With `tee` in front the change is purely additive.
- **`rotatelogs` over `tee -a`.** Bounds disk at ~128 MB across two fixed filenames with no cron and no logrotate config. Plain `tee -a` grows without limit inside a single long run — the failure mode that matters for a BYO allocator left up for weeks.
- **Redaction is required, not defensive.** `start.sh` already goes out of its way to keep the Cloudflare token out of `docker logs` because "cloudflared dumps its entire environment at INFO on startup" — that dump reaches the Postgres and admin passwords, and it lands in exactly the stream this page serves. This page widens that audience from "has Docker/SSH on the host" to "has the admin password, over the internet", so masking happens server-side in the reader, before the response leaves the process.
- **Parameterize, don't clone.** `instance-logs.html` is 414 lines and already handles the single-stream case that BYO client pages render in production. Reuse gets auto-refresh, follow-tail, line counts, and styling for free, and stops the two pages from drifting.
- **Cloud-init logs are out of scope.** They live on the EC2 host, outside this container; including them would need a host bind-mount, therefore a `lablink-template` tag and a `TEMPLATE_VERSION`/`TEMPLATE_SHA256` bump. This PR touches `packages/allocator` only.
- **No named volume for `/var/log/lablink`.** The page is deliberately *exactly as durable as `docker logs`* — survives `docker restart`, lost on container replacement, which is the guarantee admins already have. A volume would mean editing both compose templates and making `lablink destroy` reason about a third volume. Upgrade path if it bites BYO admins: add `allocator_logs:/var/log/lablink` to both templates and confirm `destroy` leaves it alone.
- **Boot-failure diagnosis stays `lablink logs` territory.** A dead allocator cannot serve its own log page.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MF7ooCL77pmAqxZMGq5t4C