### PR TITLE
feat(cli): add `lablink client doctor` for BYO client health

### DIFF
--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -379,6 +379,14 @@ def doctor() -> None:
     run_doctor()
 
 
+@client_app.command("doctor")
+def client_doctor() -> None:
+    """Check this machine's BYO client (container, log shipper)."""
+    from lablink_cli.commands.doctor import run_client_doctor
+
+    run_client_doctor()
+
+
 @client_app.command("register")
 def register(
     allocator_url: str = typer.Option(

--- a/packages/cli/src/lablink_cli/commands/doctor.py
+++ b/packages/cli/src/lablink_cli/commands/doctor.py
@@ -245,7 +245,23 @@ def _check_aws_prereqs() -> None:
     # 6. AMI for region
     checks.append(_check_ami(cfg))
 
-    # Display results
+    _render_checks(
+        checks,
+        pass_message=(
+            "[green]All checks passed.[/green] "
+            "Ready to deploy with 'lablink deploy'."
+        ),
+        fail_message=(
+            "[yellow]Some checks failed.[/yellow] "
+            "Resolve the issues above before deploying."
+        ),
+    )
+
+
+def _render_checks(
+    checks: list[dict], *, pass_message: str, fail_message: str
+) -> bool:
+    """Print a check-results table. Returns True if every check passed."""
     table = Table(show_header=True)
     table.add_column("Check")
     table.add_column("Status")
@@ -264,17 +280,8 @@ def _check_aws_prereqs() -> None:
 
     console.print(table)
     console.print()
-
-    if all_pass:
-        console.print(
-            "[green]All checks passed.[/green] "
-            "Ready to deploy with 'lablink deploy'."
-        )
-    else:
-        console.print(
-            "[yellow]Some checks failed.[/yellow] "
-            "Resolve the issues above before deploying."
-        )
+    console.print(pass_message if all_pass else fail_message)
+    return all_pass
 
 
 def _check_manual_prereqs() -> None:
@@ -308,6 +315,175 @@ def _check_manual_prereqs() -> None:
             "[red]✗[/red] docker compose: missing "
             "(install the Compose plugin)"
         )
+
+
+# --------------------------------------------------------------------
+# Client-side checks (`lablink client doctor`)
+#
+# These run ON a registered BYO box, not on the operator's deploy host.
+# `lablink doctor` answers "can I deploy from here?"; this answers "is the
+# client on this machine actually working?"
+# --------------------------------------------------------------------
+
+# A shipper that is alive but hasn't shipped in this long is reporting a
+# problem no liveness check can see — the process is up and the container is
+# healthy, but nothing is reaching the allocator. That combination went
+# unnoticed for a week (lablink#428), which is the reason this command exists.
+SHIPPER_STALE_AFTER_S = 15 * 60
+
+
+def _format_age(seconds: float) -> str:
+    """Coarse human age ("6d", "3h", "20m") for the staleness message.
+
+    A raw minute count reads as noise once it passes a few hours
+    ("8687 min ago"), and this is the one line an operator scans to decide
+    whether logs are flowing.
+    """
+    if seconds >= 86400:
+        return f"{int(seconds // 86400)}d"
+    if seconds >= 3600:
+        return f"{int(seconds // 3600)}h"
+    return f"{int(seconds // 60)}m"
+
+
+def _check_client_registered() -> dict:
+    """Check that `lablink client register` has run on this box."""
+    from lablink_cli.commands.register import DEFAULT_ENV_FILE
+
+    result = {"check": "Registered", "status": "fail"}
+    if not DEFAULT_ENV_FILE.exists():
+        result["detail"] = (
+            f"No {DEFAULT_ENV_FILE}. Run `lablink client register` first."
+        )
+        return result
+    result["status"] = "pass"
+    result["detail"] = str(DEFAULT_ENV_FILE)
+    return result
+
+
+def _check_client_container() -> dict:
+    """Report the lablink-client container's state.
+
+    Doubles as the docker-daemon check: `inspect_container` returns
+    "daemon_error" when the daemon is unreachable, so a separate probe would
+    only duplicate the same `docker inspect` call.
+    """
+    from lablink_cli.log_shipper import CONTAINER_NAME, inspect_container
+
+    result = {"check": "Client container", "status": "fail"}
+    status = inspect_container(CONTAINER_NAME)
+
+    if status == "daemon_error":
+        result["detail"] = (
+            "Docker daemon unreachable. Start Docker and re-check."
+        )
+    elif status == "missing":
+        result["detail"] = (
+            f"No container named {CONTAINER_NAME}. "
+            "Re-run `lablink client register --force` to recreate it."
+        )
+    elif status == "exited":
+        result["detail"] = (
+            f"{CONTAINER_NAME} is stopped. "
+            "Run `lablink client register` to restart it."
+        )
+    elif status == "restarting":
+        result["status"] = "warn"
+        result["detail"] = (
+            f"{CONTAINER_NAME} is restarting — it may be crash-looping. "
+            f"Check `docker logs {CONTAINER_NAME}`."
+        )
+    else:
+        result["status"] = "pass"
+        result["detail"] = f"{CONTAINER_NAME} is running"
+    return result
+
+
+def _check_log_shipper(now: float | None = None) -> dict:
+    """Check the log shipper is alive AND actually shipping.
+
+    Liveness alone is not enough. A shipper can sit blocked on a quiet
+    container with a full buffer, process up, nothing delivered — so this
+    also reports how long ago a batch last landed.
+    """
+    import time
+    from datetime import datetime, timezone
+
+    from lablink_cli.commands.register import _shipper_alive
+    from lablink_cli.log_shipper import STATE_FILE, read_last_shipped_ts
+
+    result = {"check": "Log shipper", "status": "fail"}
+
+    if not _shipper_alive():
+        result["detail"] = (
+            "Not running — client logs are not reaching the allocator. "
+            "Run `lablink client register` to restart it."
+        )
+        return result
+
+    last = read_last_shipped_ts(STATE_FILE)
+    if last is None:
+        result["status"] = "warn"
+        result["detail"] = (
+            "Running, but has never shipped a batch. Normal for the first "
+            "minute after registering; otherwise check the allocator URL "
+            "and client secret."
+        )
+        return result
+
+    try:
+        shipped_at = datetime.strptime(last, "%Y-%m-%dT%H:%M:%SZ").replace(
+            tzinfo=timezone.utc
+        )
+    except ValueError:
+        result["status"] = "warn"
+        result["detail"] = f"Running; unparseable last-shipped value {last!r}"
+        return result
+
+    current = now if now is not None else time.time()
+    age_s = current - shipped_at.timestamp()
+    if age_s > SHIPPER_STALE_AFTER_S:
+        result["status"] = "warn"
+        result["detail"] = (
+            f"Running, but last shipped {_format_age(age_s)} ago ({last}). "
+            "The process is up but nothing is reaching the allocator."
+        )
+        return result
+
+    result["status"] = "pass"
+    result["detail"] = f"Running; last shipped {last}"
+    return result
+
+
+def run_client_doctor() -> None:
+    """Run the BYO-client checks and print a results table."""
+    console.print()
+    console.print(
+        Panel(
+            "[bold]LabLink Client Doctor[/bold]\n"
+            "Checking this machine's BYO client.",
+            border_style="cyan",
+        )
+    )
+    console.print()
+
+    checks = [
+        _check_client_registered(),
+        _check_client_container(),
+        _check_log_shipper(),
+    ]
+
+    _render_checks(
+        checks,
+        pass_message=(
+            "[green]All checks passed.[/green] "
+            "This client is registered and shipping logs."
+        ),
+        fail_message=(
+            "[yellow]Some checks need attention.[/yellow] "
+            "Most are fixed by re-running `lablink client register`."
+        ),
+    )
 
 
 def run_doctor() -> None:

--- a/packages/cli/tests/test_doctor.py
+++ b/packages/cli/tests/test_doctor.py
@@ -125,3 +125,147 @@ class TestDoctorManual:
         run_doctor()
         out = capsys.readouterr().out
         assert "docker" in out.lower()
+
+
+# ------------------------------------------------------------------
+# Client-side checks (`lablink client doctor`)
+# ------------------------------------------------------------------
+class TestCheckClientRegistered:
+    def test_missing_env_file(self, tmp_path):
+        from lablink_cli.commands.doctor import _check_client_registered
+
+        with patch(
+            "lablink_cli.commands.register.DEFAULT_ENV_FILE",
+            tmp_path / "nope.env",
+        ):
+            result = _check_client_registered()
+
+        assert result["status"] == "fail"
+        assert "lablink client register" in result["detail"]
+
+    def test_env_file_present(self, tmp_path):
+        from lablink_cli.commands.doctor import _check_client_registered
+
+        env_file = tmp_path / "client.env"
+        env_file.write_text("VM_NAME=box\n")
+        with patch(
+            "lablink_cli.commands.register.DEFAULT_ENV_FILE", env_file
+        ):
+            result = _check_client_registered()
+
+        assert result["status"] == "pass"
+
+
+class TestCheckClientContainer:
+    def _run(self, status):
+        from lablink_cli.commands.doctor import _check_client_container
+
+        with patch(
+            "lablink_cli.log_shipper.inspect_container", return_value=status
+        ):
+            return _check_client_container()
+
+    def test_running_passes(self):
+        assert self._run("running")["status"] == "pass"
+
+    def test_restarting_warns_about_crash_loop(self):
+        result = self._run("restarting")
+        assert result["status"] == "warn"
+        assert "crash-looping" in result["detail"]
+
+    def test_missing_suggests_force(self):
+        result = self._run("missing")
+        assert result["status"] == "fail"
+        assert "--force" in result["detail"]
+
+    def test_exited_fails(self):
+        assert self._run("exited")["status"] == "fail"
+
+    def test_daemon_error_reported_as_daemon_problem(self):
+        result = self._run("daemon_error")
+        assert result["status"] == "fail"
+        assert "daemon" in result["detail"].lower()
+
+
+class TestCheckLogShipper:
+    # 2026-08-05T12:00:00Z
+    SHIPPED = "2026-08-05T12:00:00Z"
+    SHIPPED_EPOCH = 1785931200.0
+
+    def _run(self, *, alive, last, now=None):
+        from lablink_cli.commands.doctor import _check_log_shipper
+
+        with (
+            patch(
+                "lablink_cli.commands.register._shipper_alive",
+                return_value=alive,
+            ),
+            patch(
+                "lablink_cli.log_shipper.read_last_shipped_ts",
+                return_value=last,
+            ),
+        ):
+            return _check_log_shipper(now=now)
+
+    def test_dead_shipper_fails(self):
+        result = self._run(alive=False, last=self.SHIPPED)
+        assert result["status"] == "fail"
+        assert "not reaching the allocator" in result["detail"].lower()
+
+    def test_alive_and_recent_passes(self):
+        result = self._run(
+            alive=True, last=self.SHIPPED, now=self.SHIPPED_EPOCH + 60
+        )
+        assert result["status"] == "pass"
+
+    def test_alive_but_stale_warns(self):
+        """The failure a liveness-only check cannot see: process up,
+        container healthy, nothing reaching the allocator."""
+        result = self._run(
+            alive=True, last=self.SHIPPED, now=self.SHIPPED_EPOCH + 6 * 86400
+        )
+        assert result["status"] == "warn"
+        assert "6d ago" in result["detail"]
+        assert self.SHIPPED in result["detail"]
+
+    def test_age_formatting_stays_readable(self):
+        from lablink_cli.commands.doctor import _format_age
+
+        assert _format_age(20 * 60) == "20m"
+        assert _format_age(3 * 3600) == "3h"
+        assert _format_age(6 * 86400) == "6d"
+
+    def test_alive_but_never_shipped_warns(self):
+        result = self._run(alive=True, last=None)
+        assert result["status"] == "warn"
+        assert "never shipped" in result["detail"]
+
+    def test_unparseable_timestamp_warns(self):
+        result = self._run(alive=True, last="not-a-timestamp")
+        assert result["status"] == "warn"
+
+
+class TestRunClientDoctor:
+    def test_renders_all_three_checks(self, capsys):
+        from lablink_cli.commands.doctor import run_client_doctor
+
+        with (
+            patch(
+                "lablink_cli.commands.doctor._check_client_registered",
+                return_value={"check": "Registered", "status": "pass"},
+            ),
+            patch(
+                "lablink_cli.commands.doctor._check_client_container",
+                return_value={"check": "Client container", "status": "pass"},
+            ),
+            patch(
+                "lablink_cli.commands.doctor._check_log_shipper",
+                return_value={"check": "Log shipper", "status": "pass"},
+            ),
+        ):
+            run_client_doctor()
+
+        out = capsys.readouterr().out
+        assert "Registered" in out
+        assert "Log shipper" in out
+        assert "All checks passed" in out


### PR DESCRIPTION
## Summary

- New `lablink client doctor` — checks a registered BYO box, distinct from `lablink doctor` (operator/deploy host).
- The log-shipper check reports **staleness, not just liveness**, which is the failure mode that went unnoticed for a week.
- Extracts the shared results table so both commands use one renderer.

## Why

`lablink doctor` answers *"can I deploy from this machine?"* — terraform, AWS credentials, S3 state bucket, AMI. It says nothing about a registered BYO client, so there was no supported way to ask *"is the client on this machine actually working?"* short of reading `~/.lablink/log_shipper.log` by hand.

This came out of debugging a live BYO client that sat `running` / `Healthy` with **0 bytes** of docker logs in the allocator for a week. The shipper process was alive the whole time — it was blocked on a quiet container with a full buffer it never flushed (fixed separately in #428). Nothing surfaced that.

## Checks

| Check | Reuses | Catches |
|---|---|---|
| Registered | `DEFAULT_ENV_FILE.exists()` | never registered on this box |
| Client container | `inspect_container()` | missing / exited / restarting / daemon down |
| Log shipper | `_shipper_alive()` + `read_last_shipped_ts()` | dead shipper, **or alive-but-not-shipping** |

No new probing logic — every check calls a helper that already existed.

`inspect_container()` doubles as the docker-daemon check: it returns `daemon_error` when the daemon is unreachable, so a separate `docker info` probe would only duplicate the same call.

## The point of the shipper check

Liveness alone would have returned **PASS** for the entire week. The useful signal is the pair:

```
│ Registered       │ PASS   │ ~/.lablink/client.env                            │
│ Client container │ PASS   │ lablink-client is running                        │
│ Log shipper      │ WARN   │ Running, but last shipped 6d ago                 │
│                  │        │ (2026-07-30T17:50:47Z). The process is up but    │
│                  │        │ nothing is reaching the allocator.               │
```

Threshold is 15 minutes (`SHIPPER_STALE_AFTER_S`), comfortably above the shipper's own 15s flush interval so normal idle traffic never trips it.

## Changes Made

- `commands/doctor.py`: `_check_client_registered`, `_check_client_container`, `_check_log_shipper`, `_format_age`, `run_client_doctor`.
- `commands/doctor.py`: extracted the results table from `_check_aws_prereqs` into `_render_checks(checks, *, pass_message, fail_message)`. The new command reuses it rather than duplicating ~25 lines of Rich table setup.
- `app.py`: `@client_app.command("doctor")`.

## Testing

- 14 new tests: every container state, every shipper state (dead / never-shipped / fresh / stale / unparseable timestamp), age formatting, and the rendered summary.
- Full CLI suite: **748 passed**, `ruff check` clean.
- Ran the command for real on an unregistered box (all three FAIL with actionable detail) and against a simulated alive-but-stale shipper (the output above).
- Regression-checked the refactor by exercising `_check_aws_prereqs()` directly — the AWS table renders identically. The `lablink doctor` manual-provider path doesn't touch the table, so it needed the direct call to actually cover.

## Design Decisions

- **Staleness over liveness.** The whole reason the command exists. A binary alive check reproduces the bug it's meant to catch.
- **Extract rather than duplicate the table.** Touching `_check_aws_prereqs` is a slightly wider diff, but the alternative is two copies of the same renderer drifting apart.
- **WARN, not FAIL, for stale.** A shipper that's up but quiet may just have been restarted; the operator should see it without the command claiming the client is broken. Summary line reads "Some checks need attention" rather than the AWS path's "Some checks failed", since a WARN-only run isn't a failure.
- **No docker-daemon check of its own** — `inspect_container()` already reports it.

## Related

Complements #428, which fixes the underlying flush bug. This makes the same class of silent failure visible if it recurs.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)