### PR TITLE
fix(client): set C.UTF-8 locale in the client image

### DIFF
--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -7,6 +7,11 @@ ARG USERNAME="client"
 # Set non-interactive mode
 ENV DEBIAN_FRONTEND=noninteractive
 
+# The base image sets no locale, so the container runs as C/POSIX and desktop
+# terminals ASCII-decode UTF-8 output — rich/click box drawing turns into runs
+# of U+FFFD. C.UTF-8 is built into glibc 2.35, so no `locales` package needed.
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
 # Set NVIDIA driver capabilities
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -7,6 +7,11 @@ ARG USERNAME="client"
 # Set non-interactive mode
 ENV DEBIAN_FRONTEND=noninteractive
 
+# The base image sets no locale, so the container runs as C/POSIX and desktop
+# terminals ASCII-decode UTF-8 output — rich/click box drawing turns into runs
+# of U+FFFD. C.UTF-8 is built into glibc 2.35, so no `locales` package needed.
+ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
+
 # Set NVIDIA driver capabilities
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 


### PR DESCRIPTION
## Problem

The client container runs in the `C`/POSIX locale. The base image
(`nvidia/cuda:12.8.1-cudnn-runtime-ubuntu22.04`) sets no locale, and neither did
our `Dockerfile`, `Dockerfile.dev`, or `start.sh`.

Desktop terminals then ASCII-decode UTF-8 output, so any `rich`/`click` box
drawing renders as runs of U+FFFD — the diamond-with-question-mark — one per
byte. Found while running SLEAP over KasmVNC, where a `sleap train` error panel
came out looking like this:

```
������ Error ��������������������������������
��� No such option '--config-name'.        ���
������������������������������������������������
```

Not a font problem: the image already installs `fonts-dejavu`,
`fonts-liberation`, and `fontconfig`, and a missing glyph renders as an empty or
hex-digit box, never as U+FFFD.

## Change

One `ENV` line in both `Dockerfile` and `Dockerfile.dev`:

```dockerfile
ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
```

`C.UTF-8` is built into glibc 2.35, so this needs no `locales` package and no
`locale-gen`.

## Verification

Confirmed the two assumptions on a clean `ubuntu:22.04` (same glibc as the CUDA
base):

```
--- default locale ---      LANG= / LC_CTYPE="POSIX"
--- locales pkg?  ---       un  locales  <none>      # never installed
--- C.UTF-8 available? ---  UTF-8
```

**Not yet verified end-to-end** — needs a rebuilt client image and a look at the
terminal over KasmVNC. In the VM:

```bash
locale                      # expect LANG=C.UTF-8
printf '╭─╮\n'   # expect ╭─╮
```

If the diamonds persist *only* in text copied out of the VM, that's KasmVNC's
clipboard rather than the terminal, and this change won't affect it.

## Notes

Unrelated: the misleading `No such option '--config-name'` message is upstream —
`sleap/cli.py` registers a zero-option stub for `train` when `sleap_nn` can't be
imported, so click rejects the flag before the stub's "requires sleap-nn"
message can print. Fixed on our side by installing `sleap[nn]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)