### PR TITLE
fix(cli): poll the public hostname instead of checking it once

### DIFF
--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -48,6 +48,12 @@ ALLOCATOR_INTERNAL_PORT = 5000
 FUNNEL_ACL_NOT_GRANTED_MARKER = "Funnel is not enabled on your tailnet"
 FUNNEL_ENABLE_MAX_ATTEMPTS = 5
 FUNNEL_ENABLE_RETRY_DELAY_SECONDS = 2
+# Budget for the public-hostname check to survive cloudflared's own startup
+# (see _verify_public_hostname). Live runs registered the first edge
+# connection ~1s after `docker compose up` returned and served traffic within
+# a few seconds; 6 tries 5s apart leaves ~25s of headroom over that.
+PUBLIC_HOSTNAME_MAX_ATTEMPTS = 6
+PUBLIC_HOSTNAME_RETRY_DELAY_SECONDS = 5
 # Name of the file carrying the allocator's real public URL, staged next to
 # config.yaml and bind-mounted to /config/<name>. Must stay in sync with
 # config_helpers.CANONICAL_URL_FILENAME in the allocator package — duplicated
@@ -528,22 +534,36 @@ def _verify_public_hostname(hostname: str) -> bool:
     Cloudflare edge, the tunnel, nginx and Flask together — checking that
     cloudflared is alive says nothing about whether the edge found it.
 
-    Advisory, and deliberately a single attempt rather than a poll: by this
-    point the stack is already confirmed healthy locally, so a failure here
-    is either a still-propagating DNS record or a wrong origin in the
-    Cloudflare dashboard. Neither is something waiting fixes, and the
-    caller only warns — so retrying would just delay the same message.
+    Polled, because the local `_health_poll` above clears as soon as Flask
+    answers — which is *before* the public path exists. cloudflared is still
+    registering its edge connections at that point and nginx is still binding
+    :5000, so a single attempt fails on a perfectly good deploy (observed
+    live 2026-08-05: warned at 20:25:30, the same container served the public
+    hostname seconds later and stayed up).
+
+    Still advisory, and bounded short: the remaining failure modes — a
+    still-propagating DNS record, or a public hostname in the Cloudflare
+    dashboard pointing somewhere other than the origin — are not things
+    waiting fixes, and the caller only warns.
     """
     url = f"https://{hostname}"
-    console.print(f"[bold]Verifying public hostname {url}/api/health …[/bold]")
-    try:
-        healthy = bool(check_health_endpoint(url).get("healthy"))
-    except OSError:
-        # Unresolvable name / refused connection while the record propagates.
-        healthy = False
-    if healthy:
-        console.print(f"[green]Public hostname is live: {url}[/green]")
-    return healthy
+    console.print(
+        f"[bold]Verifying public hostname {url}/api/health "
+        f"(up to {PUBLIC_HOSTNAME_MAX_ATTEMPTS} tries) …[/bold]"
+    )
+    for attempt in range(1, PUBLIC_HOSTNAME_MAX_ATTEMPTS + 1):
+        try:
+            healthy = bool(check_health_endpoint(url).get("healthy"))
+        except OSError:
+            # Unresolvable name / refused connection while the record
+            # propagates, or while the tunnel route is still coming up.
+            healthy = False
+        if healthy:
+            console.print(f"[green]Public hostname is live: {url}[/green]")
+            return True
+        if attempt < PUBLIC_HOSTNAME_MAX_ATTEMPTS:
+            time.sleep(PUBLIC_HOSTNAME_RETRY_DELAY_SECONDS)
+    return False
 
 
 def _compose_up(target: Path) -> None:

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2375,18 +2375,44 @@ class TestVerifyPublicHostname:
         # One check proves DNS + Cloudflare edge + tunnel + nginx + Flask.
         assert mock_check.call_args[0][0] == "https://lab.example.org"
 
+    @patch("lablink_cli.commands.deploy_compose.time.sleep")
     @patch("lablink_cli.commands.deploy_compose.check_health_endpoint")
-    def test_returns_false_on_a_miss_without_retrying(self, mock_check):
-        """A single attempt: the caller only warns, so retrying would delay
-        the same message rather than change it."""
+    def test_retries_until_the_tunnel_route_comes_up(self, mock_check, mock_sleep):
+        """The local health poll clears before cloudflared has registered
+        with the edge, so the first tries legitimately miss on a good
+        deploy. Regression guard for the single-attempt version, which
+        warned on every cloudflare_tunnel deploy."""
         from lablink_cli.commands.deploy_compose import _verify_public_hostname
+
+        mock_check.side_effect = [
+            {"healthy": False},
+            OSError("connection refused"),
+            {"healthy": True},
+        ]
+        assert _verify_public_hostname("lab.example.org") is True
+        assert mock_check.call_count == 3
+        # Stops as soon as it succeeds — no sleep after the last try.
+        assert mock_sleep.call_count == 2
+
+    @patch("lablink_cli.commands.deploy_compose.time.sleep")
+    @patch("lablink_cli.commands.deploy_compose.check_health_endpoint")
+    def test_returns_false_after_exhausting_attempts(self, mock_check, mock_sleep):
+        """Bounded: a wrong origin in the Cloudflare dashboard is not
+        something waiting fixes, so the poll gives up and the caller warns."""
+        from lablink_cli.commands.deploy_compose import (
+            PUBLIC_HOSTNAME_MAX_ATTEMPTS,
+            _verify_public_hostname,
+        )
 
         mock_check.return_value = {"healthy": False}
         assert _verify_public_hostname("lab.example.org") is False
-        assert mock_check.call_count == 1
+        assert mock_check.call_count == PUBLIC_HOSTNAME_MAX_ATTEMPTS
+        # No trailing sleep once the budget is spent.
+        assert mock_sleep.call_count == PUBLIC_HOSTNAME_MAX_ATTEMPTS - 1
 
+    @patch("lablink_cli.commands.deploy_compose.time.sleep")
     @patch("lablink_cli.commands.deploy_compose.check_health_endpoint")
-    def test_survives_a_raising_check(self, mock_check):
+    def test_survives_a_raising_check(self, mock_check, mock_sleep):
         """DNS for a brand-new record may not resolve yet; a raised
         exception must be a warning, not a crashed deploy."""
         from lablink_cli.commands.deploy_compose import _verify_public_hostname


### PR DESCRIPTION
## Summary

- Every `participant_exposure=cloudflare_tunnel` deploy ended with a scary false alarm: `https://<host> did not answer`, followed by a 30-line container log dump — on a deploy that was completely fine.
- Cause: `_verify_public_hostname` made **one** request, fired the instant `_health_poll` cleared. That poll only proves Flask answers on `localhost`, which happens *before* cloudflared has registered with the Cloudflare edge and before nginx has bound `:5000` — so the public path genuinely does not exist yet at that moment.
- Fix: poll instead — 6 tries, 5s apart, returning on the first healthy answer. Still advisory, still bounded, still warns for the real failure modes.

## Why the single attempt was wrong

The old docstring argued a poll was pointless:

> Advisory, and deliberately a single attempt rather than a poll: by this point the stack is already confirmed healthy locally, so a failure here is either a still-propagating DNS record or a wrong origin in the Cloudflare dashboard. Neither is something waiting fixes.

That enumeration is missing the common case — **cloudflared's own startup** — and waiting fixes that one in seconds. "Confirmed healthy locally" is exactly the problem: local health says nothing about whether the edge has a route yet.

Observed live on 2026-08-05, from a single deploy's own log:

| time | event |
|---|---|
| 20:25:30 | Flask answers `/api/health` → local poll clears → public check fires **and fails** |
| 20:25:30 | `Starting nginx on :5000` / cloudflared `Initial protocol quic` — origin not bound yet |
| 20:25:30–33 | cloudflared registers connIndex 0, 1, 3 (lax01/lax09) |

Minutes later, against that same never-restarted container (`uptime_seconds: 436`):

```
$ curl https://<host>/api/health
{"checks":{"database":"ok","reboot_service":"ok","scheduler":"ok","tunnel":"ok"},"status":"healthy",...}
$ dig <host>   →  172.67.170.68, 104.21.63.74   (NS: elias/katja.ns.cloudflare.com)
```

So neither cause the warning named applied: DNS resolved the whole time and the origin was correct. The check was simply racing the tunnel it was trying to verify.

## Changes

- `_verify_public_hostname` loops up to `PUBLIC_HOSTNAME_MAX_ATTEMPTS = 6` with `PUBLIC_HOSTNAME_RETRY_DELAY_SECONDS = 5` between tries (~25s of headroom over the ~1–3s registration seen live), returning `True` on the first healthy response and skipping the trailing sleep.
- `OSError` is now a **retryable** miss rather than terminal. NXDOMAIN or a refused connection is precisely how a not-yet-live tunnel route presents, and it was previously indistinguishable from a permanently broken record.
- Attempt-count + delay rather than a wall-clock deadline, matching `_enable_funnel`'s existing idiom in this same module (and testable with a patched `time.sleep`).
- No behavior change for the other exposure modes — the call site is still gated on `participant_exposure == "cloudflare_tunnel"` and still only warns.

## Tests

Replaced the test that pinned the old behavior (`test_returns_false_on_a_miss_without_retrying`) with two:

- `test_retries_until_the_tunnel_route_comes_up` — miss → `OSError` → healthy; asserts 3 checks and 2 sleeps, i.e. it stops on success. This is the regression guard for the false alarm.
- `test_returns_false_after_exhausting_attempts` — asserts it gives up after `PUBLIC_HOSTNAME_MAX_ATTEMPTS` with no trailing sleep, so a genuinely wrong origin still surfaces.

`737 passed` for the CLI package; `ruff check packages/cli` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
