### PR TITLE
fix(cli): make metrics export work on the manual/BYO path

### DIFF
--- a/docs/cli/managing-deployments.md
+++ b/docs/cli/managing-deployments.md
@@ -61,8 +61,20 @@ Writes deployment metrics to disk for offline analysis. Two sources:
 | Flag | Data | Requires allocator running? |
 |---|---|---|
 | `--client` | Per-VM metrics pulled from the allocator's API (boot time, health status, logs) | Yes |
-| `--allocator` | Per-deploy metrics from the local cache at `~/.lablink/deployments/` (deploy duration, Terraform phase timings) | **No** — works after `lablink destroy` |
+| `--allocator` | Per-deploy metrics from the local cache at `~/.lablink/deployments/` (deploy duration, plus Terraform phase timings on AWS or `docker compose up` timing on the manual provider) | **No** — works after `lablink destroy` |
 | *(no flag)* | Both | Yes |
+
+Allocator metrics are **scoped to the deployment and provider in your config**.
+The cache is shared by every deployment you have ever run, so an unscoped export
+would put other deployments' rows in a file named after this one. Point
+`--config` at a different config to export that deployment instead. On a machine
+with no config at all, `--allocator` exports the whole cache and says how many
+deployments it spans.
+
+Reusing one `deployment_name` across providers is why the provider is part of the
+scope: a name deployed first on AWS and later with `provider: manual` has records
+of both shapes in the cache, and the Terraform phase columns say nothing about a
+compose stack.
 
 Other flags:
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -373,14 +373,21 @@ Writes metrics to disk for offline analysis. Two data sources:
 With no source flag, both are exported and `_client` / `_allocator` suffixes are
 appended to the base output name.
 
+Allocator metrics are scoped to the config's `deployment_name` **and** provider —
+the cache holds a record per deploy attempt for every deployment on the machine,
+and a name reused across providers has records of two different shapes in it. AWS
+deploys populate the `allocator_terraform_*` columns; manual (compose) deploys
+populate `allocator_compose_up_duration_seconds` instead. Both populate
+`allocator_health_check_duration_seconds` and the total.
+
 | Option | Description |
 |---|---|
 | `--client` | Export per-VM client metrics from the allocator. |
-| `--allocator` | Export per-deploy allocator metrics from the local cache. Skips the network. |
+| `--allocator` | Export per-deploy allocator metrics from the local cache, scoped to this config's deployment and provider. Skips the network. |
 | `-f`, `--format FMT` | `csv` (default) or `json`. |
 | `-o`, `--output PATH` | Output file path. With a single source flag it is the literal path; with both (or neither), it is a base name and `_client` / `_allocator` suffixes are added before the extension. Default: `metrics_client.<fmt>` and/or `metrics_allocator.<fmt>`. |
 | `--include-logs` | Include `cloud_init_logs` and `docker_logs` columns. Large — opt-in only. |
-| `-c`, `--config PATH` | Path to `config.yaml`. Skipped when only `--allocator` is passed. |
+| `-c`, `--config PATH` | Path to `config.yaml`. With only `--allocator`, it is loaded when present (to scope the export) but not required — the command still works on a machine that has no config, exporting the whole cache. |
 
 ---
 

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -767,8 +767,10 @@ def export_metrics(
         False,
         "--allocator",
         help=(
-            "Export per-deploy allocator metrics from the local cache. "
-            "Works without a running allocator (e.g. after `lablink destroy`)."
+            "Export per-deploy allocator metrics from the local cache, "
+            "scoped to this config's deployment_name. Works without a "
+            "running allocator (e.g. after `lablink destroy`); passed "
+            "alone it loads no config and exports every deployment."
         ),
     ),
     config: str = typer.Option(
@@ -781,15 +783,24 @@ def export_metrics(
     """Export deployment metrics to CSV or JSON.
 
     Pass --client for per-VM metrics from the allocator. Pass --allocator
-    for per-deploy metrics from the local cache. With no flag, exports
-    both. Passing only --allocator skips the network entirely.
+    for per-deploy metrics from the local cache, scoped to this config's
+    deployment_name. With no flag, exports both. Passing only --allocator
+    skips the network entirely.
     """
     from lablink_cli.commands.export_metrics import run_export_metrics
 
-    # Skip config load when only --allocator is requested — it doesn't need
-    # the config and we want this command to work even after `lablink destroy`.
-    needs_cfg = client or not allocator
-    cfg = _load_cfg(config) if needs_cfg else None
+    # --client cannot work without the config (allocator URL + admin creds),
+    # so a missing one is fatal there. --allocator does not need it, but load
+    # it when it's there anyway: the config's deployment_name is what scopes
+    # the cache export to this deployment instead of dumping every deployment
+    # the operator has ever run. Only a machine with no config at all falls
+    # through to None (unscoped), which keeps the command usable after a wipe.
+    config_path = Path(config) if config else DEFAULT_CONFIG
+    cfg = (
+        _load_cfg(config)
+        if client or not allocator or config_path.exists()
+        else None
+    )
 
     run_export_metrics(
         cfg,

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -443,6 +443,7 @@ def run_deploy(
     deploy_start_dt = datetime.now(timezone.utc)
     metrics = DeploymentMetrics(
         deployment_name=cfg.deployment_name,
+        provider=getattr(cfg, "provider", "aws"),
         region=cfg.app.region,
         template_version=template_version or TEMPLATE_VERSION,
         ssl_enabled=has_ssl,

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -489,25 +489,31 @@ def run_deploy_compose(
     metrics_path = cache_path_for(cfg.deployment_name, deploy_start_dt)
     write_metrics(metrics_path, metrics)
 
-    render_compose_dir(
-        cfg,
-        target,
-        tailscale_authkey=tailscale_authkey,
-        cloudflare_tunnel_token=cloudflare_tunnel_token,
-    )
-    console.print(f"[green]Rendered {target}[/green]")
-
-    # Explicitly disable Funnel *before* _compose_up, whenever the new
-    # config no longer wants it — this must run before --remove-orphans
-    # potentially deletes the sidecar (a removed container can't be
-    # `docker exec`'d into), and it's needed even when the sidecar
-    # sticks around unchanged (e.g. connectivity=mesh_overlay alone),
-    # since Funnel persists in the sidecar's own state regardless of
-    # whether _enable_funnel keeps getting called. See _disable_funnel.
-    if cfg.manual.participant_exposure != "tailscale_funnel":
-        _disable_funnel()
-
+    # Everything from here to the success write is inside the try: the record
+    # already exists on disk, so any escape that skips the write below strands
+    # it at in_progress — indistinguishable from a Ctrl-C, and with null
+    # timings. render_compose_dir writes files and calls save_config, and
+    # _write_canonical_url writes one too, so OSError is live in both stretches
+    # either side of the timed phases, not just in the phases themselves.
     try:
+        render_compose_dir(
+            cfg,
+            target,
+            tailscale_authkey=tailscale_authkey,
+            cloudflare_tunnel_token=cloudflare_tunnel_token,
+        )
+        console.print(f"[green]Rendered {target}[/green]")
+
+        # Explicitly disable Funnel *before* _compose_up, whenever the new
+        # config no longer wants it — this must run before --remove-orphans
+        # potentially deletes the sidecar (a removed container can't be
+        # `docker exec`'d into), and it's needed even when the sidecar
+        # sticks around unchanged (e.g. connectivity=mesh_overlay alone),
+        # since Funnel persists in the sidecar's own state regardless of
+        # whether _enable_funnel keeps getting called. See _disable_funnel.
+        if cfg.manual.participant_exposure != "tailscale_funnel":
+            _disable_funnel()
+
         with phase_timer(
             metrics, "allocator_compose_up_duration_seconds", metrics_path
         ):
@@ -516,6 +522,38 @@ def run_deploy_compose(
             metrics, "allocator_health_check_duration_seconds", metrics_path
         ):
             _health_poll()
+
+        # Disable again, now that the sidecar (if the compose file still
+        # declares one) is guaranteed running. The call above can silently
+        # no-op if the sidecar was stopped-but-not-removed at that point —
+        # `docker exec` fails on a stopped container the same way it does on
+        # a missing one, and _disable_funnel() can't tell those apart. If
+        # connectivity stays mesh_overlay, _compose_up just restarted that
+        # same stopped sidecar, reattached to tailscale_state with Funnel's
+        # last-known "on" config still intact — this second call is what
+        # actually clears it. Harmless no-op if the sidecar was removed as
+        # an orphan instead (nothing to disable).
+        if cfg.manual.participant_exposure != "tailscale_funnel":
+            _disable_funnel()
+
+        funnel_ok = True
+        funnel_url = None
+        if cfg.manual.participant_exposure == "tailscale_funnel":
+            funnel_ok, funnel_url = _enable_funnel()
+            if funnel_url:
+                _write_canonical_url(target, funnel_url)
+
+        if cfg.manual.participant_exposure == "cloudflare_tunnel":
+            if not _verify_public_hostname(cfg.manual.public_hostname):
+                console.print(
+                    f"[yellow]https://{cfg.manual.public_hostname} did not "
+                    "answer.[/yellow]\n"
+                    "The stack is up locally. Common causes: the DNS record is "
+                    "still propagating (retry in a few minutes), or the "
+                    "tunnel's public hostname in Cloudflare does not point at "
+                    "http://localhost:5000."
+                )
+                _print_last_log_lines()
     except (Exception, SystemExit) as e:
         # SystemExit IS caught here, unlike the AWS path where it means "user
         # cancelled" and in_progress is the honest state. Nothing in this
@@ -528,38 +566,7 @@ def run_deploy_compose(
         write_metrics(metrics_path, metrics)
         raise
 
-    # Disable again, now that the sidecar (if the compose file still
-    # declares one) is guaranteed running. The call above can silently
-    # no-op if the sidecar was stopped-but-not-removed at that point —
-    # `docker exec` fails on a stopped container the same way it does on
-    # a missing one, and _disable_funnel() can't tell those apart. If
-    # connectivity stays mesh_overlay, _compose_up just restarted that
-    # same stopped sidecar, reattached to tailscale_state with Funnel's
-    # last-known "on" config still intact — this second call is what
-    # actually clears it. Harmless no-op if the sidecar was removed as
-    # an orphan instead (nothing to disable).
-    if cfg.manual.participant_exposure != "tailscale_funnel":
-        _disable_funnel()
-
-    funnel_ok = True
-    funnel_url = None
-    if cfg.manual.participant_exposure == "tailscale_funnel":
-        funnel_ok, funnel_url = _enable_funnel()
-        if funnel_url:
-            _write_canonical_url(target, funnel_url)
     funnel_active = cfg.manual.participant_exposure == "tailscale_funnel" and funnel_ok
-
-    if cfg.manual.participant_exposure == "cloudflare_tunnel":
-        if not _verify_public_hostname(cfg.manual.public_hostname):
-            console.print(
-                f"[yellow]https://{cfg.manual.public_hostname} did not "
-                "answer.[/yellow]\n"
-                "The stack is up locally. Common causes: the DNS record is "
-                "still propagating (retry in a few minutes), or the tunnel's "
-                "public hostname in Cloudflare does not point at "
-                "http://localhost:5000."
-            )
-            _print_last_log_lines()
 
     # Total = sum of the timed phases, matching the AWS path's definition
     # (machine work only, excluding prompt time). Exposure setup — Funnel

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -19,6 +19,7 @@ import shutil
 import socket
 import subprocess
 import time
+from datetime import datetime, timezone
 from importlib import resources
 from pathlib import Path
 
@@ -28,6 +29,12 @@ from rich.console import Console
 from lablink_cli.commands.status import check_health_endpoint
 from lablink_cli.commands.utils import resolve_admin_credentials
 from lablink_cli.config.schema import Config, save_config
+from lablink_cli.deployment_metrics import (
+    DeploymentMetrics,
+    cache_path_for,
+    phase_timer,
+    write_metrics,
+)
 
 DEFAULT_COMPOSE_DIR = Path.home() / ".lablink" / "compose"
 DEFAULT_HTTP_PORT = "80"
@@ -467,6 +474,21 @@ def run_deploy_compose(
             console.print("Aborted.")
             raise SystemExit(1)
 
+    # Initialize deployment metrics — written incrementally so a failed
+    # deploy still leaves a record on disk, same as the AWS path. Started
+    # here, after the confirmation gate, so an aborted "Proceed?" leaves no
+    # in_progress file behind at all. region/template_version stay None:
+    # there is no region and no Terraform template in a compose deploy.
+    deploy_start_dt = datetime.now(timezone.utc)
+    metrics = DeploymentMetrics(
+        deployment_name=cfg.deployment_name,
+        provider="manual",
+        ssl_enabled=cfg.ssl.provider != "none",
+        allocator_deploy_start_time=deploy_start_dt.isoformat(),
+    )
+    metrics_path = cache_path_for(cfg.deployment_name, deploy_start_dt)
+    write_metrics(metrics_path, metrics)
+
     render_compose_dir(
         cfg,
         target,
@@ -485,8 +507,26 @@ def run_deploy_compose(
     if cfg.manual.participant_exposure != "tailscale_funnel":
         _disable_funnel()
 
-    _compose_up(target)
-    _health_poll()
+    try:
+        with phase_timer(
+            metrics, "allocator_compose_up_duration_seconds", metrics_path
+        ):
+            _compose_up(target)
+        with phase_timer(
+            metrics, "allocator_health_check_duration_seconds", metrics_path
+        ):
+            _health_poll()
+    except (Exception, SystemExit) as e:
+        # SystemExit IS caught here, unlike the AWS path where it means "user
+        # cancelled" and in_progress is the honest state. Nothing in this
+        # stretch is a cancellation — _compose_up and _health_poll both raise
+        # SystemExit for a genuine failure (non-zero compose exit, health
+        # timeout), so leaving those as in_progress would under-report real
+        # failures. KeyboardInterrupt is a BaseException and still escapes.
+        metrics.status = "failed"
+        metrics.error = str(e)
+        write_metrics(metrics_path, metrics)
+        raise
 
     # Disable again, now that the sidecar (if the compose file still
     # declares one) is guaranteed running. The call above can silently
@@ -520,6 +560,27 @@ def run_deploy_compose(
                 "http://localhost:5000."
             )
             _print_last_log_lines()
+
+    # Total = sum of the timed phases, matching the AWS path's definition
+    # (machine work only, excluding prompt time). Exposure setup — Funnel
+    # enable, public-hostname verification — is deliberately untimed, so a
+    # slow DNS propagation doesn't masquerade as slow deploy machinery.
+    metrics.allocator_deploy_end_time = datetime.now(timezone.utc).isoformat()
+    metrics.allocator_total_deployment_duration_seconds = round(
+        sum(
+            v
+            for v in (
+                metrics.allocator_compose_up_duration_seconds,
+                metrics.allocator_health_check_duration_seconds,
+            )
+            if v is not None
+        ),
+        3,
+    )
+    metrics.status = "success" if funnel_ok else "failed"
+    if not funnel_ok:
+        metrics.error = "tailscale funnel could not be enabled"
+    write_metrics(metrics_path, metrics)
 
     _print_summary(cfg, funnel_active=funnel_active, funnel_url=funnel_url)
 

--- a/packages/cli/src/lablink_cli/commands/export_metrics.py
+++ b/packages/cli/src/lablink_cli/commands/export_metrics.py
@@ -114,48 +114,33 @@ def _export_allocator_metrics(
 ) -> None:
     """Read CLI-local allocator deployment cache and write to ``output_path``.
 
-    The cache at ``~/.lablink/deployments/`` is global — one directory for
-    every deployment the operator has ever run — so records are filtered to
-    ``deployment_name`` whenever the caller knows it. Unfiltered, an export
-    named for one deployment silently carries every other deployment's rows
-    (observed on a real machine: an 88-row ``sleap-lablink`` export, 59 rows
-    of which belonged to two unrelated deployments).
+    The cache at ``~/.lablink/deployments/`` is global — one record per deploy
+    attempt for every deployment the operator has ever run — so an unfiltered
+    export puts other deployments' rows in a file named for this one.
+    ``provider`` is part of the scope because a name can be reused across
+    providers, and an AWS record's Terraform phase columns say nothing about a
+    compose stack. Records predating that field are AWS ones, hence the
+    ``"aws"`` default.
 
-    ``provider`` narrows further, because a name can be reused across
-    providers: a ``sleap-lablink`` config switched from aws to manual would
-    otherwise export the old AWS Terraform timings as if they described the
-    compose stack — different phase columns entirely. Records predating the
-    field are AWS ones, hence the ``"aws"`` default.
-
-    Either filter set to None means no config was loaded (``--allocator``
-    alone on a machine with no config, which is meant to work after
-    ``lablink destroy``) and exports the whole cache — announced below,
-    since "everything" is not what the file name suggests.
+    Either filter as None means no config was loaded (``--allocator`` alone on
+    a machine that has none, which is what keeps it working after ``lablink
+    destroy``) and exports the whole cache.
 
     Empty result → print a yellow notice and skip writing the file (don't
     create a confusing zero-row CSV / empty-list JSON).
     """
-    records = load_all_metrics()
-    if deployment_name:
-        records = [
-            r for r in records if r.get("deployment_name") == deployment_name
-        ]
-    if provider:
-        records = [
-            r for r in records if (r.get("provider") or "aws") == provider
-        ]
+    records = [
+        r
+        for r in load_all_metrics()
+        if (not deployment_name or r.get("deployment_name") == deployment_name)
+        and (not provider or (r.get("provider") or "aws") == provider)
+    ]
     if not records:
-        if deployment_name:
-            console.print(
-                f"[yellow]No allocator deployment metrics for "
-                f"'{deployment_name}' in ~/.lablink/deployments/. Run "
-                f"`lablink deploy` first.[/yellow]"
-            )
-        else:
-            console.print(
-                "[yellow]No allocator deployment metrics found in "
-                "~/.lablink/deployments/. Run `lablink deploy` first.[/yellow]"
-            )
+        scope = f" for '{deployment_name}'" if deployment_name else ""
+        console.print(
+            f"[yellow]No allocator deployment metrics{scope} in "
+            f"~/.lablink/deployments/. Run `lablink deploy` first.[/yellow]"
+        )
         return
 
     if fmt == "json":
@@ -184,13 +169,12 @@ def _export_allocator_metrics(
         f"[green]Exported {len(records)} allocator deployment "
         f"records to {output_path}[/green]"
     )
-    if deployment_name is None:
-        names = {r.get("deployment_name") for r in records}
-        if len(names) > 1:
-            console.print(
-                f"  [dim]Spanning {len(names)} deployments — no config was "
-                f"loaded to scope by.[/dim]"
-            )
+    names = {r.get("deployment_name") for r in records}
+    if deployment_name is None and len(names) > 1:
+        console.print(
+            f"  [dim]Spanning {len(names)} deployments — no config to scope by."
+            f"[/dim]"
+        )
 
 
 def run_export_metrics(

--- a/packages/cli/src/lablink_cli/commands/export_metrics.py
+++ b/packages/cli/src/lablink_cli/commands/export_metrics.py
@@ -5,10 +5,12 @@ Two metric sources, selectable via flags:
 * ``--client``    : per-VM client metrics fetched from the allocator's
                     ``/api/export-metrics`` endpoint.
 * ``--allocator`` : per-deploy allocator metrics from the local CLI cache
-                    at ``~/.lablink/deployments/`` (issue #317).
+                    at ``~/.lablink/deployments/`` (issue #317), scoped to
+                    the config's ``deployment_name``.
 
 Default (no flag) exports both. ``--allocator`` alone never touches the
-network, so it works even after ``lablink destroy``.
+network — and loads no config, so it exports the cache unscoped — which is
+what makes it work even after ``lablink destroy``.
 """
 
 from __future__ import annotations
@@ -71,7 +73,7 @@ def _export_client_metrics(
                 f"[red]The allocator rejected admin user "
                 f"'{admin_user}' (HTTP 401).[/red]"
             )
-            print_admin_credentials_hint()
+            print_admin_credentials_hint(cfg)
         else:
             console.print(f"[red]HTTP {e.code}: {e.reason}[/red]")
         raise SystemExit(1) from e
@@ -104,18 +106,56 @@ def _export_client_metrics(
     )
 
 
-def _export_allocator_metrics(output_path: Path, fmt: str) -> None:
+def _export_allocator_metrics(
+    output_path: Path,
+    fmt: str,
+    deployment_name: str | None = None,
+    provider: str | None = None,
+) -> None:
     """Read CLI-local allocator deployment cache and write to ``output_path``.
 
-    Empty cache → print a yellow notice and skip writing the file (don't
+    The cache at ``~/.lablink/deployments/`` is global — one directory for
+    every deployment the operator has ever run — so records are filtered to
+    ``deployment_name`` whenever the caller knows it. Unfiltered, an export
+    named for one deployment silently carries every other deployment's rows
+    (observed on a real machine: an 88-row ``sleap-lablink`` export, 59 rows
+    of which belonged to two unrelated deployments).
+
+    ``provider`` narrows further, because a name can be reused across
+    providers: a ``sleap-lablink`` config switched from aws to manual would
+    otherwise export the old AWS Terraform timings as if they described the
+    compose stack — different phase columns entirely. Records predating the
+    field are AWS ones, hence the ``"aws"`` default.
+
+    Either filter set to None means no config was loaded (``--allocator``
+    alone on a machine with no config, which is meant to work after
+    ``lablink destroy``) and exports the whole cache — announced below,
+    since "everything" is not what the file name suggests.
+
+    Empty result → print a yellow notice and skip writing the file (don't
     create a confusing zero-row CSV / empty-list JSON).
     """
     records = load_all_metrics()
+    if deployment_name:
+        records = [
+            r for r in records if r.get("deployment_name") == deployment_name
+        ]
+    if provider:
+        records = [
+            r for r in records if (r.get("provider") or "aws") == provider
+        ]
     if not records:
-        console.print(
-            "[yellow]No allocator deployment metrics found in "
-            "~/.lablink/deployments/. Run `lablink deploy` first.[/yellow]"
-        )
+        if deployment_name:
+            console.print(
+                f"[yellow]No allocator deployment metrics for "
+                f"'{deployment_name}' in ~/.lablink/deployments/. Run "
+                f"`lablink deploy` first.[/yellow]"
+            )
+        else:
+            console.print(
+                "[yellow]No allocator deployment metrics found in "
+                "~/.lablink/deployments/. Run `lablink deploy` first.[/yellow]"
+            )
         return
 
     if fmt == "json":
@@ -144,6 +184,13 @@ def _export_allocator_metrics(output_path: Path, fmt: str) -> None:
         f"[green]Exported {len(records)} allocator deployment "
         f"records to {output_path}[/green]"
     )
+    if deployment_name is None:
+        names = {r.get("deployment_name") for r in records}
+        if len(names) > 1:
+            console.print(
+                f"  [dim]Spanning {len(names)} deployments — no config was "
+                f"loaded to scope by.[/dim]"
+            )
 
 
 def run_export_metrics(
@@ -168,7 +215,9 @@ def run_export_metrics(
         include_logs: For client metrics, include cloud_init / docker logs.
         format: ``csv`` or ``json``.
         client: Export per-VM metrics fetched from the allocator.
-        allocator: Export per-deploy metrics from the CLI-local cache.
+        allocator: Export per-deploy metrics from the CLI-local cache,
+            scoped to ``cfg.deployment_name`` (whole cache when ``cfg`` is
+            None).
 
     No flags → both (the common "give me everything" case).
     """
@@ -203,4 +252,9 @@ def run_export_metrics(
         )
 
     if allocator:
-        _export_allocator_metrics(_path_for("allocator"), format)
+        _export_allocator_metrics(
+            _path_for("allocator"),
+            format,
+            deployment_name=getattr(cfg, "deployment_name", None),
+            provider=getattr(cfg, "provider", None) if cfg else None,
+        )

--- a/packages/cli/src/lablink_cli/commands/stats.py
+++ b/packages/cli/src/lablink_cli/commands/stats.py
@@ -46,7 +46,7 @@ def _fetch(cfg) -> dict:
                 f"[red]The allocator rejected admin user "
                 f"'{admin_user}' (HTTP 401).[/red]"
             )
-            print_admin_credentials_hint()
+            print_admin_credentials_hint(cfg)
         else:
             console.print(f"[red]Could not reach allocator: {e}[/red]")
         raise SystemExit(1) from e

--- a/packages/cli/src/lablink_cli/commands/status.py
+++ b/packages/cli/src/lablink_cli/commands/status.py
@@ -29,6 +29,7 @@ from lablink_cli.commands.utils import (
     get_deploy_dir as _get_deploy_dir,
     get_terraform_outputs,
     print_aws_error,
+    resolve_from_saved_config,
 )
 
 console = Console()
@@ -637,27 +638,16 @@ def _resolve_manual_admin_credentials(
 
     Tries cfg first, then the workdir's rendered config.yaml (which
     deploy_compose.render_compose_dir always writes with the resolved
-    credentials).
+    credentials) — the same two sources ``resolve_admin_credentials``
+    consults for a manual config, minus its interactive prompt: callers
+    here print their own guidance instead, so this returns None.
     """
     user = getattr(cfg.app, "admin_user", "") or ""
     pw = getattr(cfg.app, "admin_password", "") or ""
     if user and pw and user != "MISSING" and pw != "MISSING":
         return user, pw
 
-    compose_cfg_path = workdir / "config.yaml"
-    if not compose_cfg_path.exists():
-        return None
-
-    import yaml
-
-    with open(compose_cfg_path) as f:
-        data = yaml.safe_load(f) or {}
-    app_cfg = data.get("app", {}) or {}
-    user = app_cfg.get("admin_user", "") or ""
-    pw = app_cfg.get("admin_password", "") or ""
-    if user and pw and user != "MISSING" and pw != "MISSING":
-        return user, pw
-    return None
+    return resolve_from_saved_config(workdir / "config.yaml")
 
 
 def _fetch_registered_clients(

--- a/packages/cli/src/lablink_cli/commands/utils.py
+++ b/packages/cli/src/lablink_cli/commands/utils.py
@@ -298,7 +298,21 @@ def get_deploy_dir(cfg: Config) -> Path:
 
 
 def get_allocator_url(cfg: Config) -> str:
-    """Determine the allocator base URL from terraform outputs or config."""
+    """Determine the allocator base URL from terraform outputs or config.
+
+    Manual provider has neither input: no Terraform state to read an IP
+    from, and ``dns.enabled`` is meaningless for a compose stack. Both
+    compose templates publish ``${HTTP_PORT}:5000`` on the host, and the
+    CLI's manual paths already assume they run on that host (`status` and
+    `logs` shell into the local container), so localhost is the address —
+    the same base URL deploy_compose._health_poll polls after `up`.
+    Imported lazily: deploy_compose imports this module at load time.
+    """
+    if getattr(cfg, "provider", "aws") == "manual":
+        from lablink_cli.commands.deploy_compose import DEFAULT_HTTP_PORT
+
+        return f"http://localhost:{DEFAULT_HTTP_PORT}"
+
     deploy_dir = get_deploy_dir(cfg)
     outputs = {}
     if deploy_dir.exists():
@@ -330,10 +344,29 @@ ADMIN_CREDENTIALS_HINT_LINES = (
     "(saved at deploy time — a redeploy can change them).",
 )
 
+# Manual provider keeps its deploy-time copy somewhere else entirely (the
+# rendered compose dir, no environment scoping), so the AWS wording above
+# would send a BYO operator to a path that does not exist on their machine.
+MANUAL_ADMIN_CREDENTIALS_HINT_LINES = (
+    "Check app.admin_user / app.admin_password in your config, or in",
+    "~/.lablink/compose/<deployment>/config.yaml",
+    "(rendered at deploy time — a redeploy can change them).",
+)
 
-def print_admin_credentials_hint() -> None:
-    """Print where admin credentials come from, after a rejected login."""
-    for line in ADMIN_CREDENTIALS_HINT_LINES:
+
+def print_admin_credentials_hint(cfg: Config | None = None) -> None:
+    """Print where admin credentials come from, after a rejected login.
+
+    ``cfg`` selects which deploy-time file to name; omit it (or pass a
+    non-manual config) for the AWS deploy dir.
+    """
+    manual = cfg is not None and getattr(cfg, "provider", "aws") == "manual"
+    lines = (
+        MANUAL_ADMIN_CREDENTIALS_HINT_LINES
+        if manual
+        else ADMIN_CREDENTIALS_HINT_LINES
+    )
+    for line in lines:
         console.print(f"  [dim]{line}[/dim]")
 
 
@@ -348,28 +381,37 @@ def _resolve_from_config(
     return None
 
 
-def _resolve_from_deploy_dir(
-    cfg: Config,
-) -> tuple[str, str] | None:
-    """Try to get credentials from the deployment config."""
+def resolve_from_saved_config(path: Path) -> tuple[str, str] | None:
+    """Try to get credentials from a deploy-time config.yaml at ``path``.
+
+    Both providers stash the resolved credentials in a rendered config.yaml,
+    just in different places (AWS: the deploy dir, manual: the compose
+    workdir), so the read is shared and only the path differs.
+    """
     import yaml
 
-    deploy_config_path = (
-        get_deploy_dir(cfg) / "config" / "config.yaml"
-    )
-    if not deploy_config_path.exists():
+    if not path.exists():
         return None
 
-    with open(deploy_config_path) as f:
-        deploy_cfg = yaml.safe_load(f) or {}
+    with open(path) as f:
+        saved_cfg = yaml.safe_load(f) or {}
 
-    app_cfg = deploy_cfg.get("app", {})
+    app_cfg = saved_cfg.get("app", {}) or {}
     user = app_cfg.get("admin_user", "")
     pw = app_cfg.get("admin_password", "")
 
     if user and user not in _MISSING and pw and pw not in _MISSING:
         return user, pw
     return None
+
+
+def _resolve_from_deploy_dir(
+    cfg: Config,
+) -> tuple[str, str] | None:
+    """Try to get credentials from the AWS deployment config."""
+    return resolve_from_saved_config(
+        get_deploy_dir(cfg) / "config" / "config.yaml"
+    )
 
 
 def _resolve_from_prompt() -> tuple[str, str]:
@@ -397,13 +439,26 @@ def resolve_admin_credentials(
 
     Resolution order:
     1. Main config (``cfg.app.admin_user`` / ``cfg.app.admin_password``)
-    2. Deployment-specific config saved during deploy
+    2. Deployment-specific config written during deploy — the AWS deploy
+       dir, or the rendered compose workdir under the manual provider
+       (which has no deploy dir at all, so the AWS lookup always missed
+       and every BYO operator got prompted)
     3. Interactive prompt (last resort)
 
     Returns ``(admin_user, admin_password)``.
     """
-    return (
-        _resolve_from_config(cfg)
-        or _resolve_from_deploy_dir(cfg)
-        or _resolve_from_prompt()
-    )
+    resolved = _resolve_from_config(cfg)
+    if resolved:
+        return resolved
+
+    if getattr(cfg, "provider", "aws") == "manual":
+        # Lazy: deploy_compose imports this module at load time.
+        from lablink_cli.commands.deploy_compose import compose_workdir
+
+        resolved = resolve_from_saved_config(
+            compose_workdir(cfg) / "config.yaml"
+        )
+    else:
+        resolved = _resolve_from_deploy_dir(cfg)
+
+    return resolved or _resolve_from_prompt()

--- a/packages/cli/src/lablink_cli/commands/utils.py
+++ b/packages/cli/src/lablink_cli/commands/utils.py
@@ -344,14 +344,10 @@ ADMIN_CREDENTIALS_HINT_LINES = (
     "(saved at deploy time — a redeploy can change them).",
 )
 
-# Manual provider keeps its deploy-time copy somewhere else entirely (the
-# rendered compose dir, no environment scoping), so the AWS wording above
-# would send a BYO operator to a path that does not exist on their machine.
-MANUAL_ADMIN_CREDENTIALS_HINT_LINES = (
-    "Check app.admin_user / app.admin_password in your config, or in",
-    "~/.lablink/compose/<deployment>/config.yaml",
-    "(rendered at deploy time — a redeploy can change them).",
-)
+# Manual keeps its copy in the rendered compose dir instead, with no
+# environment scoping — only the middle line above differs, so swap that
+# rather than carrying a second near-identical tuple.
+MANUAL_SAVED_CONFIG_HINT = "~/.lablink/compose/<deployment>/config.yaml"
 
 
 def print_admin_credentials_hint(cfg: Config | None = None) -> None:
@@ -360,13 +356,10 @@ def print_admin_credentials_hint(cfg: Config | None = None) -> None:
     ``cfg`` selects which deploy-time file to name; omit it (or pass a
     non-manual config) for the AWS deploy dir.
     """
-    manual = cfg is not None and getattr(cfg, "provider", "aws") == "manual"
-    lines = (
-        MANUAL_ADMIN_CREDENTIALS_HINT_LINES
-        if manual
-        else ADMIN_CREDENTIALS_HINT_LINES
-    )
-    for line in lines:
+    header, path, footer = ADMIN_CREDENTIALS_HINT_LINES
+    if cfg is not None and getattr(cfg, "provider", "aws") == "manual":
+        path = MANUAL_SAVED_CONFIG_HINT
+    for line in (header, path, footer):
         console.print(f"  [dim]{line}[/dim]")
 
 
@@ -403,15 +396,6 @@ def resolve_from_saved_config(path: Path) -> tuple[str, str] | None:
     if user and user not in _MISSING and pw and pw not in _MISSING:
         return user, pw
     return None
-
-
-def _resolve_from_deploy_dir(
-    cfg: Config,
-) -> tuple[str, str] | None:
-    """Try to get credentials from the AWS deployment config."""
-    return resolve_from_saved_config(
-        get_deploy_dir(cfg) / "config" / "config.yaml"
-    )
 
 
 def _resolve_from_prompt() -> tuple[str, str]:
@@ -455,10 +439,8 @@ def resolve_admin_credentials(
         # Lazy: deploy_compose imports this module at load time.
         from lablink_cli.commands.deploy_compose import compose_workdir
 
-        resolved = resolve_from_saved_config(
-            compose_workdir(cfg) / "config.yaml"
-        )
+        path = compose_workdir(cfg) / "config.yaml"
     else:
-        resolved = _resolve_from_deploy_dir(cfg)
+        path = get_deploy_dir(cfg) / "config" / "config.yaml"
 
-    return resolved or _resolve_from_prompt()
+    return resolve_from_saved_config(path) or _resolve_from_prompt()

--- a/packages/cli/src/lablink_cli/deployment_metrics.py
+++ b/packages/cli/src/lablink_cli/deployment_metrics.py
@@ -26,6 +26,13 @@ DEPLOYMENTS_DIR = Path.home() / ".lablink" / "deployments"
 @dataclass
 class DeploymentMetrics:
     deployment_name: str
+    # Which deploy path produced this record. deployment_name alone does not
+    # identify it: an operator can reuse one name across providers (observed:
+    # a `sleap-lablink` config switched from aws to manual), and the AWS
+    # Terraform timings below are meaningless for a compose deploy. Records
+    # written before this field existed are all AWS ones, which is why
+    # readers default a missing value to "aws" rather than to None.
+    provider: Optional[str] = None
     region: Optional[str] = None
     template_version: Optional[str] = None
     ssl_enabled: Optional[bool] = None
@@ -34,6 +41,11 @@ class DeploymentMetrics:
     allocator_terraform_init_duration_seconds: Optional[float] = None
     allocator_terraform_plan_duration_seconds: Optional[float] = None
     allocator_terraform_apply_duration_seconds: Optional[float] = None
+    # The manual provider's equivalent of the three terraform phases above:
+    # one `docker compose up -d`, image pull included. Kept as its own field
+    # rather than reusing the apply timing, which would make a compose deploy
+    # look like a Terraform one in the exported CSV.
+    allocator_compose_up_duration_seconds: Optional[float] = None
     allocator_health_check_duration_seconds: Optional[float] = None
     allocator_total_deployment_duration_seconds: Optional[float] = None
     status: str = "in_progress"

--- a/packages/cli/tests/conftest.py
+++ b/packages/cli/tests/conftest.py
@@ -71,12 +71,42 @@ def no_real_docker(request):
         yield
 
 
+@pytest.fixture(autouse=True)
+def no_real_deployment_cache(tmp_path_factory, monkeypatch):
+    """Keep test deploys out of the developer's real metrics cache.
+
+    ``DeploymentMetrics`` records land in ``~/.lablink/deployments/`` via a
+    module-level constant, so any test reaching a deploy path writes there for
+    real. Observed: teaching the compose path to record metrics immediately
+    left 25 ``testlab-*.json`` files in the developer's own cache, which then
+    show up in their `lablink export-metrics` output as if they were real
+    deployments.
+
+    Redirected per-test rather than per-file: the three AWS metrics tests
+    already patched this constant by hand, and every other deploy test
+    silently did not. Tests that want to seed a cache still monkeypatch the
+    same attribute themselves, which simply wins over this default.
+    """
+    from lablink_cli import deployment_metrics
+
+    monkeypatch.setattr(
+        deployment_metrics,
+        "DEPLOYMENTS_DIR",
+        tmp_path_factory.mktemp("deployments"),
+    )
+
+
 @pytest.fixture()
 def mock_cfg():
     """Minimal Config-like object for testing."""
     cfg = MagicMock()
     cfg.deployment_name = "mylab"
     cfg.environment = "dev"
+    # Real Config defaults to "aws" (structured_config.Config.provider). Left
+    # as a MagicMock it is truthy but never equals any provider string, so
+    # provider-dependent code takes neither branch cleanly — and it is not
+    # JSON-serializable, which breaks anything persisting it.
+    cfg.provider = "aws"
     cfg.app.region = "us-east-1"
     cfg.app.admin_user = "admin"
     cfg.app.admin_password = "secret"

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2649,13 +2649,10 @@ class TestComposeDeploymentMetrics:
     @patch("lablink_cli.commands.deploy_compose._health_poll")
     @patch("lablink_cli.commands.deploy_compose._compose_up")
     def test_success_writes_record(
-        self, mock_up, mock_poll, mock_summary, tmp_path, monkeypatch
+        self, mock_up, mock_poll, mock_summary, tmp_path
     ):
         from lablink_cli import deployment_metrics
         from lablink_cli.commands.deploy_compose import run_deploy_compose
-
-        cache = tmp_path / "cache"
-        monkeypatch.setattr(deployment_metrics, "DEPLOYMENTS_DIR", cache)
 
         run_deploy_compose(_manual_cfg(), yes=True, workdir_root=tmp_path)
 
@@ -2677,7 +2674,7 @@ class TestComposeDeploymentMetrics:
     @patch("lablink_cli.commands.deploy_compose._print_summary")
     @patch("lablink_cli.commands.deploy_compose._compose_up")
     def test_health_timeout_records_failure(
-        self, mock_up, mock_summary, tmp_path, monkeypatch
+        self, mock_up, mock_summary, tmp_path
     ):
         """A health-poll timeout must land as 'failed', not 'in_progress'.
 
@@ -2687,9 +2684,6 @@ class TestComposeDeploymentMetrics:
         """
         from lablink_cli import deployment_metrics
         from lablink_cli.commands.deploy_compose import run_deploy_compose
-
-        cache = tmp_path / "cache"
-        monkeypatch.setattr(deployment_metrics, "DEPLOYMENTS_DIR", cache)
 
         with patch(
             "lablink_cli.commands.deploy_compose._health_poll",
@@ -2706,7 +2700,7 @@ class TestComposeDeploymentMetrics:
     @patch("lablink_cli.commands.deploy_compose._health_poll")
     @patch("lablink_cli.commands.deploy_compose._compose_up")
     def test_render_failure_records_failure(
-        self, mock_up, mock_poll, mock_summary, tmp_path, monkeypatch
+        self, mock_up, mock_poll, mock_summary, tmp_path
     ):
         """A failure *outside* the timed phases still records 'failed'.
 
@@ -2716,9 +2710,6 @@ class TestComposeDeploymentMetrics:
         """
         from lablink_cli import deployment_metrics
         from lablink_cli.commands.deploy_compose import run_deploy_compose
-
-        cache = tmp_path / "cache"
-        monkeypatch.setattr(deployment_metrics, "DEPLOYMENTS_DIR", cache)
 
         with patch(
             "lablink_cli.commands.deploy_compose.render_compose_dir",
@@ -2738,14 +2729,11 @@ class TestComposeDeploymentMetrics:
     @patch("lablink_cli.commands.deploy_compose._health_poll")
     @patch("lablink_cli.commands.deploy_compose._compose_up")
     def test_declined_confirmation_writes_nothing(
-        self, mock_up, mock_poll, mock_summary, tmp_path, monkeypatch
+        self, mock_up, mock_poll, mock_summary, tmp_path
     ):
         """Aborting at the "Proceed?" gate leaves no in_progress junk."""
         from lablink_cli import deployment_metrics
         from lablink_cli.commands.deploy_compose import run_deploy_compose
-
-        cache = tmp_path / "cache"
-        monkeypatch.setattr(deployment_metrics, "DEPLOYMENTS_DIR", cache)
 
         with patch(
             "lablink_cli.commands.deploy_compose.typer.confirm",

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2705,6 +2705,38 @@ class TestComposeDeploymentMetrics:
     @patch("lablink_cli.commands.deploy_compose._print_summary")
     @patch("lablink_cli.commands.deploy_compose._health_poll")
     @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_render_failure_records_failure(
+        self, mock_up, mock_poll, mock_summary, tmp_path, monkeypatch
+    ):
+        """A failure *outside* the timed phases still records 'failed'.
+
+        The record is written before render_compose_dir, so anything that
+        escapes between that write and the success write would strand it at
+        in_progress with null timings — indistinguishable from a Ctrl-C.
+        """
+        from lablink_cli import deployment_metrics
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cache = tmp_path / "cache"
+        monkeypatch.setattr(deployment_metrics, "DEPLOYMENTS_DIR", cache)
+
+        with patch(
+            "lablink_cli.commands.deploy_compose.render_compose_dir",
+            side_effect=OSError("disk full"),
+        ):
+            with pytest.raises(OSError):
+                run_deploy_compose(_manual_cfg(), yes=True, workdir_root=tmp_path)
+
+        records = deployment_metrics.load_all_metrics()
+        assert len(records) == 1
+        assert records[0]["status"] == "failed"
+        assert "disk full" in records[0]["error"]
+        # Never reached the phases, so their timings stay empty.
+        assert records[0]["allocator_compose_up_duration_seconds"] is None
+
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
     def test_declined_confirmation_writes_nothing(
         self, mock_up, mock_poll, mock_summary, tmp_path, monkeypatch
     ):

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -2636,3 +2636,90 @@ class TestReverseTunnelDeploy:
         out = capsys.readouterr().out
         assert "--allocator-url http://192.168.1.42" in out
         assert "--allocator-url https://lab.example.org" not in out
+
+
+class TestComposeDeploymentMetrics:
+    """The compose deploy records to the CLI-local cache, like the AWS path.
+
+    Without this, `lablink export-metrics --allocator` had nothing to report
+    for a BYO deployment — the read side worked, the write side never existed.
+    """
+
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_success_writes_record(
+        self, mock_up, mock_poll, mock_summary, tmp_path, monkeypatch
+    ):
+        from lablink_cli import deployment_metrics
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cache = tmp_path / "cache"
+        monkeypatch.setattr(deployment_metrics, "DEPLOYMENTS_DIR", cache)
+
+        run_deploy_compose(_manual_cfg(), yes=True, workdir_root=tmp_path)
+
+        records = deployment_metrics.load_all_metrics()
+        assert len(records) == 1
+        rec = records[0]
+        assert rec["deployment_name"] == "testlab"
+        # provider is what keeps these out of an AWS export of the same name.
+        assert rec["provider"] == "manual"
+        assert rec["status"] == "success"
+        assert rec["allocator_compose_up_duration_seconds"] is not None
+        assert rec["allocator_health_check_duration_seconds"] is not None
+        assert rec["allocator_total_deployment_duration_seconds"] is not None
+        assert rec["allocator_deploy_end_time"]
+        # AWS-only dimensions stay empty rather than being invented.
+        assert rec["region"] is None
+        assert rec["template_version"] is None
+
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_health_timeout_records_failure(
+        self, mock_up, mock_summary, tmp_path, monkeypatch
+    ):
+        """A health-poll timeout must land as 'failed', not 'in_progress'.
+
+        _health_poll raises SystemExit for a real failure, so the compose
+        path has to catch SystemExit where the AWS path deliberately
+        doesn't (there it means the operator cancelled).
+        """
+        from lablink_cli import deployment_metrics
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cache = tmp_path / "cache"
+        monkeypatch.setattr(deployment_metrics, "DEPLOYMENTS_DIR", cache)
+
+        with patch(
+            "lablink_cli.commands.deploy_compose._health_poll",
+            side_effect=SystemExit(1),
+        ):
+            with pytest.raises(SystemExit):
+                run_deploy_compose(_manual_cfg(), yes=True, workdir_root=tmp_path)
+
+        records = deployment_metrics.load_all_metrics()
+        assert len(records) == 1
+        assert records[0]["status"] == "failed"
+
+    @patch("lablink_cli.commands.deploy_compose._print_summary")
+    @patch("lablink_cli.commands.deploy_compose._health_poll")
+    @patch("lablink_cli.commands.deploy_compose._compose_up")
+    def test_declined_confirmation_writes_nothing(
+        self, mock_up, mock_poll, mock_summary, tmp_path, monkeypatch
+    ):
+        """Aborting at the "Proceed?" gate leaves no in_progress junk."""
+        from lablink_cli import deployment_metrics
+        from lablink_cli.commands.deploy_compose import run_deploy_compose
+
+        cache = tmp_path / "cache"
+        monkeypatch.setattr(deployment_metrics, "DEPLOYMENTS_DIR", cache)
+
+        with patch(
+            "lablink_cli.commands.deploy_compose.typer.confirm",
+            return_value=False,
+        ):
+            with pytest.raises(SystemExit):
+                run_deploy_compose(_manual_cfg(), workdir_root=tmp_path)
+
+        assert deployment_metrics.load_all_metrics() == []

--- a/packages/cli/tests/test_export_metrics.py
+++ b/packages/cli/tests/test_export_metrics.py
@@ -12,7 +12,10 @@ from urllib.error import HTTPError
 import pytest
 
 from lablink_cli import deployment_metrics
-from lablink_cli.commands.export_metrics import run_export_metrics
+from lablink_cli.commands.export_metrics import (
+    _export_allocator_metrics,
+    run_export_metrics,
+)
 
 
 class TestRunExportMetrics:
@@ -451,15 +454,20 @@ class TestExportMetricsFlags:
     def test_both_flags_writes_csv_sidecar(
         self, mock_cfg, tmp_path, monkeypatch
     ):
-        """Both flags + -o metrics.csv → _client + _allocator sidecar files."""
+        """Both flags + -o metrics.csv → _client + _allocator sidecar files.
+
+        Records carry mock_cfg's deployment_name: allocator records are
+        scoped to the current deployment, so foreign names would be filtered
+        out and there'd be no sidecar to assert on.
+        """
         records = [
             {
-                "deployment_name": "lab-a",
+                "deployment_name": "mylab",
                 "region": "us-east-1",
                 "status": "success",
             },
             {
-                "deployment_name": "lab-b",
+                "deployment_name": "mylab",
                 "region": "us-west-2",
                 "status": "failed",
             },
@@ -489,15 +497,15 @@ class TestExportMetricsFlags:
         assert not base_path.exists()
         with open(allocator_path) as f:
             rows = list(csv.DictReader(f))
-        assert {r["deployment_name"] for r in rows} == {"lab-a", "lab-b"}
+        assert {r["region"] for r in rows} == {"us-east-1", "us-west-2"}
 
     def test_both_flags_writes_json_sidecar(
         self, mock_cfg, tmp_path, monkeypatch
     ):
         """JSON mode: both flags write _client.json and _allocator.json sidecars."""
         records = [
-            {"deployment_name": "lab-a", "status": "success"},
-            {"deployment_name": "lab-b", "status": "success"},
+            {"deployment_name": "mylab", "status": "success"},
+            {"deployment_name": "mylab", "status": "failed"},
         ]
         _seed_allocator_cache(tmp_path / "cache", monkeypatch, records)
 
@@ -524,14 +532,14 @@ class TestExportMetricsFlags:
         assert not base_path.exists()
         data = json.loads(allocator_path.read_text())
         assert data["count"] == 2
-        assert {r["deployment_name"] for r in data["allocator_metrics"]} == {
-            "lab-a",
-            "lab-b",
+        assert {r["status"] for r in data["allocator_metrics"]} == {
+            "success",
+            "failed",
         }
 
     def test_no_flags_defaults_to_both(self, mock_cfg, tmp_path, monkeypatch):
         """No flags → same as --client --allocator (-o is treated as base name)."""
-        records = [{"deployment_name": "lab-a", "status": "success"}]
+        records = [{"deployment_name": "mylab", "status": "success"}]
         _seed_allocator_cache(tmp_path / "cache", monkeypatch, records)
 
         mock_resp = MagicMock()
@@ -549,6 +557,88 @@ class TestExportMetricsFlags:
         assert client_path.exists()
         assert allocator_path.exists()
         assert not base_path.exists()
+
+    def test_allocator_records_scoped_to_deployment(
+        self, mock_cfg, tmp_path, monkeypatch
+    ):
+        """Other deployments' cached records stay out of this export.
+
+        The cache is global, so before scoping an export named for one
+        deployment carried every deployment's rows.
+        """
+        records = [
+            {"deployment_name": "mylab", "status": "success"},
+            {"deployment_name": "someone-elses-lab", "status": "success"},
+            {"deployment_name": "old-aws-lab", "status": "failed"},
+        ]
+        _seed_allocator_cache(tmp_path / "cache", monkeypatch, records)
+
+        allocator_path = tmp_path / "alloc.csv"
+        _export_allocator_metrics(
+            allocator_path, "csv", deployment_name=mock_cfg.deployment_name
+        )
+
+        with open(allocator_path) as f:
+            rows = list(csv.DictReader(f))
+        assert [r["deployment_name"] for r in rows] == ["mylab"]
+
+    def test_allocator_records_scoped_to_provider(
+        self, tmp_path, monkeypatch, capsys
+    ):
+        """A reused deployment_name must not leak its AWS rows into BYO.
+
+        The real case: a `sleap-lablink` config switched from aws to manual.
+        Name-scoping alone still matched the old AWS Terraform records.
+        """
+        records = [
+            {"deployment_name": "sleap-lablink", "region": "us-west-2"},
+            {
+                "deployment_name": "sleap-lablink",
+                "provider": "aws",
+                "region": "us-west-2",
+            },
+        ]
+        _seed_allocator_cache(tmp_path / "cache", monkeypatch, records)
+
+        allocator_path = tmp_path / "alloc.csv"
+        _export_allocator_metrics(
+            allocator_path,
+            "csv",
+            deployment_name="sleap-lablink",
+            provider="manual",
+        )
+
+        assert not allocator_path.exists()
+        assert "sleap-lablink" in capsys.readouterr().out
+
+        # Same cache, AWS config: both rows export, including the legacy one
+        # written before the provider field existed.
+        aws_path = tmp_path / "aws.csv"
+        _export_allocator_metrics(
+            aws_path, "csv", deployment_name="sleap-lablink", provider="aws"
+        )
+        with open(aws_path) as f:
+            assert len(list(csv.DictReader(f))) == 2
+
+    def test_allocator_empty_after_scoping_skips_file(
+        self, mock_cfg, tmp_path, monkeypatch, capsys
+    ):
+        """A cache with no rows for this deployment writes nothing.
+
+        The manual/compose deploy path records no allocator metrics at all,
+        so this is the normal BYO outcome — it must not dump the AWS rows
+        that happen to share the cache.
+        """
+        records = [{"deployment_name": "old-aws-lab", "status": "success"}]
+        _seed_allocator_cache(tmp_path / "cache", monkeypatch, records)
+
+        allocator_path = tmp_path / "alloc.csv"
+        _export_allocator_metrics(
+            allocator_path, "csv", deployment_name="byo-lab"
+        )
+
+        assert not allocator_path.exists()
+        assert "byo-lab" in capsys.readouterr().out
 
     def test_client_only_skips_allocator_file(
         self, mock_cfg, tmp_path, monkeypatch

--- a/packages/cli/tests/test_utils_full.py
+++ b/packages/cli/tests/test_utils_full.py
@@ -12,6 +12,7 @@ from lablink_cli.commands.utils import (
     _resolve_from_deploy_dir,
     get_allocator_url,
     get_deploy_dir,
+    print_admin_credentials_hint,
     resolve_admin_credentials,
 )
 
@@ -81,6 +82,16 @@ class TestGetAllocatorUrl:
 
         assert result == ""
 
+    def test_manual_provider_uses_localhost(self, mock_cfg):
+        """Manual provider short-circuits: no Terraform state, no DNS."""
+        mock_cfg.provider = "manual"
+
+        with patch("lablink_cli.commands.utils.get_deploy_dir") as mock_dir:
+            result = get_allocator_url(mock_cfg)
+
+        assert result == "http://localhost:80"
+        mock_dir.assert_not_called()
+
     def test_deploy_dir_missing(self, mock_cfg):
         mock_cfg.dns.enabled = False
         mock_cfg.ssl.provider = "none"
@@ -136,6 +147,31 @@ class TestResolveAdminCredentials:
         assert user == "from-deploy"
         assert pw == "from-deploy"
 
+    def test_manual_reads_compose_config(self, mock_cfg, tmp_path):
+        """Manual provider: creds come from the rendered compose workdir."""
+        mock_cfg.provider = "manual"
+        mock_cfg.app.admin_user = "MISSING"
+        mock_cfg.app.admin_password = "MISSING"
+
+        compose_config = tmp_path / "mylab" / "config.yaml"
+        compose_config.parent.mkdir(parents=True)
+        compose_config.write_text(
+            yaml.dump(
+                {"app": {"admin_user": "byo-user", "admin_password": "byo-pw"}}
+            )
+        )
+
+        with patch(
+            "lablink_cli.commands.deploy_compose.DEFAULT_COMPOSE_DIR", tmp_path
+        ):
+            with patch("lablink_cli.commands.utils.get_deploy_dir") as mock_dir:
+                user, pw = resolve_admin_credentials(mock_cfg)
+
+        assert (user, pw) == ("byo-user", "byo-pw")
+        # The AWS deploy dir must not even be consulted — it never exists
+        # for a manual deployment, which is what used to force the prompt.
+        mock_dir.assert_not_called()
+
     @patch("builtins.input", return_value="prompted-user")
     @patch("getpass.getpass", return_value="prompted-pw")
     def test_interactive_prompt(self, mock_getpass, mock_input, mock_cfg, tmp_path):
@@ -188,6 +224,25 @@ class TestResolveFromConfig:
         mock_cfg.app.admin_password = "MISSING"
         result = _resolve_from_config(mock_cfg)
         assert result is None
+
+
+class TestPrintAdminCredentialsHint:
+    def test_aws_names_deploy_dir(self, capsys, mock_cfg):
+        print_admin_credentials_hint(mock_cfg)
+        out = capsys.readouterr().out
+        assert ".lablink/deploy" in out
+        assert "compose" not in out
+
+    def test_manual_names_compose_dir(self, capsys, mock_cfg):
+        mock_cfg.provider = "manual"
+        print_admin_credentials_hint(mock_cfg)
+        out = capsys.readouterr().out
+        assert ".lablink/compose" in out
+        assert "deploy/" not in out
+
+    def test_no_cfg_defaults_to_aws(self, capsys):
+        print_admin_credentials_hint()
+        assert ".lablink/deploy" in capsys.readouterr().out
 
 
 class TestResolveFromDeployDir:

--- a/packages/cli/tests/test_utils_full.py
+++ b/packages/cli/tests/test_utils_full.py
@@ -9,11 +9,11 @@ import yaml
 
 from lablink_cli.commands.utils import (
     _resolve_from_config,
-    _resolve_from_deploy_dir,
     get_allocator_url,
     get_deploy_dir,
     print_admin_credentials_hint,
     resolve_admin_credentials,
+    resolve_from_saved_config,
 )
 
 
@@ -245,28 +245,19 @@ class TestPrintAdminCredentialsHint:
         assert ".lablink/deploy" in capsys.readouterr().out
 
 
-class TestResolveFromDeployDir:
-    def test_returns_credentials(self, mock_cfg, tmp_path):
-        deploy_config = tmp_path / "config" / "config.yaml"
-        deploy_config.parent.mkdir(parents=True)
+class TestResolveFromSavedConfig:
+    """The reader both providers share; only the path differs."""
+
+    def test_returns_credentials(self, tmp_path):
+        path = tmp_path / "config.yaml"
         data = {"app": {"admin_user": "deploy-user", "admin_password": "deploy-pw"}}
-        deploy_config.write_text(yaml.dump(data))
-        with patch("lablink_cli.commands.utils.get_deploy_dir") as mock_dir:
-            mock_dir.return_value = tmp_path
-            result = _resolve_from_deploy_dir(mock_cfg)
-        assert result == ("deploy-user", "deploy-pw")
+        path.write_text(yaml.dump(data))
+        assert resolve_from_saved_config(path) == ("deploy-user", "deploy-pw")
 
-    def test_returns_none_when_no_deploy_dir(self, mock_cfg, tmp_path):
-        with patch("lablink_cli.commands.utils.get_deploy_dir") as mock_dir:
-            mock_dir.return_value = tmp_path / "nonexistent"
-            result = _resolve_from_deploy_dir(mock_cfg)
-        assert result is None
+    def test_returns_none_when_file_missing(self, tmp_path):
+        assert resolve_from_saved_config(tmp_path / "nonexistent.yaml") is None
 
-    def test_returns_none_when_missing_keys(self, mock_cfg, tmp_path):
-        deploy_config = tmp_path / "config" / "config.yaml"
-        deploy_config.parent.mkdir(parents=True)
-        deploy_config.write_text(yaml.dump({"app": {}}))
-        with patch("lablink_cli.commands.utils.get_deploy_dir") as mock_dir:
-            mock_dir.return_value = tmp_path
-            result = _resolve_from_deploy_dir(mock_cfg)
-        assert result is None
+    def test_returns_none_when_missing_keys(self, tmp_path):
+        path = tmp_path / "config.yaml"
+        path.write_text(yaml.dump({"app": {}}))
+        assert resolve_from_saved_config(path) is None


### PR DESCRIPTION
## Summary

- `lablink stats` and `lablink export-metrics --client` could not run at all on a manual/BYO deployment — allocator URL and admin credentials were resolved AWS-only.
- `export-metrics --allocator` exported the *entire* local cache, so a file named for one deployment carried every other deployment's rows.
- The compose deploy path never recorded deployment metrics in the first place, so there was nothing for a BYO operator to export.

## Changes Made

**1. Manual-provider resolution** (`utils.py`, `status.py`, `stats.py`)

`get_allocator_url()` resolves only from Terraform outputs (`ec2_public_ip`) or `cfg.dns.domain`; a compose stack has neither, so it returned `""` and both metrics commands exited with *"Could not determine allocator URL."* `status` and `logs` had each grown their own manual branch — the two metrics commands never did.

- Manual short-circuits to `http://localhost:<HTTP_PORT>`, the port both compose templates publish and the same base URL `deploy_compose._health_poll` already polls.
- `resolve_admin_credentials()` reads the rendered compose workdir's `config.yaml` instead of the AWS deploy dir (which never exists there, so every BYO operator got the interactive prompt).
- Extracted `resolve_from_saved_config(path)` so both providers share one yaml reader; `status._resolve_manual_admin_credentials` delegates to it instead of duplicating the read (-11 lines).
- `print_admin_credentials_hint(cfg)` names the compose `config.yaml` on a manual 401, not a deploy dir absent from that machine.

**2. Scoped allocator export** (`export_metrics.py`, `deployment_metrics.py`, `deploy.py`, `app.py`)

The cache is global — one file per deploy attempt, never pruned — and the export wrote all of it. Filtering by `deployment_name` alone was insufficient: a name can be reused across providers, and a `sleap-lablink` config switched from `aws` to `manual` still matched 37 old AWS Terraform records.

- Records now carry `provider`; readers default a missing value to `"aws"`, which every pre-existing record is.
- Export filters on `deployment_name` **and** `provider`. An unscoped export announces how many deployments it spans.
- `--allocator` alone now loads the config when one exists (it deliberately skipped it before), so scoping applies to the invocation a BYO operator actually reaches for. No config at all still exports unscoped — that is what kept the command working after `lablink destroy`.

**3. Compose deploy records metrics** (`deploy_compose.py`, `deployment_metrics.py`)

`run_deploy_compose` now times `docker compose up -d` and the health poll, then writes status/total. New `allocator_compose_up_duration_seconds` field — kept separate from the terraform-apply timing so a compose deploy does not look like a Terraform one in the CSV. `region`/`template_version` stay `None` rather than being invented.

## Testing

763 CLI tests pass; `ruff check` clean across all three packages. No source outside `packages/cli` is touched.

New coverage:
- `get_allocator_url` manual short-circuit, asserting it never consults `get_deploy_dir`
- manual creds read from the compose workdir, asserting the AWS deploy dir is not consulted
- hint wording for aws / manual / no-cfg
- export scoped by deployment; the reused-name-across-providers case with its AWS counterpart (legacy records with no `provider` field still export under an AWS config)
- compose deploy: success record, health-timeout → `failed`, declined confirmation → no record

Manual testing against a live compose stack:
- `export-metrics --client` reached the allocator (`200 OK`, `{"count": 0, "vms": []}`) where it previously died on URL resolution; credentials resolved with stdin closed, so no prompt
- `export-metrics --allocator` on the real cache: was 96 rows spanning 3 deployments → now 1 row, `provider=manual`, compose up 3.26s, health check 9.05s, total 12.31s, `status=success`, empty `terraform_*` columns

## Design Decisions

**`localhost` over the canonical public URL for manual.** Both compose templates publish `${HTTP_PORT}:5000` on the host, and the CLI's manual paths already assume they run on that host (`status`/`logs` shell into the local container). Correct even behind Funnel/Cloudflare, since the tunnel dials that same published port.

**`provider` on the record, not inferred at read time.** Nothing in a stored record distinguishes an AWS deploy from a compose one except which timing columns are populated — too fragile to key filtering on.

**Compose path catches `SystemExit`; the AWS path deliberately does not.** In `deploy.py`, `SystemExit` means the operator cancelled, and leaving the record `in_progress` is honest. In `run_deploy_compose`, `_compose_up` and `_health_poll` both raise it for *genuine* failures (non-zero compose exit, health timeout), so mirroring AWS would under-report real failures. `KeyboardInterrupt` still escapes both.

**Compose record is created after the confirmation gate.** A declined "Proceed?" leaves no `in_progress` file at all. The AWS path creates its record earlier and does litter — 27 of 97 records in one real cache were `in_progress` leftovers.

## Incidental fixes

Two test-isolation bugs surfaced while doing this, both in `conftest.py`:

- `mock_cfg.provider` was a `MagicMock`: truthy, never equal to any provider string, and not JSON-serializable. It was masking exactly the class of bug fixed here. Set to `"aws"`, matching the real `Config` default.
- Added an autouse `no_real_deployment_cache` fixture (sibling to the existing `no_real_docker` guard). `DEPLOYMENTS_DIR` is a module-level constant, so once the compose path recorded metrics the suite wrote 25 `testlab-*.json` files into the developer's own cache, where they then appear in `export-metrics` output as real deployments. Only three AWS tests had ever patched that constant by hand; every other deploy test silently did not.

## Known gaps (not in this PR)

- The compose destroy path has no export-before-destroy prompt, unlike `deploy.py`, and `docker volume rm` takes the Postgres volume with all session metrics.
- `bulk_seal_session_metrics()` is called only from the AWS destroy paths; BYO withdrawal (`DELETE /api/v1/clients/<id>`) hard-deletes the row, so metrics vanish unsealed.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WswonxBxQWGrr4itfRYLR