### PR TITLE
feat(cli): add `lablink client destroy` for tearing down the client fleet

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -427,7 +427,7 @@ These endpoints require HTTP Basic Authentication and are intended for administr
 
 **Endpoint:** `POST /destroy`
 
-**Description:** Runs `terraform destroy` to terminate all EC2 instances and associated resources created by LabLink. It also clears all records from the `vms` table in the database. **This is a destructive action.**
+**Description:** Runs `terraform destroy` to terminate all EC2 instances and associated resources created by LabLink. It also clears all records from the `vms` table in the database. **This is a destructive action.** Driven by `lablink client destroy`, and by `lablink destroy` as its first teardown step.
 
 **Authentication:** HTTP Basic Auth
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -201,6 +201,43 @@ Under the manual provider this command no-ops with a message pointing you at
 
 ---
 
+### `client destroy`
+
+Destroy all client VMs via the allocator service.
+
+```bash
+lablink client destroy [--config PATH] [--yes] [--verbose]
+```
+
+**AWS provider only.** Calls the allocator's destroy endpoint; the allocator runs
+`terraform destroy` over its own workspace, so Terraform is not required locally.
+
+This is the CLI equivalent of the admin UI's **Delete Instances** page. It leaves
+the allocator running — use [`destroy`](#destroy) to tear down the whole
+deployment.
+
+**Destructive.** Along with the VMs, this clears the allocator's `vms` table:
+inventory, per-VM logs, and session history are gone. Anyone connected at the
+time loses their session. Run
+[`export-metrics`](#export-metrics) with `--allocator` first if you need the
+numbers. Prompts for confirmation unless `--yes` is passed.
+
+If no client VMs were ever launched the command reports that and exits 0, so it
+is safe to re-run. If an apply or destroy is already in progress — someone using
+the admin UI at the same time — the allocator refuses and names the in-flight
+job.
+
+Under the manual provider this command no-ops with a message pointing you at
+[`client unregister`](#client-unregister).
+
+| Option | Description |
+|---|---|
+| `-c`, `--config PATH` | Path to `config.yaml`. |
+| `-y`, `--yes` | Skip the confirmation prompt. Password prompts still appear. |
+| `-v`, `--verbose` | Show the full Terraform output instead of a summary. |
+
+---
+
 ### `client register`
 
 Register this BYO box as a manual client and run the client container.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -223,9 +223,7 @@ time loses their session. Run
 numbers. Prompts for confirmation unless `--yes` is passed.
 
 If no client VMs were ever launched the command reports that and exits 0, so it
-is safe to re-run. If an apply or destroy is already in progress — someone using
-the admin UI at the same time — the allocator refuses and names the in-flight
-job.
+is safe to re-run.
 
 Under the manual provider this command no-ops with a message pointing you at
 [`client unregister`](#client-unregister).

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -12,7 +12,7 @@ app = typer.Typer(
 
 client_app = typer.Typer(
     name="client",
-    help="Manage the client fleet (register/launch/unregister).",
+    help="Manage the client fleet (register/launch/destroy/unregister).",
 )
 app.add_typer(client_app, name="client")
 
@@ -296,6 +296,41 @@ def launch_client(
     from lablink_cli.commands.launch import run_launch
 
     run_launch(_load_cfg(config), num_vms=num_vms, verbose=verbose)
+
+
+@client_app.command("destroy")
+def destroy_client(
+    config: str = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to config.yaml (default: ~/.lablink/config.yaml)",
+    ),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Skip confirmation prompts. Does not bypass credential prompts "
+        "(admin password still required interactively).",
+    ),
+    verbose: bool = typer.Option(
+        False,
+        "--verbose",
+        "-v",
+        help="Show the full Terraform output instead of a summary.",
+    ),
+) -> None:
+    """Destroy all client VMs via the allocator service.
+
+    AWS provider only: the allocator runs 'terraform destroy' over its own
+    workspace and clears the VM table. Leaves the allocator itself running
+    — use 'lablink destroy' to tear down the whole deployment. For the
+    manual provider, BYO operators run 'lablink client unregister' on each
+    box instead; this command no-ops with a friendly message.
+    """
+    from lablink_cli.commands.launch import run_client_destroy
+
+    run_client_destroy(_load_cfg(config), yes=yes, verbose=verbose)
 
 
 @app.command(rich_help_panel="Operations")

--- a/packages/cli/src/lablink_cli/commands/deploy.py
+++ b/packages/cli/src/lablink_cli/commands/deploy.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import re
 import shutil
 import subprocess
 import time
@@ -18,9 +17,11 @@ from lablink_allocator_service.conf.structured_config import Config
 from lablink_cli.commands.setup import check_credentials, _get_session
 from lablink_cli.commands.status import check_health_endpoint
 from lablink_cli.commands.utils import (
+    format_duration,
     get_allocator_url,
     get_deploy_dir,
     resolve_admin_credentials,
+    summarize_terraform,
 )
 from lablink_cli.api import (
     AllocatorAPI,
@@ -119,42 +120,6 @@ def _prepare_working_dir(
     return deploy_dir
 
 
-# Matches Terraform's `Apply complete!` and `Destroy complete!` summary lines.
-_APPLY_SUMMARY_RE = re.compile(
-    r"Apply complete!\s+Resources:\s+"
-    r"(\d+)\s+added,\s+(\d+)\s+changed,\s+(\d+)\s+destroyed",
-)
-_DESTROY_SUMMARY_RE = re.compile(
-    r"Destroy complete!\s+Resources:\s+(\d+)\s+destroyed",
-)
-
-
-def _summarize_terraform(output: str) -> str | None:
-    """Extract Terraform's apply/destroy summary line from raw output.
-
-    Returns None when neither summary matches — e.g., a no-op apply, an
-    interrupted run, or output captured before the trailing summary.
-    """
-    m = _APPLY_SUMMARY_RE.search(output)
-    if m:
-        added, changed, destroyed = m.groups()
-        return f"Resources: {added} added, {changed} changed, {destroyed} destroyed"
-    m = _DESTROY_SUMMARY_RE.search(output)
-    if m:
-        (destroyed,) = m.groups()
-        return f"Resources: {destroyed} destroyed"
-    return None
-
-
-def _format_duration(seconds: float) -> str:
-    """Render a duration as `1m 23s` or `45s`."""
-    seconds = int(seconds)
-    if seconds < 60:
-        return f"{seconds}s"
-    mins, secs = divmod(seconds, 60)
-    return f"{mins}m {secs}s"
-
-
 def _run_terraform(
     args: list[str],
     cwd: Path,
@@ -220,9 +185,9 @@ def _run_terraform(
         else:
             console.print(
                 f"  [green]✓ terraform {action}[/green]  "
-                f"[dim]({_format_duration(elapsed)})[/dim]"
+                f"[dim]({format_duration(elapsed)})[/dim]"
             )
-            summary = _summarize_terraform(output)
+            summary = summarize_terraform(output)
             if summary:
                 console.print(f"  {summary}")
 
@@ -690,10 +655,10 @@ def _destroy_client_vms(
         elapsed = time.monotonic() - started
         console.print(
             f"  [green]✓ client VMs destroyed[/green]  "
-            f"[dim]({_format_duration(elapsed)})[/dim]"
+            f"[dim]({format_duration(elapsed)})[/dim]"
         )
         output = (result or {}).get("output", "")
-        summary = _summarize_terraform(output)
+        summary = summarize_terraform(output)
         if summary:
             console.print(f"  {summary}")
         if verbose and output:

--- a/packages/cli/src/lablink_cli/commands/launch.py
+++ b/packages/cli/src/lablink_cli/commands/launch.py
@@ -2,9 +2,8 @@
 
 from __future__ import annotations
 
-import re
 import time
-from typing import Callable
+from typing import Callable, NoReturn
 
 import typer
 from rich.console import Console
@@ -20,47 +19,33 @@ from lablink_cli.api import (
     AllocatorUnavailableError,
 )
 from lablink_cli.commands.utils import (
+    format_duration,
     get_allocator_url,
     resolve_admin_credentials,
+    summarize_terraform,
 )
 
 console = Console()
 
 
-# Matches Terraform's `Apply complete!` and `Destroy complete!` summary lines.
-_APPLY_SUMMARY_RE = re.compile(
-    r"Apply complete!\s+Resources:\s+"
-    r"(\d+)\s+added,\s+(\d+)\s+changed,\s+(\d+)\s+destroyed",
-)
-_DESTROY_SUMMARY_RE = re.compile(
-    r"Destroy complete!\s+Resources:\s+(\d+)\s+destroyed",
-)
+def _resolve_api(cfg: Config) -> tuple[AllocatorAPI, str]:
+    """Build an allocator client from config, prompting for credentials if
+    they were never saved.
 
-
-def _summarize_terraform(output: str) -> str | None:
-    """Extract Terraform's apply/destroy summary line from raw output.
-
-    Returns None when neither summary matches — a no-op apply, an
-    interrupted run, or output captured before the trailing summary.
+    Returns ``(api, allocator_url)``; exits 1 if the deployment's URL
+    cannot be determined.
     """
-    m = _APPLY_SUMMARY_RE.search(output)
-    if m:
-        added, changed, destroyed = m.groups()
-        return f"Resources: {added} added, {changed} changed, {destroyed} destroyed"
-    m = _DESTROY_SUMMARY_RE.search(output)
-    if m:
-        (destroyed,) = m.groups()
-        return f"Resources: {destroyed} destroyed"
-    return None
+    allocator_url = get_allocator_url(cfg)
+    if not allocator_url:
+        console.print(
+            "[red]Could not determine allocator URL.[/red]\n"
+            "Run 'lablink deploy' first or check 'lablink status'."
+        )
+        raise SystemExit(1)
 
-
-def _format_duration(seconds: float) -> str:
-    """Render a duration as `1m 23s` or `45s`."""
-    seconds = int(seconds)
-    if seconds < 60:
-        return f"{seconds}s"
-    mins, secs = divmod(seconds, 60)
-    return f"{mins}m {secs}s"
+    admin_user, admin_pw = resolve_admin_credentials(cfg)
+    api = AllocatorAPI(allocator_url, admin_user, admin_pw, cfg.ssl.provider)
+    return api, allocator_url
 
 
 def _run_fleet_op(
@@ -76,7 +61,7 @@ def _run_fleet_op(
     the bar stays indeterminate rather than rendering a literal "None".
 
     Returns ``(result, elapsed_seconds)``. Exceptions from ``api_call``
-    propagate untouched — each caller maps them to its own messages.
+    propagate untouched — callers map them via ``_exit_fleet_error``.
     """
     started = time.monotonic()
     with Progress(
@@ -101,9 +86,57 @@ def _run_fleet_op(
     return result, time.monotonic() - started
 
 
+def _report(
+    result: dict | None,
+    elapsed: float,
+    *,
+    label: str,
+    verbose: bool,
+) -> None:
+    """Print the success line and Terraform's resource summary, plus the
+    raw Terraform output under ``verbose``."""
+    output = (result or {}).get("output", "")
+    console.print(
+        f"[green]✓ {label}[/green]  [dim]({format_duration(elapsed)})[/dim]"
+    )
+    summary = summarize_terraform(output)
+    if summary:
+        console.print(f"  {summary}")
+    if verbose and output:
+        console.print()
+        console.print("[bold]Terraform output:[/bold]")
+        console.print(output)
+    elif output:
+        console.print(
+            "  [dim]Pass --verbose to see full Terraform output.[/dim]"
+        )
+
+
+def _exit_fleet_error(e: AllocatorError, *, label: str) -> NoReturn:
+    """Report a failed fleet operation and exit 1.
+
+    Auth and connectivity failures get their own advice because the fix
+    differs. Everything else (409 already-in-progress, 405 unsupported,
+    poll timeout, HTTP 5xx) is reported verbatim under ``label`` — the
+    allocator's own message is more specific than anything we'd invent.
+    """
+    if isinstance(e, AllocatorAuthError):
+        console.print(
+            "[red]Authentication failed.[/red] Check your admin credentials."
+        )
+    elif isinstance(e, AllocatorUnavailableError):
+        console.print(f"[red]Could not connect to allocator:[/red] {e}")
+        console.print(
+            "  Check that the allocator is running with 'lablink status'."
+        )
+    else:
+        console.print(f"[red]{label}:[/red] {e}")
+    raise SystemExit(1)
+
+
 def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
     """Launch client VMs by calling the allocator /api/launch endpoint."""
-    if getattr(cfg, "provider", "aws") == "manual":
+    if cfg.provider == "manual":
         console.print(
             "Manual provider has no VMs to launch — each BYO box "
             "runs `lablink client register` to join the pool. See "
@@ -112,17 +145,7 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
         return
 
     console.print()
-
-    allocator_url = get_allocator_url(cfg)
-    if not allocator_url:
-        console.print(
-            "[red]Could not determine allocator URL.[/red]\n"
-            "Run 'lablink deploy' first or check 'lablink status'."
-        )
-        raise SystemExit(1)
-
-    admin_user, admin_pw = resolve_admin_credentials(cfg)
-    api = AllocatorAPI(allocator_url, admin_user, admin_pw, cfg.ssl.provider)
+    api, allocator_url = _resolve_api(cfg)
 
     console.print(f"  [dim]POST {allocator_url}/api/launch[/dim]")
     console.print()
@@ -134,44 +157,9 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
             ),
             description=f"[bold]Launching {num_vms} client VM(s)...[/bold]",
         )
-
-        output = (result or {}).get("output", "")
-        summary = _summarize_terraform(output)
-        console.print(
-            f"[green]✓ Launch successful[/green]  "
-            f"[dim]({_format_duration(elapsed)})[/dim]"
-        )
-        if summary:
-            console.print(f"  {summary}")
-        if verbose and output:
-            console.print()
-            console.print("[bold]Terraform output:[/bold]")
-            console.print(output)
-        elif output:
-            console.print(
-                "  [dim]Pass --verbose to see full Terraform "
-                "output.[/dim]"
-            )
-
-    except AllocatorAuthError:
-        console.print(
-            "[red]Authentication failed.[/red] "
-            "Check your admin credentials."
-        )
-        raise SystemExit(1)
-    except AllocatorUnavailableError as e:
-        console.print(
-            f"[red]Could not connect to allocator:[/red] {e}"
-        )
-        console.print(
-            "  Check that the allocator is running with 'lablink status'."
-        )
-        raise SystemExit(1)
+        _report(result, elapsed, label="Launch successful", verbose=verbose)
     except AllocatorError as e:
-        console.print(
-            f"[red]Launch failed:[/red] {e}"
-        )
-        raise SystemExit(1)
+        _exit_fleet_error(e, label="Launch failed")
 
     console.print()
     console.print(
@@ -192,7 +180,7 @@ def run_client_destroy(
         yes: Skip the confirmation prompt.
         verbose: Print the allocator's full Terraform output.
     """
-    if getattr(cfg, "provider", "aws") == "manual":
+    if cfg.provider == "manual":
         console.print(
             "Manual provider has no VMs to destroy — each BYO box "
             "leaves the pool by running `lablink client unregister` "
@@ -202,16 +190,7 @@ def run_client_destroy(
         return
 
     console.print()
-
-    allocator_url = get_allocator_url(cfg)
-    if not allocator_url:
-        console.print(
-            "[red]Could not determine allocator URL.[/red]\n"
-            "Run 'lablink deploy' first or check 'lablink status'."
-        )
-        raise SystemExit(1)
-
-    admin_user, admin_pw = resolve_admin_credentials(cfg)
+    api, allocator_url = _resolve_api(cfg)
 
     if not yes:
         console.print(
@@ -229,8 +208,6 @@ def run_client_destroy(
             return
         console.print()
 
-    api = AllocatorAPI(allocator_url, admin_user, admin_pw, cfg.ssl.provider)
-
     console.print(f"  [dim]POST {allocator_url}/destroy[/dim]")
     console.print()
 
@@ -239,45 +216,18 @@ def run_client_destroy(
             lambda on_progress: api.destroy_vms(on_progress=on_progress),
             description="[bold]Destroying client VMs...[/bold]",
         )
-
-        output = (result or {}).get("output", "")
-        summary = _summarize_terraform(output)
-        console.print(
-            f"[green]✓ client VMs destroyed[/green]  "
-            f"[dim]({_format_duration(elapsed)})[/dim]"
-        )
-        if summary:
-            console.print(f"  {summary}")
-        if verbose and output:
-            console.print()
-            console.print("[bold]Terraform output:[/bold]")
-            console.print(output)
-        elif output:
-            console.print(
-                "  [dim]Pass --verbose to see full Terraform output.[/dim]"
-            )
+        _report(result, elapsed, label="client VMs destroyed", verbose=verbose)
     except AllocatorNotFoundError:
         # Nothing was ever launched, so there is nothing to tear down.
-        # Not a failure: the command is idempotent.
+        # Not a failure: the command is idempotent. Must precede the
+        # AllocatorError clause below — it is a subclass.
         console.print(
             "[yellow]No client VMs were launched — "
             "nothing to destroy.[/yellow]"
         )
         return
-    except AllocatorAuthError:
-        console.print(
-            "[red]Authentication failed.[/red] Check your admin credentials."
-        )
-        raise SystemExit(1)
-    except AllocatorUnavailableError as e:
-        console.print(f"[red]Could not connect to allocator:[/red] {e}")
-        console.print(
-            "  Check that the allocator is running with 'lablink status'."
-        )
-        raise SystemExit(1)
     except AllocatorError as e:
-        console.print(f"[red]Client destroy failed:[/red] {e}")
-        raise SystemExit(1)
+        _exit_fleet_error(e, label="Client destroy failed")
 
     console.print()
     console.print(

--- a/packages/cli/src/lablink_cli/commands/launch.py
+++ b/packages/cli/src/lablink_cli/commands/launch.py
@@ -1,10 +1,12 @@
-"""Launch client VMs via the allocator service."""
+"""Launch and destroy client VMs via the allocator service."""
 
 from __future__ import annotations
 
 import re
 import time
+from typing import Callable
 
+import typer
 from rich.console import Console
 from rich.progress import BarColumn, Progress, SpinnerColumn, TextColumn
 
@@ -14,6 +16,7 @@ from lablink_cli.api import (
     AllocatorAPI,
     AllocatorAuthError,
     AllocatorError,
+    AllocatorNotFoundError,
     AllocatorUnavailableError,
 )
 from lablink_cli.commands.utils import (
@@ -24,21 +27,31 @@ from lablink_cli.commands.utils import (
 console = Console()
 
 
-# Matches `Apply complete! Resources: N added, N changed, N destroyed.`
+# Matches Terraform's `Apply complete!` and `Destroy complete!` summary lines.
 _APPLY_SUMMARY_RE = re.compile(
     r"Apply complete!\s+Resources:\s+"
     r"(\d+)\s+added,\s+(\d+)\s+changed,\s+(\d+)\s+destroyed",
 )
+_DESTROY_SUMMARY_RE = re.compile(
+    r"Destroy complete!\s+Resources:\s+(\d+)\s+destroyed",
+)
 
 
-def _summarize_apply(output: str) -> str | None:
-    """Extract the resource-counts line from `terraform apply` output.
-    Returns None if the line is missing (older Terraform, partial run, etc.)."""
+def _summarize_terraform(output: str) -> str | None:
+    """Extract Terraform's apply/destroy summary line from raw output.
+
+    Returns None when neither summary matches — a no-op apply, an
+    interrupted run, or output captured before the trailing summary.
+    """
     m = _APPLY_SUMMARY_RE.search(output)
-    if not m:
-        return None
-    added, changed, destroyed = m.groups()
-    return f"Resources: {added} added, {changed} changed, {destroyed} destroyed"
+    if m:
+        added, changed, destroyed = m.groups()
+        return f"Resources: {added} added, {changed} changed, {destroyed} destroyed"
+    m = _DESTROY_SUMMARY_RE.search(output)
+    if m:
+        (destroyed,) = m.groups()
+        return f"Resources: {destroyed} destroyed"
+    return None
 
 
 def _format_duration(seconds: float) -> str:
@@ -48,6 +61,44 @@ def _format_duration(seconds: float) -> str:
         return f"{seconds}s"
     mins, secs = divmod(seconds, 60)
     return f"{mins}m {secs}s"
+
+
+def _run_fleet_op(
+    api_call: Callable[..., dict | None],
+    *,
+    description: str,
+) -> tuple[dict | None, float]:
+    """Run a client-fleet operation under a progress bar.
+
+    ``api_call`` is invoked as ``api_call(on_progress=cb)``; the callback
+    updates the bar with the allocator's resource counts. The allocator
+    reports (None, None) if it predates progress reporting, in which case
+    the bar stays indeterminate rather than rendering a literal "None".
+
+    Returns ``(result, elapsed_seconds)``. Exceptions from ``api_call``
+    propagate untouched — each caller maps them to its own messages.
+    """
+    started = time.monotonic()
+    with Progress(
+        SpinnerColumn(),
+        TextColumn("[progress.description]{task.description}"),
+        BarColumn(),
+        console=console,
+        transient=True,
+    ) as progress:
+        task = progress.add_task(description, total=None)
+
+        def _on_progress(done, total):
+            if done is not None and total is not None:
+                progress.update(
+                    task,
+                    completed=done,
+                    total=total,
+                    description=f"{description} ({done}/{total} resources)",
+                )
+
+        result = api_call(on_progress=_on_progress)
+    return result, time.monotonic() - started
 
 
 def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
@@ -76,37 +127,16 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
     console.print(f"  [dim]POST {allocator_url}/api/launch[/dim]")
     console.print()
 
-    started = time.monotonic()
     try:
-        with Progress(
-            SpinnerColumn(),
-            TextColumn("[progress.description]{task.description}"),
-            BarColumn(),
-            console=console,
-            transient=True,
-        ) as progress:
-            task = progress.add_task(
-                f"[bold]Launching {num_vms} client VM(s)...[/bold]",
-                total=None,
-            )
-
-            def _on_progress(done, total):
-                if done is not None and total is not None:
-                    progress.update(
-                        task,
-                        completed=done,
-                        total=total,
-                        description=(
-                            f"[bold]Launching {num_vms} client VM(s)...[/bold] "
-                            f"({done}/{total} resources)"
-                        ),
-                    )
-
-            result = api.launch_vms(num_vms, on_progress=_on_progress)
-        elapsed = time.monotonic() - started
+        result, elapsed = _run_fleet_op(
+            lambda on_progress: api.launch_vms(
+                num_vms, on_progress=on_progress
+            ),
+            description=f"[bold]Launching {num_vms} client VM(s)...[/bold]",
+        )
 
         output = (result or {}).get("output", "")
-        summary = _summarize_apply(output)
+        summary = _summarize_terraform(output)
         console.print(
             f"[green]✓ Launch successful[/green]  "
             f"[dim]({_format_duration(elapsed)})[/dim]"
@@ -146,4 +176,111 @@ def run_launch(cfg: Config, num_vms: int, *, verbose: bool = False) -> None:
     console.print()
     console.print(
         "[dim]Run 'lablink status' to see client VMs.[/dim]"
+    )
+
+
+def run_client_destroy(
+    cfg: Config,
+    *,
+    yes: bool = False,
+    verbose: bool = False,
+) -> None:
+    """Destroy every client VM by calling the allocator's /destroy endpoint.
+
+    Args:
+        cfg: Loaded LabLink config.
+        yes: Skip the confirmation prompt.
+        verbose: Print the allocator's full Terraform output.
+    """
+    if getattr(cfg, "provider", "aws") == "manual":
+        console.print(
+            "Manual provider has no VMs to destroy — each BYO box "
+            "leaves the pool by running `lablink client unregister` "
+            "on that box. See `lablink status` for currently "
+            "registered clients."
+        )
+        return
+
+    console.print()
+
+    allocator_url = get_allocator_url(cfg)
+    if not allocator_url:
+        console.print(
+            "[red]Could not determine allocator URL.[/red]\n"
+            "Run 'lablink deploy' first or check 'lablink status'."
+        )
+        raise SystemExit(1)
+
+    admin_user, admin_pw = resolve_admin_credentials(cfg)
+
+    if not yes:
+        console.print(
+            "[bold yellow]This destroys ALL client VMs[/bold yellow] and "
+            "clears the allocator's VM table — inventory, per-VM logs, and "
+            "session history go with them. Any user connected right now "
+            "loses their session."
+        )
+        console.print(
+            "[dim]Export first if you need the numbers: "
+            "lablink export-metrics --allocator[/dim]"
+        )
+        if not typer.confirm("Destroy all client VMs?", default=False):
+            console.print("Aborted.")
+            return
+        console.print()
+
+    api = AllocatorAPI(allocator_url, admin_user, admin_pw, cfg.ssl.provider)
+
+    console.print(f"  [dim]POST {allocator_url}/destroy[/dim]")
+    console.print()
+
+    try:
+        result, elapsed = _run_fleet_op(
+            lambda on_progress: api.destroy_vms(on_progress=on_progress),
+            description="[bold]Destroying client VMs...[/bold]",
+        )
+
+        output = (result or {}).get("output", "")
+        summary = _summarize_terraform(output)
+        console.print(
+            f"[green]✓ client VMs destroyed[/green]  "
+            f"[dim]({_format_duration(elapsed)})[/dim]"
+        )
+        if summary:
+            console.print(f"  {summary}")
+        if verbose and output:
+            console.print()
+            console.print("[bold]Terraform output:[/bold]")
+            console.print(output)
+        elif output:
+            console.print(
+                "  [dim]Pass --verbose to see full Terraform output.[/dim]"
+            )
+    except AllocatorNotFoundError:
+        # Nothing was ever launched, so there is nothing to tear down.
+        # Not a failure: the command is idempotent.
+        console.print(
+            "[yellow]No client VMs were launched — "
+            "nothing to destroy.[/yellow]"
+        )
+        return
+    except AllocatorAuthError:
+        console.print(
+            "[red]Authentication failed.[/red] Check your admin credentials."
+        )
+        raise SystemExit(1)
+    except AllocatorUnavailableError as e:
+        console.print(f"[red]Could not connect to allocator:[/red] {e}")
+        console.print(
+            "  Check that the allocator is running with 'lablink status'."
+        )
+        raise SystemExit(1)
+    except AllocatorError as e:
+        console.print(f"[red]Client destroy failed:[/red] {e}")
+        raise SystemExit(1)
+
+    console.print()
+    console.print(
+        "[dim]Run 'lablink client launch --num-vms N' to refill the "
+        "pool.[/dim]"
     )

--- a/packages/cli/src/lablink_cli/commands/utils.py
+++ b/packages/cli/src/lablink_cli/commands/utils.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import re
 import subprocess
 from pathlib import Path
 
@@ -11,6 +12,45 @@ from rich.console import Console
 from lablink_allocator_service.conf.structured_config import Config
 
 console = Console()
+
+
+# ------------------------------------------------------------------
+# Terraform output formatting
+# ------------------------------------------------------------------
+# Matches Terraform's `Apply complete!` and `Destroy complete!` summary lines.
+_APPLY_SUMMARY_RE = re.compile(
+    r"Apply complete!\s+Resources:\s+"
+    r"(\d+)\s+added,\s+(\d+)\s+changed,\s+(\d+)\s+destroyed",
+)
+_DESTROY_SUMMARY_RE = re.compile(
+    r"Destroy complete!\s+Resources:\s+(\d+)\s+destroyed",
+)
+
+
+def summarize_terraform(output: str) -> str | None:
+    """Extract Terraform's apply/destroy summary line from raw output.
+
+    Returns None when neither summary matches — a no-op apply, an
+    interrupted run, or output captured before the trailing summary.
+    """
+    m = _APPLY_SUMMARY_RE.search(output)
+    if m:
+        added, changed, destroyed = m.groups()
+        return f"Resources: {added} added, {changed} changed, {destroyed} destroyed"
+    m = _DESTROY_SUMMARY_RE.search(output)
+    if m:
+        (destroyed,) = m.groups()
+        return f"Resources: {destroyed} destroyed"
+    return None
+
+
+def format_duration(seconds: float) -> str:
+    """Render a duration as `1m 23s` or `45s`."""
+    seconds = int(seconds)
+    if seconds < 60:
+        return f"{seconds}s"
+    mins, secs = divmod(seconds, 60)
+    return f"{mins}m {secs}s"
 
 
 # ------------------------------------------------------------------

--- a/packages/cli/tests/test_app.py
+++ b/packages/cli/tests/test_app.py
@@ -116,6 +116,13 @@ class TestCLICommands:
         assert result.exit_code == 0
         assert "num-vms" in _plain(result.output)
 
+    def test_destroy_client_command_exists(self):
+        result = runner.invoke(app, ["client", "destroy", "--help"])
+        assert result.exit_code == 0
+        output = _plain(result.output)
+        assert "--yes" in output
+        assert "--verbose" in output
+
     def test_logs_command_exists(self):
         result = runner.invoke(app, ["logs", "--help"])
         assert result.exit_code == 0

--- a/packages/cli/tests/test_launch.py
+++ b/packages/cli/tests/test_launch.py
@@ -9,9 +9,31 @@ import pytest
 from lablink_cli.api import (
     AllocatorAuthError,
     AllocatorError,
+    AllocatorNotFoundError,
     AllocatorUnavailableError,
 )
-from lablink_cli.commands.launch import run_launch
+from lablink_cli.commands.launch import run_client_destroy, run_launch
+
+
+class TestSummarizeTerraform:
+    def test_matches_apply_summary(self):
+        from lablink_cli.commands.launch import _summarize_terraform
+
+        output = "Apply complete! Resources: 3 added, 0 changed, 0 destroyed."
+        assert _summarize_terraform(output) == (
+            "Resources: 3 added, 0 changed, 0 destroyed"
+        )
+
+    def test_matches_destroy_summary(self):
+        from lablink_cli.commands.launch import _summarize_terraform
+
+        output = "Destroy complete! Resources: 7 destroyed."
+        assert _summarize_terraform(output) == "Resources: 7 destroyed"
+
+    def test_returns_none_when_no_summary(self):
+        from lablink_cli.commands.launch import _summarize_terraform
+
+        assert _summarize_terraform("terraform init\nno summary here") is None
 
 
 class TestRunLaunch:
@@ -238,6 +260,168 @@ class TestManualLaunchNoOp:
     ):
         mock_cfg.provider = "manual"
         run_launch(mock_cfg, num_vms=3, verbose=False)
+        mock_url.assert_not_called()
+        mock_creds.assert_not_called()
+        mock_api_cls.assert_not_called()
+
+
+class TestRunClientDestroy:
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_no_allocator_url_exits(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg
+    ):
+        mock_url.return_value = ""
+
+        with pytest.raises(SystemExit):
+            run_client_destroy(mock_cfg, yes=True)
+
+        mock_api_cls.assert_not_called()
+
+    @patch("lablink_cli.commands.launch.typer.confirm")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_declining_confirmation_touches_nothing(
+        self, mock_url, mock_creds, mock_api_cls, mock_confirm, mock_cfg
+    ):
+        mock_url.return_value = "http://1.2.3.4"
+        mock_creds.return_value = ("admin", "password")
+        mock_confirm.return_value = False
+
+        run_client_destroy(mock_cfg, yes=False)
+
+        mock_api_cls.return_value.destroy_vms.assert_not_called()
+
+    @patch("lablink_cli.commands.launch.typer.confirm")
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_yes_skips_the_prompt(
+        self, mock_url, mock_creds, mock_api_cls, mock_confirm, mock_cfg
+    ):
+        mock_url.return_value = "http://1.2.3.4"
+        mock_creds.return_value = ("admin", "password")
+        mock_api = MagicMock()
+        mock_api.destroy_vms.return_value = {"status": "success", "output": ""}
+        mock_api_cls.return_value = mock_api
+
+        run_client_destroy(mock_cfg, yes=True)
+
+        mock_confirm.assert_not_called()
+        mock_api.destroy_vms.assert_called_once()
+        assert callable(mock_api.destroy_vms.call_args.kwargs["on_progress"])
+
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_success_prints_destroy_summary(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg, capsys
+    ):
+        mock_url.return_value = "http://1.2.3.4"
+        mock_creds.return_value = ("admin", "password")
+        mock_api = MagicMock()
+        mock_api.destroy_vms.return_value = {
+            "status": "success",
+            "output": "Destroy complete! Resources: 4 destroyed.",
+        }
+        mock_api_cls.return_value = mock_api
+
+        run_client_destroy(mock_cfg, yes=True)
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "client VMs destroyed" in out
+        assert "Resources: 4 destroyed" in out
+
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_verbose_prints_raw_output(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg, capsys
+    ):
+        mock_url.return_value = "http://1.2.3.4"
+        mock_creds.return_value = ("admin", "password")
+        mock_api = MagicMock()
+        mock_api.destroy_vms.return_value = {
+            "status": "success",
+            "output": "aws_instance.x: Destroying...",
+        }
+        mock_api_cls.return_value = mock_api
+
+        run_client_destroy(mock_cfg, yes=True, verbose=True)
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "aws_instance.x: Destroying" in out
+        assert "Pass --verbose" not in out
+
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_no_vms_launched_is_not_a_failure(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg, capsys
+    ):
+        """Nothing launched means nothing to destroy — idempotent, exit 0."""
+        mock_url.return_value = "http://1.2.3.4"
+        mock_creds.return_value = ("admin", "password")
+        mock_api = MagicMock()
+        mock_api.destroy_vms.side_effect = AllocatorNotFoundError(
+            "tfvars does not exist — no client VMs were launched"
+        )
+        mock_api_cls.return_value = mock_api
+
+        # Must NOT raise.
+        run_client_destroy(mock_cfg, yes=True)
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "No client VMs were launched" in out
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            AllocatorAuthError("Authentication failed"),
+            AllocatorUnavailableError("connection refused"),
+            AllocatorError("An operation is already in progress (job #7)"),
+        ],
+    )
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_failures_exit_one(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg, exc
+    ):
+        mock_url.return_value = "http://1.2.3.4"
+        mock_creds.return_value = ("admin", "password")
+        mock_api = MagicMock()
+        mock_api.destroy_vms.side_effect = exc
+        mock_api_cls.return_value = mock_api
+
+        with pytest.raises(SystemExit) as excinfo:
+            run_client_destroy(mock_cfg, yes=True)
+
+        assert excinfo.value.code == 1
+
+
+class TestManualDestroyNoOp:
+    def test_manual_provider_points_at_unregister(self, capsys, mock_cfg):
+        mock_cfg.provider = "manual"
+
+        run_client_destroy(mock_cfg, yes=True)
+
+        out = " ".join(capsys.readouterr().out.split())
+        assert "Manual provider" in out
+        assert "lablink client unregister" in out
+
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_manual_provider_does_not_touch_allocator(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg
+    ):
+        mock_cfg.provider = "manual"
+
+        run_client_destroy(mock_cfg, yes=True)
+
         mock_url.assert_not_called()
         mock_creds.assert_not_called()
         mock_api_cls.assert_not_called()

--- a/packages/cli/tests/test_launch.py
+++ b/packages/cli/tests/test_launch.py
@@ -15,27 +15,6 @@ from lablink_cli.api import (
 from lablink_cli.commands.launch import run_client_destroy, run_launch
 
 
-class TestSummarizeTerraform:
-    def test_matches_apply_summary(self):
-        from lablink_cli.commands.launch import _summarize_terraform
-
-        output = "Apply complete! Resources: 3 added, 0 changed, 0 destroyed."
-        assert _summarize_terraform(output) == (
-            "Resources: 3 added, 0 changed, 0 destroyed"
-        )
-
-    def test_matches_destroy_summary(self):
-        from lablink_cli.commands.launch import _summarize_terraform
-
-        output = "Destroy complete! Resources: 7 destroyed."
-        assert _summarize_terraform(output) == "Resources: 7 destroyed"
-
-    def test_returns_none_when_no_summary(self):
-        from lablink_cli.commands.launch import _summarize_terraform
-
-        assert _summarize_terraform("terraform init\nno summary here") is None
-
-
 class TestRunLaunch:
     @patch("lablink_cli.commands.launch.resolve_admin_credentials")
     @patch("lablink_cli.commands.launch.get_allocator_url")
@@ -403,7 +382,12 @@ class TestRunClientDestroy:
 
 
 class TestManualDestroyNoOp:
-    def test_manual_provider_points_at_unregister(self, capsys, mock_cfg):
+    @patch("lablink_cli.commands.launch.AllocatorAPI")
+    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
+    @patch("lablink_cli.commands.launch.get_allocator_url")
+    def test_manual_provider_points_at_unregister_and_touches_nothing(
+        self, mock_url, mock_creds, mock_api_cls, mock_cfg, capsys
+    ):
         mock_cfg.provider = "manual"
 
         run_client_destroy(mock_cfg, yes=True)
@@ -411,17 +395,6 @@ class TestManualDestroyNoOp:
         out = " ".join(capsys.readouterr().out.split())
         assert "Manual provider" in out
         assert "lablink client unregister" in out
-
-    @patch("lablink_cli.commands.launch.AllocatorAPI")
-    @patch("lablink_cli.commands.launch.resolve_admin_credentials")
-    @patch("lablink_cli.commands.launch.get_allocator_url")
-    def test_manual_provider_does_not_touch_allocator(
-        self, mock_url, mock_creds, mock_api_cls, mock_cfg
-    ):
-        mock_cfg.provider = "manual"
-
-        run_client_destroy(mock_cfg, yes=True)
-
         mock_url.assert_not_called()
         mock_creds.assert_not_called()
         mock_api_cls.assert_not_called()

--- a/packages/cli/tests/test_utils.py
+++ b/packages/cli/tests/test_utils.py
@@ -25,7 +25,23 @@ from lablink_cli.commands.utils import (
     get_allocator_vm,
     get_client_vms,
     list_all_vms,
+    summarize_terraform,
 )
+
+
+class TestSummarizeTerraform:
+    def test_matches_apply_summary(self):
+        output = "Apply complete! Resources: 3 added, 0 changed, 0 destroyed."
+        assert summarize_terraform(output) == (
+            "Resources: 3 added, 0 changed, 0 destroyed"
+        )
+
+    def test_matches_destroy_summary(self):
+        output = "Destroy complete! Resources: 7 destroyed."
+        assert summarize_terraform(output) == "Resources: 7 destroyed"
+
+    def test_returns_none_when_no_summary(self):
+        assert summarize_terraform("terraform init\nno summary here") is None
 
 
 def _client_error(code: str) -> ClientError:


### PR DESCRIPTION
## Summary

- Adds `lablink client destroy` — tears down every client VM through the allocator, leaving the allocator itself running.
- Closes a web-admin/CLI parity gap: the admin UI has had a "Run terraform destroy" button (`/admin/delete-instances`) since forever, but from the CLI the only way to reach it was `lablink destroy`, which also destroys the allocator.
- No new machinery. `AllocatorAPI.destroy_vms()` already submits `POST /destroy` and polls `/api/operations/<id>` with progress callbacks — `lablink destroy` has been using it as its first teardown step all along. This exposes it as a standalone command.
- **Net effect on the codebase is a wash, by design:** the second commit pays back the duplication the first one introduced, so ~440 lines of feature became ~340 with `deploy.py` also getting lighter.

## Two commits

**`bf5f0dbd feat(cli): add lablink client destroy`** — the feature.

**`754c4f9a refactor(cli): cut the duplication the first commit left behind`** — a complexity-focused review of that commit found it had extracted the wrong seam. Same behavior, 58 fewer lines. Worth reading second-commit-first if you want the shape it landed in.

## Changes Made

**`packages/cli/src/lablink_cli/commands/utils.py`** — now owns `summarize_terraform()` and `format_duration()`. Both previously existed byte-identically in `deploy.py` and (as of the first commit) `launch.py`; `utils.py` is a module both already imported from.

**`packages/cli/src/lablink_cli/commands/launch.py`** — `run_launch` and `run_client_destroy` are now thin, sharing four helpers:

| Helper | Replaces |
|---|---|
| `_resolve_api(cfg)` | the URL-resolve / exit / credentials / `AllocatorAPI` block, duplicated verbatim |
| `_run_fleet_op(api_call, *, description)` | the progress bar, timing, and `on_progress` wiring |
| `_report(result, elapsed, *, label, verbose)` | the success line / Terraform summary / `--verbose` block, duplicated verbatim |
| `_exit_fleet_error(e, *, label)` | three `except` clauses that differed only in one label string |

`run_client_destroy()` itself:
- **Manual provider** no-ops with a pointer to `lablink client unregister`, mirroring `run_launch`. The allocator's `can_destroy_hosts` is `False` there, so the request would come back 405.
- **Confirmation prompt** (skippable with `-y`) spelling out what the web UI's `confirm()` dialog leaves implicit: this clears the `vms` table, so inventory, per-VM logs, and session history go with the VMs. Prints the `export-metrics --allocator` escape hatch first.

**`packages/cli/src/lablink_cli/commands/deploy.py`** — drops its copies of the two helpers and its now-unused `import re`. No behavior change.

**`packages/cli/src/lablink_cli/app.py`** — registers `client destroy` with `-c/--config`, `-y/--yes`, `-v/--verbose` (same surface as `client launch` plus the `-y` that `lablink destroy` already has). Also updated the `client` group's help text, which enumerated subcommands and would otherwise have been wrong.

**Docs** — new `### client destroy` section in `docs/reference/cli.md`; the "Destroy All VMs" entry in `docs/api-endpoints.md` now names its CLI drivers.

## Error handling

Ordering matters: `AllocatorNotFoundError` subclasses `AllocatorError`, so destroy's clause for it must come first.

| Condition | Behavior | Exit |
|---|---|---|
| No client VMs were ever launched | yellow "nothing to destroy" | **0** — idempotent, safe to re-run |
| Bad admin credentials | red, check credentials | 1 |
| Allocator unreachable | red, points at `lablink status` | 1 |
| Apply/destroy already in progress (409), provider can't destroy (405), poll timeout | red, surfaces the allocator's own message — which names the in-flight job id in the 409 case | 1 |

The 409 matters in practice: if someone hits destroy in the admin UI first, the allocator refuses the second job rather than running two Terraform operations at once.

## Testing

**781 passed, 1 deselected** in the CLI suite; `ruff check packages/cli` clean.

New coverage:
- `summarize_terraform` against apply output, destroy output, and output with no summary line (in `test_utils.py`, alongside the function)
- manual provider no-ops without constructing `AllocatorAPI` or resolving credentials
- declining the confirmation leaves `destroy_vms` uncalled; `-y` skips the prompt entirely
- success path renders the `Resources: N destroyed` summary; `--verbose` swaps the summary for raw Terraform output
- `AllocatorNotFoundError` does **not** raise
- one case per failure row above, asserting exit code 1
- `run_launch`'s pre-existing tests as the regression gate for both refactors, including the exact progress-description string — they were never edited

Not covered: a live run against a real deployment — that needs an AWS deployment with VMs up. Worth doing before merge: `lablink client launch --num-vms 1`, then `lablink client destroy`, confirming the VM leaves `lablink status` while the allocator stays healthy.

## Design Decisions

**Why `launch.py` and not a new module.** Launch and destroy are the same operation family — submit an allocator job, poll it, render progress. A new module would either duplicate the shared helpers or import the 27 KB `deploy.py`, which `launch.py` deliberately avoids. Renaming the module to something fleet-shaped was considered and skipped: it touches test imports for zero behavior change.

**Why not reuse `deploy.py`'s `_destroy_client_vms()`.** Its error paths print "Continuing with allocator terraform destroy…", which is wrong for a standalone command that has nothing to continue to. Auth failure there aborts a teardown mid-flight; here it should just exit.

**"Nothing launched" is a success, not a 404.** Failing would make the command non-idempotent for no benefit — there is no fleet, which is the state the caller asked for.

**No VM count in the prompt.** Considered showing "3 VMs (2 in use). Continue?" — it costs an extra `GET /api/vm-status` plus a 404-when-empty branch, and `lablink status` already answers that question. The admin UI's dialog shows no count either.

**Two intentional micro-changes in the second commit.** `AllocatorAPI` is now constructed before the confirmation prompt rather than after (its constructor does no I/O), and a Config-like object lacking `provider` now raises instead of silently defaulting to `"aws"` — the real `Config` always defines it, and `app.py` already read it directly.

**Out of scope: per-VM selective destroy.** The allocator has no endpoint for it — `destroy_hosts` ignores its handles argument and runs `terraform destroy` over the whole workspace. Would need allocator-side work first.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LQCah1yEBs2Co4rhiFnMCS
