### PR TITLE
fix(cli): flush the BYO log shipper's buffer when the container goes quiet

### DIFF
--- a/packages/cli/src/lablink_cli/log_shipper.py
+++ b/packages/cli/src/lablink_cli/log_shipper.py
@@ -10,10 +10,12 @@ from __future__ import annotations
 
 import json
 import os
+import queue
 import re
 import signal
 import subprocess
 import sys
+import threading
 import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -21,6 +23,8 @@ from typing import Callable, Literal
 from urllib.error import HTTPError, URLError
 from urllib.request import Request
 from urllib.request import urlopen as _stdlib_urlopen
+
+from lablink_cli.api import USER_AGENT
 
 
 def load_env(env_file: Path) -> dict[str, str]:
@@ -91,6 +95,11 @@ def post_batch(
     headers = {
         "Content-Type": "application/json",
         "Authorization": f"Bearer {client_secret}",
+        # urllib's default "Python-urllib/x.y" is blocked with HTTP 403 by
+        # Cloudflare-proxied allocators (see api.py's USER_AGENT) — post_batch
+        # treats any 4xx as fatal, so without this every batch kills the
+        # shipper on its first POST.
+        "User-Agent": USER_AGENT,
     }
 
     for attempt in range(MAX_RETRIES):
@@ -240,12 +249,44 @@ def _initial_since() -> str:
     return ts.strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
-def _read_lines_from_popen(proc):
-    """Wrap a Popen's stdout for line-by-line iteration."""
+# Yielded when the flush window elapses with no new log line, so the read
+# loop wakes up and re-evaluates should_flush().
+TICK = object()
+
+
+def _read_lines_from_popen(proc, *, timeout: float = FLUSH_INTERVAL_S):
+    """Yield a Popen's stdout line by line, plus TICK on each idle timeout.
+
+    A bare ``for line in proc.stdout`` only wakes when output arrives, so a
+    container that logs a burst at startup and then goes quiet holds its
+    buffer forever and the allocator never sees a single line. The shell
+    shipper avoids this with ``read -t "$FLUSH_INTERVAL"``
+    (log_shipper.sh:115); pipes aren't selectable on Windows — where BYO
+    clients actually run — so a reader thread plus a queue is the portable
+    equivalent.
+    """
     if proc.stdout is None:
         return
-    for line in proc.stdout:
-        yield line.rstrip("\n")
+    q: queue.Queue = queue.Queue()
+    eof = object()
+
+    def pump():
+        try:
+            for line in proc.stdout:
+                q.put(line.rstrip("\n"))
+        finally:
+            q.put(eof)
+
+    threading.Thread(target=pump, daemon=True).start()
+    while True:
+        try:
+            item = q.get(timeout=timeout)
+        except queue.Empty:
+            yield TICK
+            continue
+        if item is eof:
+            return
+        yield item
 
 
 def run_shipper(
@@ -283,17 +324,21 @@ def run_shipper(
         # ---- Inner read loop ----
         try:
             for line in line_source:
-                ts, msg = parse_docker_line(line)
-                # Buffer the original tagged line, preserving the timestamp
-                # prefix so admin views show it (matches log_shipper.sh's
-                # docker --timestamps + sed pipeline).
-                if ts is not None:
-                    buffer.append(f"{ts} {msg}")
-                    last_ts_in_batch = ts
-                else:
-                    buffer.append(msg)
-                if buffer_first_ts is None:
-                    buffer_first_ts = time.monotonic()
+                # TICK means the flush window elapsed with no new line —
+                # skip straight to the flush check below. should_flush()
+                # already no-ops on an empty buffer.
+                if line is not TICK:
+                    ts, msg = parse_docker_line(line)
+                    # Buffer the original tagged line, preserving the
+                    # timestamp prefix so admin views show it (matches
+                    # log_shipper.sh's docker --timestamps + sed pipeline).
+                    if ts is not None:
+                        buffer.append(f"{ts} {msg}")
+                        last_ts_in_batch = ts
+                    else:
+                        buffer.append(msg)
+                    if buffer_first_ts is None:
+                        buffer_first_ts = time.monotonic()
 
                 elapsed = (
                     time.monotonic() - buffer_first_ts

--- a/packages/cli/tests/test_log_shipper.py
+++ b/packages/cli/tests/test_log_shipper.py
@@ -118,6 +118,30 @@ class TestPostBatch:
             "messages": ["[start] booting", "[agent] ready"],
         }
 
+    def test_sends_product_user_agent(self):
+        """Cloudflare-proxied allocators 403 urllib's default UA.
+
+        Regression: post_batch built its Request without a User-Agent,
+        so every batch was blocked before the client secret was even
+        checked, and post_batch's own 4xx handling treated that as
+        fatal and killed the shipper on its first POST.
+        """
+        from unittest.mock import MagicMock
+        from lablink_cli.api import USER_AGENT
+        from lablink_cli.log_shipper import post_batch
+
+        resp = MagicMock()
+        resp.__enter__.return_value = resp
+        resp.__exit__.return_value = False
+        resp.status = 200
+        resp.read.return_value = b'{"ok": true}'
+        urlopen = MagicMock(return_value=resp)
+
+        post_batch(**self._args(), urlopen=urlopen, sleep=MagicMock())
+
+        req = urlopen.call_args.args[0]
+        assert req.get_header("User-agent") == USER_AGENT
+
     def test_retries_on_5xx_then_succeeds(self):
         from io import BytesIO
         from unittest.mock import MagicMock
@@ -337,6 +361,44 @@ class TestOpenDockerLogs:
         assert "--since" not in cmd
 
 
+class TestReadLinesFromPopen:
+    def test_yields_tick_while_source_is_idle(self):
+        """A source that emits a burst then goes quiet must still tick.
+
+        Without the idle tick the read loop blocks forever and a buffered
+        startup burst is never flushed to the allocator.
+        """
+        import subprocess
+        import sys
+        from lablink_cli.log_shipper import TICK, _read_lines_from_popen
+
+        proc = subprocess.Popen(
+            [
+                sys.executable,
+                "-c",
+                "import time; print('burst', flush=True); time.sleep(30)",
+            ],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        try:
+            seen = []
+            for item in _read_lines_from_popen(proc, timeout=0.1):
+                seen.append(item)
+                # Interpreter startup may outrun the first tick, so wait for
+                # both the burst and the ticks rather than assuming an order.
+                if "burst" in seen and seen.count(TICK) >= 2:
+                    break
+        finally:
+            proc.terminate()
+            proc.wait(timeout=5)
+
+        assert "burst" in seen
+        assert seen.count(TICK) >= 2
+
+
 class TestSelfLog:
     def test_appends_line(self, tmp_path):
         from lablink_cli.log_shipper import self_log
@@ -423,6 +485,59 @@ class TestRunShipper:
         # state updated with the timestamp of the last line in the batch
         state = (tmp_path / "log_shipper.state").read_text()
         assert "2026-05-28T14:23:49Z" in state
+
+    def test_idle_tick_flushes_a_partial_buffer(self, tmp_path, monkeypatch):
+        """A short startup burst followed by silence must still be shipped.
+
+        Regression: the flush check used to run only when a new line
+        arrived, so a container that logged at boot and then went quiet
+        held its lines forever and the allocator recorded nothing.
+        """
+        from unittest.mock import MagicMock
+        from lablink_cli.log_shipper import TICK, run_shipper
+
+        env_file = self._env(tmp_path)
+        post_calls = []
+
+        def fake_post_batch(**kw):
+            post_calls.append(kw)
+            return "ok"
+
+        def fake_iter():
+            yield "2026-05-28T14:23:01Z boot line 1"
+            yield "2026-05-28T14:23:02Z boot line 2"
+            # ...then the container goes quiet. Ticks are all we get.
+            yield TICK
+            yield TICK
+
+        # Clock advances past FLUSH_INTERVAL_S while only ticks arrive.
+        clock = iter([0, 0, 0, 100, 200])
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.time.monotonic", lambda: next(clock)
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.post_batch", fake_post_batch
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.inspect_container",
+            MagicMock(return_value="missing"),
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.STATE_FILE",
+            tmp_path / "log_shipper.state",
+        )
+        monkeypatch.setattr(
+            "lablink_cli.log_shipper.SELF_LOG_FILE",
+            tmp_path / "log_shipper.log",
+        )
+
+        run_shipper(env_file, _line_iter=fake_iter, _sleep=lambda s: None)
+
+        assert len(post_calls) == 1
+        assert post_calls[0]["messages"] == [
+            "2026-05-28T14:23:01Z boot line 1",
+            "2026-05-28T14:23:02Z boot line 2",
+        ]
 
     def test_exits_on_fatal_post(self, tmp_path, monkeypatch):
         from unittest.mock import MagicMock


### PR DESCRIPTION
## Summary

- BYO/manual clients shipped **no** docker logs to the allocator at all — a healthy, running client showed 0 bytes in `dockerlogs`.
- Two independent bugs, both found while reproducing this against a live allocator:
  1. The log shipper's flush check ran only when a new log line arrived, so a container that logs a startup burst and then goes quiet held its buffer forever.
  2. Every POST from the shipper was silently rejected (403) by the Cloudflare-proxied allocator because it sent urllib's default User-Agent, and the shipper treats any 4xx as fatal — so it exited on the very first log batch, before the flush-timer bug ever got a chance to matter.
- Fix (1) restores the timed read the AWS shell shipper already has, using a portable (Windows-safe) reader thread + queue. Fix (2) reuses the `USER_AGENT` constant `api.py` already carries for this exact Cloudflare behavior.

## Bug 1: the flush timer never fires while idle

`run_shipper` evaluated `should_flush()` **inside** the `for line in line_source` loop body. That loop blocks on `proc.stdout` until the next line appears, so the 15s flush timer only advanced when new output arrived. A container that logs at boot and then falls silent leaves the shipper parked on `read()` with a full buffer it never POSTs.

This is not a slow flush — it never happens. The `FLUSH_INTERVAL_S = 15` threshold is unreachable without a subsequent line to trigger the check.

The AWS shell shipper already handles this, and even documents why (`packages/allocator/src/lablink_allocator_service/terraform/log_shipper.sh:112-115`):

```bash
# Read with a timeout so the flush timer fires even when no new lines
# arrive (e.g., cloud-init finishes and the file stops growing).
if IFS= read -t "$FLUSH_INTERVAL" -r LINE; then
```

The Python port dropped the `-t`.

**Fix:** `_read_lines_from_popen` now runs the blocking read in a daemon thread feeding a `queue.Queue`, and yields a `TICK` sentinel whenever `get(timeout=FLUSH_INTERVAL_S)` times out. The read loop skips the buffer-append on `TICK` and falls through to the existing flush check. `should_flush()` already no-ops on an empty buffer, so idle ticks cost nothing and never produce empty POSTs. No change to batching, retry, state-file, or reconnect behavior.

**Evidence:** reproduced with the real code against a container emitting a 12-line burst then sleeping: **0 POSTs after 35s** (vs. a 15s flush interval). After the fix: **1 POST, 12 messages**.

## Bug 2: every POST 403'd on a Cloudflare-proxied allocator

Found while verifying bug 1's fix on a real deployment: the shipper still shipped nothing, and `~/.lablink/log_shipper.log` showed `POST returned fatal (4xx); exiting` within seconds of every start, with `--since` never advancing.

`post_batch` builds its own `urllib.request.Request` directly and never set a `User-Agent`. urllib's default (`Python-urllib/3.x`) is blocked with a 403 (Cloudflare error 1010) by the same Cloudflare-proxied allocators this project already accounts for elsewhere — `api.py` carries a `USER_AGENT = f"lablink-cli/{_CLI_VERSION}"` constant specifically because "urllib's default ... is blocked with HTTP 403 by Cloudflare-proxied allocators" (see `api.py`'s existing comment). `post_batch` just never used it, since it's a separate hand-rolled HTTP client instead of going through `api.py`'s helpers.

`post_batch` treats any 4xx as fatal (by design — a bad secret or unknown hostname should stop the shipper, not retry forever), so this 403 killed the shipper on its first log batch, every single time.

**Fix:** import and send `api.USER_AGENT` on the request.

**Verified live:** the same secret/hostname/URL that 403'd via plain `urllib.request` returned 200 once the header was added — confirmed with both a raw urllib script and `post_batch` itself against the live allocator.

## Testing

- `TestReadLinesFromPopen::test_yields_tick_while_source_is_idle` — real subprocess that emits one line then sleeps; asserts ticks keep arriving. Fails without fix 1.
- `TestRunShipper::test_idle_tick_flushes_a_partial_buffer` — regression test for the exact scenario: two boot lines, then only ticks, with a controlled clock; asserts the partial buffer is POSTed.
- `TestPostBatch::test_sends_product_user_agent` — asserts the outgoing request's `User-agent` header equals `api.USER_AGENT`. Fails without fix 2.
- `packages/cli/tests/test_log_shipper.py`: 38/38 passing, `ruff check` clean.
- Manually verified end-to-end against a live manual-provider allocator with a registered Windows BYO client, both before (0 POSTs, then fatal-403 exit) and after (POSTs succeed, shipper stays up) each fix.

## Design Decisions

- **Reader thread + queue rather than `selectors`**: anonymous pipes aren't selectable on Windows, and BYO clients genuinely run there (the client that surfaced this is a Windows laptop). The thread keeps all buffer mutation on the main loop, so no lock is needed.
- **A `TICK` sentinel rather than a background flush timer**: a timer thread would mutate `buffer` concurrently and require locking. The sentinel reuses the existing single-threaded flush path untouched.
- **Reused `api.USER_AGENT` rather than a new constant**: one product User-Agent string for the whole CLI, not a second one to keep in sync.
- **`_line_iter` test hook unchanged**: existing tests pass plain string lists and keep working, so this is backwards compatible.

## Notes for reviewers

Two adjacent things found while tracing, deliberately **not** changed here:

1. `_exec_docker` runs `docker rm -f lablink-client` before `docker run`, which kills the previous shipper (`container missing; exiting`) before a fresh one is spawned. Benign, but it means a manual `docker stop`/`restart` without re-registering makes the shipper give up after `MAX_EXITED_CONSECUTIVE` (~15s) and not come back. That's currently intended behavior — worth a separate discussion.
2. `post_batch` uses a bare `urlopen` with no SSL context, while `api.py` honors `ssl_provider="self_signed"`. So `register --insecure` registers fine but every log POST then fails cert verification and silently drops. Separate bug, unrelated to this one.

Context: #355 (Manual-Provider BYO Support roadmap).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
