### PR TITLE
docs: bring CLI reference and guides up to parity with the shipped CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,8 +177,6 @@ LabLink uses **independent versioning** for its packages:
 - **lablink-client-service**: [![PyPI](https://img.shields.io/pypi/v/lablink-client-service)](https://pypi.org/project/lablink-client-service/)
 - **lablink-cli**: [![PyPI](https://img.shields.io/pypi/v/lablink-cli)](https://pypi.org/project/lablink-cli/)
 
-See the [Release Process](https://talmolab.github.io/lablink/contributing/#release-process) for how releases are managed.
-
 ---
 
 ## 🤝 Contributing

--- a/docs/cli/byo-clients.md
+++ b/docs/cli/byo-clients.md
@@ -8,11 +8,11 @@ Terraform, no cloud bill.
 Set `provider: manual` in your config and every command in the
 [CLI Reference](../reference/cli.md) switches to this path.
 
+Beyond the split in [CLI Overview](index.md#two-providers), the practical
+differences:
+
 | | AWS provider | Manual provider |
 |---|---|---|
-| Where the allocator runs | EC2, via Terraform | docker-compose, on your machine |
-| Where client machines come from | `lablink client launch` provisions them | you run `lablink client register` on each box |
-| Needs AWS credentials | Yes | No |
 | Needs Terraform | Yes | No |
 | Needs docker locally | No | **Yes** (allocator + clients are containers) |
 | Cost | Per-hour EC2 + EBS + optional ALB | Your own hardware |
@@ -43,15 +43,12 @@ all.
 | `reverse_tunnel` | The client dials **out** to the allocator and holds one connection open. | The network won't carry Tailscale, or the box can't accept inbound connections at all. |
 
 !!! warning "`lan_direct` cannot serve off-LAN participants"
-    `lan_direct` sends the browser straight to a client's private LAN IP over
-    `ws://`, which is unreachable from outside the LAN and blocked as mixed content
-    from an HTTPS page. Both `lablink configure` and `lablink deploy` reject
-    `lan_direct` combined with any `manual.participant_exposure` other than `none`.
-    If participants are remote, pick `mesh_overlay` or `reverse_tunnel`.
+    If participants are remote, pick `mesh_overlay` or `reverse_tunnel` —
+    `lan_direct` combined with any exposure mode is rejected, and
+    [Configuration](../configuration.md#manual-provider-options-manual) explains why.
 
 Reaching the **allocator** from off-LAN is a separate axis —
-`manual.participant_exposure`, covered in
-[Configuration](../configuration.md#manual-provider-options-manual).
+`manual.participant_exposure`, covered on that same page.
 
 ## Step 1: Configure
 
@@ -95,9 +92,6 @@ manual:
 ```bash
 lablink doctor
 ```
-
-Under the manual provider this checks two things — that `docker` is on `PATH`, and
-that `docker compose` works. That's the whole prerequisite list.
 
 ## Step 3: Deploy the allocator
 
@@ -166,13 +160,9 @@ the returned secrets to `~/.lablink/client.env` (mode `0600`), and `docker run`s
 client container. Every auto-detected value has an override flag if you need one.
 
 The registration shape has to match the allocator's configured connectivity, or the
-allocator rejects it with a 400:
-
-| `manual.connectivity` | Register with |
-|---|---|
-| `lan_direct` | no connectivity flag |
-| `mesh_overlay` | `--overlay-hostname <name> --tailscale-authkey <key>` |
-| `reverse_tunnel` | `--tunnel` |
+allocator rejects it with a 400 — see
+[`client register`](../reference/cli.md#client-register) for which flags each mode
+requires.
 
 The allocator's admin UI also renders a ready-to-paste command at
 **`/admin/byo-onboarding`**, with the flags already matched to your mode. That's the
@@ -201,13 +191,12 @@ lablink status
 |---|---|---|
 | Check health | `lablink status` | Shows compose container status + the allocator's health endpoint. No cost estimate — the hardware is yours. |
 | Read logs | `lablink logs` | Tails the local `lablink-allocator` container. Per-VM client logs aren't centralized in this mode — run `docker logs lablink-client` on the box itself. |
-| Session metrics | `lablink stats` | Same as the AWS path. |
-| Export metrics | `lablink export-metrics --client` | Same as the AWS path. |
 | Add a box | `lablink client register` | Run on the new box. |
 | Remove a box | `lablink client unregister` | Run on that box. |
 
-`lablink client launch` does nothing here — it no-ops with a message pointing you
-back at `client register`.
+Only `client launch` is unavailable — it no-ops with a message pointing you back at
+`client register`. Every other command, `stats` and `export-metrics` included,
+behaves as it does on the AWS path.
 
 ## Removing a box
 

--- a/docs/cli/byo-clients.md
+++ b/docs/cli/byo-clients.md
@@ -1,0 +1,262 @@
+# Bring-Your-Own Clients
+
+The CLI's other deployment mode. Instead of provisioning EC2 instances, the
+allocator runs as a **local docker-compose stack** on a machine you already have,
+and the client machines are boxes you register yourself. No AWS account, no
+Terraform, no cloud bill.
+
+Set `provider: manual` in your config and every command in the
+[CLI Reference](../reference/cli.md) switches to this path.
+
+| | AWS provider | Manual provider |
+|---|---|---|
+| Where the allocator runs | EC2, via Terraform | docker-compose, on your machine |
+| Where client machines come from | `lablink client launch` provisions them | you run `lablink client register` on each box |
+| Needs AWS credentials | Yes | No |
+| Needs Terraform | Yes | No |
+| Needs docker locally | No | **Yes** (allocator + clients are containers) |
+| Cost | Per-hour EC2 + EBS + optional ALB | Your own hardware |
+
+Good fits: a lab with GPU workstations already on a bench, a workshop on
+institution-owned machines, or a scheduler-hosted workload (e.g. Run:AI) you can't
+provision from Terraform.
+
+## Prerequisites
+
+- **docker** and the **`docker compose` v2 plugin** on the allocator host and on every client box.
+- The CLI installed — see [Installation](installation.md).
+- A network path from each client box to the allocator, or from the allocator to each client. Which direction you need is what [connectivity mode](#pick-a-connectivity-mode) decides.
+
+`lablink doctor` checks the docker side for you under this provider.
+
+## Pick a connectivity mode
+
+`manual.connectivity` decides how a participant's browser reaches a client's
+KasmVNC desktop. This is the one decision worth making before you deploy, because
+it determines how each box registers and whether off-LAN participants can work at
+all.
+
+| Mode | How the desktop is reached | Use when |
+|---|---|---|
+| `lan_direct` (default) | The browser opens a WebSocket straight to the client's LAN IP. | Every client *and* every participant is on the allocator's own LAN. |
+| `mesh_overlay` | The client joins a Tailscale tailnet; the allocator reaches it over the overlay and proxies the byte path through its own nginx. | Clients aren't on the allocator's LAN — e.g. a Run:AI-hosted workload. |
+| `reverse_tunnel` | The client dials **out** to the allocator and holds one connection open. | The network won't carry Tailscale, or the box can't accept inbound connections at all. |
+
+!!! warning "`lan_direct` cannot serve off-LAN participants"
+    `lan_direct` sends the browser straight to a client's private LAN IP over
+    `ws://`, which is unreachable from outside the LAN and blocked as mixed content
+    from an HTTPS page. Both `lablink configure` and `lablink deploy` reject
+    `lan_direct` combined with any `manual.participant_exposure` other than `none`.
+    If participants are remote, pick `mesh_overlay` or `reverse_tunnel`.
+
+Reaching the **allocator** from off-LAN is a separate axis —
+`manual.participant_exposure`, covered in
+[Configuration](../configuration.md#manual-provider-options-manual).
+
+## Step 1: Configure
+
+```bash
+lablink configure
+```
+
+The wizard writes `~/.lablink/config.yaml`. Choose the manual provider, then the
+connectivity mode. Unlike the AWS path, it does **not** run `lablink setup`
+afterwards — there is no remote state to bootstrap.
+
+!!! note "The manual provider requires `ssl.provider: none`"
+    The allocator image ships no TLS terminator — on the AWS path, Caddy is part of
+    the infrastructure, not the container. `lablink deploy` exits with an error if
+    `ssl.provider` is anything but `none`.
+
+    The wizard handles this for you: picking the manual provider pins
+    `ssl.provider: none`, disables DNS, and skips the DNS/SSL screen entirely. The
+    error is only reachable from a **hand-edited** config — worth knowing, because
+    `SSLConfig`'s own default is `letsencrypt`, so a config you wrote yourself or
+    inherited from an AWS deployment will hit it.
+
+    For public TLS, either use a
+    [participant exposure mode](../configuration.md#exposure-mode-cloudflare_tunnel)
+    (which terminates TLS for you) or front the compose stack with your own reverse
+    proxy.
+
+A minimal LAN-only config:
+
+```yaml
+provider: manual
+deployment_name: smith-lab
+ssl:
+  provider: none
+manual:
+  connectivity: lan_direct
+```
+
+## Step 2: Sanity check
+
+```bash
+lablink doctor
+```
+
+Under the manual provider this checks two things — that `docker` is on `PATH`, and
+that `docker compose` works. That's the whole prerequisite list.
+
+## Step 3: Deploy the allocator
+
+```bash
+lablink deploy
+```
+
+This renders `docker-compose.yml`, a `.env`, and a copy of your `config.yaml` into
+`~/.lablink/compose/<deployment_name>/`, then runs `docker compose up -d` and waits
+for the allocator's health endpoint. Postgres runs inside the same stack, with its
+data in a named volume.
+
+You'll be prompted for an admin username and password, which are not written to
+`config.yaml`.
+
+When it finishes, `deploy` prints what you need to onboard boxes:
+
+```text
+Deployment complete.
+  Allocator URL (local): http://localhost
+  Allocator URL (LAN):   http://192.168.1.42
+  Admin user:            admin
+  Register token:        Xf3k9…
+
+Next step: on each BYO box on the same LAN, run
+  lablink client register --allocator-url http://192.168.1.42 --register-token Xf3k9…
+```
+
+The printed `client register` command is already tailored to your connectivity
+mode — mesh-overlay and reverse-tunnel deployments get the extra flags filled in.
+Copy it as-is.
+
+!!! tip "Lost the token?"
+    ```bash
+    docker logs lablink-allocator 2>&1 | grep REGISTER_TOKEN
+    ```
+    The `2>&1` matters — the allocator logs to stderr, so without it `grep` sees
+    nothing.
+
+If `deploy` could only detect `localhost` and not a LAN address, the command it
+prints is valid only for a client on the allocator host itself. Substitute the
+host's real LAN IP or hostname before handing it to anyone else.
+
+Deploying with a connectivity or exposure mode that needs Tailscale also requires
+an auth key on the **first** deploy:
+
+```bash
+lablink deploy --tailscale-authkey tskey-auth-...
+```
+
+Redeploys carry the previous key forward from the deployment's `.env`, so you only
+pass it again to rotate it.
+
+## Step 4: Register each box
+
+Run this **on the machine you're adding**, not on the allocator host:
+
+```bash
+lablink client register \
+  --allocator-url http://192.168.1.42:5000 \
+  --register-token Xf3k9…
+```
+
+It auto-detects hostname, LAN IP, machine identity, and GPU presence/model, writes
+the returned secrets to `~/.lablink/client.env` (mode `0600`), and `docker run`s the
+client container. Every auto-detected value has an override flag if you need one.
+
+The registration shape has to match the allocator's configured connectivity, or the
+allocator rejects it with a 400:
+
+| `manual.connectivity` | Register with |
+|---|---|
+| `lan_direct` | no connectivity flag |
+| `mesh_overlay` | `--overlay-hostname <name> --tailscale-authkey <key>` |
+| `reverse_tunnel` | `--tunnel` |
+
+The allocator's admin UI also renders a ready-to-paste command at
+**`/admin/byo-onboarding`**, with the flags already matched to your mode. That's the
+easiest thing to send to someone else who owns a box.
+
+!!! note "Registering ahead of time, from somewhere else"
+    For mesh-overlay and reverse-tunnel clients, `register` defaults to running the
+    container right here (`--run-locally`). Add `--no-run-locally` to instead print
+    the secrets for pasting into a separate workload submission — useful when you're
+    registering a scheduler-hosted workload from your laptop rather than from inside
+    the workload. In that case you must also pass `--hostname` and
+    `--machine-identity`, since there's nothing local to auto-detect from.
+
+If docker is missing on the box, `register` keeps the env file so you can install
+docker and re-run with `--force`.
+
+Confirm the box landed in the pool:
+
+```bash
+lablink status
+```
+
+## Day-to-day
+
+| Task | Command | Manual-provider notes |
+|---|---|---|
+| Check health | `lablink status` | Shows compose container status + the allocator's health endpoint. No cost estimate — the hardware is yours. |
+| Read logs | `lablink logs` | Tails the local `lablink-allocator` container. Per-VM client logs aren't centralized in this mode — run `docker logs lablink-client` on the box itself. |
+| Session metrics | `lablink stats` | Same as the AWS path. |
+| Export metrics | `lablink export-metrics --client` | Same as the AWS path. |
+| Add a box | `lablink client register` | Run on the new box. |
+| Remove a box | `lablink client unregister` | Run on that box. |
+
+`lablink client launch` does nothing here — it no-ops with a message pointing you
+back at `client register`.
+
+## Removing a box
+
+On the box itself:
+
+```bash
+lablink client unregister
+```
+
+Notifies the allocator best-effort, removes the `lablink-client` container, and
+deletes the env file. It's idempotent and safe to run after the allocator is already
+gone.
+
+For a mesh-overlay client, `unregister` deliberately **keeps** the Tailscale node
+identity so re-registering returns to the same tailnet node under the same name. To
+deliberately start fresh:
+
+```bash
+lablink client reset-overlay
+```
+
+!!! warning "Reset does not delete the old tailnet machine"
+    The previous node goes offline still holding its name, so the next join gets a
+    numeric suffix (`-1`, `-2`, …) until you delete the stale machine in the
+    Tailscale admin console. The container must already be removed, too — docker
+    won't detach a volume that's in use.
+
+## Tearing down
+
+```bash
+lablink destroy              # stops the stack, wipes the Postgres volume
+lablink destroy --keep-data  # stops the stack, preserves registration history
+```
+
+`--keep-data` is the one to use between sessions of the same workshop — sessions and
+registration history survive the next `lablink deploy`.
+
+To also remove the compose working directory and its volumes outright:
+
+```bash
+lablink cleanup
+```
+
+Under the manual provider this runs `docker compose down --volumes` and deletes
+`~/.lablink/compose/<deployment_name>/`. (`--dry-run` is AWS-only; the manual path
+confirms interactively instead.)
+
+## Next steps
+
+- [Configuration](../configuration.md#manual-provider-options-manual) — every `manual.*` setting, including how to publish the allocator to off-LAN participants.
+- [CLI Reference](../reference/cli.md#client-fleet-commands) — full flag list for the `client` commands.
+- [Troubleshooting](../troubleshooting.md) — general LabLink issues.

--- a/docs/cli/first-deployment.md
+++ b/docs/cli/first-deployment.md
@@ -2,6 +2,13 @@
 
 This walkthrough takes you from a clean install through a live allocator and back to an empty AWS account. Budget about 15 minutes end to end.
 
+!!! note "This is the AWS path"
+    Everything below assumes the default `provider: aws` — the allocator on EC2,
+    client VMs provisioned by Terraform. To run the allocator on a machine you
+    already have and register your own client boxes instead, follow
+    [Bring-Your-Own Clients](byo-clients.md); it needs no AWS account and no
+    Terraform.
+
 ## Before you start
 
 Make sure you've completed [Installation](installation.md) and that `lablink doctor` reports clean values for "Terraform installed" and "AWS credentials". The other checks will light up as you go.
@@ -24,6 +31,8 @@ The wizard writes `~/.lablink/config.yaml` and then **automatically runs `lablin
 1. An **S3 bucket** for Terraform state (versioned + encrypted).
 2. A **DynamoDB table** for state locking.
 
+(Manual-provider configs skip that step — there's no remote state to bootstrap.)
+
 !!! tip "Re-running the wizard"
     `lablink configure` is idempotent. Run it again anytime to edit the config — it loads your existing values as defaults.
 
@@ -39,7 +48,7 @@ lablink show-config
 lablink doctor
 ```
 
-All six checks should now pass:
+All six AWS checks should now pass:
 
 ```text
 ┌─────────────────────────┬────────┬─────────────────────────────────────┐
@@ -66,14 +75,14 @@ This will:
 
 1. Download the pinned `lablink-template` Terraform files into `~/.lablink/cache/terraform/<version>/` (first run only).
 2. Copy them into a working directory at `~/.lablink/deploys/<deployment-name>/`.
-3. Prompt you once for an **admin password** and **database password**. These are injected into the Terraform variables — they are not stored in `config.yaml`.
+3. Prompt you once for an **admin username** (default `admin`) and **admin password**. These are injected into the Terraform variables — they are not stored in `config.yaml`.
 4. Run `terraform init` + `terraform apply`, showing the plan and asking for confirmation.
 5. Wait for the allocator EC2 instance to come up and its `/api/health` endpoint to report `healthy`.
 
 Expect 2–5 minutes for Terraform + another 1–3 minutes for the allocator to finish its first-boot container start.
 
 !!! tip "Skip interactive confirmations"
-    Pass `-y` / `--yes` to skip Terraform plan confirmation. Admin/DB passwords are still prompted for.
+    Pass `-y` / `--yes` to skip Terraform plan confirmation. The admin credentials are still prompted for.
 
 When deploy completes, note the `ec2_public_ip` in the Terraform output — that's your allocator URL.
 
@@ -90,7 +99,7 @@ This shows four sections:
 - **Client VMs** — per-VM state reported by the allocator (empty until you run `lablink client launch`).
 - **Cost Estimate** — daily and monthly dollar estimates for the allocator, EBS, optional ALB/Route 53, and running client VMs.
 
-Open the allocator in a browser using `http://<ec2_public_ip>` (or your configured domain) and log in with username `admin` and the admin password you entered during deploy.
+Open the allocator in a browser using `http://<ec2_public_ip>` (or your configured domain) and log in with the admin username and password you entered during deploy.
 
 ## Step 5: Launch a client VM
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -5,6 +5,21 @@ The `lablink` command is a CLI-driven alternative to the [lablink-template](http
 !!! note "Status: pre-PyPI"
     The CLI is not yet published to PyPI. For now, install it from source with `uv sync --all-packages` — see [Installation](installation.md). `uv tool install lablink` will be the path once the package is released.
 
+## Two providers
+
+The CLI can deploy in either of two modes, selected by the `provider` field in your
+config:
+
+| `provider` | Allocator runs on | Client machines | Needs AWS? |
+|---|---|---|---|
+| `aws` (default) | EC2, provisioned by Terraform | `lablink client launch` provisions them for you | Yes |
+| `manual` | docker-compose, on a machine you already have | you register your own boxes with `lablink client register` | No |
+
+Everything below compares the **AWS** path against the template repo. If you'd
+rather run LabLink on hardware you already own — lab workstations, an on-prem
+server, a scheduler-hosted workload — see
+[Bring-Your-Own Clients](byo-clients.md) instead.
+
 ## CLI vs. template repo
 
 Both paths deploy the same allocator service and manage the same set of AWS resources. The practical difference is **how much of the deployment you own and configure yourself**.
@@ -41,6 +56,6 @@ You can switch between them later — both read the same `config.yaml` schema fo
 ## Next steps
 
 1. [Install the CLI](installation.md)
-2. [Run your first deployment](first-deployment.md)
+2. [Run your first deployment](first-deployment.md) (AWS) — or [bring your own clients](byo-clients.md) (no AWS)
 3. [Manage an existing deployment](managing-deployments.md)
 4. Full command reference: [CLI Reference](../reference/cli.md)

--- a/docs/cli/managing-deployments.md
+++ b/docs/cli/managing-deployments.md
@@ -4,15 +4,13 @@ Day-to-day operations once an allocator is running: add client machines, follow 
 
 Every command on this page reads `~/.lablink/config.yaml` by default. Pass `--config /path/to/other.yaml` to target a different deployment.
 
-!!! note "Provider-dependent behavior"
-    Most of these commands branch on your config's `provider`. The AWS behavior is
-    described below, with the manual-provider difference called out where there is
-    one. For the full bring-your-own workflow in one place, see
-    [Bring-Your-Own Clients](byo-clients.md).
+!!! note "This page describes the AWS provider"
+    Most of these commands branch on your config's `provider`. Under
+    `provider: manual` the same commands act on a local docker-compose stack
+    instead — see [Bring-Your-Own Clients](byo-clients.md#day-to-day), which covers
+    the manual workflow end to end.
 
-## Add client machines
-
-**AWS provider** — ask the allocator to provision VMs:
+## Launch client VMs
 
 ```bash
 lablink client launch --num-vms 5
@@ -28,15 +26,8 @@ The allocator runs its own Terraform workspace inside the EC2 instance — the C
 
 Watch `lablink status` to see the VMs transition from pending → running.
 
-**Manual provider** — run this *on each box you're adding*, not on the allocator host:
-
-```bash
-lablink client register --allocator-url http://192.168.1.42 --register-token <token>
-```
-
-`lablink client launch` no-ops under the manual provider. To remove a box later, run
-`lablink client unregister` on it. Details and the mesh-overlay / reverse-tunnel
-variants: [Bring-Your-Own Clients](byo-clients.md#step-4-register-each-box).
+Under the manual provider this no-ops; you add boxes with
+[`lablink client register`](byo-clients.md#step-4-register-each-box) instead.
 
 ## Check status
 
@@ -48,9 +39,6 @@ Shows Terraform outputs, health checks, per-VM state, and a cost estimate. This 
 
 See [First Deployment](first-deployment.md#step-4-verify) for what each section means.
 
-Under the manual provider it instead shows docker-compose container status and the
-allocator's health endpoint — no cost estimate, since the hardware is yours.
-
 ## Follow logs
 
 ```bash
@@ -61,10 +49,6 @@ Opens an interactive TUI that streams logs from the allocator and any running cl
 
 !!! tip "Quit and search"
     Use `q` to exit. The viewer supports `/` to search, `n` / `N` for next/previous match, and arrow keys for navigation.
-
-Under the manual provider there's no TUI — it tails the local `lablink-allocator`
-container. Per-VM client logs aren't centralized in that mode; run
-`docker logs lablink-client` on the box itself.
 
 ## Export metrics
 
@@ -100,14 +84,9 @@ lablink export-metrics --allocator --format json -o post-mortem.json
 lablink stats
 ```
 
-Prints the cohort session-metrics summary — participation funnel and aggregate
-time-in-software — in your terminal. It reads the allocator's
-`/api/session-metrics/summary` endpoint, the same view model the admin UI's
-**Session Metrics** page uses, so the two can't disagree.
-
-The figures only populate for deployments running with `monitoring.enabled: true`.
-Use `export-metrics --client` when you want the underlying per-VM rows instead of
-the summary.
+Prints the cohort summary — participation funnel and aggregate time-in-software —
+for deployments running with `monitoring.enabled: true`. See
+[`stats`](../reference/cli.md#stats).
 
 ## Show the current config
 
@@ -129,9 +108,7 @@ Runs `terraform destroy` against the deployment's working directory (`~/.lablink
 |---|---|
 | `-y`, `--yes` | Skip the confirmation prompt. Password prompts still appear. |
 | `-v`, `--verbose` | Show the full Terraform output instead of a summary. |
-| `--keep-data` | **Manual provider only** — preserve the Postgres data volume instead of the default full wipe, so registration history and sessions survive the next deploy. Ignored for AWS. |
-
-Under the manual provider this brings the compose stack down instead of running Terraform.
+| `--keep-data` | **Manual provider only** — preserve the Postgres data volume instead of the default full wipe. Ignored for AWS. |
 
 ## Cleanup orphaned resources
 
@@ -142,9 +119,7 @@ lablink cleanup --dry-run   # preview
 lablink cleanup             # actually delete
 ```
 
-On AWS it targets EC2/IAM/EIP/security-group resources tagged with your deployment name, plus the environment-specific Terraform state files. `--dry-run` prints what would be deleted without touching AWS.
-
-Under the manual provider it runs `docker compose down --volumes` and removes the compose working directory. `--dry-run` is AWS-only — the manual path confirms interactively instead.
+It targets EC2/IAM/EIP/security-group resources tagged with your deployment name, plus the environment-specific Terraform state files. `--dry-run` prints what would be deleted without touching AWS.
 
 ## Clear local caches
 

--- a/docs/cli/managing-deployments.md
+++ b/docs/cli/managing-deployments.md
@@ -1,23 +1,42 @@
 # Managing Deployments
 
-Day-to-day operations once an allocator is running: launch client VMs, follow logs, export metrics, and clean up.
+Day-to-day operations once an allocator is running: add client machines, follow logs, export metrics, and clean up.
 
 Every command on this page reads `~/.lablink/config.yaml` by default. Pass `--config /path/to/other.yaml` to target a different deployment.
 
-## Launch client VMs
+!!! note "Provider-dependent behavior"
+    Most of these commands branch on your config's `provider`. The AWS behavior is
+    described below, with the manual-provider difference called out where there is
+    one. For the full bring-your-own workflow in one place, see
+    [Bring-Your-Own Clients](byo-clients.md).
+
+## Add client machines
+
+**AWS provider** — ask the allocator to provision VMs:
 
 ```bash
 lablink client launch --num-vms 5
 ```
 
-This asks the allocator to provision client VMs on your behalf. The allocator runs its own Terraform workspace inside the EC2 instance — the CLI only hits its HTTP API, so you don't need Terraform locally for this step.
+The allocator runs its own Terraform workspace inside the EC2 instance — the CLI only hits its HTTP API, so you don't need Terraform locally for this step.
 
 | Flag | Description |
 |---|---|
 | `-n`, `--num-vms` | Number of client VMs to launch. Required. |
 | `-c`, `--config` | Override the default config path. |
+| `-v`, `--verbose` | Show the full Terraform output instead of a summary. |
 
 Watch `lablink status` to see the VMs transition from pending → running.
+
+**Manual provider** — run this *on each box you're adding*, not on the allocator host:
+
+```bash
+lablink client register --allocator-url http://192.168.1.42 --register-token <token>
+```
+
+`lablink client launch` no-ops under the manual provider. To remove a box later, run
+`lablink client unregister` on it. Details and the mesh-overlay / reverse-tunnel
+variants: [Bring-Your-Own Clients](byo-clients.md#step-4-register-each-box).
 
 ## Check status
 
@@ -29,6 +48,9 @@ Shows Terraform outputs, health checks, per-VM state, and a cost estimate. This 
 
 See [First Deployment](first-deployment.md#step-4-verify) for what each section means.
 
+Under the manual provider it instead shows docker-compose container status and the
+allocator's health endpoint — no cost estimate, since the hardware is yours.
+
 ## Follow logs
 
 ```bash
@@ -39,6 +61,10 @@ Opens an interactive TUI that streams logs from the allocator and any running cl
 
 !!! tip "Quit and search"
     Use `q` to exit. The viewer supports `/` to search, `n` / `N` for next/previous match, and arrow keys for navigation.
+
+Under the manual provider there's no TUI — it tails the local `lablink-allocator`
+container. Per-VM client logs aren't centralized in that mode; run
+`docker logs lablink-client` on the box itself.
 
 ## Export metrics
 
@@ -68,6 +94,21 @@ Example — only allocator metrics after tear-down:
 lablink export-metrics --allocator --format json -o post-mortem.json
 ```
 
+## Session metrics summary
+
+```bash
+lablink stats
+```
+
+Prints the cohort session-metrics summary — participation funnel and aggregate
+time-in-software — in your terminal. It reads the allocator's
+`/api/session-metrics/summary` endpoint, the same view model the admin UI's
+**Session Metrics** page uses, so the two can't disagree.
+
+The figures only populate for deployments running with `monitoring.enabled: true`.
+Use `export-metrics --client` when you want the underlying per-VM rows instead of
+the summary.
+
 ## Show the current config
 
 ```bash
@@ -84,7 +125,13 @@ lablink destroy
 
 Runs `terraform destroy` against the deployment's working directory (`~/.lablink/deploys/<name>/`). Tears down the allocator EC2 instance, security groups, key pair, and any ALB/Route 53 records. Client VMs owned by the allocator are destroyed along with it.
 
-Pass `-y` / `--yes` to skip the confirmation prompt. Password prompts still appear.
+| Flag | Description |
+|---|---|
+| `-y`, `--yes` | Skip the confirmation prompt. Password prompts still appear. |
+| `-v`, `--verbose` | Show the full Terraform output instead of a summary. |
+| `--keep-data` | **Manual provider only** — preserve the Postgres data volume instead of the default full wipe, so registration history and sessions survive the next deploy. Ignored for AWS. |
+
+Under the manual provider this brings the compose stack down instead of running Terraform.
 
 ## Cleanup orphaned resources
 
@@ -95,7 +142,9 @@ lablink cleanup --dry-run   # preview
 lablink cleanup             # actually delete
 ```
 
-It targets resources tagged with your deployment name. `--dry-run` prints what would be deleted without touching AWS.
+On AWS it targets EC2/IAM/EIP/security-group resources tagged with your deployment name, plus the environment-specific Terraform state files. `--dry-run` prints what would be deleted without touching AWS.
+
+Under the manual provider it runs `docker compose down --volumes` and removes the compose working directory. `--dry-run` is AWS-only — the manual path confirms interactively instead.
 
 ## Clear local caches
 
@@ -121,9 +170,11 @@ Clearing the Terraform template cache forces the next deploy to re-download temp
 
 Keep multiple config files if you manage more than one deployment:
 
+`--config` is a per-command option, not a root one — it goes *after* the command:
+
 ```bash
-lablink --config ~/configs/workshop.yaml deploy
-lablink --config ~/configs/dev.yaml status
+lablink deploy --config ~/configs/workshop.yaml
+lablink status --config ~/configs/dev.yaml
 ```
 
 Each deployment gets its own working directory under `~/.lablink/deploys/<name>/` keyed by the `deployment_name` field in its config.
@@ -131,5 +182,6 @@ Each deployment gets its own working directory under `~/.lablink/deploys/<name>/
 ## Next steps
 
 - [CLI Reference](../reference/cli.md) — every command and flag in one page.
+- [Bring-Your-Own Clients](byo-clients.md) — the manual-provider workflow end to end.
 - [Troubleshooting](../troubleshooting.md) — general LabLink issues (not CLI-specific).
 - [Configuration](../configuration.md) — full `config.yaml` schema reference.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -466,17 +466,22 @@ Applies only when `provider: manual` (bring-your-own clients, deployed with
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `connectivity` | string | `lan_direct` | How a participant's browser reaches a client's KasmVNC desktop: `lan_direct` (client is on the allocator's own LAN) or `mesh_overlay` (client is reached over a Tailscale tailnet and proxied through the allocator's nginx). |
+| `connectivity` | string | `lan_direct` | How a participant's browser reaches a client's KasmVNC desktop: `lan_direct` (client is on the allocator's own LAN), `mesh_overlay` (client is reached over a Tailscale tailnet and proxied through the allocator's nginx), or `reverse_tunnel` (client dials **out** to the allocator and holds one connection open — for networks that won't carry Tailscale and boxes that can't accept inbound connections). |
 | `overlay_tailnet` | string | `""` | The tailnet's MagicDNS suffix (e.g. `example.ts.net`). Required for `connectivity: mesh_overlay` and for `participant_exposure: tailscale_funnel`. |
 | `participant_exposure` | string | `none` | How **participants** reach the allocator itself: `none` (LAN-only), `tailscale_funnel`, or `cloudflare_tunnel`. Independent of `connectivity`. |
 | `public_hostname` | string | `""` | The hostname participants open, e.g. `lab.smithlab.org`. Required when `participant_exposure: cloudflare_tunnel`; ignored otherwise. |
 
 `participant_exposure` is not the same axis as `connectivity`: the first is about
-publishing the allocator, the second about reaching clients. Any exposure mode
-other than `none` requires `connectivity: mesh_overlay` — `lan_direct` sends the
-browser straight to a client's LAN IP over `ws://`, which is unreachable off-LAN
-and blocked as mixed content from an HTTPS page. Both `lablink configure` and
-`lablink deploy` reject that combination.
+publishing the allocator, the second about reaching clients. What they do constrain
+is that any exposure mode other than `none` rules out `connectivity: lan_direct` —
+`lan_direct` sends the browser straight to a client's LAN IP over `ws://`, which is
+unreachable off-LAN and blocked as mixed content from an HTTPS page. Both
+`lablink configure` and `lablink deploy` reject that combination. `mesh_overlay` and
+`reverse_tunnel` both work with any exposure mode.
+
+Note that `overlay_tailnet` is required whenever a tailnet is involved on *either*
+axis, so a `reverse_tunnel` deployment that publishes itself via
+`tailscale_funnel` still needs one; `reverse_tunnel` on its own does not.
 
 #### Exposure mode: `tailscale_funnel`
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -7,13 +7,30 @@ Complete reference for every `lablink` command. Grouped to match the `lablink --
 
 ## Global options
 
-Every subcommand accepts `--config` to override the default config path:
+`lablink` itself takes only `--version` / `-v`. Everything else, including
+`--config`, is a **per-command** option and goes *after* the command:
 
 ```bash
-lablink <command> --config /path/to/config.yaml
+lablink deploy --config /path/to/config.yaml   # correct
+lablink --config /path/to/config.yaml deploy   # error: No such option
 ```
 
-Default: `~/.lablink/config.yaml`. If the file is missing, the command exits with a hint to run `lablink configure`.
+Default config path: `~/.lablink/config.yaml`. If the file is missing, the command
+exits with a hint to run `lablink configure`.
+
+## Provider modes
+
+Almost every command below branches on the `provider` field in your config, so read
+the reference with your provider in mind:
+
+| `provider` | What it means | Client machines come from |
+|---|---|---|
+| `aws` (default) | The allocator runs on EC2, provisioned by Terraform from your machine. | `lablink client launch` — the allocator provisions EC2 VMs. |
+| `manual` | The allocator runs as a local docker-compose stack on a machine you already have. No AWS account needed. | `lablink client register`, run by you on each bring-your-own (BYO) box. |
+
+See [Bring-Your-Own Clients](../cli/byo-clients.md) for the manual-provider
+walkthrough, and [Configuration](../configuration.md#manual-provider-options-manual)
+for the `manual.*` settings.
 
 ---
 
@@ -27,7 +44,13 @@ Create or edit the LabLink configuration.
 lablink configure [--config PATH]
 ```
 
-Launches a TUI wizard that generates or edits `config.yaml`, then automatically runs [`setup`](#setup) to create the AWS resources Terraform needs for remote state (S3 bucket + DynamoDB lock table).
+Launches a TUI wizard that generates or edits `config.yaml`. On an AWS-provider
+config it then automatically runs [`setup`](#setup) to create the resources
+Terraform needs for remote state (S3 bucket + DynamoDB lock table). Manual-provider
+configs skip that step — there is nothing to bootstrap.
+
+The wizard is idempotent: re-run it any time to edit a config, and it loads your
+existing values as the defaults.
 
 | Option | Description |
 |---|---|
@@ -37,13 +60,19 @@ Launches a TUI wizard that generates or edits `config.yaml`, then automatically 
 
 ### `setup`
 
-Create S3 + DynamoDB for remote Terraform state.
+Provision provider-specific bootstrap resources.
 
 ```bash
 lablink setup [--config PATH]
 ```
 
-Automatically run during [`configure`](#configure). Use this command on its own to recreate state resources if they were deleted out of band.
+**AWS provider:** creates the S3 bucket (versioned + encrypted) and DynamoDB lock
+table used for Terraform remote state. Automatically run during
+[`configure`](#configure) — use this command on its own to recreate the resources
+if they were deleted out of band.
+
+**Manual provider:** a no-op. Prints a message explaining that the compose stack
+needs no remote state and exits 0.
 
 | Option | Description |
 |---|---|
@@ -59,9 +88,24 @@ Check prerequisites and configuration.
 lablink doctor
 ```
 
-Runs six pre-flight checks: Terraform installed, config file exists, config validates, AWS credentials, S3 state bucket exists, AMI known for the configured region. Exit code is non-zero if any check fails.
+Takes no options. The checks it runs depend on the provider in your config:
 
-Takes no options.
+**AWS provider** — six checks:
+
+| Check | Passes when |
+|---|---|
+| Terraform installed | The `terraform` binary is on `PATH` |
+| Config file | `config.yaml` exists at the resolved path |
+| Config validates | The file merges cleanly against the schema |
+| AWS credentials | STS can resolve an identity in the configured region |
+| S3 state bucket | The Terraform state bucket exists |
+| AMI for region | The CLI has an AMI mapping for the configured region |
+
+**Manual provider** — checks that `docker` is on `PATH` and that the
+`docker compose` v2 subcommand is available.
+
+If no config is readable yet, `doctor` falls back to the AWS checks so it can still
+tell you what's missing. Exit code is non-zero if any check fails.
 
 ---
 
@@ -69,20 +113,38 @@ Takes no options.
 
 ### `deploy`
 
-Deploy LabLink infrastructure with Terraform.
+Deploy LabLink infrastructure (AWS Terraform or docker-compose).
 
 ```bash
 lablink deploy [--config PATH] [--template-version V] [--terraform-bundle PATH] [--yes]
+               [--tailscale-authkey KEY] [--cloudflare-tunnel-token TOKEN]
 ```
 
-Downloads the pinned `lablink-template` Terraform files (or uses a cached / bundled copy), renders your config into Terraform variables, and runs `terraform apply`. Prompts once for admin and database passwords — these are **not** stored in `config.yaml`.
+**AWS provider:** downloads the pinned `lablink-template` Terraform files (or uses a
+cached / bundled copy), renders your config into Terraform variables, and runs
+`terraform apply`.
+
+**Manual provider:** renders a `docker-compose.yml`, a `.env`, and your
+`config.yaml` into `~/.lablink/compose/<deployment_name>/` and runs
+`docker compose up -d`. The stack is single-service (allocator + its internal
+Postgres), plus a Tailscale sidecar when the configuration needs one. Postgres data
+lives in a named volume.
+
+Either way it prompts once for an admin username (default `admin`) and an admin
+password. Neither is stored in `config.yaml` — they are passed to Terraform /
+the container only.
 
 | Option | Description |
 |---|---|
 | `-c`, `--config PATH` | Path to `config.yaml`. |
-| `--template-version V` | Override the pinned template version (e.g. `v0.2.0`). Skips checksum verification. |
-| `--terraform-bundle PATH` | Path to a local template tarball for offline deploys. |
-| `-y`, `--yes` | Skip confirmation prompts. Does not bypass credential prompts (admin/db passwords are still required). |
+| `--template-version V` | Override the pinned template version (e.g. `v0.2.0`). Skips checksum verification. **AWS provider only.** |
+| `--terraform-bundle PATH` | Path to a local template tarball for offline deploys. **AWS provider only.** |
+| `-y`, `--yes` | Skip confirmation prompts. Does not bypass credential prompts (the admin password is still required interactively). |
+| `--tailscale-authkey KEY` | Auth key for the allocator's own tailnet sidecar. Required on the **first** deploy when `manual.connectivity` is `mesh_overlay` and/or `manual.participant_exposure` is `tailscale_funnel`; optional on redeploys (the previous value is carried forward from the deployment's `.env`). **Manual provider only.** |
+| `--cloudflare-tunnel-token TOKEN` | Token for publishing the allocator at `manual.public_hostname`. Required on the first deploy when `manual.participant_exposure` is `cloudflare_tunnel`; optional on redeploys. Supply it again to rotate. **Manual provider only.** |
+
+Secrets passed with the last two flags are written only to the deployment's `.env`
+(mode `0600`), never to `config.yaml`.
 
 ---
 
@@ -91,34 +153,156 @@ Downloads the pinned `lablink-template` Terraform files (or uses a cached / bund
 Tear down LabLink infrastructure.
 
 ```bash
-lablink destroy [--config PATH] [--yes]
+lablink destroy [--config PATH] [--yes] [--verbose] [--keep-data]
 ```
 
-Runs `terraform destroy` against the deployment's working directory. Removes the allocator EC2 instance, security groups, key pair, and any ALB/Route 53 records Terraform owns. Client VMs owned by the allocator are destroyed along with it.
+**AWS provider:** runs `terraform destroy` against the deployment's working
+directory. Removes the allocator EC2 instance, security groups, key pair, and any
+ALB/Route 53 records Terraform owns. Client VMs owned by the allocator are
+destroyed along with it.
 
-The S3 state bucket and DynamoDB lock table are **not** removed — reuse them on the next deploy, or tear them down with [`cleanup`](#cleanup).
+The S3 state bucket and DynamoDB lock table are **not** removed — reuse them on the
+next deploy, or tear them down with [`cleanup`](#cleanup).
+
+**Manual provider:** brings the compose stack down. By default this also wipes the
+Postgres data volume.
 
 | Option | Description |
 |---|---|
 | `-c`, `--config PATH` | Path to `config.yaml`. |
 | `-y`, `--yes` | Skip confirmation prompts. Password prompts still appear. |
+| `-v`, `--verbose` | Show the full Terraform output instead of a summary. |
+| `--keep-data` | Preserve the Postgres data volume instead of the default full wipe, so registration history and sessions survive a later redeploy. **Manual provider only** — ignored for AWS. |
 
 ---
+
+## Client fleet commands
+
+`lablink client` groups everything that manages client machines.
+
+```bash
+lablink client --help
+```
 
 ### `client launch`
 
 Launch client VMs via the allocator service.
 
 ```bash
-lablink client launch --num-vms N [--config PATH]
+lablink client launch --num-vms N [--config PATH] [--verbose]
 ```
 
-Calls the allocator's create-VM endpoint. The allocator provisions the VMs in its own Terraform workspace — the CLI only speaks to its HTTP API here. Terraform is not required locally for this command.
+**AWS provider only.** Calls the allocator's create-VM endpoint; the allocator
+provisions the VMs in its own Terraform workspace, so Terraform is not required
+locally for this command.
+
+Under the manual provider this command no-ops with a message pointing you at
+[`client register`](#client-register).
 
 | Option | Description |
 |---|---|
 | `-n`, `--num-vms N` | Number of client VMs to launch. **Required.** |
 | `-c`, `--config PATH` | Path to `config.yaml`. |
+| `-v`, `--verbose` | Show the full Terraform output instead of a summary. |
+
+---
+
+### `client register`
+
+Register this BYO box as a manual client and run the client container.
+
+```bash
+lablink client register --allocator-url URL --register-token TOKEN [OPTIONS]
+```
+
+Run this **on the machine you want to add to the pool**, not on the allocator host.
+It registers the box with the allocator, writes the returned secrets to
+`~/.lablink/client.env` (mode `0600`), and then `docker run`s the client container.
+
+Auto-detects hostname, LAN IP, machine identity, and GPU presence/model; every one
+of those can be overridden. If docker is missing, the env file is preserved so you
+can install docker and re-run with `--force`.
+
+The allocator's admin UI renders a ready-to-paste command for this at
+**`/admin/byo-onboarding`**, with the flags already matched to your configured
+connectivity mode.
+
+| Option | Description |
+|---|---|
+| `--allocator-url URL` | Base URL of the allocator, e.g. `https://lablink.example.com`. **Required.** |
+| `--register-token TOKEN` | The deployment's bootstrap register token, from the allocator operator. Prompted if omitted; also read from `$LABLINK_REGISTER_TOKEN`. **Required.** |
+| `--hostname NAME` | Override the auto-detected hostname. |
+| `--lan-ip IP` | Override the auto-detected LAN IP. |
+| `--machine-identity ID` | Override the auto-detected machine identifier. |
+| `--gpu-present` / `--no-gpu-present` | Override auto-detected GPU presence. |
+| `--gpu-model STR` | Override the auto-detected GPU model string. |
+| `--overlay-hostname NAME` | Register a **mesh-overlay** client under this Tailscale hostname (your choice). Requires `--tailscale-authkey`. |
+| `--tailscale-authkey KEY` | Auth key the client will use to join the tailnet. Required with `--overlay-hostname`. |
+| `--run-locally` / `--no-run-locally` | With `--overlay-hostname`: whether to `docker run` the client here now (default: on). `--no-run-locally` instead prints the secrets for pasting into a separate workload submission, and then also requires `--hostname` and `--machine-identity`. |
+| `--tunnel` | Register a **reverse-tunnel** client: the box dials *out* to the allocator and holds one connection open, instead of the allocator dialling in. For networks that won't carry Tailscale and boxes that can't accept inbound connections. Takes no arguments — the allocator mints every value needed. |
+| `--force` | Overwrite an existing `~/.lablink/client.env`. Mints a new client secret, orphaning any running container. |
+| `--env-file PATH` | Where to write the secrets. Default `~/.lablink/client.env`. |
+| `--insecure` | Skip TLS verification. Use when the allocator's `ssl.provider` is self-signed. |
+
+The registration shape must match the allocator's configured
+`manual.connectivity`, or the allocator rejects it with a 400:
+
+| `manual.connectivity` | Register with |
+|---|---|
+| `lan_direct` | no connectivity flag |
+| `mesh_overlay` | `--overlay-hostname` + `--tailscale-authkey` |
+| `reverse_tunnel` | `--tunnel` |
+
+---
+
+### `client unregister`
+
+Tear down a registered BYO box.
+
+```bash
+lablink client unregister [--env-file PATH] [--insecure] [--yes]
+```
+
+Best-effort notifies the allocator, then removes the `lablink-client` container and
+deletes the env file. Idempotent — does nothing and exits 0 if there is no env
+file. Safe to run after `lablink destroy`, when the allocator is expected to be
+unreachable.
+
+Deliberately **keeps** a mesh-overlay client's Tailscale node identity, so
+re-registering lands back on the same tailnet node under the same name. Use
+[`client reset-overlay`](#client-reset-overlay) when you want a fresh node.
+
+| Option | Description |
+|---|---|
+| `--env-file PATH` | Path to `client.env`. Default `~/.lablink/client.env`. |
+| `--insecure` | Skip TLS verification for the notify call. |
+| `-y`, `--yes` | Skip the confirmation prompt. |
+
+---
+
+### `client reset-overlay`
+
+Discard this box's persisted mesh-overlay node identity.
+
+```bash
+lablink client reset-overlay [--yes]
+```
+
+Only relevant to a mesh-overlay client. Run it when you want the next
+`client register` to join the tailnet as a brand-new node rather than reusing the
+existing one.
+
+!!! warning "This does not delete the old machine from your tailnet"
+    The previous node goes offline still holding its name, so the new node is given
+    a numeric suffix (`-1`, `-2`, …) until you delete the stale machine in the
+    Tailscale admin console.
+
+Requires the `lablink-client` container to be gone already — docker will not remove
+an attached volume.
+
+| Option | Description |
+|---|---|
+| `-y`, `--yes` | Skip the confirmation prompt. |
 
 ---
 
@@ -126,28 +310,30 @@ Calls the allocator's create-VM endpoint. The allocator provisions the VMs in it
 
 ### `status`
 
-Health checks, Terraform state, and cost estimate.
+Show deployment health and inventory.
 
 ```bash
 lablink status [--config PATH]
 ```
 
-Shows four sections:
+**AWS provider** shows four sections:
 
 1. **Terraform State** — outputs like `ec2_public_ip`, `ec2_public_dns`, DNS/ALB records.
 2. **Health Checks** — DNS resolution, allocator `/api/health`, SSL cert expiry (if HTTPS is enabled).
 3. **Client VMs** — per-VM state and current hourly burn rate.
 4. **Cost Estimate** — daily and monthly dollar estimates, pulled from the AWS Pricing API with a fallback table.
 
-If your AWS credentials are missing or expired, an **AWS credentials**
-section is printed first with the reason and how to authenticate. The
-Terraform state and Client VM sections then say they're unavailable rather
-than showing an empty result, and costs fall back to the built-in price
-table.
+If your AWS credentials are missing or expired, an **AWS credentials** section is
+printed first with the reason and how to authenticate. The Terraform state and
+Client VM sections then say they're unavailable rather than showing an empty
+result, and costs fall back to the built-in price table.
 
-If the credentials are valid but lack a required IAM permission — or any
-other AWS error occurs — the affected section reports that error in place,
-with guidance to fix the policy rather than to re-authenticate.
+If the credentials are valid but lack a required IAM permission — or any other AWS
+error occurs — the affected section reports that error in place, with guidance to
+fix the policy rather than to re-authenticate.
+
+**Manual provider** shows the docker-compose container status and the allocator's
+HTTP health endpoint. There is no cost estimate — the hardware is yours.
 
 | Option | Description |
 |---|---|
@@ -157,19 +343,23 @@ with guidance to fix the policy rather than to re-authenticate.
 
 ### `logs`
 
-View VM logs in an interactive TUI.
+View allocator and client logs.
 
 ```bash
 lablink logs [--config PATH]
 ```
 
-Opens a Textual-based viewer that streams cloud-init and container logs from the allocator and any running client VMs.
+**AWS provider:** opens a Textual-based viewer that streams cloud-init and
+container logs from the allocator and any running client VMs. Use `q` to quit, `/`
+to search, `n`/`N` for next/previous match.
+
+**Manual provider:** tails the local `lablink-allocator` container's logs. Per-VM
+client logs are not centralized in this mode — run `docker logs lablink-client` on
+each BYO box.
 
 | Option | Description |
 |---|---|
 | `-c`, `--config PATH` | Path to `config.yaml`. |
-
-Use `q` to quit, `/` to search, `n`/`N` for next/previous match.
 
 ---
 
@@ -186,16 +376,42 @@ Writes metrics to disk for offline analysis. Two data sources:
 - `--client` — per-VM metrics from the allocator's API (requires the allocator to be running).
 - `--allocator` — per-deploy metrics from the local cache at `~/.lablink/deployments/` (works after `lablink destroy`).
 
-With no source flag, both are exported and `_client` / `_allocator` suffixes are appended to the base output name.
+With no source flag, both are exported and `_client` / `_allocator` suffixes are
+appended to the base output name.
 
 | Option | Description |
 |---|---|
 | `--client` | Export per-VM client metrics from the allocator. |
 | `--allocator` | Export per-deploy allocator metrics from the local cache. Skips the network. |
 | `-f`, `--format FMT` | `csv` (default) or `json`. |
-| `-o`, `--output PATH` | Output file path. With both sources, treated as a base name; `_client` / `_allocator` suffixes are added. Default: `metrics_client.<fmt>` and/or `metrics_allocator.<fmt>`. |
-| `--include-logs` | Include `cloud_init_logs` and `docker_logs` columns. |
+| `-o`, `--output PATH` | Output file path. With a single source flag it is the literal path; with both (or neither), it is a base name and `_client` / `_allocator` suffixes are added before the extension. Default: `metrics_client.<fmt>` and/or `metrics_allocator.<fmt>`. |
+| `--include-logs` | Include `cloud_init_logs` and `docker_logs` columns. Large — opt-in only. |
 | `-c`, `--config PATH` | Path to `config.yaml`. Skipped when only `--allocator` is passed. |
+
+---
+
+### `stats`
+
+Show a cohort session-metrics summary in the terminal.
+
+```bash
+lablink stats [--config PATH]
+```
+
+Prints the same cohort summary the admin UI shows under **Session Metrics** —
+participation funnel and aggregate time-in-software figures. It reads the
+allocator's `/api/session-metrics/summary` endpoint, the same view model the web UI
+consumes, so the two can never disagree. Needs a reachable allocator and admin
+credentials; the figures only populate for deployments running with
+`monitoring.enabled: true` (see
+[Monitoring Options](../configuration.md#monitoring-options-monitoring)).
+
+For the underlying rows rather than the summary, use
+[`export-metrics --client`](#export-metrics).
+
+| Option | Description |
+|---|---|
+| `-c`, `--config PATH` | Path to `config.yaml`. |
 
 ---
 
@@ -209,7 +425,8 @@ View the current LabLink configuration.
 lablink show-config [--config PATH]
 ```
 
-Pretty-prints the YAML with syntax highlighting and runs schema validation. Reports validation errors inline.
+Pretty-prints the YAML with syntax highlighting and runs schema validation. Reports
+validation errors inline.
 
 | Option | Description |
 |---|---|
@@ -219,17 +436,22 @@ Pretty-prints the YAML with syntax highlighting and runs schema validation. Repo
 
 ### `cleanup`
 
-Clean up orphaned AWS resources and local state.
+Remove deployment resources and local state.
 
 ```bash
 lablink cleanup [--dry-run] [--config PATH]
 ```
 
-Finds resources tagged with your deployment name that were left behind by a failed or interrupted `destroy` and removes them.
+**AWS provider:** deletes orphaned EC2/IAM/EIP/security-group resources tagged with
+your deployment name — the kind of leftovers a failed or interrupted `destroy`
+leaves behind — plus the environment-specific Terraform state files.
+
+**Manual provider:** runs `docker compose down --volumes` on the local stack and
+removes the compose working directory.
 
 | Option | Description |
 |---|---|
-| `--dry-run` | Show what would be deleted without making changes. |
+| `--dry-run` | Show what would be deleted without making changes. **AWS provider only** — the manual provider's cleanup is non-destructive until you confirm. |
 | `-c`, `--config PATH` | Path to `config.yaml`. |
 
 ---
@@ -242,7 +464,9 @@ Clear LabLink caches.
 lablink cache-clear [--deployments] [--all] [--stale]
 ```
 
-By default clears the Terraform template cache at `~/.lablink/cache/terraform/`. With `--deployments`, clears the deployment metrics cache at `~/.lablink/deployments/` instead. With `--all`, clears both.
+By default clears the Terraform template cache at `~/.lablink/cache/terraform/`.
+With `--deployments`, clears the deployment metrics cache at
+`~/.lablink/deployments/` instead. With `--all`, clears both.
 
 | Option | Description |
 |---|---|
@@ -259,4 +483,5 @@ For the authoritative, always-current help text, use:
 ```bash
 lablink --help              # top-level: lists all commands
 lablink <command> --help    # per-command: lists all flags
+lablink client --help       # the client-fleet subcommand group
 ```

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -20,17 +20,11 @@ exits with a hint to run `lablink configure`.
 
 ## Provider modes
 
-Almost every command below branches on the `provider` field in your config, so read
-the reference with your provider in mind:
-
-| `provider` | What it means | Client machines come from |
-|---|---|---|
-| `aws` (default) | The allocator runs on EC2, provisioned by Terraform from your machine. | `lablink client launch` — the allocator provisions EC2 VMs. |
-| `manual` | The allocator runs as a local docker-compose stack on a machine you already have. No AWS account needed. | `lablink client register`, run by you on each bring-your-own (BYO) box. |
-
-See [Bring-Your-Own Clients](../cli/byo-clients.md) for the manual-provider
-walkthrough, and [Configuration](../configuration.md#manual-provider-options-manual)
-for the `manual.*` settings.
+Almost every command below branches on the `provider` field in your config; each
+one notes its manual-provider behavior inline. For the two modes side by side see
+[CLI Overview](../cli/index.md#two-providers), for the manual walkthrough
+[Bring-Your-Own Clients](../cli/byo-clients.md), and for the `manual.*` settings
+[Configuration](../configuration.md#manual-provider-options-manual).
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -102,6 +102,7 @@ nav:
       - Overview: cli/index.md
       - Installation: cli/installation.md
       - First Deployment: cli/first-deployment.md
+      - Bring-Your-Own Clients: cli/byo-clients.md
       - Managing Deployments: cli/managing-deployments.md
   - Admin Guide:
       - Adapting for Your Software: adapting.md

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -774,7 +774,7 @@ def export_metrics(
 
     Pass --client for per-VM metrics from the allocator. Pass --allocator
     for per-deploy metrics from the local cache. With no flag, exports
-    both. The --allocator-only path skips the network entirely.
+    both. Passing only --allocator skips the network entirely.
     """
     from lablink_cli.commands.export_metrics import run_export_metrics
 


### PR DESCRIPTION
## Summary

- The CLI docs described an AWS-only tool with 12 commands. The CLI actually has **16 commands**, a `client` subcommand group, and a whole second deployment mode — `provider: manual`, the allocator as a local docker-compose stack with bring-your-own client boxes — that appeared **nowhere** in `docs/cli/` or the command reference.
- `docs/reference/cli.md` is rewritten from actual `--help` output, and a new `docs/cli/byo-clients.md` covers the manual provider end to end.
- Independent of #426; touches a disjoint set of files, so the two can merge in either order.

## Changes Made

### `docs/reference/cli.md` — rewritten from actual `--help`

**4 missing commands added:** `stats`, `client register`, `client unregister`, `client reset-overlay`.

**5 missing flags added:** `deploy --tailscale-authkey`, `deploy --cloudflare-tunnel-token`, `destroy --verbose`, `destroy --keep-data`, `client launch --verbose`.

**Corrections:**

| Was | Actually |
|---|---|
| `doctor` "runs six pre-flight checks" (Terraform, AWS creds, S3, AMI…) | Under `provider: manual` it runs a different branch entirely — checks `docker` and the `docker compose` v2 plugin. |
| `deploy` "runs `terraform apply`" | Branches on provider: Terraform for AWS, `docker compose up -d` for manual. Same for `destroy`, `status`, `logs`, `setup`, `cleanup`. |
| "Every subcommand accepts `--config`" framed as a global option | `--config` is per-command. The old `managing-deployments.md` example `lablink --config X deploy` exits with `No such option '--config'`. |
| `deploy` "prompts for admin and database passwords" | Prompts for an admin **username** and password. There is no DB password prompt (`_prompt_passwords`, `deploy.py:282`). |
| `client launch` described as the only way to add clients | No-ops under the manual provider, pointing at `client register`. |

### New page: `docs/cli/byo-clients.md` (added to nav)

The manual provider end to end: prerequisites, the three connectivity modes and which `register` flags each one requires, compose deploy and the register token it prints, per-box registration, day-2 ops, `unregister` vs `reset-overlay`, and teardown with `--keep-data`.

### `docs/configuration.md`

- `manual.connectivity` has **three** valid values (`VALID_CONNECTIVITY` in `validate_config.py:35`); `reverse_tunnel` was undocumented, even though the wizard has offered it for a while.
- Corrected "Any exposure mode other than `none` requires `connectivity: mesh_overlay`". The check at `validate_config.py:185` only rejects `lan_direct`, so `reverse_tunnel` works with any exposure mode.

### Supporting edits

- `cli/index.md`: two-provider table up front, so the AWS-vs-template comparison is no longer the whole story.
- `cli/first-deployment.md`: explicitly labelled the AWS path, with a pointer to the BYO page.
- `cli/managing-deployments.md`: provider-aware notes throughout, plus the missing `stats` section and `destroy`/`cleanup` flags.

### One code change

`app.py`'s `export-metrics` help text read *"The `--allocator-only` path skips the network entirely"*, naming a flag that does not exist — `lablink export-metrics --allocator-only` errors out. Now reads "Passing only `--allocator`".

## Testing

- **Flags cross-checked programmatically in both directions.** A script parsed every `--flag` out of each command's section in `reference/cli.md` and diffed it against that command's real `--help` output — nothing documented that doesn't exist, nothing existing left undocumented.
- **All 16 documented commands confirmed to exist** by invoking `lablink <cmd> --help` for each and checking the exit code.
- **All 33 anchored cross-links validated** against the built site (`site/**/index.html`), checking both that the target page exists and that the `#fragment` resolves to a real `id`. 0 broken.
- `mkdocs build` succeeds with no new warnings.
- `PYTHONPATH=src uv run pytest` in `packages/cli`: **734 passed**. `ruff check packages/cli` clean. No test asserts on the edited docstring text.

## Design Decisions

- **Kept the reference hand-written rather than auto-generating it from Typer.** Auto-generation would end the drift permanently, but the docs CI runs `uv sync --extra docs` (root only, no `--all-packages`), so `lablink_cli` isn't importable during the docs build — it would need a workflow change too. Noted as a follow-up rather than bundled in here.
- **A separate BYO page instead of provider-splitting every existing page.** The manual provider has its own ordered workflow (register each box, connectivity modes, tailnet identity) that reads badly as parenthetical asides. Existing pages get one-line provider notes and link out.
- **Corrected two things I had initially written the wrong way round**, after reading the code rather than trusting help text: the wizard does *not* trap you with `ssl.provider: letsencrypt` on a manual config (`wizard.py:213` forces it to `none` and skips the DNS/SSL screen — the error is only reachable from a hand-edited config), and `reverse_tunnel` is *not* excluded from exposure modes.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)