### PR TITLE
docs: bump stale 0.1.2 version examples to 0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ Production images are built from the PyPI packages:
 - `linux-amd64-latest` - Latest for specific platform
 - `<sha>` - Specific git commit
 - `linux-amd64-test` - Development/testing builds
-- `<version>` (e.g., `0.1.2`) - Only published when a build is triggered manually
+- `<version>` (e.g., `0.2.0`) - Only published when a build is triggered manually
 
 See [Docker Image Tags](https://talmolab.github.io/lablink/workflows/#image-tagging-strategy) for complete tagging strategy.
 

--- a/docs/workflows.md
+++ b/docs/workflows.md
@@ -148,7 +148,7 @@ Publishes Python packages to PyPI with safety guardrails.
 
 ### Triggers
 
-- **Git tags** matching package name pattern (e.g., `lablink-allocator-service_v0.1.2`)
+- **Git tags** matching package name pattern (e.g., `lablink-allocator-service_v0.2.0`)
 - **Manual dispatch** with dry-run option
 
 ### Features
@@ -184,16 +184,16 @@ Publishes Python packages to PyPI with safety guardrails.
 
 - **Format**: `{package-name}_v{version}`
 - **Examples**:
-  - `lablink-allocator-service_v0.1.2`
-  - `lablink-client-service_v0.1.2`
+  - `lablink-allocator-service_v0.2.0`
+  - `lablink-client-service_v0.2.0`
 
 ### Example: Publishing a Release
 
 ```bash
 # 1. Create and push tags
-git tag lablink-allocator-service_v0.1.2
-git tag lablink-client-service_v0.1.2
-git push origin lablink-allocator-service_v0.1.2 lablink-client-service_v0.1.2
+git tag lablink-allocator-service_v0.2.0
+git tag lablink-client-service_v0.2.0
+git push origin lablink-allocator-service_v0.2.0 lablink-client-service_v0.2.0
 
 # 2. Workflow automatically:
 #    - Detects tags
@@ -204,8 +204,8 @@ git push origin lablink-allocator-service_v0.1.2 lablink-client-service_v0.1.2
 # 3. Manually trigger Docker image build (see below)
 gh workflow run lablink-images.yml \
   -f environment=prod \
-  -f allocator_version=0.1.2 \
-  -f client_version=0.1.2
+  -f allocator_version=0.2.0 \
+  -f client_version=0.2.0
 ```
 
 ### Building Docker Images After Publishing
@@ -226,8 +226,8 @@ gh workflow run lablink-images.yml \
 # Build both images with their respective versions
 gh workflow run lablink-images.yml \
   -f environment=prod \
-  -f allocator_version=0.1.2 \
-  -f client_version=0.1.2
+  -f allocator_version=0.2.0 \
+  -f client_version=0.2.0
 ```
 
 **Option 2: Using GitHub UI**:
@@ -236,15 +236,15 @@ gh workflow run lablink-images.yml \
 2. Click "Run workflow"
 3. Select branch: `main`
 4. **Set environment: `prod`** (required!)
-5. **Enter allocator version: `0.1.2`** (required!)
-6. **Enter client version: `0.1.2`** (required!)
+5. **Enter allocator version: `0.2.0`** (required!)
+6. **Enter client version: `0.2.0`** (required!)
 7. Click "Run workflow"
 
 **What happens:**
 
 - Pulls packages from PyPI with specified versions
 - Builds Docker images using production `Dockerfile`
-- Tags images with version numbers (e.g., `:0.1.2`, `:linux-amd64-0.1.2`)
+- Tags images with version numbers (e.g., `:0.2.0`, `:linux-amd64-0.2.0`)
 - Tags images with `:latest` for convenience
 - Verifies images work correctly
 - **No `-test` suffix** on production images
@@ -359,7 +359,7 @@ sequenceDiagram
     participant Build as GitHub Actions<br/>lablink-images.yml
     participant Registry as ghcr.io
 
-    Developer->>Git: Create and push tags<br/>lablink-allocator-service_v0.1.2<br/>lablink-client-service_v0.1.2
+    Developer->>Git: Create and push tags<br/>lablink-allocator-service_v0.2.0<br/>lablink-client-service_v0.2.0
     Git->>GHA: Trigger publish-pip.yml
 
     Note over GHA: Step 1: Publish to PyPI
@@ -371,11 +371,11 @@ sequenceDiagram
 
     Note over Developer,Manual: CRITICAL: Do NOT skip Step 2
 
-    Developer->>Manual: gh workflow run lablink-images.yml<br/>-f environment=prod<br/>-f allocator_version=0.1.2<br/>-f client_version=0.1.2
+    Developer->>Manual: gh workflow run lablink-images.yml<br/>-f environment=prod<br/>-f allocator_version=0.2.0<br/>-f client_version=0.2.0
 
     Note over Build: Step 2: Build Production Images
     Manual->>Build: Trigger with versions
-    Build->>PyPI: Pull packages<br/>lablink-allocator==0.1.2<br/>lablink-client==0.1.2
+    Build->>PyPI: Pull packages<br/>lablink-allocator==0.2.0<br/>lablink-client==0.2.0
     Build->>Build: Build from Dockerfile<br/>(PyPI packages)
     Build->>Registry: Push images with<br/>version tags
     Registry-->>Developer: Images ready for<br/>deployment
@@ -385,9 +385,9 @@ sequenceDiagram
 
 ```bash
 # Create and push git tags
-git tag lablink-allocator-service_v0.1.2
-git tag lablink-client-service_v0.1.2
-git push origin lablink-allocator-service_v0.1.2 lablink-client-service_v0.1.2
+git tag lablink-allocator-service_v0.2.0
+git tag lablink-client-service_v0.2.0
+git push origin lablink-allocator-service_v0.2.0 lablink-client-service_v0.2.0
 
 # publish-pip.yml workflow automatically:
 #   - Runs tests
@@ -401,8 +401,8 @@ git push origin lablink-allocator-service_v0.1.2 lablink-client-service_v0.1.2
 # After packages are published, build production images
 gh workflow run lablink-images.yml \
   -f environment=prod \
-  -f allocator_version=0.1.2 \
-  -f client_version=0.1.2
+  -f allocator_version=0.2.0 \
+  -f client_version=0.2.0
 ```
 
 **Critical**: Do NOT skip Step 2. Without it, your published packages won't have corresponding Docker images, and deployments will fail.
@@ -435,7 +435,7 @@ gh workflow run lablink-images.yml -f environment=ci-test
 
 ```bash
 # Published to PyPI but forgot Step 2
-git push origin lablink-allocator-service_v0.1.2
+git push origin lablink-allocator-service_v0.2.0
 # Result: Package exists but no Docker image with version tag
 ```
 
@@ -450,15 +450,15 @@ gh workflow run lablink-images.yml -f environment=prod
 
 ```bash
 # 1. Publish packages
-git push origin lablink-allocator-service_v0.1.2 lablink-client-service_v0.1.2
+git push origin lablink-allocator-service_v0.2.0 lablink-client-service_v0.2.0
 
 # 2. Wait for publish-pip.yml to complete successfully
 
 # 3. Build Docker images with explicit versions
 gh workflow run lablink-images.yml \
   -f environment=prod \
-  -f allocator_version=0.1.2 \
-  -f client_version=0.1.2
+  -f allocator_version=0.2.0 \
+  -f client_version=0.2.0
 ```
 
 ### Smart Dockerfile Selection
@@ -490,14 +490,14 @@ Docker images are tagged differently based on how they are triggered. This allow
 ```bash
 gh workflow run lablink-images.yml \
   -f environment=prod \
-  -f allocator_version=0.1.2 \
-  -f client_version=0.1.2
+  -f allocator_version=0.2.0 \
+  -f client_version=0.2.0
 ```
 
 Creates images tagged with:
 
-- `ghcr.io/talmolab/lablink-allocator-image:0.1.2` - **Version-specific tag**
-- `ghcr.io/talmolab/lablink-allocator-image:linux-amd64-0.1.2` - Platform + version
+- `ghcr.io/talmolab/lablink-allocator-image:0.2.0` - **Version-specific tag**
+- `ghcr.io/talmolab/lablink-allocator-image:linux-amd64-0.2.0` - Platform + version
 - `ghcr.io/talmolab/lablink-allocator-image:linux-amd64-latest` - Latest for platform
 - `ghcr.io/talmolab/lablink-allocator-image:linux-amd64` - Platform tag
 - `ghcr.io/talmolab/lablink-allocator-image:linux-amd64-tofu-1.12.5` - Metadata tag
@@ -538,14 +538,14 @@ Creates images tagged with `-test` suffix:
 ```bash
 gh workflow run lablink-images.yml \
   -f environment=prod \
-  -f allocator_version=0.1.2 \
-  -f client_version=0.1.2
+  -f allocator_version=0.2.0 \
+  -f client_version=0.2.0
 ```
 
 Creates images tagged with:
 
-- `ghcr.io/talmolab/lablink-client-base-image:0.1.2` - **Version-specific tag**
-- `ghcr.io/talmolab/lablink-client-base-image:linux-amd64-0.1.2` - Platform + version
+- `ghcr.io/talmolab/lablink-client-base-image:0.2.0` - **Version-specific tag**
+- `ghcr.io/talmolab/lablink-client-base-image:linux-amd64-0.2.0` - Platform + version
 - `ghcr.io/talmolab/lablink-client-base-image:linux-amd64-latest` - Latest for platform
 - `ghcr.io/talmolab/lablink-client-base-image:linux-amd64-nvidia-cuda-11.6.1-cudnn8-runtime-ubuntu20.04`
 - `ghcr.io/talmolab/lablink-client-base-image:linux-amd64-ubuntu20.04-nvm-0.40.2-uv-0.6.8-miniforge3-24.11.3`
@@ -554,7 +554,7 @@ Creates images tagged with:
 
 **Push to main branch (automatic):**
 
-Creates same tags as manual trigger except without version-specific tags (`0.1.2`, `linux-amd64-0.1.2`)
+Creates same tags as manual trigger except without version-specific tags (`0.2.0`, `linux-amd64-0.2.0`)
 
 **Pull requests / test branch (automatic):**
 
@@ -566,8 +566,8 @@ For production deployments, always use version-specific tags in your OpenTofu co
 
 ```hcl
 # terraform.tfvars or -var flags
-allocator_image_tag = "0.1.2"  # Pin to specific version
-client_image_tag    = "0.1.2"  # Pin to specific version
+allocator_image_tag = "0.2.0"  # Pin to specific version
+client_image_tag    = "0.2.0"  # Pin to specific version
 ```
 
 For development/testing, you can use environment-specific tags:


### PR DESCRIPTION
## Summary

- Every version example in the docs used `0.1.2` — the allocator and client version from **April**. Both packages are `0.2.0`, so the examples pointed two releases back.
- 37 occurrences across two files: 1 in `README.md`, 36 in `docs/workflows.md`.
- Several are commands a reader copy-pastes, where a stale version is a trap rather than an eyesore.

## Changes Made

**`README.md:62`** — the `<version>` image-tag example in the *Available Tags* list.

**`docs/workflows.md`** — 36 occurrences. The ones that actually matter, because someone will paste them:

| Location | What it is | Risk if stale |
|---|---|---|
| `:194-196`, `:388-390`, `:438`, `:453` | tag-and-push release steps | **tags the wrong version** |
| `:207-208`, `:229-230`, `:404-405`, `:460-461`, `:493-494`, `:541-542` | `gh workflow run -f allocator_version=… -f client_version=…` | **builds the wrong version** |
| `:569-570` | `terraform.tfvars` image-tag pinning | **deploys the wrong image** |
| `:239-240` | "Enter allocator version: `0.1.2` (required!)" — manual dispatch walkthrough | wrong value entered |

The rest are cosmetic: tag-pattern examples (`:151`, `:187-188`), image-tag examples (`:247`, `:499-500`, `:547-548`, `:557`), and two mermaid sequence diagrams (`:362`, `:374`, `:378`).

## Design Decisions

**Verified none were historical before replacing.** A blind find-and-replace would have been wrong if any occurrence were a changelog entry or a "since 0.1.2" note. Grepped for `since|as of|introduced|changed in|deprecated` near every match — no hits — and spot-checked the contexts. All 36 are illustrative, including the one inside a *"Published to PyPI but forgot Step 2"* failure example, which reads correctly with a current version.

**The examples now name tags that actually exist.** `lablink-allocator-service_v0.2.0` and `lablink-client-service_v0.2.0` are both real published releases, so these commands are valid as written, not merely less old.

**Why the README needed only one line.** This started from "why wasn't the README updated for the client v0.2.0 release?" — and mostly it *was*: the PyPI badges are dynamic shields.io endpoints that read PyPI live and already serve `v0.2.0`:

```
$ curl -s "https://img.shields.io/pypi/v/lablink-client-service?label=client"
>client: v0.2.0<
```

They only *look* stale because shields.io sets `cache-control: max-age=10800` (3 hours) and GitHub proxies README images through `camo.githubusercontent.com`. So a release never requires a README edit — which is exactly why nobody had to remember one, and why this single hardcoded example drifted unnoticed.

## Testing

Documentation-only; no code, no behavior, no test surface.

- Verified the replacement was complete and exact: **0** occurrences of `0.1.2` remain and **36** of `0.2.0` are present in `workflows.md`; the diff is `36 insertions(+), 36 deletions(-)` — a pure one-for-one swap with no incidental edits.
- Confirmed both referenced release tags exist.
- `ruff check` on all three packages passes (unchanged — no Python touched). Nothing in `.github/` or any test asserts on docs contents.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
