### PR TITLE
feat(cli): auto-fetch logs in the `lablink logs` viewer

### DIFF
--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -440,8 +440,16 @@ lablink logs [--config PATH]
 ```
 
 **AWS provider:** opens a Textual-based viewer that streams cloud-init and
-container logs from the allocator and any running client VMs. Use `q` to quit, `/`
-to search, `n`/`N` for next/previous match.
+container logs from the allocator and any running client VMs. Logs auto-fetch
+every 5 seconds for the selected VM; the status bar shows the last fetch time and
+the current cadence. Use `a` to toggle auto-fetch off (and back on), `r` to fetch
+once now, `1`/`2` to switch between the cloud-init and container tabs, and `q` to
+quit.
+
+The view only repaints when the logs actually changed, so scrolling back through
+an error is not interrupted by a tick that found nothing new. Each tick is armed
+only after the previous fetch finishes, so a slow allocator SSH round-trip
+stretches the cadence instead of stacking up connections.
 
 **Manual provider:** tails the local `lablink-allocator` container's logs. Per-VM
 client logs are not centralized in this mode — run `docker logs lablink-client` on

--- a/packages/cli/src/lablink_cli/tui/logs_viewer.py
+++ b/packages/cli/src/lablink_cli/tui/logs_viewer.py
@@ -9,6 +9,7 @@ from textual import work
 from textual.app import App, ComposeResult
 from textual.binding import Binding
 from textual.containers import Horizontal, Vertical
+from textual.timer import Timer
 from textual.widgets import (
     Footer,
     Header,
@@ -20,6 +21,12 @@ from textual.widgets import (
 )
 
 from lablink_allocator_service.conf.structured_config import Config
+
+# Cadence for auto-fetch. The timer is self-clocking — the next tick is armed
+# only once the previous fetch has settled — so fetches can never overlap and a
+# slow SSH round-trip backs the cadence off on its own. That is also why this
+# is a constant and not a flag: it needs no tuning for slow links.
+_AUTO_REFRESH_SECONDS = 5.0
 
 
 class VMListItem(ListItem):
@@ -44,6 +51,7 @@ class LogsApp(App):
     BINDINGS = [
         Binding("q", "quit", "Quit"),
         Binding("r", "refresh", "Refresh"),
+        Binding("a", "toggle_auto", "Auto-fetch"),
         Binding("1", "show_cloud_init", "Cloud-Init"),
         Binding("2", "show_docker", "Docker"),
     ]
@@ -131,6 +139,9 @@ class LogsApp(App):
         # themselves); default to docker and skip the cloud-init tab UI.
         self._current_tab = "docker" if manual else "cloud_init"
         self._cached_logs: dict | None = None
+        self._auto = True
+        self._auto_timer: Timer | None = None
+        self._last_fetched: str | None = None
 
     def compose(self) -> ComposeResult:
         yield Header()
@@ -183,6 +194,9 @@ class LogsApp(App):
         log_output.write(
             "[dim]Select a VM from the list to view its logs.[/dim]"
         )
+        # Surface the auto-fetch cadence before the first fetch, so it is
+        # discoverable without waiting for a tick.
+        self._refresh_status()
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
         """Handle VM selection."""
@@ -190,6 +204,9 @@ class LogsApp(App):
         if isinstance(item, VMListItem):
             self._selected_vm = item.vm
             self._cached_logs = None
+            # Drop the tick queued for the previous VM; the fetch below
+            # re-arms the timer against the new selection.
+            self._cancel_auto_timer()
             self._update_vm_info()
             # Clear log panel immediately and show loading state
             log_output = self.query_one("#log-output", RichLog)
@@ -275,63 +292,114 @@ class LogsApp(App):
         if not vm:
             return
 
-        if vm["vm_type"] == "client":
-            if not self._allocator_url:
-                logs = {
-                    "cloud_init_logs": None,
-                    "docker_logs": None,
-                    "error": (
-                        "Allocator URL not available. "
-                        "Cannot fetch client logs."
-                    ),
-                }
+        try:
+            if vm["vm_type"] == "client":
+                if not self._allocator_url:
+                    logs = {
+                        "cloud_init_logs": None,
+                        "docker_logs": None,
+                        "error": (
+                            "Allocator URL not available. "
+                            "Cannot fetch client logs."
+                        ),
+                    }
+                else:
+                    from lablink_cli.commands.logs import fetch_client_logs
+
+                    logs = fetch_client_logs(
+                        allocator_url=self._allocator_url,
+                        hostname=vm["name"],
+                        admin_user=self._admin_user,
+                        admin_pw=self._admin_pw,
+                        ssl_provider=self._cfg.ssl.provider,
+                    )
             else:
-                from lablink_cli.commands.logs import fetch_client_logs
+                # Manual provider's allocator is a local docker container, not
+                # an EC2 instance — bypass SSH and read `docker logs` directly.
+                if self._manual:
+                    from lablink_cli.commands.logs import (
+                        fetch_manual_allocator_logs,
+                    )
 
-                logs = fetch_client_logs(
-                    allocator_url=self._allocator_url,
-                    hostname=vm["name"],
-                    admin_user=self._admin_user,
-                    admin_pw=self._admin_pw,
-                    ssl_provider=self._cfg.ssl.provider,
-                )
-        else:
-            # Manual provider's allocator is a local docker container, not
-            # an EC2 instance — bypass SSH and read `docker logs` directly.
-            if self._manual:
-                from lablink_cli.commands.logs import (
-                    fetch_manual_allocator_logs,
-                )
+                    logs = fetch_manual_allocator_logs()
+                else:
+                    from lablink_cli.commands.logs import fetch_allocator_logs
 
-                logs = fetch_manual_allocator_logs()
-            else:
-                from lablink_cli.commands.logs import fetch_allocator_logs
+                    logs = fetch_allocator_logs(
+                        instance_id=vm["instance_id"],
+                        public_ip=vm.get("public_ip", "—"),
+                        region=self._cfg.app.region,
+                        deploy_dir=self._deploy_dir,
+                    )
 
-                logs = fetch_allocator_logs(
-                    instance_id=vm["instance_id"],
-                    public_ip=vm.get("public_ip", "—"),
-                    region=self._cfg.app.region,
-                    deploy_dir=self._deploy_dir,
-                )
+            # Guard: discard results if user selected a different VM while
+            # fetching
+            if self._selected_vm is not vm:
+                return
 
-        # Guard: discard results if user selected a different VM while fetching
-        if self._selected_vm is not vm:
-            return
+            # Repaint only on change. _display_logs clears and rewrites the
+            # RichLog, and auto_scroll drags the view to the bottom — so an
+            # unconditional repaint every tick would yank you off whatever you
+            # had scrolled up to read. Most ticks find nothing new.
+            unchanged = logs == self._cached_logs
+            self._cached_logs = logs
+            self._last_fetched = datetime.now().strftime("%H:%M:%S")
+            if not unchanged:
+                self.call_from_thread(self._display_logs)
+            self.call_from_thread(self._refresh_status)
+        finally:
+            # Re-arm even if the fetch raised, or one transient error would
+            # kill auto-fetch for the rest of the session.
+            self.call_from_thread(self._schedule_next_fetch)
 
-        self._cached_logs = logs
-        now = datetime.now().strftime("%H:%M:%S")
-        self.call_from_thread(self._display_logs)
-        self.call_from_thread(self._set_status, f"Last fetched: {now}")
+    def _cancel_auto_timer(self) -> None:
+        """Drop any queued auto-fetch tick."""
+        if self._auto_timer is not None:
+            self._auto_timer.stop()
+            self._auto_timer = None
+
+    def _schedule_next_fetch(self) -> None:
+        """Arm the next auto-fetch tick, if auto-fetch is on.
+
+        Self-clocking rather than ``set_interval``: the next tick is armed
+        only after the previous fetch settles, so fetches cannot overlap.
+        Cancelling first keeps this idempotent — at most one timer is ever
+        outstanding, however many times it is called.
+        """
+        self._cancel_auto_timer()
+        if self._auto and self._selected_vm:
+            self._auto_timer = self.set_timer(
+                _AUTO_REFRESH_SECONDS, self._fetch_logs
+            )
 
     def _set_status(self, text: str) -> None:
         """Update the status bar."""
         status = self.query_one("#status-bar", Label)
         status.update(f"[dim]{text}[/dim]")
 
+    def _refresh_status(self) -> None:
+        """Redraw the status bar from last-fetch time and auto-fetch state."""
+        auto = (
+            f"auto {_AUTO_REFRESH_SECONDS:g}s" if self._auto else "auto off"
+        )
+        self._set_status(
+            f"Last fetched: {self._last_fetched or '—'} · {auto}"
+        )
+
     def action_refresh(self) -> None:
         """Refresh logs for the selected VM."""
         if self._selected_vm:
             self._fetch_logs()
+
+    def action_toggle_auto(self) -> None:
+        """Turn auto-fetch on or off."""
+        self._auto = not self._auto
+        if self._auto:
+            # Fetch now; completing that fetch arms the timer.
+            self._fetch_logs()
+        else:
+            self._cancel_auto_timer()
+        self._refresh_status()
 
     def action_show_cloud_init(self) -> None:
         """Switch to cloud-init log tab."""

--- a/packages/cli/src/lablink_cli/tui/logs_viewer.py
+++ b/packages/cli/src/lablink_cli/tui/logs_viewer.py
@@ -108,8 +108,12 @@ class LogsApp(App):
         border-top: solid $primary-lighten-3;
     }
 
+    /* height must cover the border AND a content row: Textual sizes with
+       border-box, so `height: 1` here spent its only row on border-top and
+       left the text zero rows to render in. */
     #status-bar {
-        height: 1;
+        height: 2;
+        width: 1fr;
         padding: 0 1;
         color: $text-muted;
         border-top: solid $primary-lighten-3;

--- a/packages/cli/src/lablink_cli/tui/logs_viewer.py
+++ b/packages/cli/src/lablink_cli/tui/logs_viewer.py
@@ -22,11 +22,8 @@ from textual.widgets import (
 
 from lablink_allocator_service.conf.structured_config import Config
 
-# Cadence for auto-fetch. The timer is self-clocking — the next tick is armed
-# only once the previous fetch has settled — so fetches can never overlap and a
-# slow SSH round-trip backs the cadence off on its own. That is also why this
-# is a constant and not a flag: it needs no tuning for slow links.
-_AUTO_REFRESH_SECONDS = 5.0
+# Self-clocking; see _schedule_next_fetch.
+_AUTO_REFRESH_SECONDS = 5
 
 
 class VMListItem(ListItem):
@@ -198,8 +195,7 @@ class LogsApp(App):
         log_output.write(
             "[dim]Select a VM from the list to view its logs.[/dim]"
         )
-        # Surface the auto-fetch cadence before the first fetch, so it is
-        # discoverable without waiting for a tick.
+        # Show cadence before the first tick.
         self._refresh_status()
 
     def on_list_view_selected(self, event: ListView.Selected) -> None:
@@ -363,12 +359,11 @@ class LogsApp(App):
             self._auto_timer = None
 
     def _schedule_next_fetch(self) -> None:
-        """Arm the next auto-fetch tick, if auto-fetch is on.
+        """Arm the next tick. Cancels first, so at most one is outstanding.
 
-        Self-clocking rather than ``set_interval``: the next tick is armed
-        only after the previous fetch settles, so fetches cannot overlap.
-        Cancelling first keeps this idempotent — at most one timer is ever
-        outstanding, however many times it is called.
+        Self-clocking rather than ``set_interval``: armed only once the
+        previous fetch settles, so fetches cannot overlap and a slow SSH
+        round-trip backs the cadence off instead of stacking up.
         """
         self._cancel_auto_timer()
         if self._auto and self._selected_vm:
@@ -382,18 +377,9 @@ class LogsApp(App):
         status.update(f"[dim]{text}[/dim]")
 
     def _refresh_status(self) -> None:
-        """Redraw the status bar from auto-fetch state and last-fetch time.
-
-        Auto-fetch state leads because a narrow terminal truncates the bar
-        from the right — the state is what the user needs to see, so the
-        timestamp is the part that should be sacrificed.
-        """
-        auto = (
-            f"auto {_AUTO_REFRESH_SECONDS:g}s" if self._auto else "auto off"
-        )
-        self._set_status(
-            f"{auto} · last fetched {self._last_fetched or '—'}"
-        )
+        """Redraw the status bar. State leads so truncation eats the clock."""
+        auto = f"auto {_AUTO_REFRESH_SECONDS}s" if self._auto else "auto off"
+        self._set_status(f"{auto} · last fetched {self._last_fetched or '—'}")
 
     def action_refresh(self) -> None:
         """Refresh logs for the selected VM."""

--- a/packages/cli/src/lablink_cli/tui/logs_viewer.py
+++ b/packages/cli/src/lablink_cli/tui/logs_viewer.py
@@ -382,12 +382,17 @@ class LogsApp(App):
         status.update(f"[dim]{text}[/dim]")
 
     def _refresh_status(self) -> None:
-        """Redraw the status bar from last-fetch time and auto-fetch state."""
+        """Redraw the status bar from auto-fetch state and last-fetch time.
+
+        Auto-fetch state leads because a narrow terminal truncates the bar
+        from the right — the state is what the user needs to see, so the
+        timestamp is the part that should be sacrificed.
+        """
         auto = (
             f"auto {_AUTO_REFRESH_SECONDS:g}s" if self._auto else "auto off"
         )
         self._set_status(
-            f"Last fetched: {self._last_fetched or '—'} · {auto}"
+            f"{auto} · last fetched {self._last_fetched or '—'}"
         )
 
     def action_refresh(self) -> None:


### PR DESCRIPTION
## Summary

- `lablink logs` now fetches the selected VM's logs every 5 seconds on its own, instead of requiring a keypress per refresh. Pressing `r` repeatedly to watch a VM come up was tedious.
- `a` toggles auto-fetch off and back on; `r` still performs a one-shot fetch.
- The status bar reports both the last fetch time and the current cadence: `Last fetched: 14:22:03 · auto 5s` / `· auto off`.

## Changes Made

`packages/cli/src/lablink_cli/tui/logs_viewer.py`

- Added `_AUTO_REFRESH_SECONDS = 5.0` and an `a` → `action_toggle_auto` binding (auto-fetch defaults to on).
- Added `_schedule_next_fetch` / `_cancel_auto_timer`, arming a single `set_timer` tick. `_schedule_next_fetch` cancels before arming, so it is idempotent — at most one timer is ever outstanding no matter how many times it is called.
- `_fetch_logs` now re-arms the timer in a `finally` block, and skips the repaint when the fetched logs are identical to the cache.
- Added `_refresh_status` (fed by a new `_last_fetched` field), replacing the bare `Last fetched: <time>` status write. `on_mount` calls it so the cadence is visible before the first tick.
- VM selection cancels the tick queued for the previous VM; the immediate fetch re-arms against the new selection.

`docs/reference/cli.md`

- Documented the auto-fetch cadence, the `a` toggle, and the repaint/backoff behavior.
- Removed the documented `/` and `n`/`N` search keys for this viewer. Those bindings were never implemented in `logs_viewer.py`; the claim sat in the sentence being rewritten.

## Testing

Verified headless against the real Textual event loop via `App.run_test()` / Pilot, with the fetch stubbed at 0.1s and the interval shortened to 0.3s. All assertions passed:

| Check | Result |
|---|---|
| Ticks with zero keypresses (2.5s window) | 7 fetches |
| Overlapping fetches | 0 |
| Repaints across those 7 fetches | 2 (initial + the single real content change) |
| Fetches during 1.5s after `a` (off) | 0, timer released |
| Fetches during 1.5s after `a` again (on) | 4 |

- `ruff check packages/cli/src packages/cli/tests` — clean.
- CLI suite: 816 passed, 12 failed. Those 12 failures are byte-identical to a baseline run on unmodified `main` (same 12 tests, same counts); they are pre-existing ANSI/terminal-rendering assertions in `test_status.py`, `test_utils.py`, `test_register.py` and friends, unrelated to this change and not in the logs viewer.

No automated Textual test is committed, per the project's standing preference against automated TUI tests; the behavior above was verified by hand with the numbers reported.

## Design Decisions

**Self-clocking `set_timer` rather than `set_interval`.** The next tick is armed only once the previous fetch settles. Two reasons this matters over a plain interval:

- The allocator path is SSH with a 30s timeout. A fixed 5s interval could stack up to six concurrent SSH subprocesses on a slow link. Self-clocking makes overlap impossible by construction, and a slow round-trip stretches the cadence instead of piling on connections.
- Because the cadence self-adjusts to fetch latency, there is no `--interval` flag to tune. Deliberately omitted rather than overlooked.

The re-arm lives in a `finally` so a single transient exception cannot silently kill auto-fetch for the rest of the session — a dead poller that still claims to be polling is worse than no poller.

**Repaint only when content changed.** `_display_logs` clears and rewrites a `RichLog(auto_scroll=True)`, so an unconditional repaint every tick would drag the viewport to the bottom while the user was scrolled up reading a stack trace — making auto-fetch actively worse than pressing `r`. Comparing the fetched dict against the cache means most ticks paint nothing, which also removes the flicker. When logs genuinely change, scrolling to the bottom is correct tail behavior.

**On by default.** The friction being fixed is the keypress, so opt-in would leave it in place for anyone who does not find the toggle. `a` is the escape hatch. Note this differs from the allocator's web logs page, where auto-refresh is opt-in — that page has no per-VM selection step to anchor a poll to.

**Considered and rejected:** pause-on-scroll-position detection (inspect the scroll offset and suppress ticks while the user is scrolled up). The change-detection skip already covers the common case at a fraction of the complexity; worth revisiting only if the self-adjusting cadence proves insufficient in practice.