### PR TITLE
chore(client): bump to 0.2.0

### DIFF
--- a/packages/client/pyproject.toml
+++ b/packages/client/pyproject.toml
@@ -28,7 +28,7 @@ keywords = ["vm", "docker", "postgres", "tutorial", "AWS"]
 name = "lablink-client-service"
 readme = "README.md"
 requires-python = ">=3.10"
-version = "0.1.2"
+version = "0.2.0"
 
 [project.optional-dependencies]
 dev = ["twine", "build", "pytest", "ruff", "pytest-cov"]


### PR DESCRIPTION
Unblocks the prod client image, which is currently broken.

## What's wrong

`lablink-client-service` on PyPI is **0.1.2, tagged 2026-04-03**. `main` is **29 commits / 53 files (+4268 −2104)** ahead of it. Prod images install from PyPI, so every prod client image built since April has shipped that April package.

This surfaced as a failed verification on the prod image build I just ran:

```
Testing client console scripts...
agent:
##[error]Process completed with exit code 1
```

`which agent` found nothing. The console scripts have drifted apart completely:

| | scripts |
|---|---|
| PyPI 0.1.2 | `check_gpu`, `subscribe`, `update_inuse_status` |
| `main` | `agent`, `check_gpu`, `heartbeat`, `lablink-monitoring`, `update_inuse_status` |

`agent` is the client's **main entry point** and does not exist in the published package. `subscribe` was removed from `main` months ago but is still what PyPI ships.

## Heads-up: `:latest` is currently bad

The build job pushes before the verify job runs, so that failed build still published:

```
ghcr.io/talmolab/lablink-client-base-image:latest
ghcr.io/talmolab/lablink-client-base-image:0.1.2
ghcr.io/talmolab/lablink-client-base-image:linux-amd64
ghcr.io/talmolab/lablink-client-base-image:linux-amd64-latest
```

All built from PyPI 0.1.2 and missing `agent`. Merging this and rebuilding prod images repoints those tags at a correct image.

Worth noting separately: **verification runs after the push, so a failing verify cannot prevent a bad image reaching `:latest`.** That ordering is its own issue, not fixed here.

## Why 0.2.0 and not 0.1.3

Dropping a console script and adding three is breaking for anything invoking them — more than a patch. The span also covers the Ubuntu 24.04 / XFCE desktop rebuild (#439), the KasmVNC quality fix (#438), and reverse-tunnel connectivity (#419).

It also lines up with the allocator, which went to 0.2.0 in this same release.

## Testing

`ruff` clean, 156 client tests pass, and the package builds:

```
lablink_client_service-0.2.0-py3-none-any.whl   26.8 KB
lablink_client_service-0.2.0.tar.gz             17.9 KB
```

## After merge

1. Tag `lablink-client-service_v0.2.0` → publishes to PyPI
2. Re-run `lablink-images.yml` with `environment=prod`, `allocator_version=0.2.0`, `client_version=0.2.0`

The allocator side is already correct — its prod image was verified directly:

```
/usr/local/bin/tofu        →  OpenTofu v1.12.5
terraform                  →  not present
lablink-allocator-service  →  0.2.0
installed code calls       →  "tofu", init/plan/apply/show/output
```

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)