### PR TITLE
ci: skip the PyPI upload when the version is already published

### DIFF
--- a/.github/workflows/publish-pip.yml
+++ b/.github/workflows/publish-pip.yml
@@ -191,11 +191,40 @@ jobs:
           echo "Build artifacts:"
           ls -lh dist/
 
+      # Makes re-runs idempotent. PyPI forbids file-name reuse, so a second
+      # run over an already-published version dies in `uv publish` with
+      # 400 "File already exists" — hit by re-running a flaky publish, or by
+      # creating the GitHub Release after the tag push already published.
+      #
+      # Deliberately not `uv publish --check-url`: that compares local and
+      # remote hashes, and `uv build` is not byte-reproducible (two builds of
+      # identical source differ), so on a re-run it fails with "Local file and
+      # index file do not match" — the same failure wearing a scarier name.
+      # Asking PyPI whether the version exists sidesteps the hashes entirely.
+      - name: Check whether this version is already on PyPI
+        id: already_published
+        if: |
+          steps.should_run.outputs.should_run == 'true' &&
+          (github.event_name != 'workflow_dispatch' ||
+           inputs.dry_run == false)
+        run: |
+          VERSION=$(grep '^version = ' ${{ matrix.dir }}/pyproject.toml | cut -d'"' -f2)
+          URL="https://pypi.org/pypi/${{ matrix.package }}/${VERSION}/json"
+          if curl -sfL --max-time 30 -o /dev/null "$URL"; then
+            echo "published=true" >> $GITHUB_OUTPUT
+            echo "⏭️  ${{ matrix.package }} ${VERSION} is already on PyPI — skipping upload."
+            echo "    Versions are immutable there; publish a new version to ship changes."
+          else
+            echo "published=false" >> $GITHUB_OUTPUT
+            echo "${{ matrix.package }} ${VERSION} is not on PyPI yet."
+          fi
+
       # PUBLISH (unless dry run)
       - name: Publish to PyPI
         id: publish
         if: |
           steps.should_run.outputs.should_run == 'true' &&
+          steps.already_published.outputs.published != 'true' &&
           (github.event_name != 'workflow_dispatch' ||
            inputs.dry_run == false)
         run: |


### PR DESCRIPTION
Makes re-runs of `publish-pip.yml` idempotent.

## The problem

PyPI forbids file-name reuse, so a second run over an already-published version dies in `uv publish`:

```
error: Failed to publish `dist/lablink_cli-0.1.0a1-py3-none-any.whl`
  Caused by: Server returned status code 400 Bad Request.
  Server says: 400 File already exists (...). See https://pypi.org/help/#file-name-reuse
```

Two ordinary ways to hit it:

- re-running a publish that failed for an unrelated reason (a flaky test, a runner hiccup)
- creating the GitHub Release *after* the tag push already published — the workflow fires on both `push: tags` and `release: published`, so the second event re-runs the whole job

The second one just happened on `lablink-cli_v0.1.0a1`: a red run against a perfectly good release, nothing actually wrong.

## The fix

A step that asks PyPI whether the version exists, gating the upload on the answer:

```yaml
- name: Check whether this version is already on PyPI
  id: already_published
  run: |
    if curl -sfL --max-time 30 -o /dev/null "https://pypi.org/pypi/${PKG}/${VERSION}/json"; then
      echo "published=true" >> $GITHUB_OUTPUT
    ...
```

A re-run now reports `⏭️ already on PyPI — skipping upload` and stays green. A genuine first publish is untouched.

## Why not `uv publish --check-url`

That is the documented flag for this ("Check an index URL for existing files to skip duplicate uploads") and it does **not** work here, which is worth recording so nobody swaps it back in.

`--check-url` compares local and remote **hashes**, and `uv build` is not byte-reproducible. Two builds of identical source, same machine, same uv version:

```
build 1: 1b7bc8c4ae489069866a52c2388629ea3a4cabfbe31084090b9b128b2e082c9c
build 2: 571097a6f2ff3dd8ee48e76b3e02a29c99e442e7cba1b69da6f3d4048fa72b18
```

Since the workflow rebuilds before publishing, the local artifact can never match what is on the index. Verified against real PyPI:

```
error: Local file and index file do not match for lablink_cli-0.1.0a1-py3-none-any.whl.
  Local:  sha256=5cf02b5f497f1250d8b631f1beef78ee5851296fd7a6b707cddd13304414aaa7
  Remote: sha256=28884790b7adcea1c244762cf8363bda60304f4dae30926ac3cc94f8df1fd7f2
```

So it trades `400 File already exists` for `Local file and index file do not match` — the same failure wearing a name that reads like artifact corruption. Asking whether the version exists sidesteps hashing entirely.

## Testing

Guard logic exercised against live PyPI, both branches:

| Package / version | Result |
|---|---|
| `lablink-allocator-service` 0.2.0 | `published=true` → skip |
| `lablink-cli` 0.1.0a1 | `published=true` → skip |
| `lablink-client-service` 0.1.2 | `published=true` → skip |
| `lablink-allocator-service` 0.3.0 | `published=false` → publish |
| `lablink-cli` 0.2.0 | `published=false` → publish |
| `lablink-client-service` 0.1.3 | `published=false` → publish |

Workflow YAML parses, and the publish step's `if` picks up the new condition alongside the existing `should_run` and dry-run gates.

`-f` on curl matters: without it a 404 body still exits 0 and every version would look published.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)