### PR TITLE
feat(cli): add `lablink configure --template` so template repos get the TUI

### DIFF
--- a/docs/quickstart-template.md
+++ b/docs/quickstart-template.md
@@ -68,18 +68,31 @@ It automatically:
 
 After setup completes, the script automatically runs `./scripts/configure.sh` to generate your deployment configuration.
 
-The configure script prompts for:
+Either tool below writes the same `lablink-infrastructure/config/config.yaml`, with the same prompts — instance type and AMI settings, DNS and SSL configuration. Pick whichever you prefer.
 
-- Instance type and AMI settings
-- DNS and SSL configuration
+=== "Shell script (no install)"
 
-It generates `lablink-infrastructure/config/config.yaml` with your settings.
-
-!!! note "Re-running Configuration"
-    You can re-run the configuration script at any time to update settings:
     ```bash
     ./scripts/configure.sh
     ```
+
+    Included in the template repo, so there is nothing extra to install.
+
+=== "TUI wizard (recommended)"
+
+    ```bash
+    uv tool install lablink-cli
+    lablink configure --template
+    ```
+
+    The same interactive wizard the [CLI quickstart](cli/first-deployment.md) uses — arrow-key menus, live validation, and a built-in editor for custom startup scripts. Run it from your repository root.
+
+    `--template` is what makes it write the repo's config file instead of `~/.lablink/config.yaml`, fill in the password placeholders the deploy workflow expects, and skip the AWS state setup that Step 2 already did. See the [CLI reference](reference/cli.md#configuring-a-template-repo) for details.
+
+Both tools leave the passwords as `PLACEHOLDER_ADMIN_PASSWORD` and `PLACEHOLDER_DB_PASSWORD`. The Terraform Deploy workflow replaces them with the `ADMIN_PASSWORD` and `DB_PASSWORD` secrets that Step 2 created, so the config file is safe to commit — and you should leave those two values alone.
+
+!!! note "Re-running Configuration"
+    You can re-run either tool at any time to update settings; both load your existing values as the defaults.
 
 ## Step 4: Commit and Deploy
 

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -35,7 +35,7 @@ one notes its manual-provider behavior inline. For the two modes side by side se
 Create or edit the LabLink configuration.
 
 ```bash
-lablink configure [--config PATH]
+lablink configure [--config PATH] [--template]
 ```
 
 Launches a TUI wizard that generates or edits `config.yaml`. On an AWS-provider
@@ -49,6 +49,43 @@ existing values as the defaults.
 | Option | Description |
 |---|---|
 | `-c`, `--config PATH` | Path to `config.yaml`. Default: `~/.lablink/config.yaml`. |
+| `--template` | Configure a [template repo](../quickstart-template.md) checkout instead of the local deployment. |
+
+#### Configuring a template repo
+
+`--template` points the same wizard at a
+[lablink-template](https://github.com/talmolab/lablink-template) checkout, so
+deployments driven by GitHub Actions get the TUI too rather than only the
+`scripts/configure.sh` prompts. Run it from the repository root:
+
+```bash
+lablink configure --template
+```
+
+It differs from a normal run in three ways:
+
+- Writes `lablink-infrastructure/config/config.yaml` — the file the Terraform
+  Deploy workflow reads — instead of `~/.lablink/config.yaml`.
+- Writes `PLACEHOLDER_ADMIN_PASSWORD` and `PLACEHOLDER_DB_PASSWORD` in place of
+  real passwords, which the workflow substitutes with your `ADMIN_PASSWORD` and
+  `DB_PASSWORD` repository secrets at deploy time. **The generated file is safe
+  to commit; it never contains a password.**
+- Skips the automatic [`setup`](#setup) step, because the template's
+  `scripts/setup.sh` already created the state bucket and lock table.
+
+Commit the result and push to deploy:
+
+```bash
+git add lablink-infrastructure/config/config.yaml
+git commit -m "Update deployment configuration"
+git push
+```
+
+!!! warning "Don't hand-edit the password fields"
+    Leave the two `PLACEHOLDER_*` values exactly as written. The deploy workflow
+    matches them literally, and its safety check only catches placeholders left
+    *un*-substituted — a config with real-looking passwords in those fields
+    passes the check and deploys without ever reading your secrets.
 
 ---
 

--- a/packages/cli/src/lablink_cli/app.py
+++ b/packages/cli/src/lablink_cli/app.py
@@ -18,6 +18,41 @@ app.add_typer(client_app, name="client")
 
 DEFAULT_CONFIG = Path.home() / ".lablink" / "config.yaml"
 
+# Where a lablink-template checkout keeps its committed config.
+TEMPLATE_CONFIG = Path("lablink-infrastructure") / "config" / "config.yaml"
+
+# The credential fields template mode pins, matching what the template's own
+# scripts/configure.sh emits: passwords as sentinels for CI to substitute,
+# admin_user as the literal the workflow never touches.
+TEMPLATE_CREDENTIALS = {
+    ("app", "admin_user"): "admin",
+    ("app", "admin_password"): "PLACEHOLDER_ADMIN_PASSWORD",
+    ("db", "password"): "PLACEHOLDER_DB_PASSWORD",
+}
+
+
+def _write_template_credentials(path: Path) -> None:
+    """Rewrite the wizard's credential defaults to the template's convention.
+
+    lablink-template commits config.yaml and injects the real passwords in
+    CI with ``sed s/PLACEHOLDER_<NAME>/.../``. The wizard never collects
+    credentials (they're resolved at deploy time on the local path), so it
+    writes the ``MISSING`` secret sentinel and the ``db.password`` default —
+    neither of which that sed matches. Without this the substitution
+    silently does nothing, and the workflow's own ``grep -q PLACEHOLDER_``
+    guard still passes, because it only catches placeholders left over, not
+    placeholders that were never there. ``admin_user`` gets no sed at all,
+    so it has to be a usable value here rather than a sentinel.
+    """
+    import yaml
+
+    data = yaml.safe_load(path.read_text())
+    for (section, key), value in TEMPLATE_CREDENTIALS.items():
+        data.setdefault(section, {})[key] = value
+    path.write_text(
+        yaml.dump(data, default_flow_style=False, sort_keys=False)
+    )
+
 
 def _version_callback(value: bool) -> None:
     if value:
@@ -92,6 +127,14 @@ def configure(
         "-c",
         help="Path to config.yaml (default: ~/.lablink/config.yaml)",
     ),
+    template: bool = typer.Option(
+        False,
+        "--template",
+        help="Configure a lablink-template checkout instead of the local "
+        "deployment: writes lablink-infrastructure/config/config.yaml with "
+        "PLACEHOLDER_* passwords for GitHub Actions to substitute, and "
+        "skips AWS state setup (the template's setup.sh does that).",
+    ),
 ) -> None:
     """Create or edit the LabLink configuration.
 
@@ -99,10 +142,28 @@ def configure(
     then automatically creates the AWS resources needed for
     Terraform remote state (S3 bucket + DynamoDB lock table).
     Manual-provider configs skip the AWS setup step.
+
+    With --template, generates the config a lablink-template repo commits
+    and deploys via GitHub Actions, so that path gets the same wizard.
     """
     from lablink_cli.tui.wizard import ConfigWizard
 
-    config_path = Path(config) if config else DEFAULT_CONFIG
+    if config:
+        config_path = Path(config)
+    elif template:
+        config_path = TEMPLATE_CONFIG
+        # Same guard as the template's own scripts/configure.sh: without it
+        # a wrong cwd silently creates a stray lablink-infrastructure/ tree
+        # that no workflow will ever read.
+        if not TEMPLATE_CONFIG.parent.parent.is_dir():
+            typer.echo(
+                "--template must be run from the root of a lablink-template "
+                f"checkout ({TEMPLATE_CONFIG.parent.parent}/ not found).\n"
+                "Pass --config to write somewhere else."
+            )
+            raise typer.Exit(1)
+    else:
+        config_path = DEFAULT_CONFIG
 
     existing = None
     if config_path.exists():
@@ -114,6 +175,17 @@ def configure(
     # After the wizard saves config, run AWS setup automatically
     if not config_path.exists():
         # User quit the wizard without saving
+        return
+
+    if template:
+        _write_template_credentials(config_path)
+        from rich.console import Console
+
+        Console().print(
+            f"[dim]Wrote {config_path} with placeholder passwords. "
+            "Commit it and push — the Terraform Deploy workflow "
+            "substitutes your ADMIN_PASSWORD/DB_PASSWORD secrets.[/dim]"
+        )
         return
 
     cfg_after = load_config(config_path)

--- a/packages/cli/tests/test_app.py
+++ b/packages/cli/tests/test_app.py
@@ -566,3 +566,86 @@ def test_deploy_help_documents_the_cloudflare_token_flag():
     result = runner.invoke(app, ["deploy", "--help"])
     assert result.exit_code == 0
     assert "--cloudflare-tunnel-token" in _plain(result.output)
+
+
+# ------------------------------------------------------------------
+# configure --template (issue #339: give Path B users the TUI)
+# ------------------------------------------------------------------
+class TestConfigureTemplate:
+    """--template must emit the sentinels lablink-template's CI sed matches."""
+
+    @staticmethod
+    def _fake_wizard(mock_wizard_cls, config_path: Path):
+        """Stand in for the TUI: write what the real wizard would save."""
+        from lablink_cli.config.schema import Config, save_config
+
+        def _run():
+            cfg = Config()
+            cfg.deployment_name = "demo-lab"
+            save_config(cfg, config_path)
+
+        mock_wizard_cls.return_value = MagicMock(run=_run)
+
+    @patch("lablink_cli.commands.setup.run_setup")
+    @patch("lablink_cli.tui.wizard.ConfigWizard")
+    def test_writes_placeholders_and_skips_setup(
+        self, mock_wizard_cls, mock_run_setup, tmp_path, monkeypatch
+    ):
+        import yaml
+
+        from lablink_cli.app import TEMPLATE_CONFIG
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / TEMPLATE_CONFIG).parent.mkdir(parents=True)
+        self._fake_wizard(mock_wizard_cls, TEMPLATE_CONFIG)
+
+        result = runner.invoke(app, ["configure", "--template"])
+        assert result.exit_code == 0, result.output
+
+        data = yaml.safe_load((tmp_path / TEMPLATE_CONFIG).read_text())
+        assert data["app"]["admin_password"] == "PLACEHOLDER_ADMIN_PASSWORD"
+        assert data["db"]["password"] == "PLACEHOLDER_DB_PASSWORD"
+        # The workflow seds only the passwords, so this one must be usable.
+        assert data["app"]["admin_user"] == "admin"
+        # setup.sh already created the state bucket for this path.
+        mock_run_setup.assert_not_called()
+
+    @patch("lablink_cli.commands.setup.run_setup")
+    @patch("lablink_cli.tui.wizard.ConfigWizard")
+    def test_output_survives_the_workflows_sed_injection(
+        self, mock_wizard_cls, mock_run_setup, tmp_path, monkeypatch
+    ):
+        """Replay terraform-deploy.yml's substitution against the real output.
+
+        The workflow seds PLACEHOLDER_* to the GitHub secrets, then greps for
+        a leftover PLACEHOLDER_ as its only safety net. A config carrying the
+        wizard's own defaults instead passes that grep while injecting
+        nothing — deploying admin_password "MISSING" and a default DB
+        password. This asserts the generated file actually takes the secrets.
+        """
+        from lablink_cli.app import TEMPLATE_CONFIG
+
+        monkeypatch.chdir(tmp_path)
+        (tmp_path / TEMPLATE_CONFIG).parent.mkdir(parents=True)
+        self._fake_wizard(mock_wizard_cls, TEMPLATE_CONFIG)
+
+        assert runner.invoke(app, ["configure", "--template"]).exit_code == 0
+
+        text = (tmp_path / TEMPLATE_CONFIG).read_text()
+        text = text.replace("PLACEHOLDER_ADMIN_PASSWORD", "s3cret-admin")
+        text = text.replace("PLACEHOLDER_DB_PASSWORD", "s3cret-db")
+
+        assert "PLACEHOLDER_" not in text  # the workflow's own guard
+        assert "s3cret-admin" in text and "s3cret-db" in text
+        assert "MISSING" not in text
+        mock_run_setup.assert_not_called()
+
+    @patch("lablink_cli.tui.wizard.ConfigWizard")
+    def test_rejects_a_non_template_checkout(
+        self, mock_wizard_cls, tmp_path, monkeypatch
+    ):
+        monkeypatch.chdir(tmp_path)  # no lablink-infrastructure/ here
+        result = runner.invoke(app, ["configure", "--template"])
+        assert result.exit_code == 1
+        assert "lablink-template" in _plain(result.output)
+        mock_wizard_cls.assert_not_called()


### PR DESCRIPTION
## Summary

- Adds `lablink configure --template`, pointing the existing Textual wizard at a [lablink-template](https://github.com/talmolab/lablink-template) checkout so Path B (fork → GitHub Actions) users get the same TUI as Path A.
- Along the way this fixes a **silent credential-injection failure** that would have made the issue's own recommended fix (documentation only) actively unsafe — see below.
- No changes to the wizard itself; it already produced compatible output.

## Why documentation alone wasn't enough

Issue #339 recommends option (1): just tell Path B users to run the CLI locally and push. I started there, and the schemas cooperate — `lablink_cli.config.schema` re-exports the allocator's canonical `Config`, and the template's `scripts/configure.sh` is a bash reimplementation writing the same keys, so the wizard's output is already structurally valid. `--config` even accepts an arbitrary path.

But the template commits `config.yaml` and injects credentials in CI with a **literal** sed:

```bash
sed -i "s/PLACEHOLDER_ADMIN_PASSWORD/${ADMIN_PASSWORD}/g" "$CONFIG_FILE"
sed -i "s/PLACEHOLDER_DB_PASSWORD/${DB_PASSWORD}/g" "$CONFIG_FILE"

# Verify no placeholders remain
if grep -q "PLACEHOLDER_" "$CONFIG_FILE"; then ... exit 1; fi
```

The wizard deliberately never collects credentials — the local path resolves them at deploy time and writes them only into the ephemeral deploy dir, never into the persisted config. So it emits `admin_password: MISSING` and the `db.password` default. Verified on disk:

```yaml
db:
  password: lablink        # DatabaseConfig default
app:
  admin_user: MISSING      # MISSING_SECRET sentinel
  admin_password: MISSING
```

Neither matches that sed. So for a user following a naive "run `lablink configure`, then commit" doc:

1. the sed injects **nothing**;
2. the workflow's only safety net, `grep -q "PLACEHOLDER_"`, **passes** — it catches placeholders left *un*-substituted, never placeholders that were never there;
3. the allocator deploys with a `MISSING` admin credential and the publicly-known default DB password, with no signal anywhere in the logs.

`admin_user` is never sed'd at all — `scripts/configure.sh` hardcodes `"admin"` — so it has the same failure mode with no guard covering it. (My own test caught this one after I'd missed it.)

## Changes Made

**`packages/cli/src/lablink_cli/app.py`** (+73)
- `--template` flag on `configure`.
- `TEMPLATE_CREDENTIALS` pins the three fields to the template's convention: `admin_user: admin`, and the two `PLACEHOLDER_*` password sentinels.
- Writes `lablink-infrastructure/config/config.yaml` instead of `~/.lablink/config.yaml`.
- Skips the automatic AWS state setup — the template's `setup.sh` already created the bucket and lock table, and re-tweaking an AMI shouldn't demand local AWS credentials.
- Refuses to run outside a template checkout (same guard as `scripts/configure.sh`) rather than silently creating a stray `lablink-infrastructure/` tree no workflow reads.

**`packages/cli/tests/test_app.py`** (+83) — three tests, detailed below.

**`docs/quickstart-template.md`** — Step 3 now presents the shell script and the TUI as tabbed alternatives, with an explicit note that both leave the passwords as placeholders and the file is safe to commit.

**`docs/reference/cli.md`** — new "Configuring a template repo" section documenting the flag's three behavioral differences, plus a warning not to hand-edit the placeholder fields.

## Testing

- **784 CLI tests pass**, lint clean (`ruff check src tests`).
  - Note: run with `NO_COLOR=1`. Without it, 8 unrelated tests fail on rich ANSI codes embedded mid-phrase; I confirmed the identical failures reproduce on unmodified `main`, so they're a local-terminal artifact, not a regression. CI runs non-tty so color is off there.
- **`mkdocs build --strict`**: zero link warnings from these changes (it aborts only on 6 pre-existing griffe warnings about allocator docstrings untouched here), confirming the new cross-links and anchor resolve.
- New tests:
  - `test_writes_placeholders_and_skips_setup` — asserts the three credential values and that `run_setup` is never called.
  - `test_output_survives_the_workflows_sed_injection` — **replays the deploy workflow's actual sed-then-grep against real generated output**, asserting the secrets land and no `MISSING` survives. This is the one that matters: it fails loudly if someone "tidies" the credential defaults, instead of silently shipping an un-injected config.
  - `test_rejects_a_non_template_checkout` — wrong-cwd guard exits 1 without launching the wizard.
- Per the project's no-TUI-tests convention, the wizard is mocked; none of this tests Textual internals.

## Design Decisions

- **A flag, not a separate command or a new wizard.** The wizard and schema are already shared; only the output plumbing differed. The whole change is one flag plus a credential-rewrite helper.
- **Post-process after save rather than teach the wizard about template mode.** Keeps the TUI untouched and the template-specific knowledge in one readable dict.
- **Fixed here rather than in the template's workflow.** Changing `terraform-deploy.yml` only helps *newly created* forks — existing forks keep their copy of the workflow. Emitting correct sentinels works for every fork immediately.
- **Left the wizard's `startup_script` flow alone** — it already normalizes the path to the relative `config/custom-startup.sh` the template's Terraform expects by default, and writes the script next to the config, which lands correctly under `--template`.
- **Dropped keys are harmless**: the wizard writes exactly the canonical dataclass fields, omitting three stale keys in the template's `example.config.yaml` (`eip.tag_name`, `db.message_channel`, `machine.extension`). The template's Terraform reads config through `try(..., default)` everywhere and never references those three.

## Follow-up

The workflow guard's blind spot is independent of this PR and is filed as **talmolab/lablink-template#56**, with a suggested fix (assert the sentinels are present *before* substituting, keeping the existing check too — the two catch opposite failures).

Also worth noting for the paper: OM§3 currently distinguishes Path A and Path B partly on TUI availability. With this merged, that asymmetry is closed and the section can describe the wizard as available on both paths.

## Related Issues

Closes #339

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
