### PR TITLE
chore: bump package versions for the OpenTofu release

### DIFF
--- a/.claude/commands/publish-cli.md
+++ b/.claude/commands/publish-cli.md
@@ -1,0 +1,35 @@
+# Publish CLI to PyPI
+
+Tag-triggered:
+
+```bash
+git tag lablink-cli_v0.1.0a1
+git push origin lablink-cli_v0.1.0a1
+gh run watch
+```
+
+Or dispatch manually (`dry_run` defaults to **true**):
+
+```bash
+gh workflow run publish-pip.yml \
+  -f package=lablink-cli -f dry_run=false
+```
+
+The version comes from `packages/cli/pyproject.toml` and the tag suffix must
+match it exactly, or guardrail 2 fails the run.
+
+Two things specific to this package:
+
+- **Release the allocator first.** `lablink-cli` depends on
+  `lablink-allocator-service[config]>=0.2.0`, and `deploy_compose.py` imports
+  `PUBLIC_HOSTNAME_HINT`, `is_valid_public_hostname` and
+  `is_weak_admin_password` from it. Publishing the CLI against an allocator
+  that predates those symbols leaves `provider: manual` raising ImportError at
+  runtime — the AWS path and `--help` still work, so it does not fail loudly.
+- **Alpha versions need `--pre`.** `pip install lablink-cli` skips `0.1.0a1`;
+  users need `pip install --pre lablink-cli` until a final version ships.
+
+PyPI auth is OIDC trusted publishing — no token. The workflow grants
+`id-token: write` and `uv publish` defaults to `--trusted-publishing automatic`.
+The publish job declares no `environment:`, so the PyPI publisher must leave
+its environment field blank.

--- a/docs/scripts/gen_changelog.py
+++ b/docs/scripts/gen_changelog.py
@@ -161,12 +161,20 @@ generate_package_changelog(
     "packages/client"
 )
 
+generate_package_changelog(
+    "lablink-cli",
+    "cli",
+    "lablink-cli_v",
+    "packages/cli"
+)
+
 # Generate unified changelog index
 with mkdocs_gen_files.open("changelog.md", "w") as changelog:
     changelog.write("# Changelog\n\n")
-    changelog.write("LabLink consists of two independently versioned packages:\n\n")
+    changelog.write("LabLink consists of three independently versioned packages:\n\n")
     changelog.write("## Package Changelogs\n\n")
     changelog.write("- **[lablink-allocator-service](changelog-allocator.md)** - VM Allocator Service\n")
-    changelog.write("- **[lablink-client-service](changelog-client.md)** - Client Service\n\n")
+    changelog.write("- **[lablink-client-service](changelog-client.md)** - Client Service\n")
+    changelog.write("- **[lablink-cli](changelog-cli.md)** - Command-line interface\n\n")
     changelog.write("---\n\n")
     changelog.write("For release notes and downloads, see the [GitHub Releases page](https://github.com/talmolab/lablink/releases).\n")

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -124,6 +124,7 @@ nav:
       - Changelog: changelog.md
       - Allocator Changelog: changelog-allocator.md
       - Client Changelog: changelog-client.md
+      - CLI Changelog: changelog-cli.md
       - Releases: https://github.com/talmolab/lablink/releases
   - Reference: reference/
 

--- a/packages/allocator/pyproject.toml
+++ b/packages/allocator/pyproject.toml
@@ -2,6 +2,15 @@
 requires = ["uv_build>=0.8.11,<0.12.0"]
 build-backend = "uv_build"
 
+[tool.uv.build-backend]
+# The terraform/ directory ships as package data, and a developer who has run
+# `tofu init` (or `terraform init`) in the source tree leaves a .terraform/
+# provider cache there — ~850 MB of platform-specific provider binaries. The
+# backend does not consult .gitignore, so without this the local wheel balloons
+# past PyPI's 100 MB per-file limit. CI builds from a clean checkout and never
+# hits it, which is exactly what makes it a trap.
+source-exclude = ["**/.terraform", "**/.terraform.lock.hcl"]
+
 [project]
 authors = [
   {name = "Elizabeth Berrigan", email = "eberrigan@salk.edu"},
@@ -27,7 +36,7 @@ description = "VM Allocator Service Package for Lablink"
 name = "lablink-allocator-service"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.1.2"
+version = "0.2.0"
 
 [project.optional-dependencies]
 config = []  # Config schema only (pure dataclasses, no heavy deps)

--- a/packages/cli/pyproject.toml
+++ b/packages/cli/pyproject.toml
@@ -5,12 +5,15 @@ authors = [
   {name = "Talmo Pereira", email = "talmo@salk.edu"},
   {name = "Andrew Park", email = "hep003@ucsd.edu"},
 ]
-version = "0.1.0"
+version = "0.1.0a1"
 description = "CLI tool for deploying and managing LabLink infrastructure"
 readme = "README.md"
 requires-python = ">=3.10"
 dependencies = [
-    "lablink-allocator-service[config]",
+    # >=0.2.0: deploy_compose imports PUBLIC_HOSTNAME_HINT,
+    # is_valid_public_hostname and is_weak_admin_password, none of which
+    # exist in 0.1.2 — an unpinned resolve breaks `provider: manual`.
+    "lablink-allocator-service[config]>=0.2.0",
     "typer>=0.15",
     "textual>=3.0",
     "rich>=13.0",

--- a/packages/cli/src/lablink_cli/__init__.py
+++ b/packages/cli/src/lablink_cli/__init__.py
@@ -1,8 +1,8 @@
 """LabLink CLI - Deploy and manage LabLink infrastructure."""
 
 TEMPLATE_REPO = "talmolab/lablink-template"
-TEMPLATE_VERSION = "v0.2.2"
+TEMPLATE_VERSION = "v0.3.0"
 # SHA-256 of the GitHub release tarball for TEMPLATE_VERSION.
 # Update this when bumping TEMPLATE_VERSION.
 # To compute: curl -sL <tarball_url> | sha256sum
-TEMPLATE_SHA256 = "5f3a03968057410000d9634cc43001fb27785508a0ed78ab2551542670b15ce6"
+TEMPLATE_SHA256 = "3d3f8803990f80e6bcda0b3098178d909bc454315fdf2304e70dbee5d43e3bb6"


### PR DESCRIPTION
Release prep for the OpenTofu migration (#446, #447). Two of these changes fix things that would have shipped broken releases.

## Versions

| Package | From | To | Why |
|---|---|---|---|
| `lablink-allocator-service` | 0.1.2 | **0.2.0** | Minor, not patch: the image now requires the `tofu` binary, the `TerraformApply*` columns were renamed, and the client-VM version floor moved. Anyone pinning `~=0.1.2` should not pick this up silently. |
| `lablink-cli` | 0.1.0 | **0.1.0a1** | First publish, alpha. |
| `lablink-client-service` | 0.1.2 | — | Unchanged. Its only diff this cycle is a docstring; no release needed. |

## Fix 1 — the CLI's unpinned dependency would have broken `provider: manual`

`lablink-cli` depended on `lablink-allocator-service[config]` with no lower bound. `deploy_compose.py` imports three symbols from it, and **none exist in the published 0.1.2**:

```
get_config_errors         in v0.1.2: YES
PUBLIC_HOSTNAME_HINT      in v0.1.2: *** MISSING ***
is_valid_public_hostname  in v0.1.2: *** MISSING ***
is_weak_admin_password    in v0.1.2: *** MISSING ***
```

A fresh `pip install --pre lablink-cli` would have resolved allocator 0.1.2 and raised `ImportError` for every BYO user. All three are *lazy* imports inside `deploy_compose.py`, so `lablink --help` and the entire AWS path would have worked — the release would have looked healthy and failed only for manual-provider users.

Now pinned `>=0.2.0`, which also turns the allocator-first release order from a convention into something the resolver enforces.

## Fix 2 — the allocator wheel was 182 MB, and PyPI rejects anything over 100 MB

`uv build --package lablink-allocator-service` produced a 182 MB artifact locally. Cause:

```
811.5 MB  .../terraform/.terraform/providers/registry.terraform.io/hashicorp/aws/6.45.0/darwin_arm64/...
 18.6 MB  .../hashicorp/tls/4.3.0/darwin_arm64/...
 17.3 MB  .../hashicorp/time/0.14.0/darwin_arm64/...
```

A stale `.terraform` provider cache from a local `terraform init` in the source tree. It *is* gitignored (`.gitignore:174`), but the uv build backend does not consult `.gitignore`, and `terraform/` ships as package data.

CI builds from a clean checkout and never hits this — the published 0.1.2 is 0.07 MB — which is exactly what makes it worth a permanent guard rather than a one-off `rm`. The next person to build locally after running `tofu init` would have hit a confusing PyPI size rejection.

Added `[tool.uv.build-backend] source-exclude`. Verified after the change:
- wheel drops to **169 KB**
- all eleven `.tf` / `.hcl` / `.sh` files still ship, including `versions.tf` with the new 1.10.0 floor
- no `.terraform/` entries remain

## Fix 3 — `lablink-cli` had no changelog page

`docs/scripts/gen_changelog.py` generated changelogs for the allocator and client only. Changelogs are built from git tags, so tagging `lablink-cli_v*` would have produced a release with no page at all. Added the CLI to the generator and the mkdocs nav.

## Also

Adds `.claude/commands/publish-cli.md`, which was missing alongside `publish-allocator` and `publish-client`. It documents the two CLI-specific gotchas: release the allocator first, and alpha versions need `pip install --pre`.

## Testing

`ruff` clean; 922 allocator + 828 CLI + 156 client tests pass. Both release artifacts build:

```
lablink_cli-0.1.0a1-py3-none-any.whl                131.7 KB
lablink_allocator_service-0.2.0-py3-none-any.whl    169.1 KB
```

## Release order after this merges

1. Add the PyPI **pending publisher** for `lablink-cli` — owner `talmolab`, repo `lablink`, workflow `publish-pip.yml`, environment **blank** (the publish job declares no `environment:`, so a value there makes the OIDC claim mismatch).
2. Dry run: `gh workflow run publish-pip.yml -f package=lablink-cli -f dry_run=true`
3. Tag `lablink-allocator-service_v0.2.0` — **must be first**, per the pin above.
4. Tag `lablink-cli_v0.1.0a1`
5. Build prod images with `allocator_version=0.2.0`. An image built against 0.1.2 gets the `tofu` binary alongside Python that still calls `terraform`, and fails at container boot.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)