### PR TITLE
feat(allocator): report Postgres connection usage on /api/health/connections and /admin

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -133,30 +133,18 @@ reverse-tunnel deployments.
 Reports PostgreSQL connection usage against the server's configured maximum,
 for checking headroom before scaling a deployment up.
 
-`active_connections` counts **client backends** across every database on the
-server — the things `max_connections` actually bounds. It deliberately excludes
-the rows `pg_stat_activity` carries for background processes (checkpointer,
-background writer, walwriter, autovacuum launcher, logical replication
-launcher), which hold no connection slot; counting them roughly doubles
-reported usage on an idle deployment. The count does include the connection
-serving this request.
-
-`max_connections` is read from PostgreSQL, so it tracks whatever `start.sh` or
-an operator actually configured. The effective ceiling for the allocator's
-non-superuser role is slightly lower, since `superuser_reserved_connections`
-(default 3) is carved out of it.
+`active_connections` counts client backends only — the things `max_connections`
+bounds — excluding the background-worker rows `pg_stat_activity` also carries.
+It includes the connection serving this request. `max_connections` is read from
+PostgreSQL, so it tracks whatever is actually configured.
 
 `idle_in_transaction` distinguishes a leaked pooled connection from ordinary
 load; a non-zero value that doesn't fall back to zero is worth investigating.
-It counts both `idle in transaction` and `idle in transaction (aborted)` — an
-aborted-but-open transaction pins locks and blocks vacuum just like a live one.
+It counts `idle in transaction (aborted)` too — an aborted-but-open transaction
+pins locks just like a live one.
 
-The same numbers are rendered on the `/admin` panel, so reaching for `curl` is
-optional. Above 90% the panel escalates from a plain line to a red banner naming
-what breaks (new connections refused → failed VM registration and admin
-actions) and what to raise, plus a pointer at `idle_in_transaction` when it's
-non-zero. If the numbers can't be read, the panel shows
-`DB connections unavailable` rather than breaking.
+The same numbers appear on the [`/admin` panel](#admin-pages), which escalates
+to a banner above 90%.
 
 **Success Response:**
 
@@ -169,24 +157,18 @@ non-zero. If the numbers can't be read, the panel shows
     "idle_in_transaction": 0,
     "max_connections": 300,
     "utilization_percent": 20.3,
-    "warning": false,
-    "critical": false
+    "level": "ok"
   }
   ```
 
-`warning` is set above 80% utilization and `critical` above 90%.
+`level` is `ok`, `warning` above 80% utilization, or `critical` above 90%. High
+utilization still answers `200` — busy is not broken.
 
 **Error Response:**
 
 - **Code:** `503 Service Unavailable` with `{"status": "unavailable"}` when the
   numbers can't be read — the database isn't initialized yet, or the query
   failed (including a pool with no free connections).
-
-!!! note "Busy is not broken"
-    High utilization still answers `200`; the `warning` and `critical` booleans
-    carry that signal instead. A `503` here means the numbers are *unreadable*,
-    not that the pool is saturated — otherwise any monitor treating status codes
-    as liveness would try to restart the allocator for being popular.
 
 ## Client VM API Endpoints
 

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -131,14 +131,25 @@ reverse-tunnel deployments.
 **Authentication:** Admin (HTTP Basic) — the same gate as `/admin/*`.
 
 Reports PostgreSQL connection usage against the server's configured maximum,
-for checking headroom before scaling a deployment up. `active_connections` is
-server-wide (every database, plus autovacuum workers and admin sessions), which
-is the right comparison against `max_connections` — read from PostgreSQL, so it
-tracks whatever `start.sh` or an operator actually configured. Counts include
-the connection serving this request.
+for checking headroom before scaling a deployment up.
+
+`active_connections` counts **client backends** across every database on the
+server — the things `max_connections` actually bounds. It deliberately excludes
+the rows `pg_stat_activity` carries for background processes (checkpointer,
+background writer, walwriter, autovacuum launcher, logical replication
+launcher), which hold no connection slot; counting them roughly doubles
+reported usage on an idle deployment. The count does include the connection
+serving this request.
+
+`max_connections` is read from PostgreSQL, so it tracks whatever `start.sh` or
+an operator actually configured. The effective ceiling for the allocator's
+non-superuser role is slightly lower, since `superuser_reserved_connections`
+(default 3) is carved out of it.
 
 `idle_in_transaction` distinguishes a leaked pooled connection from ordinary
 load; a non-zero value that doesn't fall back to zero is worth investigating.
+It counts both `idle in transaction` and `idle in transaction (aborted)` — an
+aborted-but-open transaction pins locks and blocks vacuum just like a live one.
 
 The same numbers are rendered on the `/admin` panel, so reaching for `curl` is
 optional. Above 90% the panel escalates from a plain line to a red banner naming

--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -124,6 +124,59 @@ reverse-tunnel deployments.
     registering client is unattached until its tunnel comes up. The allocator's own
     dependencies (tunnel server, database) do gate.
 
+### Connection Usage
+
+**Endpoint:** `GET /api/health/connections`
+
+**Authentication:** Admin (HTTP Basic) — the same gate as `/admin/*`.
+
+Reports PostgreSQL connection usage against the server's configured maximum,
+for checking headroom before scaling a deployment up. `active_connections` is
+server-wide (every database, plus autovacuum workers and admin sessions), which
+is the right comparison against `max_connections` — read from PostgreSQL, so it
+tracks whatever `start.sh` or an operator actually configured. Counts include
+the connection serving this request.
+
+`idle_in_transaction` distinguishes a leaked pooled connection from ordinary
+load; a non-zero value that doesn't fall back to zero is worth investigating.
+
+The same numbers are rendered on the `/admin` panel, so reaching for `curl` is
+optional. Above 90% the panel escalates from a plain line to a red banner naming
+what breaks (new connections refused → failed VM registration and admin
+actions) and what to raise, plus a pointer at `idle_in_transaction` when it's
+non-zero. If the numbers can't be read, the panel shows
+`DB connections unavailable` rather than breaking.
+
+**Success Response:**
+
+- **Code:** `200 OK`
+- **Content:**
+  ```json
+  {
+    "status": "ok",
+    "active_connections": 61,
+    "idle_in_transaction": 0,
+    "max_connections": 300,
+    "utilization_percent": 20.3,
+    "warning": false,
+    "critical": false
+  }
+  ```
+
+`warning` is set above 80% utilization and `critical` above 90%.
+
+**Error Response:**
+
+- **Code:** `503 Service Unavailable` with `{"status": "unavailable"}` when the
+  numbers can't be read — the database isn't initialized yet, or the query
+  failed (including a pool with no free connections).
+
+!!! note "Busy is not broken"
+    High utilization still answers `200`; the `warning` and `critical` booleans
+    carry that signal instead. A `503` here means the numbers are *unreadable*,
+    not that the pool is saturated — otherwise any monitor treating status codes
+    as liveness would try to restart the allocator for being popular.
+
 ## Client VM API Endpoints
 
 These endpoints are used by client VMs to report to the allocator. They require that

--- a/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
+++ b/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
@@ -20,6 +20,13 @@ ALTER USER {DB_USER} WITH LOGIN;
 CREATE DATABASE {DB_NAME} OWNER {DB_USER};
 GRANT ALL PRIVILEGES ON DATABASE {DB_NAME} TO {DB_USER};
 
+-- Read-only access to the stats views, for /api/health/connections. Without
+-- it, pg_stat_activity still returns a row per backend (so count(*) is right)
+-- but masks `state` as NULL for sessions owned by any other role, which would
+-- make the idle-in-transaction count silently undercount. Grants no data
+-- access and no write privileges of any kind.
+GRANT pg_read_all_stats TO {DB_USER};
+
 \\c {DB_NAME};
 
 SET ROLE {DB_USER};

--- a/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
+++ b/packages/allocator/src/lablink_allocator_service/generate_init_sql.py
@@ -20,11 +20,8 @@ ALTER USER {DB_USER} WITH LOGIN;
 CREATE DATABASE {DB_NAME} OWNER {DB_USER};
 GRANT ALL PRIVILEGES ON DATABASE {DB_NAME} TO {DB_USER};
 
--- Read-only access to the stats views, for /api/health/connections. Without
--- it, pg_stat_activity still returns a row per backend (so count(*) is right)
--- but masks `state` as NULL for sessions owned by any other role, which would
--- make the idle-in-transaction count silently undercount. Grants no data
--- access and no write privileges of any kind.
+-- For /api/health/connections: without it, pg_stat_activity masks other roles'
+-- `state` as NULL. Read-only access to the stats views, nothing else.
 GRANT pg_read_all_stats TO {DB_USER};
 
 \\c {DB_NAME};

--- a/packages/allocator/src/lablink_allocator_service/routes/admin_pages.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/admin_pages.py
@@ -8,6 +8,7 @@ import logging
 from flask import Blueprint, current_app, jsonify, render_template, request
 
 from lablink_allocator_service.auth import auth
+from lablink_allocator_service.routes.health import connection_stats
 from lablink_allocator_service.utils.config_helpers import (
     canonical_base_url,
     is_self_signed_ssl,
@@ -37,6 +38,9 @@ def admin():
         can_provision_hosts=provider.can_provision_hosts,
         can_destroy_hosts=provider.can_destroy_hosts,
         monitoring_enabled=monitoring_enabled,
+        # One aggregate query per admin page load. Low-traffic operator page,
+        # and None renders as "unavailable" rather than breaking the panel.
+        connections=connection_stats(),
     )
 
 

--- a/packages/allocator/src/lablink_allocator_service/routes/health.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/health.py
@@ -90,49 +90,24 @@ def _tunnel_status() -> str:
 
 
 def connection_stats() -> dict | None:
-    """Postgres *client* connection usage, or None if unreadable.
+    """Postgres client connection usage, or None if unreadable.
 
-    Counts client backends across every database on the server -- the things
-    max_connections actually bounds -- not every row in pg_stat_activity. See
-    the query comment for why that distinction matters.
-
-    None rather than an exception because both callers have to degrade: the
-    /admin panel renders "unavailable" and the JSON route answers 503. Neither
-    a 500 on the admin page nor a traceback out of a gauge is a useful outcome.
-
-    Not underscore-prefixed, unlike this module's other helpers: routes
-    /admin_pages.py imports it, so it is a deliberate cross-module API rather
-    than module-private.
+    None rather than raising: both callers must degrade -- /admin renders
+    "unavailable" and the JSON route answers 503.
     """
     from lablink_allocator_service import main
 
-    if main.database is None:
-        return None
     try:
-        # backend_type = 'client backend' is load-bearing, not a nicety.
-        # pg_stat_activity has a row per server *process*, so a bare count(*)
-        # also counts the checkpointer, background writer, walwriter, autovacuum
-        # launcher and logical replication launcher -- none of which occupy a
-        # max_connections slot. Measured live on a real deployment: 10 rows for
-        # 5 actual client connections, i.e. the bare count roughly doubled the
-        # reported usage. The bias is not even constant, since parallel and
-        # autovacuum workers come and go.
+        # client backends only: pg_stat_activity rows include background workers
+        # (checkpointer, walwriter, the launchers), which hold no
+        # max_connections slot. Measured live: 10 rows for 5 real connections.
+        # LIKE, not '=', so 'idle in transaction (aborted)' counts too -- it
+        # pins locks the same way. max_connections read from Postgres because
+        # start.sh sets it and a literal here would drift.
         #
-        # state LIKE 'idle in transaction%' rather than '=' so it also catches
-        # 'idle in transaction (aborted)'. An aborted-but-open transaction pins
-        # locks and blocks vacuum exactly like a live one; verified live that an
-        # '=' comparison reported 0 while one was being held.
-        #
-        # max_connections is read from Postgres, not hardcoded: start.sh sets
-        # it to 300 and any literal here would drift out of agreement with the
-        # shell script that actually configures the server. Note the effective
-        # ceiling for the allocator's non-superuser role is slightly lower --
-        # superuser_reserved_connections (default 3) is carved out of it.
-        #
-        # ponytail: measured *through* the pool, so a genuinely exhausted pool
-        # raises PoolError (a psycopg2.Error) and this returns None -- no
-        # numbers at the moment saturation is the question. Open a dedicated
-        # connection here if saturation reporting has to survive saturation.
+        # ponytail: measured *through* the pool, so an exhausted pool returns
+        # None instead of numbers. Use a dedicated connection if saturation
+        # reporting has to survive saturation.
         with PooledCursor(main.database.pool) as cursor:
             cursor.execute(
                 "SELECT count(*) FILTER (WHERE backend_type = 'client backend'), "
@@ -142,23 +117,18 @@ def connection_stats() -> dict | None:
             )
             active, idle_in_transaction, max_connections = cursor.fetchone()
     except Exception:
-        # Deliberately broad. psycopg2.Error (including PoolError) is the
-        # expected failure, but this is a report-only gauge rendered inside
-        # /admin: there is no failure mode where propagating beats reporting
-        # "unavailable", and a narrower catch let an unexpected shape from
-        # fetchone() take the whole admin panel down with a 500. Logged with a
-        # traceback so nothing is swallowed silently.
+        # Broad on purpose: rendered inside /admin, so anything escaping here
+        # 500s the operator's panel. Logged with a traceback, never swallowed.
         logger.warning("Postgres connection stats unavailable", exc_info=True)
         return None
 
-    utilization = active / max(max_connections, 1)
+    util = active / max(max_connections, 1)
     return {
         "active_connections": active,
         "idle_in_transaction": idle_in_transaction,
         "max_connections": max_connections,
-        "utilization_percent": round(utilization * 100, 1),
-        "warning": utilization > 0.8,
-        "critical": utilization > 0.9,
+        "utilization_percent": round(util * 100, 1),
+        "level": "critical" if util > 0.9 else "warning" if util > 0.8 else "ok",
     }
 
 
@@ -212,16 +182,8 @@ def health_check():
 @bp.route("/api/health/connections", methods=["GET"])
 @auth.login_required
 def connection_health():
-    """Report Postgres connection usage. Admin Basic auth, same gate as
-    /admin/* — the allocator is publicly reachable via Funnel/Cloudflare and
-    connection counts are operator detail.
-
-    High utilization still answers 200, with `warning`/`critical` in the body:
-    a gauge that 503s gets read as "restart me" by anything treating status
-    codes as liveness, and this module already documents a 503 that deadlocked
-    client startup exactly that way. 503 here means the numbers are
-    *unreadable*, not that the pool is busy.
-    """
+    """Report Postgres connection usage. Admin-gated; 503 means the numbers are
+    unreadable, never that the pool is merely busy."""
     stats = connection_stats()
     if stats is None:
         return jsonify({"status": "unavailable"}), 503

--- a/packages/allocator/src/lablink_allocator_service/routes/health.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/health.py
@@ -1,16 +1,26 @@
-"""GET /api/health — structured readiness probe.
+"""Health and capacity reporting.
 
-Reports per-dependency readiness rather than a bare 200 so a deployment
-stuck mid-startup is distinguishable from a healthy one: 200 + "healthy"
-only once every check passes, 503 + "starting" otherwise.
+`GET /api/health` reports per-dependency readiness rather than a bare 200 so
+a deployment stuck mid-startup is distinguishable from a healthy one: 200 +
+"healthy" only once every check passes, 503 + "starting" otherwise.
+
+`GET /api/health/connections` reports Postgres connection usage against the
+configured maximum. Deliberately a *separate* route: /api/health is polled in
+a tight loop by start.sh during boot and by `lablink deploy` afterwards, and
+neither should pay for a Postgres aggregate to learn whether the service is up.
 """
+import logging
 import subprocess
 import time
 
 import psycopg2
 from flask import Blueprint, current_app, jsonify
 
+from lablink_allocator_service.auth import auth
+from lablink_allocator_service.db.pool import PooledCursor
+
 bp = Blueprint("health", __name__)
+logger = logging.getLogger(__name__)
 
 # Shared by _tunnel_status() (which produces it) and health_check() (which
 # excludes it from the readiness gate). One constant rather than two literals
@@ -79,6 +89,64 @@ def _tunnel_status() -> str:
     return f"{len(missing)}{_UNATTACHED_SUFFIX}" if missing else "ok"
 
 
+def connection_stats() -> dict | None:
+    """Server-wide Postgres connection usage, or None if unreadable.
+
+    None rather than an exception because both callers have to degrade: the
+    /admin panel renders "unavailable" and the JSON route answers 503. Neither
+    a 500 on the admin page nor a traceback out of a gauge is a useful outcome.
+
+    Not underscore-prefixed, unlike this module's other helpers: routes
+    /admin_pages.py imports it, so it is a deliberate cross-module API rather
+    than module-private.
+    """
+    from lablink_allocator_service import main
+
+    if main.database is None:
+        return None
+    try:
+        # count(*) over pg_stat_activity is server-wide (every database, plus
+        # autovacuum workers and admin sessions), which is the right numerator
+        # for a server-wide max_connections. The reading includes this
+        # request's own checked-out connection.
+        #
+        # max_connections is read from Postgres, not hardcoded: start.sh sets
+        # it to 300 and any literal here would drift out of agreement with the
+        # shell script that actually configures the server.
+        #
+        # ponytail: measured *through* the pool, so a genuinely exhausted pool
+        # raises PoolError (a psycopg2.Error) and this returns None -- no
+        # numbers at the moment saturation is the question. Open a dedicated
+        # connection here if saturation reporting has to survive saturation.
+        with PooledCursor(main.database.pool) as cursor:
+            cursor.execute(
+                "SELECT count(*), "
+                "count(*) FILTER (WHERE state = 'idle in transaction'), "
+                "current_setting('max_connections')::int "
+                "FROM pg_stat_activity"
+            )
+            active, idle_in_transaction, max_connections = cursor.fetchone()
+    except Exception:
+        # Deliberately broad. psycopg2.Error (including PoolError) is the
+        # expected failure, but this is a report-only gauge rendered inside
+        # /admin: there is no failure mode where propagating beats reporting
+        # "unavailable", and a narrower catch let an unexpected shape from
+        # fetchone() take the whole admin panel down with a 500. Logged with a
+        # traceback so nothing is swallowed silently.
+        logger.warning("Postgres connection stats unavailable", exc_info=True)
+        return None
+
+    utilization = active / max(max_connections, 1)
+    return {
+        "active_connections": active,
+        "idle_in_transaction": idle_in_transaction,
+        "max_connections": max_connections,
+        "utilization_percent": round(utilization * 100, 1),
+        "warning": utilization > 0.8,
+        "critical": utilization > 0.9,
+    }
+
+
 @bp.route("/api/health", methods=["GET"])
 def health_check():
     """Return structured readiness status."""
@@ -124,3 +192,22 @@ def health_check():
         payload["uptime_seconds"] = round(time.monotonic() - main._startup_time, 1)
 
     return jsonify(payload), code
+
+
+@bp.route("/api/health/connections", methods=["GET"])
+@auth.login_required
+def connection_health():
+    """Report Postgres connection usage. Admin Basic auth, same gate as
+    /admin/* — the allocator is publicly reachable via Funnel/Cloudflare and
+    connection counts are operator detail.
+
+    High utilization still answers 200, with `warning`/`critical` in the body:
+    a gauge that 503s gets read as "restart me" by anything treating status
+    codes as liveness, and this module already documents a 503 that deadlocked
+    client startup exactly that way. 503 here means the numbers are
+    *unreadable*, not that the pool is busy.
+    """
+    stats = connection_stats()
+    if stats is None:
+        return jsonify({"status": "unavailable"}), 503
+    return jsonify({"status": "ok", **stats}), 200

--- a/packages/allocator/src/lablink_allocator_service/routes/health.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/health.py
@@ -90,7 +90,11 @@ def _tunnel_status() -> str:
 
 
 def connection_stats() -> dict | None:
-    """Server-wide Postgres connection usage, or None if unreadable.
+    """Postgres *client* connection usage, or None if unreadable.
+
+    Counts client backends across every database on the server -- the things
+    max_connections actually bounds -- not every row in pg_stat_activity. See
+    the query comment for why that distinction matters.
 
     None rather than an exception because both callers have to degrade: the
     /admin panel renders "unavailable" and the JSON route answers 503. Neither
@@ -105,14 +109,25 @@ def connection_stats() -> dict | None:
     if main.database is None:
         return None
     try:
-        # count(*) over pg_stat_activity is server-wide (every database, plus
-        # autovacuum workers and admin sessions), which is the right numerator
-        # for a server-wide max_connections. The reading includes this
-        # request's own checked-out connection.
+        # backend_type = 'client backend' is load-bearing, not a nicety.
+        # pg_stat_activity has a row per server *process*, so a bare count(*)
+        # also counts the checkpointer, background writer, walwriter, autovacuum
+        # launcher and logical replication launcher -- none of which occupy a
+        # max_connections slot. Measured live on a real deployment: 10 rows for
+        # 5 actual client connections, i.e. the bare count roughly doubled the
+        # reported usage. The bias is not even constant, since parallel and
+        # autovacuum workers come and go.
+        #
+        # state LIKE 'idle in transaction%' rather than '=' so it also catches
+        # 'idle in transaction (aborted)'. An aborted-but-open transaction pins
+        # locks and blocks vacuum exactly like a live one; verified live that an
+        # '=' comparison reported 0 while one was being held.
         #
         # max_connections is read from Postgres, not hardcoded: start.sh sets
         # it to 300 and any literal here would drift out of agreement with the
-        # shell script that actually configures the server.
+        # shell script that actually configures the server. Note the effective
+        # ceiling for the allocator's non-superuser role is slightly lower --
+        # superuser_reserved_connections (default 3) is carved out of it.
         #
         # ponytail: measured *through* the pool, so a genuinely exhausted pool
         # raises PoolError (a psycopg2.Error) and this returns None -- no
@@ -120,8 +135,8 @@ def connection_stats() -> dict | None:
         # connection here if saturation reporting has to survive saturation.
         with PooledCursor(main.database.pool) as cursor:
             cursor.execute(
-                "SELECT count(*), "
-                "count(*) FILTER (WHERE state = 'idle in transaction'), "
+                "SELECT count(*) FILTER (WHERE backend_type = 'client backend'), "
+                "count(*) FILTER (WHERE state LIKE 'idle in transaction%'), "
                 "current_setting('max_connections')::int "
                 "FROM pg_stat_activity"
             )

--- a/packages/allocator/src/lablink_allocator_service/templates/admin.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/admin.html
@@ -74,6 +74,35 @@
         transition: background-color 0.3s;
       }
 
+      .connections {
+        margin: 0 0 20px;
+        text-align: center;
+        font-size: 14px;
+        color: #666;
+      }
+
+      .connections.warning {
+        color: #b26a00;
+      }
+
+      /* Warning stays plain amber text — a boxed alert at 81% is noise.
+         Critical escalates to a banner, because at that point the next
+         connection attempt can actually be refused. */
+      .connections.critical {
+        color: #c62828;
+        text-align: left;
+        background-color: #fdecea;
+        border: 1px solid #f5c6cb;
+        border-radius: 8px;
+        padding: 12px 16px;
+      }
+
+      .connections.critical code {
+        background-color: rgba(198, 40, 40, 0.1);
+        border-radius: 4px;
+        padding: 1px 4px;
+      }
+
       @media (max-width: 600px) {
         .panel {
           padding: 30px 20px;
@@ -90,6 +119,20 @@
   <body>
     <div class="panel">
       <h2>LabLink Admin Panel</h2>
+
+      {% if connections %}
+      {% if connections.critical %}{% set level = " critical" %}
+      {% elif connections.warning %}{% set level = " warning" %}
+      {% else %}{% set level = "" %}{% endif %}
+      <p class="connections{{ level }}">
+        {% if connections.critical %}<strong>Database connections critical</strong> &mdash; {% else %}DB connections {% endif %}{{ connections.active_connections }} / {{ connections.max_connections }} ({{ connections.utilization_percent }}%)
+        {% if connections.critical %}
+        <br />New connections may be refused, which fails VM registration and admin actions. Raise <code>max_connections</code> and <code>LABLINK_DB_POOL_MAX_SIZE</code>{% if connections.idle_in_transaction %}, or investigate the {{ connections.idle_in_transaction }} connection(s) idle in transaction{% endif %}.
+        {% endif %}
+      </p>
+      {% else %}
+      <p class="connections">DB connections unavailable</p>
+      {% endif %}
 
       <div class="button-group">
         <button onclick="location.href='/admin/instances'">

--- a/packages/allocator/src/lablink_allocator_service/templates/admin.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/admin.html
@@ -97,12 +97,6 @@
         padding: 12px 16px;
       }
 
-      .connections.critical code {
-        background-color: rgba(198, 40, 40, 0.1);
-        border-radius: 4px;
-        padding: 1px 4px;
-      }
-
       @media (max-width: 600px) {
         .panel {
           padding: 30px 20px;
@@ -121,12 +115,10 @@
       <h2>LabLink Admin Panel</h2>
 
       {% if connections %}
-      {% if connections.critical %}{% set level = " critical" %}
-      {% elif connections.warning %}{% set level = " warning" %}
-      {% else %}{% set level = "" %}{% endif %}
-      <p class="connections{{ level }}">
-        {% if connections.critical %}<strong>Database connections critical</strong> &mdash; {% else %}DB connections {% endif %}{{ connections.active_connections }} / {{ connections.max_connections }} ({{ connections.utilization_percent }}%)
-        {% if connections.critical %}
+      {% set critical = connections.level == "critical" %}
+      <p class="connections {{ connections.level }}">
+        {% if critical %}<strong>Database connections critical</strong> &mdash; {% else %}DB connections {% endif %}{{ connections.active_connections }} / {{ connections.max_connections }} ({{ connections.utilization_percent }}%)
+        {% if critical %}
         <br />New connections may be refused, which fails VM registration and admin actions. Raise <code>max_connections</code> and <code>LABLINK_DB_POOL_MAX_SIZE</code>{% if connections.idle_in_transaction %}, or investigate the {{ connections.idle_in_transaction }} connection(s) idle in transaction{% endif %}.
         {% endif %}
       </p>

--- a/packages/allocator/tests/test_generate_init_sql.py
+++ b/packages/allocator/tests/test_generate_init_sql.py
@@ -9,6 +9,15 @@ def test_build_init_sql_returns_string():
     assert "CREATE TABLE" in sql
 
 
+def test_stats_role_granted():
+    """/api/health/connections' idle-in-transaction count reads `state` from
+    pg_stat_activity, which Postgres masks as NULL for sessions owned by other
+    roles unless the reader holds pg_read_all_stats. Without this grant the
+    count silently undercounts instead of erroring."""
+    sql = build_init_sql()
+    assert "GRANT pg_read_all_stats TO" in sql
+
+
 def test_per_session_columns_present():
     sql = build_init_sql()
     for col in ("SessionId", "BrowserToken", "VncPassword",

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -357,11 +357,29 @@ class _FakeCursor:
 @pytest.fixture
 def stats_db(monkeypatch):
     """Patch main.database with a mock exposing .pool, so connection_stats()
-    gets past its `is None` guard. Returns the monkeypatch fixture."""
+    reaches its query. Returns the monkeypatch fixture."""
     from lablink_allocator_service import main
 
     monkeypatch.setattr(main, "database", MagicMock(), raising=False)
     return monkeypatch
+
+
+# Shared by the route and panel tests, which exercise presentation rather than
+# the query. Variants: {**STATS_OK, "level": "warning"}.
+STATS_OK = {
+    "active_connections": 61,
+    "idle_in_transaction": 0,
+    "max_connections": 300,
+    "utilization_percent": 20.3,
+    "level": "ok",
+}
+STATS_CRITICAL = {
+    "active_connections": 295,
+    "idle_in_transaction": 0,
+    "max_connections": 300,
+    "utilization_percent": 98.3,
+    "level": "critical",
+}
 
 
 class TestConnectionStats:
@@ -403,40 +421,24 @@ class TestConnectionStats:
 
         assert "state LIKE 'idle in transaction%'" in fake.sql
 
-    def test_reports_counts_and_utilization(self, stats_db):
-        stats = self._stats(stats_db, row=(61, 0, 300))
+    @pytest.mark.parametrize(
+        "row, pct, level",
+        [
+            ((61, 0, 300), 20.3, "ok"),
+            ((243, 0, 300), 81.0, "warning"),   # >80%
+            ((273, 2, 300), 91.0, "critical"),  # >90%
+            ((60, 0, 600), 10.0, "ok"),         # denominator follows the server
+            ((0, 0, 0), 0.0, "ok"),             # no ZeroDivisionError
+        ],
+    )
+    def test_utilization_and_level(self, stats_db, row, pct, level):
+        stats = self._stats(stats_db, row=row)
 
-        assert stats == {
-            "active_connections": 61,
-            "idle_in_transaction": 0,
-            "max_connections": 300,
-            "utilization_percent": 20.3,
-            "warning": False,
-            "critical": False,
-        }
-
-    def test_warning_above_80_percent(self, stats_db):
-        stats = self._stats(stats_db, row=(243, 0, 300))
-
-        assert stats["utilization_percent"] == 81.0
-        assert stats["warning"] is True
-        assert stats["critical"] is False
-
-    def test_critical_above_90_percent(self, stats_db):
-        stats = self._stats(stats_db, row=(273, 2, 300))
-
-        assert stats["utilization_percent"] == 91.0
-        assert stats["warning"] is True
-        assert stats["critical"] is True
-        assert stats["idle_in_transaction"] == 2
-
-    def test_max_connections_read_from_postgres_not_hardcoded(self, stats_db):
-        """start.sh sets max_connections=300 today and an operator can raise
-        it further; the denominator must follow the server, not a literal."""
-        stats = self._stats(stats_db, row=(60, 0, 600))
-
-        assert stats["max_connections"] == 600
-        assert stats["utilization_percent"] == 10.0
+        assert stats["active_connections"] == row[0]
+        assert stats["idle_in_transaction"] == row[1]
+        assert stats["max_connections"] == row[2]
+        assert stats["utilization_percent"] == pct
+        assert stats["level"] == level
 
     def test_none_when_database_not_initialized(self, monkeypatch):
         from lablink_allocator_service import main
@@ -459,12 +461,6 @@ class TestConnectionStats:
         was narrow. Don't narrow it again."""
         assert self._stats(stats_db, error=RuntimeError("unexpected")) is None
 
-    def test_no_zero_division_when_max_connections_is_zero(self, stats_db):
-        stats = self._stats(stats_db, row=(0, 0, 0))
-
-        assert stats["utilization_percent"] == 0.0
-
-
 class TestConnectionHealthEndpoint:
     """GET /api/health/connections."""
 
@@ -479,25 +475,12 @@ class TestConnectionHealthEndpoint:
         assert client.get("/api/health/connections").status_code == 401
 
     def test_returns_stats(self, client, admin_headers, monkeypatch):
-        self._patch_stats(
-            monkeypatch,
-            {
-                "active_connections": 61,
-                "idle_in_transaction": 0,
-                "max_connections": 300,
-                "utilization_percent": 20.3,
-                "warning": False,
-                "critical": False,
-            },
-        )
+        self._patch_stats(monkeypatch, STATS_OK)
 
         resp = client.get("/api/health/connections", headers=admin_headers)
 
         assert resp.status_code == 200
-        body = resp.get_json()
-        assert body["status"] == "ok"
-        assert body["active_connections"] == 61
-        assert body["max_connections"] == 300
+        assert resp.get_json() == {"status": "ok", **STATS_OK}
 
     def test_503_when_unreadable(self, client, admin_headers, monkeypatch):
         self._patch_stats(monkeypatch, None)
@@ -511,22 +494,12 @@ class TestConnectionHealthEndpoint:
         """Busy is not broken: a saturated pool must not answer non-200, or
         anything treating status codes as liveness will try to restart the
         allocator for being popular."""
-        self._patch_stats(
-            monkeypatch,
-            {
-                "active_connections": 295,
-                "idle_in_transaction": 0,
-                "max_connections": 300,
-                "utilization_percent": 98.3,
-                "warning": True,
-                "critical": True,
-            },
-        )
+        self._patch_stats(monkeypatch, STATS_CRITICAL)
 
         resp = client.get("/api/health/connections", headers=admin_headers)
 
         assert resp.status_code == 200
-        assert resp.get_json()["critical"] is True
+        assert resp.get_json()["level"] == "critical"
 
 
 class TestAdminPanelConnectionLine:
@@ -542,20 +515,12 @@ class TestAdminPanelConnectionLine:
 
         monkeypatch.setattr(admin_mod, "connection_stats", lambda: value)
 
-    def test_renders_the_line(self, client, admin_headers, monkeypatch):
-        self._patch_stats(
-            monkeypatch,
-            {
-                "active_connections": 61,
-                "idle_in_transaction": 0,
-                "max_connections": 300,
-                "utilization_percent": 20.3,
-                "warning": False,
-                "critical": False,
-            },
-        )
+    def _html(self, client, admin_headers, monkeypatch, stats):
+        self._patch_stats(monkeypatch, stats)
+        return client.get("/admin", headers=admin_headers).data.decode()
 
-        html = client.get("/admin", headers=admin_headers).data.decode()
+    def test_renders_the_line(self, client, admin_headers, monkeypatch):
+        html = self._html(client, admin_headers, monkeypatch, STATS_OK)
 
         assert "61 / 300" in html
         assert "20.3%" in html
@@ -566,19 +531,7 @@ class TestAdminPanelConnectionLine:
         """At critical the line escalates to a banner that says what is at
         stake and what to change — a red number alone doesn't tell an operator
         what to do about it."""
-        self._patch_stats(
-            monkeypatch,
-            {
-                "active_connections": 295,
-                "idle_in_transaction": 0,
-                "max_connections": 300,
-                "utilization_percent": 98.3,
-                "warning": True,
-                "critical": True,
-            },
-        )
-
-        html = client.get("/admin", headers=admin_headers).data.decode()
+        html = self._html(client, admin_headers, monkeypatch, STATS_CRITICAL)
 
         assert "connections critical" in html
         assert "Database connections critical" in html
@@ -592,38 +545,25 @@ class TestAdminPanelConnectionLine:
     ):
         """Saturation caused by leaked connections has a different fix than
         saturation caused by load, so name it when the count is non-zero."""
-        self._patch_stats(
+        html = self._html(
+            client,
+            admin_headers,
             monkeypatch,
-            {
-                "active_connections": 295,
-                "idle_in_transaction": 7,
-                "max_connections": 300,
-                "utilization_percent": 98.3,
-                "warning": True,
-                "critical": True,
-            },
+            {**STATS_CRITICAL, "idle_in_transaction": 7},
         )
-
-        html = client.get("/admin", headers=admin_headers).data.decode()
 
         assert "7 connection(s) idle in transaction" in html
 
     def test_warning_stays_a_plain_line(self, client, admin_headers, monkeypatch):
         """80% is worth noticing, not worth a banner. Escalating here would
         train operators to ignore the banner that matters."""
-        self._patch_stats(
+        html = self._html(
+            client,
+            admin_headers,
             monkeypatch,
-            {
-                "active_connections": 243,
-                "idle_in_transaction": 0,
-                "max_connections": 300,
-                "utilization_percent": 81.0,
-                "warning": True,
-                "critical": False,
-            },
+            {**STATS_OK, "active_connections": 243, "utilization_percent": 81.0,
+             "level": "warning"},
         )
-
-        html = client.get("/admin", headers=admin_headers).data.decode()
 
         assert "connections warning" in html
         assert "243 / 300" in html
@@ -634,11 +574,7 @@ class TestAdminPanelConnectionLine:
         self, client, admin_headers, monkeypatch
     ):
         """A database problem costs one line, not the whole admin page."""
-        self._patch_stats(monkeypatch, None)
+        html = self._html(client, admin_headers, monkeypatch, None)
 
-        resp = client.get("/admin", headers=admin_headers)
-        html = resp.data.decode()
-
-        assert resp.status_code == 200
         assert "DB connections unavailable" in html
         assert "View Current Instances" in html

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -339,14 +339,19 @@ class _FakeCursor:
         return self
 
     def __enter__(self):
-        cursor = MagicMock()
+        self.cursor = MagicMock()
         if self._error is not None:
-            cursor.execute.side_effect = self._error
-        cursor.fetchone.return_value = self._row
-        return cursor
+            self.cursor.execute.side_effect = self._error
+        self.cursor.fetchone.return_value = self._row
+        return self.cursor
 
     def __exit__(self, *exc):
         return False
+
+    @property
+    def sql(self):
+        """The SQL the helper executed, for tests that pin its semantics."""
+        return self.cursor.execute.call_args[0][0]
 
 
 @pytest.fixture
@@ -370,6 +375,33 @@ class TestConnectionStats:
             health_mod, "PooledCursor", _FakeCursor(row=row, error=error)
         )
         return health_mod.connection_stats()
+
+    def test_counts_only_client_backends(self, stats_db):
+        """pg_stat_activity has a row per server *process*, so a bare count(*)
+        also counts the checkpointer, background writer, walwriter and the two
+        launchers -- none of which occupy a max_connections slot. Measured on a
+        live deployment: 10 rows for 5 real client connections. Without this
+        filter the gauge roughly doubles reported usage."""
+        import lablink_allocator_service.routes.health as health_mod
+
+        fake = _FakeCursor(row=(5, 0, 300))
+        stats_db.setattr(health_mod, "PooledCursor", fake)
+        health_mod.connection_stats()
+
+        assert "backend_type = 'client backend'" in fake.sql
+
+    def test_idle_filter_catches_aborted_transactions(self, stats_db):
+        """'idle in transaction (aborted)' is a distinct state, and an
+        aborted-but-open transaction pins locks and blocks vacuum exactly like a
+        live one. Verified live that an '=' comparison reported 0 while one was
+        held, so the filter must be a prefix match."""
+        import lablink_allocator_service.routes.health as health_mod
+
+        fake = _FakeCursor(row=(5, 1, 300))
+        stats_db.setattr(health_mod, "PooledCursor", fake)
+        health_mod.connection_stats()
+
+        assert "state LIKE 'idle in transaction%'" in fake.sql
 
     def test_reports_counts_and_utilization(self, stats_db):
         stats = self._stats(stats_db, row=(61, 0, 300))

--- a/packages/allocator/tests/test_health.py
+++ b/packages/allocator/tests/test_health.py
@@ -324,3 +324,289 @@ class TestTunnelStatus:
         resp = client.get("/api/health")
         assert resp.status_code == 200
         assert "tunnel" not in resp.get_json()["checks"]
+
+
+class _FakeCursor:
+    """Stands in for PooledCursor: yields a cursor whose fetchone() returns a
+    real tuple. A bare MagicMock is not enough — fetchone() would hand back
+    another mock and unpacking it into three names raises."""
+
+    def __init__(self, row=None, error=None):
+        self._row = row
+        self._error = error
+
+    def __call__(self, _pool):
+        return self
+
+    def __enter__(self):
+        cursor = MagicMock()
+        if self._error is not None:
+            cursor.execute.side_effect = self._error
+        cursor.fetchone.return_value = self._row
+        return cursor
+
+    def __exit__(self, *exc):
+        return False
+
+
+@pytest.fixture
+def stats_db(monkeypatch):
+    """Patch main.database with a mock exposing .pool, so connection_stats()
+    gets past its `is None` guard. Returns the monkeypatch fixture."""
+    from lablink_allocator_service import main
+
+    monkeypatch.setattr(main, "database", MagicMock(), raising=False)
+    return monkeypatch
+
+
+class TestConnectionStats:
+    """Unit tests for connection_stats(), which reports Postgres connection
+    usage for both /api/health/connections and the /admin panel line."""
+
+    def _stats(self, monkeypatch, row=None, error=None):
+        import lablink_allocator_service.routes.health as health_mod
+
+        monkeypatch.setattr(
+            health_mod, "PooledCursor", _FakeCursor(row=row, error=error)
+        )
+        return health_mod.connection_stats()
+
+    def test_reports_counts_and_utilization(self, stats_db):
+        stats = self._stats(stats_db, row=(61, 0, 300))
+
+        assert stats == {
+            "active_connections": 61,
+            "idle_in_transaction": 0,
+            "max_connections": 300,
+            "utilization_percent": 20.3,
+            "warning": False,
+            "critical": False,
+        }
+
+    def test_warning_above_80_percent(self, stats_db):
+        stats = self._stats(stats_db, row=(243, 0, 300))
+
+        assert stats["utilization_percent"] == 81.0
+        assert stats["warning"] is True
+        assert stats["critical"] is False
+
+    def test_critical_above_90_percent(self, stats_db):
+        stats = self._stats(stats_db, row=(273, 2, 300))
+
+        assert stats["utilization_percent"] == 91.0
+        assert stats["warning"] is True
+        assert stats["critical"] is True
+        assert stats["idle_in_transaction"] == 2
+
+    def test_max_connections_read_from_postgres_not_hardcoded(self, stats_db):
+        """start.sh sets max_connections=300 today and an operator can raise
+        it further; the denominator must follow the server, not a literal."""
+        stats = self._stats(stats_db, row=(60, 0, 600))
+
+        assert stats["max_connections"] == 600
+        assert stats["utilization_percent"] == 10.0
+
+    def test_none_when_database_not_initialized(self, monkeypatch):
+        from lablink_allocator_service import main
+
+        monkeypatch.setattr(main, "database", None, raising=False)
+
+        assert self._stats(monkeypatch, row=(61, 0, 300)) is None
+
+    def test_none_on_psycopg2_error(self, stats_db):
+        """Covers pool exhaustion too: psycopg2.pool.PoolError subclasses
+        psycopg2.Error, so an exhausted pool degrades instead of raising."""
+        import psycopg2
+
+        assert self._stats(stats_db, error=psycopg2.Error("nope")) is None
+
+    def test_none_on_unexpected_error(self, stats_db):
+        """The catch is deliberately broader than psycopg2.Error. This helper
+        is rendered inside /admin, so any exception escaping it 500s the whole
+        panel — which is how six existing /admin tests failed when the catch
+        was narrow. Don't narrow it again."""
+        assert self._stats(stats_db, error=RuntimeError("unexpected")) is None
+
+    def test_no_zero_division_when_max_connections_is_zero(self, stats_db):
+        stats = self._stats(stats_db, row=(0, 0, 0))
+
+        assert stats["utilization_percent"] == 0.0
+
+
+class TestConnectionHealthEndpoint:
+    """GET /api/health/connections."""
+
+    def _patch_stats(self, monkeypatch, value):
+        import lablink_allocator_service.routes.health as health_mod
+
+        monkeypatch.setattr(health_mod, "connection_stats", lambda: value)
+
+    def test_requires_admin_auth(self, client):
+        """Guards against a future edit quietly dropping the decorator and
+        publishing connection counts on a Funnel-exposed host."""
+        assert client.get("/api/health/connections").status_code == 401
+
+    def test_returns_stats(self, client, admin_headers, monkeypatch):
+        self._patch_stats(
+            monkeypatch,
+            {
+                "active_connections": 61,
+                "idle_in_transaction": 0,
+                "max_connections": 300,
+                "utilization_percent": 20.3,
+                "warning": False,
+                "critical": False,
+            },
+        )
+
+        resp = client.get("/api/health/connections", headers=admin_headers)
+
+        assert resp.status_code == 200
+        body = resp.get_json()
+        assert body["status"] == "ok"
+        assert body["active_connections"] == 61
+        assert body["max_connections"] == 300
+
+    def test_503_when_unreadable(self, client, admin_headers, monkeypatch):
+        self._patch_stats(monkeypatch, None)
+
+        resp = client.get("/api/health/connections", headers=admin_headers)
+
+        assert resp.status_code == 503
+        assert resp.get_json()["status"] == "unavailable"
+
+    def test_200_when_saturated(self, client, admin_headers, monkeypatch):
+        """Busy is not broken: a saturated pool must not answer non-200, or
+        anything treating status codes as liveness will try to restart the
+        allocator for being popular."""
+        self._patch_stats(
+            monkeypatch,
+            {
+                "active_connections": 295,
+                "idle_in_transaction": 0,
+                "max_connections": 300,
+                "utilization_percent": 98.3,
+                "warning": True,
+                "critical": True,
+            },
+        )
+
+        resp = client.get("/api/health/connections", headers=admin_headers)
+
+        assert resp.status_code == 200
+        assert resp.get_json()["critical"] is True
+
+
+class TestAdminPanelConnectionLine:
+    """The /admin panel renders the same numbers server-side.
+
+    Patches admin_pages.connection_stats, not health.connection_stats:
+    admin_pages binds the name at import time, so patching the definition site
+    would not be seen here.
+    """
+
+    def _patch_stats(self, monkeypatch, value):
+        import lablink_allocator_service.routes.admin_pages as admin_mod
+
+        monkeypatch.setattr(admin_mod, "connection_stats", lambda: value)
+
+    def test_renders_the_line(self, client, admin_headers, monkeypatch):
+        self._patch_stats(
+            monkeypatch,
+            {
+                "active_connections": 61,
+                "idle_in_transaction": 0,
+                "max_connections": 300,
+                "utilization_percent": 20.3,
+                "warning": False,
+                "critical": False,
+            },
+        )
+
+        html = client.get("/admin", headers=admin_headers).data.decode()
+
+        assert "61 / 300" in html
+        assert "20.3%" in html
+
+    def test_critical_renders_an_actionable_banner(
+        self, client, admin_headers, monkeypatch
+    ):
+        """At critical the line escalates to a banner that says what is at
+        stake and what to change — a red number alone doesn't tell an operator
+        what to do about it."""
+        self._patch_stats(
+            monkeypatch,
+            {
+                "active_connections": 295,
+                "idle_in_transaction": 0,
+                "max_connections": 300,
+                "utilization_percent": 98.3,
+                "warning": True,
+                "critical": True,
+            },
+        )
+
+        html = client.get("/admin", headers=admin_headers).data.decode()
+
+        assert "connections critical" in html
+        assert "Database connections critical" in html
+        assert "may be refused" in html
+        assert "LABLINK_DB_POOL_MAX_SIZE" in html
+        # No leak to report, so no leak sentence.
+        assert "idle in transaction" not in html
+
+    def test_critical_points_at_a_leak_when_there_is_one(
+        self, client, admin_headers, monkeypatch
+    ):
+        """Saturation caused by leaked connections has a different fix than
+        saturation caused by load, so name it when the count is non-zero."""
+        self._patch_stats(
+            monkeypatch,
+            {
+                "active_connections": 295,
+                "idle_in_transaction": 7,
+                "max_connections": 300,
+                "utilization_percent": 98.3,
+                "warning": True,
+                "critical": True,
+            },
+        )
+
+        html = client.get("/admin", headers=admin_headers).data.decode()
+
+        assert "7 connection(s) idle in transaction" in html
+
+    def test_warning_stays_a_plain_line(self, client, admin_headers, monkeypatch):
+        """80% is worth noticing, not worth a banner. Escalating here would
+        train operators to ignore the banner that matters."""
+        self._patch_stats(
+            monkeypatch,
+            {
+                "active_connections": 243,
+                "idle_in_transaction": 0,
+                "max_connections": 300,
+                "utilization_percent": 81.0,
+                "warning": True,
+                "critical": False,
+            },
+        )
+
+        html = client.get("/admin", headers=admin_headers).data.decode()
+
+        assert "connections warning" in html
+        assert "243 / 300" in html
+        assert "Database connections critical" not in html
+        assert "may be refused" not in html
+
+    def test_degrades_without_breaking_the_panel(
+        self, client, admin_headers, monkeypatch
+    ):
+        """A database problem costs one line, not the whole admin page."""
+        self._patch_stats(monkeypatch, None)
+
+        resp = client.get("/admin", headers=admin_headers)
+        html = resp.data.decode()
+
+        assert resp.status_code == 200
+        assert "DB connections unavailable" in html
+        assert "View Current Instances" in html


### PR DESCRIPTION
## Summary

- Adds `GET /api/health/connections` (admin Basic auth) reporting PostgreSQL **client connection** usage against the server's configured maximum.
- Renders the same numbers server-side on the `/admin` panel, escalating to a red banner above 90% that names what breaks and what to raise.
- Closes the last unimplemented item from issue #240's Phase 1 plan. **Deliberately does not auto-close #240** — see *Remaining* below.

## Context

The scalability ceiling #240 analyzed no longer exists: LISTEN/NOTIFY and the per-VM long-poll were removed by #344, pooling landed in `db/pool.py`, and `start.sh:40` raises `max_connections` to 300. What was never built is the operator-facing half — there was no way to see how much of that connection budget is actually in use.

## Changes Made

- **`routes/health.py`** — `connection_stats()` helper (one aggregate query) plus the `/api/health/connections` view behind `@auth.login_required`.
- **`routes/admin_pages.py`** + **`templates/admin.html`** — one line above the button group; amber above 80%, red banner above 90%, `DB connections unavailable` when unreadable.
- **`generate_init_sql.py`** — `GRANT pg_read_all_stats TO lablink`. Required: see *Verified live* below.
- **`tests/test_health.py`** — 20 new tests. **`docs/api-endpoints.md`** — new "Connection Usage" section.

`/api/health` itself is untouched. `start.sh:112` curls it in a tight boot loop and `deploy_compose.py` polls it during deploys, so it stays free of a Postgres aggregate — and a capacity gauge never influences the readiness gate.

## Response shape

```json
{
  "status": "ok",
  "active_connections": 61,
  "idle_in_transaction": 0,
  "max_connections": 300,
  "utilization_percent": 20.3,
  "level": "ok"
}
```

`level` is `ok` / `warning` (>80%) / `critical` (>90%). High utilization still answers `200`; `503` means the numbers are *unreadable*, not that the pool is busy. A gauge that 503s gets read as "restart me" by anything treating status codes as liveness, and `health.py` already documents a 503 that deadlocked client startup exactly that way (observed live 2026-07-31).

## Verified live, and two bugs it caught

Tested against a real deployment rather than trusting the query — which is how both of these surfaced. **Both were in the first commit and are fixed in `9df881f2`:**

1. **The numerator counted the wrong thing.** `pg_stat_activity` carries a row per server *process*, so a bare `count(*)` also counted the checkpointer, background writer, walwriter, autovacuum launcher and logical replication launcher — none of which occupy a `max_connections` slot. It reported `8 / 300` where only **3** client connections existed; a controlled sample showed **10 rows for 5 real connections**. The bias isn't even constant, since parallel and autovacuum workers come and go. Now filtered to `backend_type = 'client backend'`.

2. **The idle filter used `=`,** which silently skips the distinct state `idle in transaction (aborted)`. An aborted-but-open transaction pins locks and blocks vacuum exactly like a live one, so it's precisely the leak the field exists to surface. While one was held: `=` reported `0`, prefix match reported `1`. Now `LIKE 'idle in transaction%'`.

The `pg_read_all_stats` grant was validated the same way. A control role with no grants reported `idle_in_transaction = 0` while the superuser saw `1` — PostgreSQL masks `state` as `NULL` for other roles' sessions, so without the grant that field would silently undercount. Note this needs a **fresh deployment** to take effect; on a running box, `GRANT pg_read_all_stats TO lablink;`.

Other live checks: `max_connections` matches `SHOW max_connections` (300); opening 10 sessions and closing them moved the count `8 → 18 → 8` exactly; unauthenticated requests get `401`; all four panel states render correctly.

## Testing

`906 passed, 20 skipped` (`PYTHONPATH=src pytest --ignore=tests/terraform`), `ruff check` clean. Coverage includes utilization math and both thresholds (parametrized), `None` on `psycopg2.Error` *and* on unexpected errors, `200`/`503`/`401` on the route, all panel states, and two tests asserting against the executed SQL — a mocked cursor can't exercise the client-backend filter or the aborted-transaction prefix match, and both cost a live investigation to establish.

## Design Decisions

**Separate route rather than extending `/api/health`** — keeps the boot-loop readiness path query-free and keeps a gauge out of the 200/503 gate.

**Admin auth** — the allocator is publicly reachable via Funnel/Cloudflare, and connection counts are operator detail.

**Server-rendered panel line, no JS** — the route and the page share one helper, so there's one source of truth for the query and the thresholds. Costs one aggregate query per `/admin` load; that page is operator-only.

**`connection_stats()` catches broadly and returns `None`.** It renders inside `/admin`, so anything escaping it 500s the operator's main page. Not theoretical: a narrow `except psycopg2.Error` broke six pre-existing `/admin` tests whose `MagicMock` database returned a `fetchone()` that wouldn't unpack. Widening fixed all six without touching a test; a test now pins it.

**One `level` string rather than `warning`/`critical` booleans** — collapsed in `1127edc6`, which also removed the Jinja ladder that existed only to translate them into a CSS class.

**Warning stays a plain line — no banner at 81%.** Escalating there trains operators to ignore the banner that matters.

**`max_connections` read from Postgres**, not hardcoded to 150 as in #240's snippet — `start.sh` already sets 300.

**`listen_connections` dropped** from that snippet — LISTEN/NOTIFY no longer exists, so it would report `0` forever.

## Known ceiling

Marked with a `ponytail:` comment: the helper measures the pool by checking a connection *out of* it, so a genuinely exhausted pool reports `unavailable` rather than numbers. Fix is a dedicated non-pooled connection; deferred until observed.

This is also a *pull* notification — it appears when someone opens `/admin`. Proactive detection would need a scheduled sampler (APScheduler is already running) with edge-triggered logging.

## Commits

| | |
|---|---|
| `495906be` | feat: the endpoint + panel line |
| `56591890` | fix: `GRANT pg_read_all_stats` so `idle_in_transaction` is truthful |
| `9df881f2` | fix: count client backends, not every `pg_stat_activity` row |
| `1127edc6` | refactor: complexity pass — 92 insertions against 223 deletions |

## Remaining from #240

Not in this PR, so #240 should stay open or be re-scoped by hand:

- **Gunicorn** — still `app.run(threaded=True)` at `main.py:345`. Not a one-line change: each worker gets its own pool, so `POOL_MAX_SIZE = 200` × 4 workers would exceed `max_connections = 300`, and the APScheduler jobs would fire once per worker.
- **`docs/database.md:690`** — the "Connection Pooling" section still recommends pgBouncer and never mentions the real in-process pool.
- Phases 2–4 (Redis migration, instance resizing, CloudWatch alarms) are obsolete — they existed to solve the LISTEN/NOTIFY problem, and monitoring was since removed.

Related: #240, #344

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
