### PR TITLE
docs: document lablink-cli's PyPI release

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 
 [![PyPI - lablink-allocator-service](https://img.shields.io/pypi/v/lablink-allocator-service?label=allocator)](https://pypi.org/project/lablink-allocator-service/)
 [![PyPI - lablink-client-service](https://img.shields.io/pypi/v/lablink-client-service?label=client)](https://pypi.org/project/lablink-client-service/)
+[![PyPI - lablink-cli](https://img.shields.io/pypi/v/lablink-cli?label=cli)](https://pypi.org/project/lablink-cli/)
 [![CI](https://img.shields.io/github/actions/workflow/status/talmolab/lablink/ci.yml?event=pull_request&label=CI)](https://github.com/talmolab/lablink/actions/workflows/ci.yml)
 [![Documentation](https://img.shields.io/badge/docs-latest-blue)](https://talmolab.github.io/lablink/)
 [![License](https://img.shields.io/github/license/talmolab/lablink)](LICENSE)
@@ -30,13 +31,15 @@ Published to PyPI:
   pip install lablink-client-service
   ```
 
-Not yet on PyPI — install from source:
-
 - **[lablink-cli](packages/cli/)** - Command-line tool to deploy and manage LabLink infrastructure
+
   ```bash
-  git clone https://github.com/talmolab/lablink.git
-  cd lablink && uv sync --all-packages
+  uv tool install lablink-cli   # or: pip install lablink-cli
   ```
+
+  Currently a pre-release (`0.1.0a1`). The package is `lablink-cli`; the command it
+  installs is `lablink`. To work on the CLI itself, install from source instead —
+  see the [Contributing Guide](https://talmolab.github.io/lablink/contributing/).
 
 ### Docker Images (Published to GHCR)
 
@@ -79,7 +82,7 @@ See [Docker Image Tags](https://talmolab.github.io/lablink/workflows/#image-tagg
 
 |           | **Path A — CLI (recommended)**        | **Path B — Template fork**                                            |
 | --------- | ------------------------------------- | --------------------------------------------------------------------- |
-| Install   | `uv sync --all-packages`              | Fork [lablink-template](https://github.com/talmolab/lablink-template) |
+| Install   | `uv tool install lablink-cli`         | Fork [lablink-template](https://github.com/talmolab/lablink-template) |
 | Configure | Interactive TUI (`lablink configure`) | Edit `lablink.yaml` by hand                                           |
 | Deploy    | `lablink deploy`                      | `terraform apply`                                                     |
 | Best for  | Most users                            | Custom Terraform workflows                                            |
@@ -87,10 +90,8 @@ See [Docker Image Tags](https://talmolab.github.io/lablink/workflows/#image-tagg
 ### Using the CLI
 
 ```bash
-# Install from source (see docs/cli/installation.md)
-git clone https://github.com/talmolab/lablink.git
-cd lablink && uv sync --all-packages
-source .venv/bin/activate
+# Install from PyPI (see docs/cli/installation.md)
+uv tool install lablink-cli
 
 # Interactive configuration wizard (Textual TUI)
 lablink configure
@@ -178,7 +179,7 @@ LabLink uses **independent versioning** for its packages:
 
 - **lablink-allocator-service**: [![PyPI](https://img.shields.io/pypi/v/lablink-allocator-service)](https://pypi.org/project/lablink-allocator-service/)
 - **lablink-client-service**: [![PyPI](https://img.shields.io/pypi/v/lablink-client-service)](https://pypi.org/project/lablink-client-service/)
-- **lablink-cli**: not yet published to PyPI (install from source)
+- **lablink-cli**: [![PyPI](https://img.shields.io/pypi/v/lablink-cli)](https://pypi.org/project/lablink-cli/) — pre-release
 
 ---
 

--- a/docs/cli/index.md
+++ b/docs/cli/index.md
@@ -2,8 +2,10 @@
 
 The `lablink` command is a CLI-driven alternative to the [lablink-template](https://github.com/talmolab/lablink-template) repository. It deploys the same allocator infrastructure to AWS — cloud resources are identical either way — but drives OpenTofu from your own machine instead of GitHub Actions.
 
-!!! note "Status: pre-PyPI"
-    The CLI is not yet published to PyPI. For now, install it from source with `uv sync --all-packages` — see [Installation](installation.md). `uv tool install lablink` will be the path once the package is released.
+!!! note "Status: pre-release"
+    The CLI is on PyPI as [`lablink-cli`](https://pypi.org/project/lablink-cli/). Install it with `uv tool install lablink-cli` (or `pip install lablink-cli`) — see [Installation](installation.md). The published version is a pre-release, so expect rough edges and pin the version if you need reproducibility.
+
+    Note the package is `lablink-cli` while the command it installs is `lablink`.
 
 ## Two providers
 

--- a/docs/cli/installation.md
+++ b/docs/cli/installation.md
@@ -1,9 +1,12 @@
 # Installing the CLI
 
-The `lablink` command is distributed with the [LabLink repository](https://github.com/talmolab/lablink) as one of three packages in a `uv` workspace (`packages/allocator`, `packages/client`, `packages/cli`). Until the CLI is published to PyPI, install it from source with `uv sync --all-packages`.
+The `lablink` command is published to PyPI as [`lablink-cli`](https://pypi.org/project/lablink-cli/). Install it as a standalone tool to deploy and manage LabLink, or [from source](#install-from-source) if you intend to work on the CLI itself — it is also one of three packages in this repo's `uv` workspace (`packages/allocator`, `packages/client`, `packages/cli`).
 
-!!! note "PyPI coming soon"
-    Once published, `uv tool install lablink` (or `pip install lablink`) will be the recommended install. For now, use the workspace install below.
+!!! note "The package and the command have different names"
+    The PyPI package is **`lablink-cli`**; the command it installs is **`lablink`**. There is no `lablink` package on PyPI, so `pip install lablink` will fail.
+
+!!! warning "Pre-release"
+    The published version is a pre-release (`0.1.0a1`). Expect rough edges, and pin an exact version (`lablink-cli==0.1.0a1`) if you need a reproducible install.
 
 ## Prerequisites
 
@@ -23,9 +26,25 @@ The rest depends on which provider you deploy with.
     - **Docker** and the **`docker compose` v2 plugin**, on the allocator host and on every client box. The allocator runs as a compose stack and each client runs the client container.
     - No AWS account, no AWS credentials, and no OpenTofu — see [Bring-Your-Own Clients](byo-clients.md).
 
+## Install from PyPI
+
+This is the path for using the CLI. Install it as a standalone tool:
+
+```bash
+uv tool install lablink-cli
+```
+
+That puts `lablink` on your `PATH` in its own isolated environment, which is what you want for a command-line tool — it cannot collide with another project's dependencies. Verify it:
+
+```bash
+lablink --version
+```
+
+`pip install lablink-cli` works too, into whichever environment is currently active. No `--pre` flag is needed despite the alpha version: it is the only release right now, so both installers select it. Once a stable release exists, plain installs will prefer that instead, and you would need `--pre` to keep getting alphas.
+
 ## Install from source
 
-Clone the repo and run `uv sync --all-packages` at the root. This installs all three workspace packages (allocator, client, CLI) as editable — the CLI depends on `lablink-allocator-service`, which uv resolves from the workspace automatically.
+Use this if you intend to modify the CLI. Clone the repo and run `uv sync --all-packages` at the root. This installs all three workspace packages (allocator, client, CLI) as editable — the CLI depends on `lablink-allocator-service`, which uv resolves from the workspace automatically.
 
 ```bash
 git clone https://github.com/talmolab/lablink.git
@@ -56,8 +75,10 @@ You should see the grouped command list (Setup, Deployment, Operations, Maintena
 Once installed, run `lablink` with no arguments to confirm everything is wired up:
 
 ```bash
-uv run lablink
+lablink
 ```
+
+If you installed from source rather than PyPI, use `uv run lablink` instead, or activate the venv first.
 
 On a fresh install (no config yet), you'll see a **Getting started** panel pointing at the next three commands:
 
@@ -111,7 +132,13 @@ Pass `--config /path/to/config.yaml` to any command to use a different config fi
 
 ## Upgrading
 
-Pull the latest source and re-sync:
+If you installed from PyPI:
+
+```bash
+uv tool upgrade lablink-cli   # or: pip install --upgrade lablink-cli
+```
+
+If you installed from source, pull and re-sync:
 
 ```bash
 cd lablink


### PR DESCRIPTION
## Summary

- `lablink-cli` is on PyPI as **`0.1.0a1`**, but the docs still told readers it was unpublished and to install from source.
- Adds the PyPI install path, a version badge alongside the allocator and client ones, and reorders the installation page so PyPI is the default and source is for people modifying the CLI.
- Fixes two accuracy problems found along the way, one of which would have handed readers a command that fails outright.

## Changes Made

**`README.md`**

- New `cli` PyPI badge next to the allocator and client badges.
- Package list: dropped the "Not yet on PyPI — install from source" separator, so the CLI now sits under **Published to PyPI** with `uv tool install lablink-cli`.
- Deployment-paths table: Path A install is `uv tool install lablink-cli`, not `uv sync --all-packages`.
- Quick Start: installs from PyPI instead of cloning the repo.
- Versioning section: badge instead of "not yet published to PyPI".

**`docs/cli/index.md`** — the "Status: pre-PyPI" note now points at the published package.

**`docs/cli/installation.md`** — new `## Install from PyPI` section, placed after Prerequisites and before `## Install from source`, which is now framed as the path for modifying the CLI.

## Design Decisions

**Two bugs fixed beyond the staleness.**

1. **The promised install command would have failed.** Both pages advertised `uv tool install lablink` / `pip install lablink`. The package is **`lablink-cli`** — `lablink` is only the command it installs — and there is no `lablink` project on PyPI (confirmed **404**), so those commands would error out. The installation page now states the package/command distinction explicitly, because it is easy to trip over.

2. **Adding a PyPI path left the page self-contradictory.** Its later sections assumed a source checkout: *Verify the installation* said to run `uv run lablink`, which does not exist for a tool install, and *Upgrading* only documented `git pull` + re-sync. Both now cover each install path. Without this, the page would have told a PyPI user to run a command they don't have.

**Documented `pip install lablink-cli` with no `--pre`, having verified it.** An alpha-only package is exactly the case where the obvious command can fail, so I tested it rather than assuming: in a clean venv, pip selects `0.1.0a1` (`Would install lablink-cli-0.1.0a1`) because it is the only release. The page notes that once a stable release exists, plain installs will prefer it and `--pre` becomes necessary for alphas — so the instruction doesn't silently rot.

**Kept the pre-release status visible.** It appears in the README bullet, the CLI index note, and as a warning admonition on the installation page. `0.1.0a1` installs cleanly but is an alpha, and readers deciding whether to depend on it should not have to check PyPI to find that out.

## Testing

- **Install actually works, end to end**: `pip install lablink-cli` into a clean venv, then `lablink --version` → `lablink-cli 0.1.0a1` / `lablink-template 0.3.0`. The documented command produces a working CLI rather than just resolving.
- **Resolver behavior confirmed on both installers**: pip selects the alpha without `--pre`, and `uv pip compile` resolves `lablink-cli==0.1.0a1`. (This machine also already had it installed via `uv tool install lablink-cli`, independently confirming that path.)
- **New badge renders**: the shields.io endpoint returns `cli: v0.1.0a1`, not `invalid`.
- **`mkdocs build`**: no link or anchor warnings, so the new `#install-from-source` cross-reference resolves. `--strict` does abort, but only on 6 pre-existing `griffe` "no type annotation" warnings in allocator Python source that this PR does not touch.
- **Swept for remaining false claims**: no "not yet published"/"not yet on PyPI" text remains, and the only surviving mention of a bare `lablink` package is the deliberate warning that it does not exist.

**Deliberately unchanged:** `docs/quickstart-template.md` already used the correct `uv tool install lablink-cli`, and `contributing.md`'s `uv sync --all-packages` is the right instruction for contributors.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
