### PR TITLE
perf(client): stop the KasmVNC desktop holding max quality while the screen moves

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -191,6 +191,23 @@ contract.
    - Exposes a local agent the allocator calls to rotate the VNC password per session
    - Clones the configured repository and runs the containerized research software
 
+**Desktop performance**: `start.sh` deliberately overrides four upstream
+defaults, because stock KasmVNC and XFCE never reduce cost while the screen is
+moving — they hold near-maximum quality through a full-screen redraw and fall
+behind, which participants perceive as choppy motion. Do not revert these to
+their defaults without re-measuring:
+
+| Override | Default | Why |
+|---|---|---|
+| `xfwm4` `use_compositing: false` | on | The compositor recomposites the whole screen on every window move, so Xvnc sees one full-screen damage rect instead of a few small ones. |
+| `rect_encoding_mode.min_quality: 4` | 7 | The stock 7–8 band is pinned near maximum. KasmVNC varies quality within the band by how fast the screen is *changing*, not by network feedback, so the floor is what governs motion smoothness. |
+| `enter_video_encoding_mode.time_threshold: 2` | 5 | Sustained motion otherwise spends five seconds in per-rect JPEG/WebP before video mode engages. |
+| `scrolling.detect_vertical_scrolling: true` | off | Sends a cheap region shift instead of re-encoding the scrolled region. |
+
+The compositing setting is written to the xfconf XML store rather than applied
+with `xfconf-query`, which would need the session dbus already up and would
+race `xfce4-session`.
+
 **Configuration**: See `packages/client/src/lablink_client/conf/structured_config.py`
 
 ### Database Schema

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -200,13 +200,20 @@ their defaults without re-measuring:
 | Override | Default | Why |
 |---|---|---|
 | `xfwm4` `use_compositing: false` | on | The compositor recomposites the whole screen on every window move, so Xvnc sees one full-screen damage rect instead of a few small ones. |
-| `rect_encoding_mode.min_quality: 4` | 7 | The stock 7–8 band is pinned near maximum. KasmVNC varies quality within the band by how fast the screen is *changing*, not by network feedback, so the floor is what governs motion smoothness. |
-| `enter_video_encoding_mode.time_threshold: 2` | 5 | Sustained motion otherwise spends five seconds in per-rect JPEG/WebP before video mode engages. |
-| `scrolling.detect_vertical_scrolling: true` | off | Sends a cheap region shift instead of re-encoding the scrolled region. |
+| `-DynamicQualityMin 4` | 7 | The stock 7–8 band is pinned near maximum. KasmVNC varies quality within the band by how fast the screen is *changing*, not by network feedback, so the floor is what governs motion smoothness. |
+| `-VideoTime 2` | 5 | Sustained motion otherwise spends five seconds in per-rect JPEG/WebP before video mode engages. |
+| `-DetectScrolling 1` | off | Sends a cheap region shift instead of re-encoding the scrolled region. |
+
+The three encoder settings are passed on the `Xvnc` command line, not written
+to `~/.vnc/kasmvnc.yaml`. That file is read only by the `kasmvncserver` Perl
+wrapper, which `start.sh` bypasses to exec `Xvnc` directly, so tuning placed
+there is silently ignored.
 
 The compositing setting is written to the xfconf XML store rather than applied
 with `xfconf-query`, which would need the session dbus already up and would
-race `xfce4-session`.
+race `xfce4-session`. Turning the compositor off costs window drop shadows and
+ARGB transparency — `xfce4-terminal`'s transparent background, for instance,
+renders opaque. That is the trade, not a bug.
 
 **Configuration**: See `packages/client/src/lablink_client/conf/structured_config.py`
 

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -413,6 +413,23 @@ fi
 touch /home/client/.Xauthority
 chmod 600 /home/client/.Xauthority
 
+# XFCE's compositor recomposites the whole screen on every window move, so
+# Xvnc sees one full-screen damage rect instead of a few small ones and
+# re-encodes the entire framebuffer for each frame of a drag -- the single
+# largest source of choppy motion in the participant desktop. Write the
+# setting straight into the xfconf XML store rather than calling
+# `xfconf-query`, which needs the session dbus to already be up and would
+# race xfce4-session.
+mkdir -p /home/client/.config/xfce4/xfconf/xfce-perchannel-xml
+cat > /home/client/.config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml <<'XFWM'
+<?xml version="1.0" encoding="UTF-8"?>
+<channel name="xfwm4" version="1.0">
+  <property name="general" type="empty">
+    <property name="use_compositing" type="bool" value="false"/>
+  </property>
+</channel>
+XFWM
+
 # Pre-seed the xstartup script kasmvncserver invokes after Xkasmvnc is up.
 # We use `xfce4-session` (not the `startxfce4` wrapper) because the wrapper
 # tries to spawn its own Xorg, which fails in a container with no GPU node

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -449,13 +449,13 @@ chmod +x /home/client/.vnc/xstartup
 # a non-tty container, select-de.sh has no stdin and aborts the launch.
 touch /home/client/.vnc/.de-was-selected
 
-# kasmvncserver tries to open `network.ssl.pem_certificate` and `pem_key`
-# at startup regardless of `require_ssl`. The wrapper's defaults point at
-# /etc/ssl/private/ssl-cert-snakeoil.key, which the `client` user can't
-# read (root:ssl-cert 0640). Generate a fresh per-VM keypair under ~/.vnc/
-# and override the config to point at it. nginx terminates TLS at the
-# allocator, so we just need *some* valid keypair here; we never serve
-# it on the public path.
+# Inert, retained pending a separate cleanup. kasmvnc.yaml is read only by
+# the kasmvncserver Perl wrapper, which we bypass to exec Xvnc directly
+# (see the launch comment below) -- Xkasmvnc never opens the file. So these
+# cert paths are never read, this keypair is never used, and the unreadable
+# root:ssl-cert 0640 snakeoil key it was written to work around cannot be
+# reached in the first place. We run on the binary's compiled-in defaults.
+# Anything that must actually take effect belongs on the Xvnc argv.
 if [ ! -s /home/client/.vnc/kasmvnc.pem ]; then
   openssl req -x509 -newkey rsa:2048 -nodes \
     -keyout /home/client/.vnc/kasmvnc.key \
@@ -465,9 +465,10 @@ if [ ! -s /home/client/.vnc/kasmvnc.pem ]; then
   chmod 600 /home/client/.vnc/kasmvnc.key
 fi
 
-# Write the per-user kasmvnc.yaml that overrides the system-default cert
-# paths and disables SSL enforcement on the listener. nginx upstream is
-# plain ws:// because TLS is terminated one layer up at the allocator.
+# Same never-read consumer as the keypair above: this file only means
+# something to the Perl wrapper. Kept so that a future switch back to the
+# wrapper is not a rediscovery exercise. Do NOT add encoder settings here
+# -- they would be silently ignored. They go on the Xvnc argv below.
 cat > /home/client/.vnc/kasmvnc.yaml <<'KASMYAML'
 network:
   protocol: http
@@ -479,27 +480,6 @@ logging:
   log_writer_name: all
   log_dest: logfile
   level: 100
-# Encoder tuning. Without this block KasmVNC runs stock 1.4.0 defaults,
-# which hold near-maximum quality through a full-screen redraw and fall
-# behind rather than degrading -- the desktop never chooses to get cheaper
-# when it moves, which is what participants perceive as choppiness.
-encoding:
-  rect_encoding_mode:
-    # Stock band is 7-8, pinned near the top. KasmVNC varies quality within
-    # this band by how fast the screen is CHANGING, not by network feedback,
-    # so widening the floor is what buys smooth motion. It returns to 8 once
-    # the screen is static.
-    min_quality: 4
-    max_quality: 8
-  video_encoding_mode:
-    enter_video_encoding_mode:
-      # Stock 5s: a drag or scroll spends five seconds in per-rect
-      # JPEG/WebP before video mode engages. Note the matching exit
-      # threshold is 3s and is deliberately left at its default.
-      time_threshold: 2
-  scrolling:
-    # Ships off. Sends a cheap region shift instead of re-encoding.
-    detect_vertical_scrolling: true
 KASMYAML
 
 # Pick the KasmVNC auth scheme based on how the browser will reach us:
@@ -571,6 +551,23 @@ fi
 #      xterm pin below).
 # -interface 0.0.0.0 binds all interfaces; SG ingress (allocator SG only)
 # is the network-layer firewall.
+#
+# The three encoder flags are the desktop-responsiveness tuning. They are on
+# the argv rather than in kasmvnc.yaml *because* of the wrapper bypass above:
+# that file is parsed only by the wrapper, so an `encoding:` block there
+# never reaches this process. Stock KasmVNC never gets cheaper while the
+# screen moves -- it holds near-maximum quality through a full-screen redraw
+# and falls behind, which participants perceive as choppiness.
+#   -DynamicQualityMin 4  stock 7. The 7-8 band is pinned near the top, and
+#       KasmVNC varies quality within it by how fast the screen is CHANGING,
+#       not by network feedback, so the floor is what buys smooth motion. It
+#       returns to 8 once the screen is static. -DynamicQualityMax is left
+#       at its compiled default of 8.
+#   -VideoTime 2          stock 5. A drag or scroll otherwise spends five
+#       seconds in per-rect JPEG/WebP before video mode engages. The matching
+#       exit threshold is 3s and is deliberately left alone.
+#   -DetectScrolling 1    ships off. Sends a cheap region shift instead of
+#       re-encoding the scrolled region.
 stdbuf -oL -eL Xvnc :1 \
     -auth /home/client/.Xauthority \
     -desktop kasmvnc \
@@ -581,6 +578,9 @@ stdbuf -oL -eL Xvnc :1 \
     -localhost 0 \
     "${AUTH_ARGS[@]}" \
     -AlwaysShared 1 \
+    -DynamicQualityMin 4 \
+    -VideoTime 2 \
+    -DetectScrolling 1 \
     -noreset \
     2>&1 | sed -u 's/^/[kasmvnc] /' >&5 &
 

--- a/packages/client/start.sh
+++ b/packages/client/start.sh
@@ -468,18 +468,39 @@ fi
 # Write the per-user kasmvnc.yaml that overrides the system-default cert
 # paths and disables SSL enforcement on the listener. nginx upstream is
 # plain ws:// because TLS is terminated one layer up at the allocator.
-{
-  echo 'network:'
-  echo '  protocol: http'
-  echo '  ssl:'
-  echo '    require_ssl: false'
-  echo '    pem_certificate: /home/client/.vnc/kasmvnc.pem'
-  echo '    pem_key: /home/client/.vnc/kasmvnc.key'
-  echo 'logging:'
-  echo '  log_writer_name: all'
-  echo '  log_dest: logfile'
-  echo '  level: 100'
-} > /home/client/.vnc/kasmvnc.yaml
+cat > /home/client/.vnc/kasmvnc.yaml <<'KASMYAML'
+network:
+  protocol: http
+  ssl:
+    require_ssl: false
+    pem_certificate: /home/client/.vnc/kasmvnc.pem
+    pem_key: /home/client/.vnc/kasmvnc.key
+logging:
+  log_writer_name: all
+  log_dest: logfile
+  level: 100
+# Encoder tuning. Without this block KasmVNC runs stock 1.4.0 defaults,
+# which hold near-maximum quality through a full-screen redraw and fall
+# behind rather than degrading -- the desktop never chooses to get cheaper
+# when it moves, which is what participants perceive as choppiness.
+encoding:
+  rect_encoding_mode:
+    # Stock band is 7-8, pinned near the top. KasmVNC varies quality within
+    # this band by how fast the screen is CHANGING, not by network feedback,
+    # so widening the floor is what buys smooth motion. It returns to 8 once
+    # the screen is static.
+    min_quality: 4
+    max_quality: 8
+  video_encoding_mode:
+    enter_video_encoding_mode:
+      # Stock 5s: a drag or scroll spends five seconds in per-rect
+      # JPEG/WebP before video mode engages. Note the matching exit
+      # threshold is 3s and is deliberately left at its default.
+      time_threshold: 2
+  scrolling:
+    # Ships off. Sends a cheap region shift instead of re-encoding.
+    detect_vertical_scrolling: true
+KASMYAML
 
 # Pick the KasmVNC auth scheme based on how the browser will reach us:
 #   * allocator_proxied (AWS / default): allocator nginx attaches HTTP

--- a/packages/client/tests/test_start_sh_kasmvnc_tuning.py
+++ b/packages/client/tests/test_start_sh_kasmvnc_tuning.py
@@ -100,3 +100,55 @@ def test_xfwm4_config_written_before_the_session_launches(script_text):
         if "/home/client/.vnc/xstartup" in ln and "DISPLAY=:1" in ln
     )
     assert xml_at < launch_at
+
+
+@pytest.fixture(scope="module")
+def kasmvnc_yaml(generated) -> dict:
+    return yaml.safe_load((generated / ".vnc/kasmvnc.yaml").read_text())
+
+
+def test_encoding_is_a_top_level_key(kasmvnc_yaml):
+    """One indent level too deep and `encoding:` nests under `logging:`,
+    where KasmVNC ignores it silently -- no warning, no error, just the
+    stock defaults. This is the assertion a string grep cannot make."""
+    assert "encoding" in kasmvnc_yaml
+    assert "encoding" not in kasmvnc_yaml.get("logging", {})
+    assert "encoding" not in kasmvnc_yaml.get("network", {})
+
+
+def test_dynamic_quality_floor_is_widened(kasmvnc_yaml):
+    """Stock band is 7-8, pinned near maximum, so the encoder holds
+    near-lossless through a full-screen redraw and falls behind rather
+    than degrading. KasmVNC varies quality within this band by how fast
+    the screen is CHANGING -- not by network feedback -- so lowering the
+    floor is what buys smooth motion."""
+    rect = kasmvnc_yaml["encoding"]["rect_encoding_mode"]
+    assert rect["min_quality"] == 4
+    assert rect["max_quality"] == 8
+
+
+def test_video_mode_engages_sooner(kasmvnc_yaml):
+    """Stock 5s: a drag or scroll spends five seconds in per-rect
+    JPEG/WebP before video mode engages."""
+    video = kasmvnc_yaml["encoding"]["video_encoding_mode"]
+    assert video["enter_video_encoding_mode"]["time_threshold"] == 2
+
+
+def test_vertical_scroll_detection_is_enabled(kasmvnc_yaml):
+    """Ships off. Sends a cheap region shift instead of re-encoding the
+    scrolled region."""
+    scrolling = kasmvnc_yaml["encoding"]["scrolling"]
+    assert scrolling["detect_vertical_scrolling"] is True
+
+
+def test_heredoc_conversion_preserved_the_existing_settings(kasmvnc_yaml):
+    """The echo-line block became a heredoc in the same edit that added
+    `encoding:`. These four are what the old block existed for: without
+    them Xvnc will not start (unreadable snakeoil cert) or nginx cannot
+    reach it (require_ssl on a plain-ws upstream)."""
+    assert kasmvnc_yaml["network"]["protocol"] == "http"
+    assert kasmvnc_yaml["network"]["ssl"]["require_ssl"] is False
+    assert kasmvnc_yaml["network"]["ssl"]["pem_certificate"].endswith(
+        "/.vnc/kasmvnc.pem"
+    )
+    assert kasmvnc_yaml["logging"]["level"] == 100

--- a/packages/client/tests/test_start_sh_kasmvnc_tuning.py
+++ b/packages/client/tests/test_start_sh_kasmvnc_tuning.py
@@ -6,11 +6,13 @@ and launches long-running services -- so these extract just the two
 config-generator blocks, run them in a bash subprocess against a temporary
 HOME, and parse the files they produce.
 
-Parsing rather than grepping is the point for the YAML. `encoding:` must be
-a TOP-LEVEL key; appended one indent level too deep it nests under
-`logging:` and KasmVNC ignores it *without an error*. A string assertion
-passes on that broken config and the deployment silently keeps the stock
-defaults, which is exactly the bug this work exists to fix.
+The encoder tuning is asserted against the *Xvnc argv*, not against
+kasmvnc.yaml. That file is read only by the kasmvncserver Perl wrapper,
+which start.sh deliberately bypasses to exec Xvnc directly, so settings
+placed there are inert -- an earlier version of these tests passed while
+asserting on a file nothing in the deployment opens. Asserting on the
+extracted argv block (rather than grepping the whole script) also means a
+flag named only in a comment cannot satisfy a test.
 """
 
 import subprocess
@@ -25,8 +27,14 @@ START_SH = Path(__file__).resolve().parents[1] / "start.sh"
 # (marker that identifies the block's first line, exact closing line)
 BLOCKS = [
     ("mkdir -p /home/client/.config/xfce4/xfconf", "XFWM"),
-    ("cat > /home/client/.vnc/kasmvnc.yaml", "KASMYAML"),
+    # Starts at the `mkdir -p ~/.vnc` that creates the heredoc's parent
+    # directory, so the block has to prove it makes its own parent rather
+    # than leaning on a directory the fixture pre-created.
+    ("mkdir -p /home/client/.vnc", "KASMYAML"),
 ]
+
+XVNC_LAUNCH = "stdbuf -oL -eL Xvnc :1"
+XVNC_LAUNCH_CLOSER = "    2>&1 | sed -u 's/^/[kasmvnc] /' >&5 &"
 
 
 def _extract(script_text: str, start_contains: str, closer: str) -> str:
@@ -52,16 +60,18 @@ def generated(tmp_path_factory, script_text) -> Path:
     """Run both generator blocks with /home/client redirected at a tmpdir,
     and return that tmpdir."""
     home = tmp_path_factory.mktemp("home")
-    (home / ".vnc").mkdir()
     for marker, closer in BLOCKS:
         snippet = _extract(script_text, marker, closer).replace(
             "/home/client", str(home)
         )
         result = subprocess.run(
-            ["bash", "-c", snippet],
+            # `set -e` because returncode otherwise reflects only the last
+            # command in the snippet: a failing mkdir followed by a
+            # succeeding cat would look like a pass.
+            ["bash", "-c", "set -e\n" + snippet],
             capture_output=True,
             text=True,
-            timeout=10,
+            timeout=30,
         )
         assert result.returncode == 0, result.stderr
     return home
@@ -103,42 +113,53 @@ def test_xfwm4_config_written_before_the_session_launches(script_text):
 
 
 @pytest.fixture(scope="module")
-def kasmvnc_yaml(generated) -> dict:
-    return yaml.safe_load((generated / ".vnc/kasmvnc.yaml").read_text())
+def xvnc_argv(script_text) -> list[str]:
+    """The Xvnc launch command's tokens, line continuations collapsed.
+    Scoped to the launch block so comment text can't satisfy a test."""
+    block = _extract(script_text, XVNC_LAUNCH, XVNC_LAUNCH_CLOSER)
+    return block.replace("\\\n", " ").split()
 
 
-def test_encoding_is_a_top_level_key(kasmvnc_yaml):
-    """One indent level too deep and `encoding:` nests under `logging:`,
-    where KasmVNC ignores it silently -- no warning, no error, just the
-    stock defaults. This is the assertion a string grep cannot make."""
-    assert "encoding" in kasmvnc_yaml
-    assert "encoding" not in kasmvnc_yaml.get("logging", {})
-    assert "encoding" not in kasmvnc_yaml.get("network", {})
+def _flag_value(argv: list[str], flag: str) -> str:
+    """The token immediately following `flag`, which is how Xvnc reads its
+    options -- the adjacency is the thing worth asserting."""
+    assert flag in argv, f"{flag} is not on the Xvnc argv"
+    return argv[argv.index(flag) + 1]
 
 
-def test_dynamic_quality_floor_is_widened(kasmvnc_yaml):
+def test_dynamic_quality_floor_is_widened(xvnc_argv):
     """Stock band is 7-8, pinned near maximum, so the encoder holds
     near-lossless through a full-screen redraw and falls behind rather
     than degrading. KasmVNC varies quality within this band by how fast
     the screen is CHANGING -- not by network feedback -- so lowering the
     floor is what buys smooth motion."""
-    rect = kasmvnc_yaml["encoding"]["rect_encoding_mode"]
-    assert rect["min_quality"] == 4
-    assert rect["max_quality"] == 8
+    assert _flag_value(xvnc_argv, "-DynamicQualityMin") == "4"
 
 
-def test_video_mode_engages_sooner(kasmvnc_yaml):
+def test_video_mode_engages_sooner(xvnc_argv):
     """Stock 5s: a drag or scroll spends five seconds in per-rect
     JPEG/WebP before video mode engages."""
-    video = kasmvnc_yaml["encoding"]["video_encoding_mode"]
-    assert video["enter_video_encoding_mode"]["time_threshold"] == 2
+    assert _flag_value(xvnc_argv, "-VideoTime") == "2"
 
 
-def test_vertical_scroll_detection_is_enabled(kasmvnc_yaml):
+def test_vertical_scroll_detection_is_enabled(xvnc_argv):
     """Ships off. Sends a cheap region shift instead of re-encoding the
-    scrolled region."""
-    scrolling = kasmvnc_yaml["encoding"]["scrolling"]
-    assert scrolling["detect_vertical_scrolling"] is True
+    scrolled region. `1`, not `true`, matching -AlwaysShared/-localhost
+    in the same argv."""
+    assert _flag_value(xvnc_argv, "-DetectScrolling") == "1"
+
+
+@pytest.fixture(scope="module")
+def kasmvnc_yaml(generated) -> dict:
+    return yaml.safe_load((generated / ".vnc/kasmvnc.yaml").read_text())
+
+
+def test_yaml_carries_no_encoder_settings(kasmvnc_yaml):
+    """Regression guard. kasmvnc.yaml is parsed only by the kasmvncserver
+    Perl wrapper, and start.sh bypasses that wrapper to exec Xvnc
+    directly -- so an `encoding:` block here reads as working tuning and
+    does nothing at all. Encoder settings belong on the argv."""
+    assert "encoding" not in kasmvnc_yaml
 
 
 def test_heredoc_conversion_preserved_the_existing_settings(kasmvnc_yaml):

--- a/packages/client/tests/test_start_sh_kasmvnc_tuning.py
+++ b/packages/client/tests/test_start_sh_kasmvnc_tuning.py
@@ -1,0 +1,102 @@
+"""Structural tests for start.sh's XFCE compositing override and KasmVNC
+encoder tuning.
+
+start.sh isn't sourceable as a whole -- it `exec`s stdout through a tagger
+and launches long-running services -- so these extract just the two
+config-generator blocks, run them in a bash subprocess against a temporary
+HOME, and parse the files they produce.
+
+Parsing rather than grepping is the point for the YAML. `encoding:` must be
+a TOP-LEVEL key; appended one indent level too deep it nests under
+`logging:` and KasmVNC ignores it *without an error*. A string assertion
+passes on that broken config and the deployment silently keeps the stock
+defaults, which is exactly the bug this work exists to fix.
+"""
+
+import subprocess
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+import pytest
+import yaml
+
+START_SH = Path(__file__).resolve().parents[1] / "start.sh"
+
+# (marker that identifies the block's first line, exact closing line)
+BLOCKS = [
+    ("mkdir -p /home/client/.config/xfce4/xfconf", "XFWM"),
+    ("cat > /home/client/.vnc/kasmvnc.yaml", "KASMYAML"),
+]
+
+
+def _extract(script_text: str, start_contains: str, closer: str) -> str:
+    """Lines from the first line containing `start_contains` through the
+    next line exactly equal to `closer`, inclusive. The search for the
+    closer starts one line down because a heredoc's opening line also
+    contains its delimiter."""
+    lines = script_text.splitlines()
+    start = next(i for i, ln in enumerate(lines) if start_contains in ln)
+    end = next(
+        i for i in range(start + 1, len(lines)) if lines[i] == closer
+    )
+    return "\n".join(lines[start : end + 1])
+
+
+@pytest.fixture(scope="module")
+def script_text() -> str:
+    return START_SH.read_text()
+
+
+@pytest.fixture(scope="module")
+def generated(tmp_path_factory, script_text) -> Path:
+    """Run both generator blocks with /home/client redirected at a tmpdir,
+    and return that tmpdir."""
+    home = tmp_path_factory.mktemp("home")
+    (home / ".vnc").mkdir()
+    for marker, closer in BLOCKS:
+        snippet = _extract(script_text, marker, closer).replace(
+            "/home/client", str(home)
+        )
+        result = subprocess.run(
+            ["bash", "-c", snippet],
+            capture_output=True,
+            text=True,
+            timeout=10,
+        )
+        assert result.returncode == 0, result.stderr
+    return home
+
+
+@pytest.fixture(scope="module")
+def xfwm4_xml(generated) -> ET.Element:
+    path = (
+        generated
+        / ".config/xfce4/xfconf/xfce-perchannel-xml/xfwm4.xml"
+    )
+    return ET.parse(path).getroot()
+
+
+def test_xfwm4_channel_disables_compositing(xfwm4_xml):
+    """The compositor is what turns a window drag into one full-screen
+    damage rect, so Xvnc re-encodes the whole framebuffer per frame."""
+    assert xfwm4_xml.get("name") == "xfwm4"
+    general = xfwm4_xml.find("./property[@name='general']")
+    assert general is not None, "no <property name='general'> in channel"
+    prop = general.find("./property[@name='use_compositing']")
+    assert prop is not None, "use_compositing not set under general"
+    assert prop.get("type") == "bool"
+    assert prop.get("value") == "false"
+
+
+def test_xfwm4_config_written_before_the_session_launches(script_text):
+    """xfconf reads the XML store once, at session start. Written after
+    xfce4-session is up it would be ignored until the next boot -- and
+    there is no next boot inside one participant session."""
+    lines = script_text.splitlines()
+    xml_at = next(i for i, ln in enumerate(lines) if "xfwm4.xml" in ln)
+    launch_at = next(
+        i
+        for i, ln in enumerate(lines)
+        if "/home/client/.vnc/xstartup" in ln and "DISPLAY=:1" in ln
+    )
+    assert xml_at < launch_at


### PR DESCRIPTION
## Summary

- The participant desktop feels choppy because **nothing in the stack ever chooses to get cheaper when the screen is moving** — XFCE's compositor turns every window drag into one full-screen damage rect, and KasmVNC's dynamic quality band ships pinned at 7–8, so the encoder holds near-maximum quality through a full-screen redraw and falls behind.
- Four value changes fix that: disable compositing, and widen/retune three encoder knobs.
- Confirmed on a live client VM: window dragging is visibly smoother with the branch image. See "Live verification" below for what that does and does not establish.

## Changes Made

All in `packages/client/start.sh`, plus a docs note.

| Change | Mechanism | Stock |
|---|---|---|
| Disable XFCE compositing | `xfwm4.xml` written to the xfconf XML store before the session starts | on |
| `-DynamicQualityMin 4` | Xvnc argv | 7 |
| `-VideoTime 2` | Xvnc argv | 5 |
| `-DetectScrolling 1` | Xvnc argv | off |

`-DynamicQualityMax 8` is deliberately **not** passed — 8 is already the compiled default.

Also: `docs/architecture.md` gains a "Desktop performance" table recording why each non-default exists, so the next person doesn't tidy them away.

## Design Decisions

**Why the argv and not `kasmvnc.yaml`.** This is the correction the commit history shows. `~/.vnc/kasmvnc.yaml` is read **only** by the `kasmvncserver` Perl wrapper, which translates it into `Xvnc` flags — and `start.sh:562-585` deliberately bypasses that wrapper to exec `Xvnc` directly. An `encoding:` block in that file is inert. The first pass at this PR put the settings there and shipped three no-ops behind a green test suite.

Verified against the pinned artifact (`kasmvncserver_jammy_1.4.0_amd64.deb`, `Dockerfile:103`):

- `strings -a /usr/bin/Xkasmvnc | grep -c yaml` → **0**
- the same grep on `/usr/bin/kasmvncserver` → 6, and `file` reports it as a Perl script
- `/usr/bin/Xvnc` is an `update-alternatives` symlink to `Xkasmvnc`

The `1` boolean form is what KasmVNC's own wrapper emits: `CliOption.pm:36-44` renders options as `-$name '$value'`, and `DetectScrolling` uses that default renderer. It also matches the neighbouring `-AlwaysShared 1` already in this argv.

**Why the xfconf XML store rather than `xfconf-query`.** `xfconf-query` needs the session dbus already up, which would race `xfce4-session`. Writing the XML directly is race-free, and there is no `xfconfd` running at that point, so the usual "edit-while-cached gets clobbered on writeback" hazard doesn't apply.

**Why `min_quality` is the load-bearing knob.** KasmVNC varies quality within the band by how fast the screen is *changing* — not by network feedback. The stock 7–8 band is too narrow to degrade, so lowering the floor is what converts lag into briefly-softer motion.

## Live verification

Run on a real client VM against the branch image (`linux-amd64-latest-test`), not asserted from the diff.

**The desktop is measurably better to use.** Window dragging — the symptom that opened this investigation — is visibly smoother than on the stock image.

**What that does not establish:** the four knobs were tested as a set, so the improvement is not attributed per knob. `-DynamicQualityMin 4` and compositing-off carry articulable mechanisms and are the expected sources. `-VideoTime 2` and `-DetectScrolling 1` ride along on mechanism alone; an isolating A/B (scripted `xdotool` drag/scroll/idle workload, fps + Mbps off the Kasm stats panel, 3 runs each) would be needed to say either earns its place. Both are single-token argv entries and cheap to drop later if a regression ever points at them — video mode downscales to 1920×1080 with bilinear scaling and takes 3s to exit, and scroll detection can false-positive into artifacts at its 25% threshold.

**Xvnc started and accepted every flag** — a rejected parameter kills startup, so a live PID with these in its argv is the proof:

```
$ docker exec $(docker ps -q) pgrep -a Xvnc
59 Xvnc :1 -auth /home/client/.Xauthority -desktop kasmvnc \
  -httpd /usr/share/kasmvnc/www -rfbport 5901 -interface 0.0.0.0 \
  -websocketPort 6080 -localhost 0 -SecurityTypes None \
  -PasswordFile /home/client/.vnc/passwd \
  -KasmPasswordFile /home/client/.kasmpasswd -AlwaysShared 1 \
  -DynamicQualityMin 4 -VideoTime 2 -DetectScrolling 1 -noreset
```

This also settles the one syntax question worth having: `-DetectScrolling` is documented in the man page as a *bare* flag, so the `1` value form was the least certain part of this change. It is accepted.

**Compositing is genuinely off** — queried from the live `xfconfd`, so this proves the XML was read and honored rather than merely written:

```
$ docker exec -u client -e DISPLAY=:1 $(docker ps -q) \
    xfconf-query -c xfwm4 -p /general/use_compositing
false
```

## Testing

- Client: **163 passed** (baseline 156; +7 from the new test file)
- Allocator: **906 passed, 20 skipped** (unaffected; run because the rebase pulled in #437)
- `ruff check` clean across allocator, client, and cli
- `bash -n packages/client/start.sh` clean

**The tests were proven able to fail.** This matters because the first attempt shipped a green 163-test suite over three no-ops. The new tests extract the Xvnc argv block from `start.sh` and assert flag/value adjacency on the token list, so a flag named only in a comment cannot satisfy them. Five deliberate mutations were each confirmed to fail the matching test: `-DynamicQualityMin 4→7`, `-VideoTime` deleted, `-DetectScrolling 1→0`, an `encoding:` block reintroduced into the YAML, and the block's own `mkdir -p ~/.vnc` removed. A `set -e` fix was proven with a two-variable run showing a mid-block failure previously returned rc=0.

There is also a regression guard asserting the generated YAML carries **no** `encoding` key, so nobody moves these back.

## Incidental finding (not fixed here)

The **pre-existing** `network:`/`logging:` block in that same `kasmvnc.yaml` is inert for exactly the same reason. So `logging.level: 100` has never taken effect, and the `openssl` keypair generated at `start.sh:459-466` is dead work. Its comments asserted the opposite — and those comments are what produced the wrong first approach here.

The misleading comments are corrected in this PR. **Removing the machinery is deliberately left out of scope**, since it carries its own deployment risk and wants its own live test. One known-stale docstring remains in `test_heredoc_conversion_preserved_the_existing_settings`, to be cleaned up with it.

## Not in scope

Each considered and cut, recorded so they aren't silently re-litigated: `max_frame_rate` (no confident mechanism — if the encoder is already CPU-bound the cap does nothing, and if not, halving it makes the symptom worse), a solid desktop backdrop (second-order once compositing is off), `--shm-size` (governs how fast apps *draw*, not how fast the encoder *ships*), `detect_horizontal_scrolling`, and `desktop.gpu.hw3d` (KasmVNC 1.4 has a hardware-3D path that ships off — needs verifying `/dev/dri` is present under `--gpus all`).

Larger items the investigation surfaced: every pixel relays through one shared `t3.large` doing TLS + a userland `docker-proxy` copy + nginx, which is the concurrency cliff rather than a single-session framerate problem; and KasmVNC 1.4 ships a UDP transport with STUN that would answer TCP head-of-line blocking but is unusable while everything is proxied through nginx.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
