### PR TITLE
docs: bring the developer guide up to parity with the shipped allocator

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -4,83 +4,135 @@ This document outlines the API endpoints provided by the LabLink Allocator servi
 
 ## Authentication
 
-LabLink uses two authentication mechanisms:
+LabLink uses four gates. All bearer credentials go in `Authorization: Bearer <token>`.
 
-- **HTTP Basic Auth**: For admin endpoints (dashboard, VM management). Credentials are configured via `app.admin_user` and `app.admin_password` in `config.yaml`.
-- **Bearer Token**: For machine-to-machine endpoints (client VM → allocator). A random token is auto-generated at allocator startup and distributed to client VMs via Terraform/cloud-init. Requests must include `Authorization: Bearer <token>`.
+| Gate | Credential | Guards |
+|---|---|---|
+| **HTTP Basic** | `app.admin_user` / `app.admin_password` from `config.yaml` | `/admin/*` pages and the operator JSON APIs |
+| **Client secret** | A per-client secret minted when that client registers, stored as an argon2 hash | client → allocator telemetry (`/api/heartbeat`, `/api/vm-status`, …) |
+| **Register token** | One deployment-wide bootstrap token, also stored hashed | `POST /api/v1/clients/register` only |
+| **Signed cookie** | `lablink_session`, minted by `/api/request_vm` | `GET /desktop` |
+
+A handful of endpoints are deliberately unauthenticated: `/` and
+`/api/request_vm` (participant-facing), `/api/health` and
+`/api/unassigned_vms_count` (health/monitoring), and `/internal/*` (reachable only
+from the allocator's own nginx, never exposed publicly).
+
+Secrets are per-client, so a leaked one compromises a single machine. The register
+token is the only deployment-wide credential, and it can do nothing but register.
 
 ## Student Endpoint
 
+### Landing Page
+
+**Endpoint:** `GET /`
+
+**Authentication:** None.
+
+Renders `index.html`, the email form a participant submits to claim a seat.
+
 ### Request a VM
 
-Assigns an available VM to a user.
+Claims a seat for a participant and redirects them to their desktop.
 
 **Endpoint:** `POST /api/request_vm`
 
-**Description:** Submits a user's email and a Chrome Remote Desktop (CRD) command to be assigned to an available VM. If a VM is available, it is assigned to the user, and the user is shown a success page with connection details.
-
-**Authentication:** None (student-facing)
+**Authentication:** None — this is the only unauthenticated state-changing endpoint in the allocator.
 
 **Request Body:** `application/x-www-form-urlencoded`
 
-- `email` (string, required): The user's email address.
-- `crd_command` (string, required): The CRD command for the session.
+- `email` (string, required): The participant's email address.
+
+**What it does:**
+
+1. **Idempotent rejoin.** If this email already owns a running seat, it keeps that seat rather than consuming a second one.
+2. **Atomic claim.** Otherwise `assign_vm` claims a free seat with `SELECT … FOR UPDATE SKIP LOCKED`, so concurrent requesters cannot collide on one VM. An empty pool raises and returns `503` with `no_seats.html`.
+3. **Per-session prep.** Mints a `session_id` and `browser_token`, then rotates the KasmVNC password on the assigned client through that client's local agent. This runs inside the assignment transaction, so a rotation failure rolls the assignment back.
+4. **Cookie + redirect.** Signs a `lablink_session` cookie bound to the `session_id` and redirects to [`/desktop`](#the-participant-desktop).
 
 **Success Response:**
 
-- **Code:** `200 OK`
-- **Content:** An HTML page (`success.html`) displaying the assigned VM's hostname and PIN.
+- **Code:** `302 Found` → `/desktop`, with the `lablink_session` cookie set.
 
 **Error Response:**
 
-- **Code:** `200 OK`
-- **Content:** An HTML page (`index.html`) with an error message displayed if no VMs are available, if required fields are missing, or if an invalid CRD command is provided.
+- **Code:** `503 Service Unavailable` — `no_seats.html` when the pool is empty, or `rotation_failed.html` when the assigned client could not be reached. On a rotation failure the seat is released and the VM flagged `Unhealthy` so the participant isn't wedged on a dead machine.
+- **Code:** `200 OK` — `index.html` re-rendered with an error if `email` is missing.
 
-**Client Usage:** This endpoint is not used by the client service. It is called from the allocator's web interface when an end-user manually requests a VM.
+The participant supplies nothing but an email address — the old `crd_command` and
+PIN contract is gone, along with the mechanism behind it
+([Database](database.md#triggers)).
 
-## Client VM API Endpoints
+### The participant desktop
 
-These endpoints are used by client VMs to communicate with the allocator. They require a valid bearer token (`Authorization: Bearer <token>`), which is auto-generated at allocator startup and distributed to client VMs via cloud-init.
+**Endpoint:** `GET /desktop`
 
-### VM Startup Registration
+**Authentication:** The signed `lablink_session` cookie.
 
-Used by a client VM to register itself with the allocator upon startup and to listen for an assignment.
+Renders the noVNC viewer page. Reads the cookie minted by `/api/request_vm`, looks
+up the assigned VM by `session_id`, and configures the viewer from the persisted
+`browser_ws_url` and `browser_credential`. If the cookie is missing, invalid, or the
+bound VM is no longer running, it redirects to `/` so the participant can submit
+their email again.
 
-**Endpoint:** `POST /vm_startup`
+### Internal proxy authorization
 
-**Description:** A client VM calls this endpoint after it boots up. It sends its hostname and then listens for a PostgreSQL notification that contains the assigned `CrdCommand` and `Pin`. This is a long-polling request.
+**Endpoints:** `GET|POST /internal/proxy_auth`, `GET|POST /internal/tunnel_auth`
 
-**Authentication:** Bearer Token
+**Authentication:** None — these are `auth_request` subrequest targets for the
+allocator's own nginx and are never routed publicly.
 
-**Request Body:** `application/json`
+nginx calls these before proxying desktop bytes, to check that the requesting
+session is entitled to the client it is asking for. `tunnel_auth` is the
+equivalent gate for reverse-tunnel clients.
 
-```json
-{
-  "hostname": "lablink-vm-prod-1"
-}
-```
+## Health
+
+### Readiness Check
+
+**Endpoint:** `GET /api/health`
+
+**Authentication:** None — this is what load balancers, `lablink deploy` and
+`lablink status` poll.
+
+Returns a structured readiness report rather than a bare 200. The `checks` map
+always covers `database`, `scheduler` and `reboot_service`, and gains a `tailscale`
+entry when the configured connectivity needs one, or a `tunnel` entry for
+reverse-tunnel deployments.
 
 **Success Response:**
 
-- **Code:** `200 OK`
+- **Code:** `200 OK` when every gating check is `ok`
 - **Content:**
   ```json
   {
-    "status": "success",
-    "pin": "123456",
-    "command": "crd --code=..."
+    "status": "ready",
+    "checks": {
+      "database": "ok",
+      "scheduler": "ok",
+      "reboot_service": "ok"
+    }
   }
   ```
 
 **Error Response:**
 
-- **Code:** `400 Bad Request` if `hostname` is not provided.
-- **Code:** `404 Not Found` if the VM with the given `hostname` is not found in the database.
+- **Code:** `503 Service Unavailable` when a gating check fails.
 
-**Client Usage:**
+!!! note "A dead client tunnel does not make the allocator unready"
+    Unattached client tunnels are reported but deliberately don't gate readiness — a
+    registering client is unattached until its tunnel comes up. The allocator's own
+    dependencies (tunnel server, database) do gate.
 
-- **When:** Called by the `subscribe` service, which is started by `start.sh` when the client container boots.
-- **How:** The service sends a POST request with the VM's hostname. It then waits indefinitely for a response. When an end-user is assigned this VM, the allocator responds with the CRD command and PIN, which the client then uses to start the remote desktop session.
+## Client VM API Endpoints
+
+These endpoints are used by client VMs to report to the allocator. They require that
+client's own secret as a bearer token — see [Authentication](#authentication).
+
+Clients only ever *report upward* through these; they are never told about an
+assignment. The allocator pushes that the other way, by calling the client's local
+agent (see [`/api/request_vm`](#request-a-vm) and
+[Database](database.md#triggers)).
 
 ### Get Unassigned VM Count
 
@@ -90,7 +142,7 @@ Retrieves the number of available (unassigned) VMs.
 
 **Description:** Returns the current count of VMs that are running and not yet assigned to a user.
 
-**Authentication:** Bearer Token
+**Authentication:** None (health/monitoring)
 
 **Request Body:** None
 
@@ -114,7 +166,7 @@ Updates the "in-use" status of a VM.
 
 **Description:** Called by the client VM to indicate whether a user is actively using it.
 
-**Authentication:** Bearer Token
+**Authentication:** Client secret
 
 **Request Body:** `application/json`
 
@@ -153,7 +205,7 @@ Updates the GPU health status of a VM.
 
 **Description:** Called by the client VM to report its GPU health status.
 
-**Authentication:** Bearer Token
+**Authentication:** Client secret
 
 **Request Body:** `application/json`
 
@@ -190,7 +242,7 @@ Updates the overall status of a VM (e.g., `initializing`, `running`, `error`, `r
 
 **Description:** Called by the client VM during its startup sequence to report its current status.
 
-**Authentication:** Bearer Token
+**Authentication:** Client secret
 
 **Request Body:** `application/json`
 
@@ -225,7 +277,7 @@ Receives and stores startup metrics from a VM.
 
 **Description:** Called by the client VM's `user_data.sh` script to post timing metrics for `cloud-init` and container startup.
 
-**Authentication:** Bearer Token
+**Authentication:** Client secret
 
 **URL Parameters:**
 
@@ -265,11 +317,11 @@ Receives and stores startup metrics from a VM.
 
 Receives and stores logs pushed from a VM.
 
-**Endpoint:** `POST /api/vm-logs`
+**Endpoint:** `POST /api/vm-logs/<hostname>`
 
 **Description:** Receives batched log lines pushed from a VM by the `log_shipper.sh` script, which tails the VM's `cloud-init` output and the client container's Docker logs.
 
-**Authentication:** Bearer Token
+**Authentication:** Client secret
 
 **Request Body:** `application/json`
 
@@ -345,34 +397,13 @@ These endpoints require HTTP Basic Authentication and are intended for administr
 - **Code:** `200 OK`
 - **Content:** An HTML page (`delete-dashboard.html`) displaying the Terraform error output.
 
-### Download All User Data
-
-**Endpoint:** `GET /api/scp-client`
-
-**Description:** Connects to each running VM via SSH, finds all files matching the configured `extension`, copies them to a temporary directory on the allocator, zips them, and provides the zip file for download.
-
-**Authentication:** HTTP Basic Auth
-
-**Request Body:** None
-
-**Success Response:**
-
-- **Code:** `200 OK`
-- **Content-Type:** `application/zip`
-- **Content:** A zip file containing the data from all VMs.
-
-**Error Response:**
-
-- **Code:** `404 Not Found` if no VMs or no files are found.
-- **Code:** `500 Internal Server Error` if an error occurs during the SSH/SCP process.
-
 ### Get Status of All VMs
 
 **Endpoint:** `GET /api/vm-status`
 
 **Description:** Returns a JSON object mapping each VM hostname to its current status. Used by the admin dashboard.
 
-**Authentication:** Bearer Token
+**Authentication:** HTTP Basic Auth
 
 **Request Body:** None
 
@@ -392,42 +423,13 @@ These endpoints require HTTP Basic Authentication and are intended for administr
 - **Code:** `404 Not Found` if no VMs are found in the database.
 - **Code:** `500 Internal Server Error` on failure.
 
-### Get Status of a Specific VM
-
-**Endpoint:** `GET /api/vm-status/<hostname>`
-
-**Description:** Returns the status of a specific VM.
-
-**Authentication:** Bearer Token
-
-**URL Parameters:**
-
-- `hostname` (string, required): The hostname of the VM.
-  **Request Body:** None
-
-**Success Response:**
-
-- **Code:** `200 OK`
-- **Content:**
-  ```json
-  {
-    "hostname": "lablink-vm-prod-1",
-    "status": "running"
-  }
-  ```
-
-**Error Response:**
-
-- **Code:** `404 Not Found` if the VM is not found.
-- **Code:** `500 Internal Server Error` on failure.
-
 ### Get Logs for a Specific VM
 
 **Endpoint:** `GET /api/vm-logs/<hostname>`
 
 **Description:** Returns the stored logs for a specific VM. Used by the admin log viewer page.
 
-**Authentication:** Bearer Token
+**Authentication:** HTTP Basic Auth
 
 **URL Parameters:**
 
@@ -480,3 +482,208 @@ These endpoints require HTTP Basic Authentication and are intended for administr
 **Error Response:**
 
 - **Code:** `401 Unauthorized` without admin credentials.
+
+### Heartbeat
+
+**Endpoint:** `POST /api/heartbeat`
+
+**Description:** Periodic liveness ping. Lets the allocator detect silent failures — a dead container, a broken network, a hung host, an OOM, or an out-of-band VM termination — that no other endpoint would reveal. The body also carries cheap health signals for early warning.
+
+**Authentication:** Client secret (resolved from the `vm_id` field)
+
+**Request Body:** `application/json`
+
+```json
+{
+  "vm_id": "lablink-vm-prod-1",
+  "boot_id": "…",
+  "disk_free_pct": 62
+}
+```
+
+**Client Usage:** Sent by the client's `heartbeat` service every `HEARTBEAT_INTERVAL_SECONDS`. A client that stops heartbeating for longer than the staleness window becomes eligible for automatic recovery — see [Troubleshooting](troubleshooting.md#vm-auto-reboot-not-working).
+
+---
+
+## Client Registration API
+
+Used by bring-your-own (BYO) client machines to enrol themselves under the
+`manual` provider. AWS-provisioned clients do not use these endpoints — Terraform
+supplies their credentials directly.
+
+Registration is what the CLI's `lablink client register` drives — see
+[Bring-Your-Own Clients](cli/byo-clients.md#step-4-register-each-box) for the
+operator-facing walkthrough, and
+[Configuration](configuration.md#manual-provider-options-manual) for the `manual.*`
+settings it depends on.
+
+### Register a Client
+
+**Endpoint:** `POST /api/v1/clients/register`
+
+**Authentication:** Register token (the one deployment-wide bearer credential)
+
+**Request Body:** `application/json`
+
+| Field | Required | Description |
+|---|---|---|
+| `hostname` | yes | The client's self-declared hostname, which becomes its `client_id`. Must start with a letter or digit and contain only letters, digits, dots, dashes and underscores (max 253 chars). |
+| `machine_identity` | yes | Stable machine identifier, unique across the deployment. Re-registering the same identity replaces the old row rather than adding a seat. |
+| `provider` | no | Defaults to `aws`. BYO clients send `manual`. |
+| `provider_metadata` | no | Shape must match the deployment's configured `manual.connectivity` — `lan_ip` for `lan_direct`, `overlay_hostname` for `mesh_overlay`, `reverse_tunnel: true` for `reverse_tunnel`. A mismatch is rejected here rather than failing opaquely at assignment time. |
+| `endpoint_url`, `gpu_present`, `gpu_model` | no | Reported by the client; all auto-detected by the CLI. |
+
+**Success Response:**
+
+- **Code:** `200 OK`
+- **Content:** the client's credentials and the configuration it needs to start:
+
+```json
+{
+  "client_id": "gpu-box-3",
+  "client_secret": "…",
+  "agent_token": "…",
+  "allocator_url": "https://lab.example.org",
+  "connectivity": "lan_direct",
+  "client_image": "ghcr.io/talmolab/lablink-client-base-image:latest",
+  "repository": "https://github.com/talmolab/sleap-tutorial-data.git",
+  "subject_software": "sleap",
+  "register_token": "…",
+  "startup_script_b64": "",
+  "startup_on_error": "continue",
+  "startup_max_attempts": 3,
+  "startup_base_delay_seconds": 30,
+  "startup_success_check_b64": "",
+  "monitoring": { "enabled": false }
+}
+```
+
+`client_secret` is returned **once** and stored only as an argon2 hash. Reverse-tunnel
+registrations additionally receive `tunnel_url`, `tunnel_path_prefix` and
+`tunnel_bind_addr`, all minted by the allocator.
+
+**Error Response:**
+
+- **Code:** `400 Bad Request` — missing/invalid `hostname` or `machine_identity`, or a `provider_metadata` shape that doesn't match the configured connectivity.
+- **Code:** `401 Unauthorized` — bad or missing register token.
+
+### Get Client Status
+
+**Endpoint:** `GET /api/v1/clients/<client_id>/status`
+
+**Authentication:** That client's own secret.
+
+Lets a registered client confirm the allocator still knows about it.
+
+### Unregister a Client
+
+**Endpoint:** `DELETE /api/v1/clients/<client_id>`
+
+**Authentication:** That client's own secret.
+
+Removes the client's row. Driven by `lablink client unregister`, which calls this
+best-effort — a client whose allocator is already gone still tears itself down
+locally.
+
+### List Clients
+
+**Endpoint:** `GET /api/v1/clients`
+
+**Authentication:** HTTP Basic Auth
+
+Operator view of every registered client.
+
+### Report Overlay Hostname
+
+**Endpoint:** `POST /api/overlay-hostname`
+
+**Authentication:** Client secret
+
+A mesh-overlay client reports the tailnet hostname it actually joined under. This
+matters because MagicDNS appends a numeric suffix when a name is already held by an
+offline node, so the name the client *asked* for and the name it *got* can differ.
+
+---
+
+## Operations API
+
+Long-running provisioning work runs asynchronously; these endpoints expose it.
+
+### List Operations
+
+**Endpoint:** `GET /api/operations`
+
+**Authentication:** HTTP Basic Auth
+
+Returns recent operations with their `op_type`, `status`, timestamps, and
+`resources_completed` / `resources_total` progress counters.
+
+### Get an Operation
+
+**Endpoint:** `GET /api/operations/<operation_id>`
+
+**Authentication:** HTTP Basic Auth
+
+Returns one operation, including its captured `output` and `error`. This is what
+the CLI polls while `client launch` runs.
+
+---
+
+## Scheduled Destruction API
+
+Lets an operator schedule tear-down ahead of time — useful for capping the cost of
+a workshop deployment.
+
+| Endpoint | Method | Description |
+|---|---|---|
+| `/api/schedule-destruction` | `POST` | Create a schedule. |
+| `/api/schedule-destruction` | `GET` | List schedules. |
+| `/api/schedule-destruction/<schedule_id>` | `GET` | Fetch one schedule. |
+| `/api/schedule-destruction/<schedule_id>` | `DELETE` | Cancel a schedule. |
+
+**Authentication:** HTTP Basic Auth on all four.
+
+Schedules are persisted in the `scheduled_destructions` table — see
+[Database](database.md#scheduled_destructions-table).
+
+---
+
+## Session Metrics API
+
+Populated only when `monitoring.enabled` is true.
+
+### Report Session Metrics
+
+**Endpoint:** `POST /api/session-metrics/<hostname>`
+
+**Authentication:** Client secret
+
+The client's monitoring sampler posts its accumulated per-session counters
+(time-in-software, GPU activity, training progress).
+
+### Get the Cohort Summary
+
+**Endpoint:** `GET /api/session-metrics/summary`
+
+**Authentication:** HTTP Basic Auth
+
+Returns the aggregate view model — participation funnel plus cohort totals. Both
+the admin **Session Metrics** page and `lablink stats` render this same payload, so
+the two can never disagree.
+
+### Export Metrics
+
+**Endpoint:** `GET /api/export-metrics`
+
+**Authentication:** HTTP Basic Auth
+
+Per-VM metrics as CSV or JSON. Backs `lablink export-metrics --client`.
+
+---
+
+## Admin Pages
+
+The allocator also serves operator HTML pages under `/admin`, all behind HTTP Basic
+Auth. They are walked through in the [Workshop Guide](workshop-guide.md), and
+`/admin/byo-onboarding` in [Bring-Your-Own Clients](cli/byo-clients.md#step-4-register-each-box).
+Only the JSON APIs above are documented here.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -65,6 +65,50 @@ graph TB
     style Research fill:#8bc34a,color:#fff
 ```
 
+## Providers and Connectivity
+
+Two axes decide how a LabLink deployment is shaped. Both are resolved once at
+startup, in `providers/registry.py`, and the rest of the codebase talks to the
+resulting objects rather than branching on provider type.
+
+### Compute provider — where client machines come from
+
+Discovered through the `lablink.providers` entry-point group, so a new backend can be
+added without touching core code. Two ship today:
+
+| `provider` | Behaviour |
+|---|---|
+| `aws` | Provisions EC2 client VMs with Terraform. |
+| `manual` | Provisions nothing. Machines you already own register themselves via `POST /api/v1/clients/register`. |
+
+Capability flags, not provider-type checks, gate the behaviour that differs:
+
+- **`can_provision_hosts`** — false for `manual`, which is why that deployment surfaces its register token in the container logs for the CLI to pick up, rather than passing it through a Terraform output.
+- **`can_recover_hosts`** — false for `manual`, so the auto-reboot loop skips BYO boxes instead of attempting AWS calls against machines it doesn't own.
+
+### Client connectivity — how the desktop is reached
+
+Selectable for the `manual` provider only, as a small closed set:
+
+| `manual.connectivity` | Byte path |
+|---|---|
+| `lan_direct` | The browser opens a WebSocket straight to the client's LAN IP. Requires the client and participant on the allocator's LAN. |
+| `mesh_overlay` | The client joins a Tailscale tailnet; the allocator reaches it over the overlay and proxies through its own nginx. |
+| `reverse_tunnel` | The client dials **out** to the allocator and holds one connection open, for boxes that can't accept inbound connections. |
+
+Each strategy implements `prepare_browser_session`, which is what
+`/api/request_vm` calls to rotate the client's VNC password and persist the
+`browser_ws_url` the viewer page will open — which is why the assignment path has no
+connectivity-specific branches in it.
+
+AWS deployments always use the allocator-proxied path and ignore this setting.
+
+See [Bring-Your-Own Clients](cli/byo-clients.md#pick-a-connectivity-mode) for
+choosing between these,
+[Configuration](configuration.md#manual-provider-options-manual) for the settings,
+and [API Endpoints](api-endpoints.md#client-registration-api) for the registration
+contract.
+
 ## Component Details
 
 ### Allocator Service
@@ -89,17 +133,19 @@ graph TB
 
 2. **API Endpoints**:
 
-   - `/request_vm`: Allocate VM to user
+   - `/api/request_vm`: Claim a seat for a participant
+   - `/desktop`: Cookie-gated noVNC viewer
    - `/admin/create`: Create new VM instances
    - `/admin/instances`: List all instances
-   - `/admin/destroy`: Destroy instances
-   - `/vm_startup`: Client registration
+   - `/api/v1/clients/register`: BYO client self-registration
+   - `/api/heartbeat`: Client liveness reporting
+
+   See [API Endpoints](api-endpoints.md) for the full surface.
 
 3. **Database Management**:
 
-   - Tracks VM states (available, in-use, failed)
-   - PostgreSQL listen/notify for real-time updates
-   - Automated triggers for state changes
+   - Tracks VM states (`initializing`, `running`, `error`, `rebooting`)
+   - Claims seats atomically with `FOR UPDATE SKIP LOCKED`
 
 4. **Infrastructure Orchestration**:
    - Spawns client VMs via Terraform
@@ -135,35 +181,31 @@ graph TB
 
 2. **Allocator Communication**:
 
-   - Authenticated via bearer token (auto-distributed at launch)
+   - Authenticated with its own per-client secret, issued at registration
    - Heartbeat mechanism
-   - Status updates (in-use, available)
+   - Status updates (in-use, health, startup timings)
    - Failure reporting
 
-3. **Research Execution**:
-   - Clones configured repository
-   - Runs containerized research software
-   - Executes user-defined CRD commands
+3. **Desktop Session**:
+   - Runs a KasmVNC desktop the participant reaches in a browser
+   - Exposes a local agent the allocator calls to rotate the VNC password per session
+   - Clones the configured repository and runs the containerized research software
 
 **Configuration**: See `packages/client/src/lablink_client/conf/structured_config.py`
 
 ### Database Schema
 
-**Table: `vms`**
+Four tables: `vms` (one row per client machine), `operations` (async provisioning
+work), `scheduled_destructions`, and `settings` (deployment-wide key/value state).
 
-| Column            | Type         | Description                                            |
-| ----------------- | ------------ | ------------------------------------------------------ |
-| `Hostname`        | VARCHAR(255) | VM hostname/identifier (Primary Key)                   |
-| `UserEmail`       | VARCHAR(255) | User email                                             |
-| `Status`          | VARCHAR(50)  | VM status (running/initializing/error/rebooting)       |
-| `CrdCommand`      | TEXT         | Command to execute on VM                               |
-| `CreatedAt`       | TIMESTAMP    | Creation timestamp                                     |
-| `reboot_count`    | INTEGER      | Number of reboot attempts (default: 0)                 |
-| `last_reboot_time`| TIMESTAMP    | When the last reboot was attempted                     |
+The `vms` row carries the machine's identity and assignment, its provider and
+connectivity details, per-session browser state, liveness counters, startup timings,
+and — when enabled — session metrics. Full column-by-column reference:
+[Database](database.md#vms-table).
 
-**Triggers**:
-
-- `notify_vm_update`: Sends PostgreSQL NOTIFY on row changes
+**Triggers**: one, maintaining `updated_at` on `scheduled_destructions`. LabLink no
+longer uses `LISTEN`/`NOTIFY`; see
+[Database](database.md#triggers) for what replaced it.
 
 ### VM State Machine
 
@@ -269,36 +311,44 @@ stateDiagram-v2
 
 ## Data Flow
 
-### VM Request Flow
+### Seat Assignment Flow
 
 ```mermaid
 sequenceDiagram
     actor User
-    participant WebUI as Web UI/API
-    participant Flask as Flask App
+    participant Flask as Allocator
     participant DB as PostgreSQL
-    participant Client as Client VM
+    participant Agent as Client agent
 
-    User->>WebUI: Submit VM request
-    WebUI->>Flask: POST /request_vm
-    Flask->>DB: SELECT * FROM vms<br/>WHERE status='available'<br/>LIMIT 1
+    User->>Flask: POST /api/request_vm<br/>(email only)
+    Flask->>DB: Already own a running seat?
 
-    alt VM Available
-        DB-->>Flask: Return VM details
-        Flask-->>WebUI: Return VM hostname<br/>and connection details
-        WebUI-->>User: Display VM info
-        Flask->>DB: PostgreSQL NOTIFY<br/>vm_update
-        DB-->>Client: Notify event
-    else No VM Available
-        DB-->>Flask: No results
-        Flask-->>WebUI: Error: No VMs available
-        WebUI-->>User: Queue request or<br/>show error message
+    alt Rejoin
+        DB-->>Flask: Existing seat
+    else Fresh claim
+        Flask->>DB: assign_vm — SELECT … <br/>FOR UPDATE SKIP LOCKED
+        alt Pool empty
+            DB-->>Flask: no rows
+            Flask-->>User: 503 no_seats.html
+        end
     end
 
-    Note over Client: Later: update_inuse_status service<br/>monitors for software process
-    Client->>Client: Software process starts
-    Client->>Flask: Update status to in-use
-    Flask->>DB: UPDATE vms<br/>SET status='in-use'
+    Flask->>Flask: Mint session_id + browser_token
+    Flask->>Agent: POST /api/session/start<br/>(rotate KasmVNC password)
+
+    alt Rotation OK
+        Agent-->>Flask: 200
+        Flask->>DB: Persist session state,<br/>clear Unhealthy
+        Flask-->>User: 302 /desktop<br/>+ signed lablink_session cookie
+        User->>Flask: GET /desktop
+        Flask-->>User: noVNC viewer
+    else RotationFailed
+        Flask->>DB: Mark Unhealthy,<br/>release seat
+        Flask-->>User: 503 rotation_failed.html
+    end
+
+    Note over Agent: Later: update_inuse_status reports<br/>whether the software is running
+    Agent->>Flask: POST /api/update_inuse_status
 ```
 
 ### VM Creation Flow
@@ -326,8 +376,8 @@ sequenceDiagram
 
     VM->>Docker: Pull Docker image<br/>from ghcr.io
     VM->>VM: Clone user repository<br/>(if configured)
-    VM->>Docker: Start client service<br/>(subscribe, check_gpu, etc.)
-    Docker->>Flask: POST /vm_startup<br/>(hostname registration)
+    VM->>Docker: Start client services<br/>(agent, heartbeat, check_gpu)
+    Docker->>Flask: POST /api/vm-status<br/>(status: running)
 
     Flask-->>Admin: VMs created successfully<br/>(show instance details)
 ```
@@ -427,7 +477,7 @@ See [Security](security.md) for detailed security considerations.
 | Component     | Technology      | Rationale                          |
 | ------------- | --------------- | ---------------------------------- |
 | Web Framework | Flask           | Lightweight, Python ecosystem      |
-| Database      | PostgreSQL      | LISTEN/NOTIFY, ACID compliance     |
+| Database      | PostgreSQL      | ACID compliance, `SKIP LOCKED` for race-free seat claims |
 | IaC           | Terraform       | Declarative, AWS support           |
 | Containers    | Docker          | Portability, dependency isolation  |
 | CI/CD         | GitHub Actions  | Native GitHub integration          |

--- a/docs/database.md
+++ b/docs/database.md
@@ -6,10 +6,12 @@ This guide covers the PostgreSQL database used by LabLink, including schema, man
 
 LabLink uses **PostgreSQL** for:
 
-- Tracking VM states (available, in-use, failed)
-- Storing user assignments
-- Real-time notifications (LISTEN/NOTIFY)
-- Audit logging
+- Tracking VM states (`initializing`, `running`, `error`, `rebooting`)
+- Storing seat assignments, and claiming them atomically so concurrent requesters can't collide
+- Holding per-session browser state (session IDs, rotated VNC credentials)
+- Registration records and hashed secrets for BYO clients
+- Async operation and scheduled-destruction bookkeeping
+- Session metrics, when `monitoring.enabled` is set
 
 **Version**: PostgreSQL 13+
 **Location**: Runs in allocator Docker container
@@ -17,188 +19,167 @@ LabLink uses **PostgreSQL** for:
 
 ## Database Schema
 
-### Schema Overview
+The schema is created once, at container start, by `generate-init-sql` writing
+`init.sql` for Postgres' bootstrap step. There are four tables.
 
-```mermaid
-erDiagram
-    VMS {
-        varchar_1024 HostName PK "VM hostname/instance ID"
-        varchar_1024 Pin "VM pin/identifier"
-        varchar_1024 CrdCommand "Command to execute"
-        varchar_1024 UserEmail "User email address"
-        boolean InUse "Whether software is running"
-        varchar_1024 Healthy "Health status"
-        varchar_1024 Status "VM status"
-        text Logs "VM logs"
-        timestamp TerraformApplyStartTime "Terraform start"
-        timestamp TerraformApplyEndTime "Terraform end"
-        float TerraformApplyDurationSeconds "Terraform duration"
-        timestamp CloudInitStartTime "Cloud-init start"
-        timestamp CloudInitEndTime "Cloud-init end"
-        float CloudInitDurationSeconds "Cloud-init duration"
-        timestamp ContainerStartTime "Container start"
-        timestamp ContainerEndTime "Container end"
-        float ContainerStartupDurationSeconds "Container startup duration"
-        float TotalStartupDurationSeconds "Total startup duration"
-        timestamp CreatedAt "Creation timestamp"
-        integer reboot_count "Reboot attempt count"
-        timestamp last_reboot_time "Last reboot time"
-    }
+!!! note "One-time-use database"
+    A LabLink database is created fresh for each deployment and thrown away with it,
+    so there is no migration machinery. New schema goes in `generate_init_sql.py`,
+    not into a runtime upgrade path.
 
-    VMS ||--o{ trigger_crd_command_insert_or_update : "fires on notify_crd_command_update()"
-```
+### `vms` Table
 
-### Tables
+The main table. One row per client machine, whether it was provisioned by Terraform
+or registered itself as a BYO box. The table name is configurable via
+`db.table_name` (default `vm_table`); this page calls it `vms`.
 
-#### `vms` Table
+It carries five groups of columns:
 
-Primary table tracking all VM instances with comprehensive timing metrics.
+**Identity and assignment**
 
-| Column                            | Type          | Constraints   | Description                                             |
-| --------------------------------- | ------------- | ------------- | ------------------------------------------------------- |
-| `HostName`                        | VARCHAR(1024) | PRIMARY KEY   | VM hostname/instance ID                                 |
-| `Pin`                             | VARCHAR(1024) |               | VM pin/identifier for access                            |
-| `CrdCommand`                      | VARCHAR(1024) |               | Command to execute on VM                                |
-| `UserEmail`                       | VARCHAR(1024) |               | User email address                                      |
-| `InUse`                           | BOOLEAN       | NOT NULL      | Whether configured software is running (default: FALSE) |
-| `Healthy`                         | VARCHAR(1024) |               | Health status of the VM                                 |
-| `Status`                          | VARCHAR(1024) |               | VM status                                               |
-| `Logs`                            | TEXT          |               | VM logs                                                 |
-| `TerraformApplyStartTime`         | TIMESTAMP     |               | When Terraform apply started                            |
-| `TerraformApplyEndTime`           | TIMESTAMP     |               | When Terraform apply completed                          |
-| `TerraformApplyDurationSeconds`   | FLOAT         |               | Duration of Terraform apply in seconds                  |
-| `CloudInitStartTime`              | TIMESTAMP     |               | When cloud-init started                                 |
-| `CloudInitEndTime`                | TIMESTAMP     |               | When cloud-init completed                               |
-| `CloudInitDurationSeconds`        | FLOAT         |               | Duration of cloud-init in seconds                       |
-| `ContainerStartTime`              | TIMESTAMP     |               | When container startup started                          |
-| `ContainerEndTime`                | TIMESTAMP     |               | When container became ready                             |
-| `ContainerStartupDurationSeconds` | FLOAT         |               | Duration of container startup in seconds                |
-| `TotalStartupDurationSeconds`     | FLOAT         |               | Total VM startup duration in seconds                    |
-| `CreatedAt`                       | TIMESTAMP     | DEFAULT NOW() | Creation timestamp                                      |
-| `reboot_count`                    | INTEGER       | DEFAULT 0     | Number of reboot attempts                               |
-| `last_reboot_time`               | TIMESTAMP     |               | When the last reboot was attempted                      |
+| Column | Type | Description |
+|---|---|---|
+| `HostName` | VARCHAR(1024) PK | Hostname / instance ID |
+| `UserEmail` | VARCHAR(1024) | Assigned participant, `NULL` when free |
+| `InUse` | BOOLEAN NOT NULL | Whether the configured software is actively running |
+| `Healthy` | VARCHAR(1024) | Health status |
+| `Status` | VARCHAR(1024) | `initializing`, `running`, `error`, `rebooting` |
+| `CreatedAt` | TIMESTAMP | Row creation time |
+| `last_release_time` | TIMESTAMP | When the seat was last released |
 
-**InUse Status**:
+**Provider and connectivity** — how the allocator reaches this machine
 
-The `InUse` column indicates whether the configured software (e.g., SLEAP) is actively running on the VM, not just whether a user has been assigned. This is monitored by the `update_inuse_status` service running on the client VM.
+| Column | Type | Description |
+|---|---|---|
+| `provider` | TEXT NOT NULL | `aws` or `manual`. Defaults to `aws` |
+| `machine_identity` | TEXT | Stable machine ID, unique where non-NULL. Lets a BYO box re-register without consuming a second seat |
+| `endpoint_url` | TEXT | Reported endpoint, if any |
+| `provider_metadata` | JSONB NOT NULL | Connectivity-specific payload: `lan_ip`, `overlay_hostname`, or the reverse-tunnel alias octet and path prefix |
+| `client_secret_hash` | TEXT | Argon2 hash of this client's own secret |
+| `gpu_present` | BOOLEAN | Whether a GPU was detected |
+| `gpu_model` | TEXT | Reported GPU model |
 
-- `FALSE`: Software process not running
-- `TRUE`: Software process actively running
+**Browser session** — per-assignment state, rewritten on each new session
 
-**Timing Metrics**:
+| Column | Type | Description |
+|---|---|---|
+| `SessionId` | UUID | Per-session ID, unique where non-NULL. Bound to the `lablink_session` cookie |
+| `BrowserToken` | TEXT | Per-session token, unique where non-NULL |
+| `VncPassword` | TEXT | Current KasmVNC password, rotated at assignment |
+| `browser_ws_url` | TEXT | The URL the viewer page opens |
+| `browser_credential` | TEXT | Sent as HTTP Basic by the viewer, when required |
+| `Upstream` | TEXT | Proxy upstream for this client |
+| `SessionStartedAt` | TIMESTAMPTZ | Session start |
+| `AdminReservedAt` | TIMESTAMPTZ | Set while an admin holds the VM for troubleshooting |
 
-The table tracks three phases of VM startup:
+**Liveness and recovery**
 
-1. **Terraform Apply**: Infrastructure provisioning (EC2 instance creation)
-2. **Cloud-init**: OS-level initialization and Docker setup
-3. **Container Startup**: Application container becoming ready
+| Column | Type | Description |
+|---|---|---|
+| `last_seen_at` | TIMESTAMP | Last heartbeat |
+| `boot_id` | VARCHAR(64) | Changes across reboots, so a silent restart is detectable |
+| `disk_free_pct` | SMALLINT | Reported free disk percentage |
+| `reboot_count` | INTEGER | Reboot attempts so far |
+| `last_reboot_time` | TIMESTAMP | Last reboot attempt |
 
-These metrics help identify bottlenecks in the VM creation process.
+The last two are added by `ensure_reboot_columns()` at reboot-service startup, not
+by `init.sql` — the one exception to the note above.
 
-**Example Row**:
+**Startup timings and logs**
+
+`CloudInitLogs`, `DockerLogs`, and the `TerraformApply*`, `CloudInit*`, `Container*`
+and `TotalStartupDurationSeconds` timing columns, which break VM startup into its
+Terraform / cloud-init / container-start phases for bottleneck analysis.
+
+**Session metrics** — populated only when `monitoring.enabled` is true
+
+The `SessionMetrics*`, `SecondsIn*`, `SecondsToFirst*`, `Gpu*`, `Vram*` and
+`Training*` columns, plus `MaxLabeledFrames` — per-session time-in-software, GPU
+activity and training-progress counters.
+
+#### Indexes
 
 ```sql
-HostName          | UserEmail        | InUse | CrdCommand       | TotalStartupDurationSeconds | CreatedAt
-------------------+------------------+-------+------------------+-----------------------------+---------------------
-i-0abc123def456   | user@example.com | true  | python train.py  | 245.67                      | 2025-01-15 10:30:00
+CREATE UNIQUE INDEX vms_browser_token_idx     ON vms(BrowserToken)      WHERE BrowserToken IS NOT NULL;
+CREATE UNIQUE INDEX vms_session_id_idx        ON vms(SessionId)         WHERE SessionId IS NOT NULL;
+CREATE UNIQUE INDEX vms_machine_identity_idx  ON vms(machine_identity)  WHERE machine_identity IS NOT NULL;
+CREATE INDEX        vms_provider_idx          ON vms(provider);
+CREATE INDEX        vms_assignable_idx        ON vms(status, useremail, last_release_time)
+    WHERE useremail IS NULL AND status = 'running' AND adminreservedat IS NULL;
 ```
+
+`vms_assignable_idx` is the one that matters for assignment: it covers exactly the
+rows a seat request can claim, so `assign_vm`'s `FOR UPDATE SKIP LOCKED` scan stays
+cheap as the pool grows.
+
+**`InUse` vs assignment.** `InUse` means *the configured software is running*, not
+*a participant is assigned*. A participant can hold a seat with `InUse = FALSE`
+if they haven't launched anything yet. It's maintained by the client's
+`update_inuse_status` service.
+
+### `operations` Table
+
+Tracks asynchronous provisioning work so the CLI and admin UI can poll progress
+instead of blocking on a long Terraform run.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | SERIAL PK | |
+| `op_type` | VARCHAR(16) NOT NULL | What kind of operation |
+| `status` | VARCHAR(16) NOT NULL | Current state |
+| `params` | TEXT | Serialized request parameters |
+| `created_by` | VARCHAR(255) | Requesting admin |
+| `created_at` | TIMESTAMP NOT NULL | Defaults to `NOW()` |
+| `started_at` / `finished_at` | TIMESTAMP | Execution window |
+| `output` / `error` | TEXT | Captured result |
+| `resources_total` / `resources_completed` | INTEGER | Progress counters |
+
+Exposed via [`/api/operations`](api-endpoints.md#operations-api).
+
+### `scheduled_destructions` Table
+
+Backs scheduled tear-down, so a workshop deployment can be capped ahead of time.
+
+| Column | Type | Description |
+|---|---|---|
+| `id` | SERIAL PK | |
+| `schedule_name` | VARCHAR(255) NOT NULL UNIQUE | |
+| `destruction_time` | TIMESTAMP NOT NULL | When to tear down |
+| `recurrence_rule` | VARCHAR(255) | Optional recurrence |
+| `created_by` | VARCHAR(255) | |
+| `status` | VARCHAR(50) NOT NULL | Defaults to `scheduled` |
+| `execution_count` | INTEGER | Defaults to 0 |
+| `last_execution_time` | TIMESTAMP | |
+| `last_execution_result` | TEXT | |
+| `notification_enabled` | BOOLEAN | Defaults to `TRUE` |
+| `notification_hours_before` | INTEGER | Defaults to 1 |
+| `created_at` / `updated_at` | TIMESTAMP | Default `NOW()` |
+
+Exposed via [`/api/schedule-destruction`](api-endpoints.md#scheduled-destruction-api).
+
+### `settings` Table
+
+A two-column key/value store (`key TEXT PRIMARY KEY`, `value TEXT NOT NULL`) for
+deployment-wide state that has to survive a restart. Its main use is holding
+`register_token_hash`, the argon2 hash of the deployment's register token, so
+client registration can be verified without keeping the token in memory alone.
 
 ### Triggers
 
-#### `notify_vm_update`
+One, `scheduled_destructions_updated_at`, which maintains `updated_at` on that
+table.
 
-Sends PostgreSQL NOTIFY when VM table changes.
+!!! note "LISTEN/NOTIFY has been removed"
+    LabLink used to drive client assignment through a `notify_vm_changes` trigger
+    firing `pg_notify` on a `vm_updates` channel, with each client holding a
+    `LISTEN` connection open and blocking on `POST /vm_startup` for a CRD command
+    and PIN. All of it — the trigger, the channel, the `db.message_channel` config
+    key, the endpoint, and the client-side `subscribe` service — is gone.
 
-**Purpose**: Real-time updates to client VMs
-
-**Definition**:
-
-```sql
-CREATE OR REPLACE FUNCTION notify_vm_changes()
-RETURNS trigger AS $$
-BEGIN
-  PERFORM pg_notify('vm_updates', row_to_json(NEW)::text);
-  RETURN NEW;
-END;
-$$ LANGUAGE plpgsql;
-
-CREATE TRIGGER vm_update_trigger
-AFTER INSERT OR UPDATE ON vms
-FOR EACH ROW
-EXECUTE FUNCTION notify_vm_changes();
-```
-
-**How it works**:
-
-1. Client VM starts up and sends HTTP POST to `/vm_startup` endpoint
-
-2. Allocator validates VM exists in database and establishes `LISTEN vm_updates` connection
-
-3. HTTP request blocks while allocator waits for VM assignment
-
-4. User requests a VM via web UI (POST `/api/request_vm`)
-
-5. Allocator assigns first available VM by updating database with `CrdCommand` and `Pin`
-
-6. Database trigger fires on UPDATE and sends `pg_notify()` with JSON payload to `vm_updates` channel
-
-7. Allocator receives notification via PostgreSQL LISTEN connection
-
-8. Allocator parses notification and matches hostname to the pending `/vm_startup` request
-
-9. HTTP response returns to client with command and pin
-
-10. Client executes the CrdCommand to connect to the configured software
-
-### NOTIFY/LISTEN Flow Diagram
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant Client as Client VM
-    participant Flask as Flask App<br/>(Allocator)
-    participant DB as PostgreSQL
-    participant Trigger as notify_crd_command_update<br/>Trigger
-
-    Note over Client: Client VM starts up
-
-    Client->>Flask: POST /vm_startup<br/>{hostname: "vm-123"}<br/>
-
-    Note over Flask: Allocator validates VM<br/>and establishes LISTEN
-
-    Flask->>DB: SELECT * WHERE hostname='vm-123'
-    DB-->>Flask: VM found
-
-    Flask->>DB: LISTEN vm_updates
-
-    Note over Flask,DB: Allocator waits for notification<br/>(HTTP response blocked)
-
-    Note over User: User requests a VM
-
-    User->>Flask: POST /api/request_vm<br/>{email: "user@example.com",<br/>crd_command: "..."}
-
-    Note over Flask: Allocator assigns first<br/>available VM
-
-    Flask->>DB: UPDATE vms<br/>SET UserEmail='user@example.com',<br/>CrdCommand='...', Pin='...'<br/>WHERE hostname='vm-123'
-
-    DB->>Trigger: Row modified<br/>(AFTER INSERT/UPDATE trigger)
-
-    Trigger->>Trigger: Build JSON payload<br/>{HostName, CrdCommand, Pin}
-
-    Trigger->>DB: pg_notify('vm_updates',<br/>JSON payload)
-
-    DB-->>Flask: NOTIFY event received<br/>(on LISTEN connection)
-
-    Flask->>Flask: Parse notification<br/>Check if HostName matches<br/>pending vm_startup request
-
-    alt Hostname matches
-        Flask-->>Client: HTTP 200 OK<br/>{status: "success",<br/>command: "...", pin: "..."}
-        Flask-->>User: Success page<br/>with VM hostname
-        Client->>Client: Execute CrdCommand<br/>(connect to software)
-    else Hostname doesn't match
-        Note over Flask: Continue waiting for<br/>matching notification
-    end
-```
+    Assignment now runs the other direction: `/api/request_vm` claims a seat with
+    `FOR UPDATE SKIP LOCKED` and the allocator calls the assigned client's local
+    agent to rotate its VNC password. No pub/sub, and no long-lived database
+    connection per client.
 
 ## Accessing the Database
 
@@ -261,26 +242,32 @@ SELECT * FROM vms;
 
 ### View Available VMs
 
-```sql
-SELECT hostname, status, created_at
-FROM vms
-WHERE status = 'available'
-ORDER BY created_at;
-```
-
-### View In-Use VMs
+A seat is claimable when it is `running`, unassigned, and not reserved by an admin —
+the same predicate `vms_assignable_idx` covers.
 
 ```sql
-SELECT hostname, email, status, crd_command, updated_at
+SELECT hostname, status, gpu_model, createdat
 FROM vms
-WHERE status = 'in-use'
-ORDER BY updated_at DESC;
+WHERE status = 'running' AND useremail IS NULL AND adminreservedat IS NULL
+ORDER BY createdat;
 ```
+
+### View Assigned VMs
+
+```sql
+SELECT hostname, useremail, status, inuse, sessionstartedat
+FROM vms
+WHERE useremail IS NOT NULL
+ORDER BY sessionstartedat DESC;
+```
+
+`inuse` tells you whether the configured software is actually running, which is not
+the same as a seat being assigned.
 
 ### Count VMs by Status
 
 ```sql
-SELECT status, COUNT(*) as count
+SELECT status, COUNT(*) AS count
 FROM vms
 GROUP BY status;
 ```
@@ -290,32 +277,58 @@ Expected output:
 ```
  status       | count
 --------------+-------
- available    |     5
- in-use       |     3
+ running      |     8
+ initializing |     1
  error        |     1
- rebooting    |     1
 ```
 
-### Find VM by Email
+### Find a VM by Email
 
 ```sql
-SELECT hostname, status, crd_command
+SELECT hostname, status, healthy, sessionstartedat
 FROM vms
-WHERE email = 'user@example.com';
+WHERE useremail = 'user@example.com';
 ```
 
-### Update VM Status
+### Release a Seat
+
+Clearing the assignment and the per-session state returns a VM to the pool:
 
 ```sql
--- Mark VM as available
 UPDATE vms
-SET status = 'available', email = NULL, crd_command = NULL, updated_at = NOW()
+SET useremail = NULL, sessionid = NULL, browsertoken = NULL,
+    sessionstartedat = NULL, last_release_time = NOW()
 WHERE hostname = 'i-0abc123def456';
+```
 
--- Mark VM as failed
-UPDATE vms
-SET status = 'failed', updated_at = NOW()
-WHERE hostname = 'i-0abc123def456';
+### Clear a Stuck Unhealthy Flag
+
+A single transient rotation failure can leave a client marked `Unhealthy`. The admin
+UI exposes this as **clear-unhealthy**; the equivalent query is:
+
+```sql
+UPDATE vms SET healthy = NULL WHERE hostname = 'i-0abc123def456';
+```
+
+### View BYO Client Registrations
+
+```sql
+SELECT hostname, machine_identity, provider, gpu_model,
+       provider_metadata, last_seen_at
+FROM vms
+WHERE provider = 'manual'
+ORDER BY last_seen_at DESC NULLS LAST;
+```
+
+### Find Silent Clients
+
+Clients that stopped heartbeating — the signal the recovery loop acts on:
+
+```sql
+SELECT hostname, status, last_seen_at, reboot_count
+FROM vms
+WHERE status = 'running'
+  AND (last_seen_at IS NULL OR last_seen_at < NOW() - INTERVAL '3 minutes');
 ```
 
 ### Delete VM Record
@@ -332,50 +345,6 @@ Only delete after VM instance is terminated in AWS.
 ```sql
 -- Use with caution!
 TRUNCATE TABLE vms;
-```
-
-## Monitoring LISTEN/NOTIFY
-
-### Listen for VM Updates
-
-```sql
--- In psql session
-LISTEN vm_updates;
-
--- In another session, make a change:
-UPDATE vms SET status = 'in-use' WHERE id = 1;
-
--- First session receives:
-Asynchronous notification "vm_updates" received from server process with PID 12345.
-```
-
-### Listen from Python
-
-```python
-import psycopg2
-import select
-
-conn = psycopg2.connect(
-    dbname="lablink_db",
-    user="lablink",
-    password="lablink",
-    host="localhost"
-)
-
-conn.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
-cursor = conn.cursor()
-cursor.execute("LISTEN vm_updates;")
-
-print("Waiting for notifications...")
-
-while True:
-    if select.select([conn], [], [], 5) == ([], [], []):
-        print("Timeout")
-    else:
-        conn.poll()
-        while conn.notifies:
-            notify = conn.notifies.pop(0)
-            print(f"Notification: {notify.payload}")
 ```
 
 ## Database Backup
@@ -751,11 +720,13 @@ SELECT * FROM vms;
 -- Count by status
 SELECT status, COUNT(*) FROM vms GROUP BY status;
 
--- Find available VMs
-SELECT * FROM vms WHERE status = 'available';
+-- Find claimable seats
+SELECT * FROM vms
+WHERE status = 'running' AND useremail IS NULL AND adminreservedat IS NULL;
 
--- Update VM status
-UPDATE vms SET status = 'available' WHERE hostname = 'i-xxxxx';
+-- Release a seat back to the pool
+UPDATE vms SET useremail = NULL, sessionid = NULL, browsertoken = NULL
+WHERE hostname = 'i-xxxxx';
 
 -- Backup
 pg_dump -U lablink lablink_db > backup.sql


### PR DESCRIPTION
## Summary

`api-endpoints.md`, `database.md` and `architecture.md` still described the **Chrome-Remote-Desktop era**: a client that long-polled `POST /vm_startup` and blocked on a PostgreSQL `NOTIFY` carrying a CRD command and PIN. None of that exists — not the endpoint, not the trigger, not the channel, not the client service that called it.

Every endpoint below was checked against the allocator's actual route table and every column against `generate_init_sql.py`.

This is the follow-up flagged in #426, which deliberately scoped `/vm_startup` out because fixing it coherently meant touching all three files at once.

**Scope:** the JSON API surface. The `/admin` HTML pages are not inventoried here — see [Design Decisions](#design-decisions).

## Removed — documented, does not exist

| Thing | Where it was |
|---|---|
| `POST /vm_startup` and the `crd_command`/PIN contract on `/api/request_vm` | `api-endpoints.md`, `architecture.md`, `database.md` |
| `GET /api/scp-client` | `api-endpoints.md` |
| `GET /api/vm-status/<hostname>` | `api-endpoints.md` |
| `notify_vm_changes` trigger, the `vm_updates` channel, `db.message_channel`, and ~190 lines of LISTEN/NOTIFY flow diagram + monitoring recipes | `database.md`, `architecture.md` |
| `Pin`, `CrdCommand`, `Logs` columns | schema tables in `database.md`, `architecture.md` |
| Example queries selecting `crd_command` / `email` / `updated_at` and the `'available'` / `'in-use'` statuses | `database.md` |

The only trigger left in the schema is `scheduled_destructions_updated_at`. `grep` for `pg_notify`/`LISTEN` across the allocator returns nothing.

## Added — exists, was not documented

- **The entire client registration API** — `POST /api/v1/clients/register` with its request contract and credential response, plus `/status`, `DELETE`, the operator list, and `/api/overlay-hostname` (which exists because MagicDNS suffixes a name already held by an offline node, so the name a client asks for and the one it gets can differ).
- **`GET /api/health`** — which `lablink deploy` and `lablink status` both poll, and which returns a structured readiness report, not a bare 200. Documented including why an unattached client tunnel is reported but deliberately doesn't gate readiness.
- `/api/heartbeat`, the operations API, the scheduled-destruction API, the session-metrics API, `/desktop`, `/internal/proxy_auth` and `/internal/tunnel_auth`.
- **Three missing tables** (`operations`, `scheduled_destructions`, `settings`), **~40 missing `vms` columns** grouped by role rather than dumped as one flat list, and **all five indexes** — including `vms_assignable_idx`, which is what keeps the seat claim cheap as the pool grows.
- **A Providers and Connectivity section** in `architecture.md`, which previously read as though AWS were the only mode. Covers the compute-provider axis (`aws`/`manual`, gated on the `can_provision_hosts` / `can_recover_hosts` capability flags rather than provider-type checks) and the client-connectivity axis (`lan_direct` / `mesh_overlay` / `reverse_tunnel`).

## Corrected

- **The auth model.** It was described as one bearer token generated at allocator startup and distributed via cloud-init. It is four gates, and client telemetry uses **per-client secrets** minted at registration and stored as argon2 hashes — so a leaked secret compromises one machine, not the fleet. Eight endpoints had the wrong gate labelled (client-secret endpoints marked "Bearer Token", two admin endpoints likewise, and `/api/unassigned_vms_count` marked authenticated when it isn't). `POST /api/vm-logs` was missing its `/<hostname>`.
- **The seat assignment flow**, rewritten around what actually happens: the atomic `FOR UPDATE SKIP LOCKED` claim (so concurrent requesters can't collide), the idempotent rejoin, and the VNC password rotation that runs *inside* the assignment transaction so a rotation failure rolls the seat back rather than parking a participant on a dead machine.
- **`architecture.md`'s Database Management bullets**, which still claimed "PostgreSQL listen/notify for real-time updates" and "automated triggers for state changes" — both of which the rest of this change removes. Two lines that would have contradicted the whole PR.

## Testing

- **Bidirectional endpoint check.** A script extracted every `@bp.route` from the allocator's route modules and diffed it against every endpoint named in `api-endpoints.md`, both ways. Result: no documented endpoint that doesn't exist, no real endpoint undocumented (`/admin/*` pages excluded by scope). The check is what caught `/api/health` missing after my first pass.
- **Schema checked column-by-column** against `generate_init_sql.py`, including the four `CREATE TABLE`s and five indexes.
- **All anchored cross-links validated** against the built site — target page exists *and* the `#fragment` resolves to a real `id`. This caught a link to `troubleshooting.md#vm-stuck-in-error-state`, an anchor that doesn't exist (the real heading is `#vm-auto-reboot-not-working`).
- **Stale-term sweep** for `vm_startup`, `CrdCommand`, `crd_command`, `scp-client`, `subscribe`, `message_channel`: every surviving occurrence is inside an explicit "this was removed" note, none in live prose.
- `mkdocs build` clean, no new warnings.

## Design Decisions

- **Scoped to the JSON API surface; no `/admin` page inventory.** The `/admin/*` routes are operator UI, not a callable API, and the two that are callable (`/api/launch`, `POST /destroy`) already have their own sections. Inventorying them here would have created a second place to drift — they're walked through with screenshots in `workshop-guide.md`, and `/admin/byo-onboarding` in `cli/byo-clients.md`. `api-endpoints.md` now points at both instead.
- **Kept `/desktop` and `/internal/*_auth`** despite neither being under `/api`. `/desktop` is the 302 target of `/api/request_vm` and carries the `lablink_session` cookie contract; the `/internal/*` routes are nginx `auth_request` subrequests, which is machine-callable regardless of the path they sit on.
- **One canonical note per removed mechanism.** The `/vm_startup` + LISTEN/NOTIFY + CRD removal is explained once, in `database.md`, with the `api-endpoints.md` mentions linking to it. Someone who remembers `/vm_startup` still gets told it's gone, without three copies of the explanation to keep in sync.
- **Grouped the `vms` columns by role** (identity/assignment, provider/connectivity, browser session, liveness, timings, metrics) rather than listing 60+ rows in one table. The old flat table is how it drifted: nobody could tell which columns mattered for what. Session-metrics columns are named by prefix rather than enumerated, since a bare list of 17 names carries no information a `grep` doesn't.
- **Flagged `ensure_reboot_columns()` as the one exception** to "no migration machinery". `reboot_count` and `last_reboot_time` really are added at runtime rather than by `init.sql`, so the note says so instead of stating an absolute the code contradicts.
- **Left the "Migrating to RDS" section alone.** It's speculative (no RDS support exists) but it's pre-existing and reads as guidance rather than a false claim about current behavior. Flagging rather than cutting it here.

## Related

- Follows #426 (merged), which scoped this out explicitly.
- Rebased onto #427 (merged), so cross-links now point at `cli/byo-clients.md` directly rather than at `configuration.md` as a stand-in.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
