### PR TITLE
fix: bump Terraform to 1.9.8 to stop S3 backend state corruption

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,7 @@ jobs:
         if: matrix.needs-terraform
         uses: hashicorp/setup-terraform@v4
         with:
-          terraform_version: 1.6.6
+          terraform_version: 1.9.8
           terraform_wrapper: false
 
       - name: Install dependencies

--- a/.github/workflows/lablink-images.yml
+++ b/.github/workflows/lablink-images.yml
@@ -171,7 +171,7 @@ jobs:
           fi
 
           if [ "${{ matrix.image-name }}" == "lablink-allocator-image" ]; then
-            tags="ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM$ENV_SUFFIX,ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM-$SHA$ENV_SUFFIX,ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM-latest$ENV_SUFFIX,ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM-terraform-1.6.6$ENV_SUFFIX,ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM-postgres-15$ENV_SUFFIX"
+            tags="ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM$ENV_SUFFIX,ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM-$SHA$ENV_SUFFIX,ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM-latest$ENV_SUFFIX,ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM-terraform-1.9.8$ENV_SUFFIX,ghcr.io/$REPO_OWNER/lablink-allocator-image:$PLATFORM-postgres-15$ENV_SUFFIX"
 
             # Add package version tag if available
             if [ -n "$PKG_VERSION" ]; then

--- a/packages/allocator/Dockerfile
+++ b/packages/allocator/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y curl unzip && \
-    curl -fsSL https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_amd64.zip -o /tmp/terraform.zip && \
+    curl -fsSL https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_linux_amd64.zip -o /tmp/terraform.zip && \
     unzip /tmp/terraform.zip -d /usr/local/bin && \
     rm /tmp/terraform.zip && \
     rm -rf /var/lib/apt/lists/*

--- a/packages/allocator/Dockerfile.dev
+++ b/packages/allocator/Dockerfile.dev
@@ -16,7 +16,7 @@ RUN apt-get update && apt-get install -y \
     rm -rf /var/lib/apt/lists/*
 
 RUN apt-get update && apt-get install -y curl unzip && \
-    curl -fsSL https://releases.hashicorp.com/terraform/1.6.6/terraform_1.6.6_linux_amd64.zip -o /tmp/terraform.zip && \
+    curl -fsSL https://releases.hashicorp.com/terraform/1.9.8/terraform_1.9.8_linux_amd64.zip -o /tmp/terraform.zip && \
     unzip /tmp/terraform.zip -d /usr/local/bin && \
     rm /tmp/terraform.zip && \
     rm -rf /var/lib/apt/lists/*

--- a/packages/allocator/src/lablink_allocator_service/terraform/versions.tf
+++ b/packages/allocator/src/lablink_allocator_service/terraform/versions.tf
@@ -1,5 +1,9 @@
 terraform {
-  required_version = ">= 1.6.0, < 2.0.0"
+  # Floor is 1.9, not 1.6: below the 1.8.0 line the S3 backend can corrupt
+  # state on a retried upload rather than fail cleanly, because an
+  # aws-sdk-go-v2 bug leaves the PutObject body non-seekable
+  # (hashicorp/terraform#34528). Let terraform refuse rather than risk it.
+  required_version = ">= 1.9.0, < 2.0.0"
   required_providers {
     aws = {
       source  = "hashicorp/aws"

--- a/packages/cli/src/lablink_cli/commands/doctor.py
+++ b/packages/cli/src/lablink_cli/commands/doctor.py
@@ -22,6 +22,29 @@ STATUS_STYLES = {
     "warn": "[yellow]WARN[/yellow]",
 }
 
+# Terraform's S3 backend corrupts state below this version: an aws-sdk-go-v2 bug
+# leaves the PutObject body non-seekable, so a retried state upload fails with
+# "failed to rewind transport stream for retry" *after* apply/destroy has already
+# run. Fixed in the 1.8.0 line (hashicorp/terraform#34528, PR #34796); we require
+# 1.9.0 to match the version the allocator image ships.
+MIN_TERRAFORM_VERSION = (1, 9, 0)
+
+
+def _parse_version(version: str) -> tuple[int, ...] | None:
+    """Parse a dotted version string into a comparable tuple.
+
+    Args:
+        version: Version string such as ``"1.9.8"``. Pre-release suffixes
+            (``"1.10.0-beta1"``) are truncated at the first hyphen.
+
+    Returns:
+        Tuple of integers, or None if the string is not parseable.
+    """
+    try:
+        return tuple(int(part) for part in version.split("-")[0].split("."))
+    except (AttributeError, ValueError):
+        return None
+
 
 def _load_config_safe():
     """Load config from default path; return None if missing/invalid.
@@ -69,8 +92,19 @@ def _check_terraform() -> dict:
             version = info.get(
                 "terraform_version", "unknown"
             )
-            result["status"] = "pass"
-            result["detail"] = f"v{version} ({path})"
+            parsed = _parse_version(version)
+            minimum = ".".join(str(p) for p in MIN_TERRAFORM_VERSION)
+            if parsed is not None and parsed < MIN_TERRAFORM_VERSION:
+                result["status"] = "fail"
+                result["detail"] = (
+                    f"v{version} ({path}) is too old — need {minimum}+. "
+                    "Older versions corrupt Terraform state on S3 upload "
+                    "retries instead of failing cleanly "
+                    "(hashicorp/terraform#34528)."
+                )
+            else:
+                result["status"] = "pass"
+                result["detail"] = f"v{version} ({path})"
         else:
             result["status"] = "warn"
             result["detail"] = (

--- a/packages/cli/tests/test_doctor.py
+++ b/packages/cli/tests/test_doctor.py
@@ -27,12 +27,50 @@ class TestCheckTerraform:
     def test_installed_with_version(self, _mock_which, mock_run):
         mock_run.return_value = MagicMock(
             returncode=0,
-            stdout=json.dumps({"terraform_version": "1.6.6"}),
+            stdout=json.dumps({"terraform_version": "1.9.8"}),
         )
 
         result = _check_terraform()
         assert result["status"] == "pass"
-        assert "1.6.6" in result["detail"]
+        assert "1.9.8" in result["detail"]
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    def test_version_below_minimum_fails(self, _mock_which, mock_run):
+        """Below 1.9.0 the S3 backend can corrupt state — refuse, don't warn."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"terraform_version": "1.6.6"}),
+        )
+
+        result = _check_terraform()
+        assert result["status"] == "fail"
+        assert "1.9.0+" in result["detail"]
+        assert "34528" in result["detail"]
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    def test_newer_major_minor_passes(self, _mock_which, mock_run):
+        """A two-component version must not crash the tuple comparison."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"terraform_version": "1.10"}),
+        )
+
+        result = _check_terraform()
+        assert result["status"] == "pass"
+
+    @patch("subprocess.run")
+    @patch("shutil.which", return_value="/usr/bin/terraform")
+    def test_unparseable_version_passes(self, _mock_which, mock_run):
+        """An unrecognised version string must not block the operator."""
+        mock_run.return_value = MagicMock(
+            returncode=0,
+            stdout=json.dumps({"terraform_version": "unknown"}),
+        )
+
+        result = _check_terraform()
+        assert result["status"] == "pass"
 
     @patch("subprocess.run")
     @patch("shutil.which", return_value="/usr/bin/terraform")


### PR DESCRIPTION
## Summary

Destroying client VMs failed with:

```
Error: failed to upload state: operation error S3: PutObject,
failed to rewind transport stream for retry, request stream is not seekable
```

This is [hashicorp/terraform#34528](https://github.com/hashicorp/terraform/issues/34528) — Terraform 1.6.x ships an `aws-sdk-go-v2` that doesn't set `isStreamSeekable` correctly for the S3 backend's `PutObject`. When a state upload hits a transient error and the SDK retries, it can't rewind the body and dies.

**The error is not the worst part.** That issue reports Terraform *continuing with corrupted state* afterwards, causing incorrect resource creation and deletion. It was filed against **1.6.5 with an encrypted S3 backend** — exactly our client-VM setup (`backend-client-*.hcl` sets `encrypt = true`), and we pin **1.6.6**.

Fixed upstream by [#34796](https://github.com/hashicorp/terraform/pull/34796) ("Update AWS SDK versions to the latest"), merged 2024-03-08, first released in the **1.8.0** line.

!!! note
    Bumping the AWS *provider* would not have helped. The S3 backend is compiled into the `terraform` binary; it doesn't come from the provider.

## Changes

| File | Change |
|---|---|
| `packages/allocator/Dockerfile` | 1.6.6 → 1.9.8 — **the binary that actually runs client-VM plan/apply/destroy** |
| `packages/allocator/.../Dockerfile.dev` | same |
| `.github/workflows/ci.yml` | `terraform_version: 1.9.8` |
| `.github/workflows/lablink-images.yml` | image tag `terraform-1.6.6` → `terraform-1.9.8` |
| `.../terraform/versions.tf` | `required_version` floor 1.6.0 → 1.9.0, so Terraform refuses rather than risking state |
| `packages/cli/.../doctor.py` | `lablink doctor` now **fails** on terraform < 1.9.0 instead of passing green |

The doctor check matters most: CLI users bring their own `terraform` binary, so bumping the image alone leaves them exposed. Previously `_check_terraform` reported the version but never validated it — someone on 1.6.x got a green PASS and then corrupted state.

### Why 1.9.8 and not latest

1.9.8 is comfortably past the 1.8.0 fix while staying close enough to 1.6.6 that nothing else changes. The 1.11+ line deprecates `dynamodb_table` in the S3 backend in favour of S3-native locking (`use_lockfile`), which would mean migrating all four `backend-client-*.hcl` files — worth doing deliberately, not as a side effect of a bug fix.

## Testing

- `packages/cli`: **767 passed**
- `packages/allocator`: **906 passed, 20 skipped** (`--ignore=tests/terraform`)
- `ruff check` clean

New `_check_terraform` cases cover the below-minimum failure, a two-component version string (`1.10` must not compare as older than `1.9.0`), and an unparseable one (must not block the operator).

## Operator note

If you hit this error, your remote state and AWS may have diverged — the destroy ran, the state upload didn't. Reconcile before the next apply:

```bash
# what still exists
aws ec2 describe-instances --region us-west-2 \
  --filters "Name=tag:Name,Values=*client*" "Name=instance-state-name,Values=running,pending,stopping"

# what terraform thinks exists
terraform state list

# and check for a lock the failed run never released
aws dynamodb scan --table-name lock-table --region us-west-2
```

## Follow-ups

- **`talmolab/lablink-template`** pins 1.6.6 in `terraform-deploy.yml:49` and `terraform-destroy.yml:48` — needs the same bump in its own PR, or CI deploys keep using the broken version.
- Doc strings still saying 1.6.6 (`prerequisites.md`, `deployment.md`, `contributing.md`, `cli/first-deployment.md`) are left alone here to avoid conflicting with #436, which already rewrites several of those files.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017WswonxBxQWGrr4itfRYLR