### PR TITLE
feat(client): add a text editor and desktop tooling to the client image

### DIFF
--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -59,12 +59,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Pager. Absent, git falls back to dumping the whole of `git log` /
     # `git diff` straight into the scrollback, and man pages lose paging.
     less \
-    # git is installed, so `git clone git@github.com:...` looks like it should
-    # work; without an ssh client it fails on any private or SSH-remote repo.
-    openssh-client \
-    # Reachability triage from inside the container, which is the only vantage
-    # point that tells apart a dead mesh-overlay/tunnel path from a dead app.
-    iputils-ping \
     # Text editor -- the image shipped none at all, not even vi. micro's
     # defaults match GUI muscle memory and it takes mouse input in a terminal.
     micro \

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -12,9 +12,8 @@ ENV DEBIAN_FRONTEND=noninteractive
 # of U+FFFD. C.UTF-8 is built into glibc 2.35, so no `locales` package needed.
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
-# Anything that shells out to an editor (git commit, crontab -e, visudo) reads
-# these and otherwise falls through to a hardcoded vi that isn't installed.
-# /etc/profile never sets them, so unlike PATH this survives into login shells.
+# Otherwise anything shelling out to an editor hits a hardcoded vi that is not
+# installed. /etc/profile never sets these, so unlike PATH they reach subshells.
 ENV EDITOR=micro VISUAL=micro
 
 # Set NVIDIA driver capabilities
@@ -66,17 +65,11 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # Reachability triage from inside the container, which is the only vantage
     # point that tells apart a dead mesh-overlay/tunnel path from a dead app.
     iputils-ping \
-    # Text editor. The image shipped none at all -- not even vi -- so `git
-    # commit` without -m, `crontab -e`, and every "now edit this file"
-    # instruction dead-ended. micro is chosen over nano/vim because its
-    # defaults are the shortcuts students already know (Ctrl+S save, Ctrl+Q
-    # quit, Ctrl+C/Ctrl+V copy/paste) and it handles mouse click-to-position
-    # and drag-select inside xfce4-terminal. One Go binary, ~13 MB.
+    # Text editor -- the image shipped none at all, not even vi. micro's
+    # defaults match GUI muscle memory and it takes mouse input in a terminal.
     micro \
-    # micro copies through the X11 CLIPBOARD selection via xclip. Without it
-    # Ctrl+C only fills micro's own internal buffer, so a copy never reaches
-    # KasmVNC's clipboard bridge and can't be pasted into Chrome or onto the
-    # student's own machine. 53 KB.
+    # micro copies via the X11 CLIPBOARD selection; without xclip Ctrl+C never
+    # reaches KasmVNC's clipboard bridge, so nothing pastes outside micro.
     xclip \
     # XFCE apps and plugins named individually rather than via xfce4-goodies:
     # that metapackage costs 92 MB and 82 packages, most of it ~25 panel
@@ -85,15 +78,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # libnotify call silently does nothing.
     xfce4-whiskermenu-plugin \
     xfce4-notifyd \
-    # GUI counterparts to the terminal tools above, for students who never
-    # open a terminal: no editor or image viewer existed, and archives could
-    # only be unpacked from the command line. thunar-archive-plugin is the
-    # piece that puts "Extract Here" in Thunar's context menu -- xarchiver on
-    # its own only installs a standalone app.
-    #
-    # These do NOT win their mime types by default: Chrome's .deb claims
-    # image/png and image/jpeg, and micro's .desktop claims text/plain with
-    # Terminal=true. desktop-config.sh pins mimeapps.list to override both.
+    # GUI counterparts to the terminal tools above, for students who never open
+    # a terminal: no editor or image viewer existed, and archives could only be
+    # unpacked from the command line. thunar-archive-plugin is what puts
+    # "Extract Here" and "Create Archive" in Thunar's context menu -- xarchiver
+    # alone only installs a standalone app. Images need a mime pin to beat
+    # Chrome; see desktop-config.sh.
     mousepad \
     ristretto \
     xarchiver \
@@ -153,6 +143,19 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # a student who types `fd` would get "command not found" for something that
 # is installed.
 RUN ln -s "$(command -v fdfind)" /usr/local/bin/fd
+
+# micro's .desktop claims text/plain plus ~15 source types with Terminal=true,
+# outranking mousepad -- a double-clicked .py would open a terminal editor in a
+# graphical session. Dropping MimeType beats pinning each type: GIO resolves an
+# unclaimed type through its parent, so mousepad wins all of text/* via
+# text/plain alone. micro is unaffected as $EDITOR or from the shell. The cache
+# rebuild is mandatory -- without it mimeinfo.cache serves the old claims.
+RUN grep -q '^MimeType=' /usr/share/applications/micro.desktop \
+        || { echo "ERROR: no MimeType line in micro.desktop -- the package may have changed; review this patch"; exit 1; }; \
+    sed -i '/^MimeType=/d' /usr/share/applications/micro.desktop; \
+    ! grep -q '^MimeType=' /usr/share/applications/micro.desktop \
+        || { echo "ERROR: sed did not remove MimeType from micro.desktop"; exit 1; }; \
+    update-desktop-database /usr/share/applications
 
 # Tailscale — joined at container start (start.sh) only when a
 # mesh-overlay client was registered with TAILSCALE_AUTHKEY set;

--- a/packages/client/Dockerfile
+++ b/packages/client/Dockerfile
@@ -12,6 +12,11 @@ ENV DEBIAN_FRONTEND=noninteractive
 # of U+FFFD. C.UTF-8 is built into glibc 2.35, so no `locales` package needed.
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
+# Anything that shells out to an editor (git commit, crontab -e, visudo) reads
+# these and otherwise falls through to a hardcoded vi that isn't installed.
+# /etc/profile never sets them, so unlike PATH this survives into login shells.
+ENV EDITOR=micro VISUAL=micro
+
 # Set NVIDIA driver capabilities
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
@@ -45,20 +50,54 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     xfce4 \
     desktop-base \
     xfce4-terminal \
-    # Terminal tooling. Small, and the two search tools are what students
-    # actually reach for in a repository. ~9 MB total.
+    # Terminal tooling. All small, and the two search tools are what students
+    # actually reach for in a repository.
     ripgrep \
     fd-find \
     htop \
     tree \
     jq \
-    # Named directly instead of via xfce4-goodies. That metapackage pulls
-    # ~25 panel plugins plus mousepad, ristretto, xfburn and xfce4-dict --
-    # 92 MB and 82 packages for the two things this desktop actually uses.
+    # Pager. Absent, git falls back to dumping the whole of `git log` /
+    # `git diff` straight into the scrollback, and man pages lose paging.
+    less \
+    # git is installed, so `git clone git@github.com:...` looks like it should
+    # work; without an ssh client it fails on any private or SSH-remote repo.
+    openssh-client \
+    # Reachability triage from inside the container, which is the only vantage
+    # point that tells apart a dead mesh-overlay/tunnel path from a dead app.
+    iputils-ping \
+    # Text editor. The image shipped none at all -- not even vi -- so `git
+    # commit` without -m, `crontab -e`, and every "now edit this file"
+    # instruction dead-ended. micro is chosen over nano/vim because its
+    # defaults are the shortcuts students already know (Ctrl+S save, Ctrl+Q
+    # quit, Ctrl+C/Ctrl+V copy/paste) and it handles mouse click-to-position
+    # and drag-select inside xfce4-terminal. One Go binary, ~13 MB.
+    micro \
+    # micro copies through the X11 CLIPBOARD selection via xclip. Without it
+    # Ctrl+C only fills micro's own internal buffer, so a copy never reaches
+    # KasmVNC's clipboard bridge and can't be pasted into Chrome or onto the
+    # student's own machine. 53 KB.
+    xclip \
+    # XFCE apps and plugins named individually rather than via xfce4-goodies:
+    # that metapackage costs 92 MB and 82 packages, most of it ~25 panel
+    # plugins plus xfburn and xfce4-dict that this desktop never uses.
     # notifyd is dbus-activated and needs no configuration; without it any
     # libnotify call silently does nothing.
     xfce4-whiskermenu-plugin \
     xfce4-notifyd \
+    # GUI counterparts to the terminal tools above, for students who never
+    # open a terminal: no editor or image viewer existed, and archives could
+    # only be unpacked from the command line. thunar-archive-plugin is the
+    # piece that puts "Extract Here" in Thunar's context menu -- xarchiver on
+    # its own only installs a standalone app.
+    #
+    # These do NOT win their mime types by default: Chrome's .deb claims
+    # image/png and image/jpeg, and micro's .desktop claims text/plain with
+    # Terminal=true. desktop-config.sh pins mimeapps.list to override both.
+    mousepad \
+    ristretto \
+    xarchiver \
+    thunar-archive-plugin \
     # Ubuntu 24.04's own theme. Yaru ships xfwm4 window decorations as well
     # as the GTK theme and icons, so the desktop is themed end to end rather
     # than GTK-only with fallback borders.

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -50,8 +50,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     tree \
     jq \
     less \
-    openssh-client \
-    iputils-ping \
     micro \
     xclip \
     xfce4-whiskermenu-plugin \

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -12,6 +12,9 @@ ENV DEBIAN_FRONTEND=noninteractive
 # of U+FFFD. C.UTF-8 is built into glibc 2.35, so no `locales` package needed.
 ENV LANG=C.UTF-8 LC_ALL=C.UTF-8
 
+# Editor for anything that shells out to one -- see Dockerfile for why.
+ENV EDITOR=micro VISUAL=micro
+
 # Set NVIDIA driver capabilities
 ENV NVIDIA_DRIVER_CAPABILITIES=all
 
@@ -46,8 +49,17 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     htop \
     tree \
     jq \
+    less \
+    openssh-client \
+    iputils-ping \
+    micro \
+    xclip \
     xfce4-whiskermenu-plugin \
     xfce4-notifyd \
+    mousepad \
+    ristretto \
+    xarchiver \
+    thunar-archive-plugin \
     yaru-theme-gtk \
     yaru-theme-icon \
     fonts-ubuntu \

--- a/packages/client/Dockerfile.dev
+++ b/packages/client/Dockerfile.dev
@@ -101,6 +101,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # fd-find installs its binary as `fdfind`; see Dockerfile.
 RUN ln -s "$(command -v fdfind)" /usr/local/bin/fd
 
+# Drop micro's MimeType claims so mousepad wins text/*; see Dockerfile for why
+# the cache rebuild is required.
+RUN grep -q '^MimeType=' /usr/share/applications/micro.desktop \
+        || { echo "ERROR: no MimeType line in micro.desktop -- the package may have changed; review this patch"; exit 1; }; \
+    sed -i '/^MimeType=/d' /usr/share/applications/micro.desktop; \
+    ! grep -q '^MimeType=' /usr/share/applications/micro.desktop \
+        || { echo "ERROR: sed did not remove MimeType from micro.desktop"; exit 1; }; \
+    update-desktop-database /usr/share/applications
+
 # Tailscale — joined at container start (start.sh) only when a
 # mesh-overlay client was registered with TAILSCALE_AUTHKEY set;
 # lan_direct/allocator_proxied clients never invoke `tailscale up`.

--- a/packages/client/desktop-config.sh
+++ b/packages/client/desktop-config.sh
@@ -168,7 +168,7 @@ category-show-name=true
 position-search-alternate=true
 position-commands-alternate=true
 recent-items-max=10
-favorites=xfce4-terminal.desktop,google-chrome.desktop,Thunar.desktop
+favorites=xfce4-terminal.desktop,google-chrome.desktop,Thunar.desktop,org.xfce.mousepad.desktop
 WHISKERRC
 
 # Window-management keybindings, set explicitly rather than inherited.
@@ -235,5 +235,34 @@ ScrollingLines=10000
 ScrollingOnOutput=FALSE
 ScrollingBar=TERMINAL_SCROLLBAR_RIGHT
 TERMINALRC
+
+# Default applications for a double-click in Thunar and for xdg-open.
+#
+# Pinned because both defaults are wrong when left to mimeinfo.cache ordering.
+# Chrome's .deb registers itself for image/png and image/jpeg, so an image
+# opens a whole browser window rather than a viewer -- painful when flipping
+# through labelled frames. And micro's .desktop claims text/plain plus most
+# source types with Terminal=true, which outranks mousepad and turns a
+# double-clicked config file into a terminal editor. micro stays the $EDITOR
+# for terminal work; a double-click in a graphical session should land in the
+# graphical app. application/x-yaml has no registered handler at all.
+cat > "${CONFIG_HOME}/.config/mimeapps.list" <<'MIMEAPPS'
+[Default Applications]
+text/plain=org.xfce.mousepad.desktop
+text/markdown=org.xfce.mousepad.desktop
+text/csv=org.xfce.mousepad.desktop
+text/x-python=org.xfce.mousepad.desktop
+text/x-shellscript=org.xfce.mousepad.desktop
+text/x-log=org.xfce.mousepad.desktop
+application/json=org.xfce.mousepad.desktop
+application/x-yaml=org.xfce.mousepad.desktop
+text/x-yaml=org.xfce.mousepad.desktop
+image/png=org.xfce.ristretto.desktop
+image/jpeg=org.xfce.ristretto.desktop
+image/gif=org.xfce.ristretto.desktop
+image/bmp=org.xfce.ristretto.desktop
+image/tiff=org.xfce.ristretto.desktop
+image/webp=org.xfce.ristretto.desktop
+MIMEAPPS
 
 echo "desktop-config: wrote configuration under ${XFCONF}"

--- a/packages/client/desktop-config.sh
+++ b/packages/client/desktop-config.sh
@@ -236,33 +236,20 @@ ScrollingOnOutput=FALSE
 ScrollingBar=TERMINAL_SCROLLBAR_RIGHT
 TERMINALRC
 
-# Default applications for a double-click in Thunar and for xdg-open.
+# Images only. Chrome's .deb claims png/jpeg/gif and outranks ristretto, so a
+# double-clicked frame opens a whole browser window instead of a viewer --
+# painful when flipping through labelled frames. Every other type sorts itself
+# out: GIO resolves an unclaimed type through its parent, so once the Dockerfile
+# drops micro's MimeType line, mousepad wins all of text/* via text/plain and
+# ristretto already wins bmp/tiff/svg unaided. Nothing to pin for those.
 #
-# Pinned because both defaults are wrong when left to mimeinfo.cache ordering.
-# Chrome's .deb registers itself for image/png and image/jpeg, so an image
-# opens a whole browser window rather than a viewer -- painful when flipping
-# through labelled frames. And micro's .desktop claims text/plain plus most
-# source types with Terminal=true, which outranks mousepad and turns a
-# double-clicked config file into a terminal editor. micro stays the $EDITOR
-# for terminal work; a double-click in a graphical session should land in the
-# graphical app. application/x-yaml has no registered handler at all.
+# webp is deliberately absent -- ristretto's .desktop does not claim it, so it
+# stays with Chrome rather than being pointed at an app that never declared it.
 cat > "${CONFIG_HOME}/.config/mimeapps.list" <<'MIMEAPPS'
 [Default Applications]
-text/plain=org.xfce.mousepad.desktop
-text/markdown=org.xfce.mousepad.desktop
-text/csv=org.xfce.mousepad.desktop
-text/x-python=org.xfce.mousepad.desktop
-text/x-shellscript=org.xfce.mousepad.desktop
-text/x-log=org.xfce.mousepad.desktop
-application/json=org.xfce.mousepad.desktop
-application/x-yaml=org.xfce.mousepad.desktop
-text/x-yaml=org.xfce.mousepad.desktop
 image/png=org.xfce.ristretto.desktop
 image/jpeg=org.xfce.ristretto.desktop
 image/gif=org.xfce.ristretto.desktop
-image/bmp=org.xfce.ristretto.desktop
-image/tiff=org.xfce.ristretto.desktop
-image/webp=org.xfce.ristretto.desktop
 MIMEAPPS
 
 echo "desktop-config: wrote configuration under ${XFCONF}"


### PR DESCRIPTION
## Summary

- The client image shipped **no text editor at all** — not `nano`, not `vim`, not even `vi`. Verified by probing the published image directly.
- Adds `micro` as the terminal editor, plus a pager and GUI handlers for text files, images, and archives.
- Removes `micro`'s `MimeType` claims so the GUI editor wins text files, and pins three image types so the image viewer beats Chrome.

## Changes Made

`Dockerfile` and `Dockerfile.dev` (kept in lockstep):

| Package | Why |
|---|---|
| `micro` | Terminal editor. Chosen over nano/vim because its defaults are the shortcuts students already know (Ctrl+S save, Ctrl+Q quit, Ctrl+C/Ctrl+V copy/paste) and it handles mouse click-to-position and drag-select inside `xfce4-terminal`. |
| `xclip` | Not optional for the above — micro copies via the X11 CLIPBOARD selection. Without it Ctrl+C fills only micro's internal buffer and never crosses KasmVNC's clipboard bridge to Chrome or the student's own machine. |
| `less` | Absent, git dumps all of `git log` / `git diff` into the scrollback and man pages lose paging. |
| `mousepad` | GUI editor, for students who never open a terminal. |
| `ristretto` | Image viewer. |
| `xarchiver` + `thunar-archive-plugin` | The plugin supplies Thunar's right-click **Extract Here** and **Create Archive**; xarchiver alone only installs a standalone app. |

Also sets `ENV EDITOR=micro VISUAL=micro`, so anything shelling out to an editor (`git commit`, `crontab -e`, `visudo`) stops falling through to a hardcoded `vi` that isn't installed. `/etc/profile` never sets these, so unlike `PATH` they survive into login shells.

`desktop-config.sh`: pins three image types in `mimeapps.list`, and adds mousepad to the whiskermenu favorites.

**Dropped during review:** `openssh-client` and `iputils-ping` were in an earlier revision and have been removed. Nothing in `start.sh`, `desktop-config.sh` or the client source references `ssh`, `scp`, `ssh-keygen` or `ping`, so neither was ever called. The ssh client was justified by "a student might clone over SSH", but these VMs are ephemeral with no user keys configured and public repos clone over HTTPS. `ping` was for operator triage, and `sudo` is in the image, so anyone who genuinely needs either can install it on demand rather than every student carrying it.

## Design Decisions

**The mime problem, and why the fix is a deletion rather than a list of overrides.**

Installing the GUI apps is not sufficient, for two non-obvious reasons:

- `micro`'s own `.desktop` claims `text/plain` **plus ~15 source types** with `Terminal=true`, which *outranks* mousepad. A double-clicked `.py` would open a terminal editor inside a graphical session.
- Chrome's `.deb` claims `image/png`/`jpeg`/`gif`, outranking ristretto, so a double-clicked frame opened a whole browser window.

The obvious fix — pin every affected type in `mimeapps.list` — is wrong twice over: it can only cover the types you think to enumerate (leaving `.css`, `.xml`, `.diff`, `.c`, `.sql` still broken), and it breaks again whenever micro's package revises its `MimeType` list.

So instead the `MimeType` line is deleted from `micro.desktop`. GIO resolves an unclaimed type through its **parent type**, so mousepad then wins the entire `text/*` tree via `text/plain` alone — no per-type entries at all. micro is unaffected as `$EDITOR` or from the shell; a `.desktop` file governs neither. The cache rebuild is not optional: verified that the `sed` alone is a **no-op**, because `mimeinfo.cache` keeps serving the old claims until `update-desktop-database` regenerates it. Guarded verify-patch-verify, matching the existing noVNC `sed` in this file.

That leaves `mimeapps.list` with three entries — `png`/`jpeg`/`gif` → ristretto — the only cases where a legitimate competing claim (Chrome's) has to be overridden. `image/webp` is deliberately left with Chrome because ristretto's `.desktop` does not claim it, and `bmp`/`tiff` need no entry because ristretto already wins them.

**Measure with `gio mime`, not `xdg-mime query default`.** The `xdg-mime` tool ignores mime inheritance and reports an unclaimed subtype as empty, which is what made per-type pinning look necessary. Thunar uses GIO, which does follow inheritance.

**Why `micro` over `nano`.** `nano` is 836 KB against micro's 12.9 MB, but nano's `^O WriteOut` / `^X Exit` bindings are exactly what strands a student who has only used a GUI editor. micro's defaults match muscle memory and it accepts mouse input in the terminal, which matters in a browser-delivered desktop.

**Why individual packages, not `xfce4-goodies`.** The metapackage is 92 MB / 82 packages, mostly ~25 panel plugins plus `xfburn` and `xfce4-dict` this desktop never uses.

**Cost:** ~37 MB measured with dependencies, on a 7.15 GB image.

## Testing

Empirical, against the published image (`ghcr.io/talmolab/lablink-client-base-image:latest`) rather than by inspection:

- Confirmed the starting state: all of `nano`/`vim`/`vi`/`vim.tiny`/`mousepad`/`gedit`/`emacs`/`pico`/`ed`/`micro` reported MISSING.
- Installed exactly what this diff adds; every binary resolves, and `thunar-archive-plugin.so` lands in `thunarx-3/`.
- `git var GIT_EDITOR` → `micro` (previously a missing `vi`); `git var GIT_PAGER` → `pager` → `less`.
- Ran the guarded `MimeType` strip plus the modified `desktop-config.sh`, then read every default back with `gio mime`:
  - `text/plain`, `text/x-python`, `text/css`, `text/x-diff`, `text/markdown`, `application/json`, `application/yaml`, `text/x-csrc` → mousepad
  - `text/html`, `application/xml` → Chrome (correct — it renders them)
  - `image/png`, `image/jpeg`, `image/gif`, `image/bmp`, `image/tiff` → ristretto
  - `application/zip` → xarchiver
- Verified the `sed`-without-cache-rebuild failure mode directly: `mimeinfo.cache` still listed micro for 19 types and `text/plain` still resolved to `micro.desktop`.
- Confirmed xarchiver's format backends: `zip`/`tar`/`gzip`/`bzip2`/`xz` present, so `.zip` and all `.tar.*` work. `.7z`/`.rar`/`.zst` are **not** supported (`p7zip`/`unrar`/`zstd` absent) — left out deliberately as unlikely for this workload.
- After removing `openssh-client`/`iputils-ping`: re-confirmed the remaining set installs with every binary resolving, and that `ssh`/`ping` are absent.
- `docker build --check` clean on both Dockerfiles; `bash -n` clean on `desktop-config.sh`.
- `ruff check` passes; 156 client tests pass. No Python changed, and nothing in `.github/` or `tests/` asserts on these files.

**Not covered:** how mousepad and ristretto feel over KasmVNC (encoder load on window drags, ristretto's redraw when flipping frames). That needs a real GPU host — an arm64 build aborts on the amd64-only kasmvnc `.deb`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)