### PR TITLE
chore(ci): skip CI and image builds for package-local markdown changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize, reopened]
     paths:
       - "packages/**"
+      - "!packages/**/*.md"
       - ".github/workflows/ci.yml"
 
 permissions:

--- a/.github/workflows/lablink-images.yml
+++ b/.github/workflows/lablink-images.yml
@@ -25,6 +25,7 @@ on:
     paths:
       - "packages/allocator/**"
       - "packages/client/**"
+      - "!packages/**/*.md"
       - ".github/workflows/lablink-images.yml"
   push:
     branches:
@@ -33,6 +34,7 @@ on:
     paths:
       - "packages/allocator/**"
       - "packages/client/**"
+      - "!packages/**/*.md"
       - ".github/workflows/lablink-images.yml"
 
 jobs:


### PR DESCRIPTION
## Summary
- Docs-only PRs were running the full CI matrix and both Docker image builds.
- Cause: the existing path filters use directory globs (`packages/**`, `packages/allocator/**`, `packages/client/**`) which also match the `README.md` files that live inside each package.
- Fix: add a `!packages/**/*.md` negation after the positive globs in both workflows.

## Changes Made
- `.github/workflows/ci.yml` — added `!packages/**/*.md` to the `pull_request` paths filter.
- `.github/workflows/lablink-images.yml` — added `!packages/**/*.md` to both the `pull_request` and `push` paths filters.

## Testing
No code changes, so no test additions. Verified both files still parse and that the negation lands *after* the positive globs (GitHub evaluates path filters in order, last match wins):

```
ci.yml            pull_request: ['packages/**', '!packages/**/*.md', '.github/workflows/ci.yml']
lablink-images.yml pull_request: ['packages/allocator/**', 'packages/client/**', '!packages/**/*.md', '.github/workflows/lablink-images.yml']
lablink-images.yml push:         ['packages/allocator/**', 'packages/client/**', '!packages/**/*.md', '.github/workflows/lablink-images.yml']
```

Real-world check against the two most recent docs PRs:
- **#426** touched `packages/allocator/README.md`, `packages/cli/README.md`, `packages/client/README.md` — previously triggered CI *and* both image builds; now triggers neither.
- **#427** touched `packages/cli/src/lablink_cli/app.py` — still triggers CI, correctly, since it changed real code. (It never triggered the image build; `packages/cli` isn't in that filter.)

## Design Decisions
- Used GitHub's negative path patterns rather than splitting into `paths-ignore`, because a workflow trigger cannot use both `paths` and `paths-ignore`, and the positive globs still need to be narrow.
- Scoped the negation to `*.md` only. Did not pre-emptively exclude `packages/**/docs/**` or other text extensions — no such directories exist today.
- A PR that touches both docs and code still runs CI, which is the desired behavior.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)