### PR TITLE
fix(cli): highlight the configured region in the wizard's region screen

### DIFF
--- a/packages/cli/src/lablink_cli/tui/wizard.py
+++ b/packages/cli/src/lablink_cli/tui/wizard.py
@@ -573,6 +573,26 @@ class RegionScreen(Screen):
                 yield Button("Next", variant="primary", id="next")
         yield Footer()
 
+    def on_mount(self) -> None:
+        """Highlight the region the config already names.
+
+        OptionList highlights index 0 on its own, so without this the screen
+        shows us-east-1 as the current choice no matter what the config says.
+        An operator whose deployment lives elsewhere then either accepts a row
+        that misreports their setting, or presses Enter on it and silently
+        moves app.region — along with machine.ami_id, which is region-scoped.
+        In --template mode this is how a config ends up naming a region that
+        holds none of the resources lablink-template's setup.sh just created.
+
+        A region absent from AWS_REGIONS clears the highlight rather than
+        pointing at an unrelated row: nothing on this screen represents it.
+        """
+        region_ids = [r["id"] for r in AWS_REGIONS]
+        configured = self.app.config.app.region
+        self.query_one("#region-list", OptionList).highlighted = (
+            region_ids.index(configured) if configured in region_ids else None
+        )
+
     @on(OptionList.OptionSelected)
     def _select(self, event: OptionList.OptionSelected) -> None:
         region = str(event.option.id)

--- a/packages/cli/tests/test_wizard.py
+++ b/packages/cli/tests/test_wizard.py
@@ -972,3 +972,78 @@ def test_connectivity_screen_cloudflare_hostname_is_stripped():
         public_hostname="  lab.example.org  ",
     )
     assert cfg.manual.public_hostname == "lab.example.org"
+
+
+# ---------------------------------------------------------------------------
+# RegionScreen — the configured region must be visible, and stay put
+# ---------------------------------------------------------------------------
+def _drive_region_screen(configured_region: str) -> tuple[str | None, str, str]:
+    """Push RegionScreen over *configured_region*, then press Next.
+
+    Returns the highlighted option's region id (None if nothing is
+    highlighted), plus cfg.app.region and cfg.machine.ami_id afterwards, so a
+    test can assert both what the screen showed and what it left behind.
+    """
+    from lablink_cli.config.schema import Config
+    from lablink_cli.tui.wizard import ConfigWizard, RegionScreen
+
+    cfg = Config()
+    cfg.app.region = configured_region
+    cfg.machine.ami_id = "ami-sentinel"
+    app = ConfigWizard(existing_config=cfg)
+    highlighted: list[str | None] = []
+
+    async def _run() -> None:
+        from textual.widgets import OptionList
+
+        async with app.run_test() as pilot:
+            await pilot.pause()
+            screen = RegionScreen()
+            app.push_screen(screen)
+            await pilot.pause()
+            await pilot.pause()
+            option_list = screen.query_one("#region-list", OptionList)
+            index = option_list.highlighted
+            highlighted.append(
+                None
+                if index is None
+                else str(option_list.get_option_at_index(index).id)
+            )
+            # Advance without touching the list, the way a user who accepts
+            # the shown region would.
+            screen._next()
+            await pilot.pause()
+
+    asyncio.run(_run())
+    return highlighted[0], cfg.app.region, cfg.machine.ami_id
+
+
+def test_region_screen_highlights_the_configured_region():
+    """The region already in the config must be the highlighted option."""
+    highlighted, _, _ = _drive_region_screen("ap-northeast-1")
+    assert highlighted == "ap-northeast-1"
+
+
+def test_region_screen_highlights_configured_region_not_just_the_first():
+    """Guards against 'highlighted' defaulting to index 0 and looking correct."""
+    highlighted, _, _ = _drive_region_screen("eu-central-1")
+    assert highlighted == "eu-central-1"
+
+
+def test_region_screen_untouched_leaves_region_and_ami_alone():
+    """Pre-selecting must not fire OptionSelected and rewrite the config.
+
+    Highlighting is a display concern. If it triggered the selection handler,
+    machine.ami_id would be remapped on every visit to the screen — silently
+    replacing an AMI the operator may have set deliberately.
+    """
+    _, region, ami_id = _drive_region_screen("us-east-2")
+    assert region == "us-east-2"
+    assert ami_id == "ami-sentinel"
+
+
+def test_region_screen_tolerates_a_region_outside_the_list():
+    """A config naming a region the wizard does not offer must not crash it."""
+    highlighted, region, _ = _drive_region_screen("sa-east-1")
+    assert highlighted is None
+    assert region == "sa-east-1"


### PR DESCRIPTION
## Summary

`RegionScreen` never showed which region the config already used. `OptionList` highlights index 0 by itself, so the screen presented **`us-east-1` as the current choice regardless** — a deployment in `us-west-2` opened the wizard and saw a row that misreported its own setting.

`on_mount` now highlights the row matching `app.region`.

**+95 / −0 across 2 files** (20 lines of fix, 75 of test).

## Why it matters

Accepting the mis-highlighted row is harmless — nothing writes unless `OptionSelected` fires. Pressing Enter on it is not: `_select` rewrites `app.region` *and* remaps `machine.ami_id`. AMI IDs are region-scoped, so one keystroke on a screen that looked like a no-op moves the region and swaps in an AMI for it.

[lablink-template](https://github.com/talmolab/lablink-template) is where this surfaced. Its `setup.sh` creates the S3 state bucket and DynamoDB lock table in a region the operator picks, and its `configure.sh` then treats that region as a fixed value it displays rather than asks for — precisely because a re-typed answer would point OpenTofu at a different backend. A `config.yaml` from that repo opened with `lablink configure --template` therefore already carries the only correct region, and the screen was showing `us-east-1` instead.

## What changed

```python
def on_mount(self) -> None:
    region_ids = [r["id"] for r in AWS_REGIONS]
    configured = self.app.config.app.region
    self.query_one("#region-list", OptionList).highlighted = (
        region_ids.index(configured) if configured in region_ids else None
    )
```

A region absent from `AWS_REGIONS` clears the highlight instead of pointing at an unrelated row — nothing on the screen represents it. Highlighting stays display-only: it posts `OptionHighlighted`, not `OptionSelected`, so visiting the screen still implies no write. A test pins that down, since the day it changes `machine.ami_id` gets silently rewritten on every visit.

## Testing

Four tests in `test_wizard.py`, following the existing `run_test()` + pilot pattern:

| Test | Guards |
|---|---|
| configured region is highlighted | the fix itself |
| a non-first region is highlighted | a bare index-0 default would otherwise look correct |
| untouched screen preserves `app.region` and `machine.ami_id` | pre-selection must not imply a write |
| region outside `AWS_REGIONS` | no crash, no mis-highlight |

All four fail on `main` before the fix — the third passes, the others report `us-east-1`.

```
this branch: 12 failed, 820 passed
main:        12 failed, 816 passed
```

Same twelve pre-existing failures (`test_register`/`test_status`/`test_utils` rich-markup assertions, unrelated to this change). `ruff check packages/cli` clean. `ruff format` deliberately not run — it already reports both files as unformatted on `main`, so reformatting would bury a 20-line fix in an unrelated diff.

## Considered and dropped: skipping the screen in `--template` mode

Since lablink-template owns the region, an earlier revision of this PR skipped `RegionScreen` entirely under `--template`, threading a `template=` flag through `ConfigWizard`. That was deliberately dropped: it would have left `--template` users unable to change region from the wizard at all, and correcting the display is enough to make the second look-at-the-region harmless. Recorded here so it isn't silently re-proposed.

## Related, not fixed here

`AMI_MAP` covers only the four US regions while `AWS_REGIONS` offers eight. Selecting `eu-west-1`, `eu-central-1`, `ap-northeast-1`, or `ap-southeast-1` leaves `machine.ami_id` at its previous US-region value, which does not exist in the chosen region. That wants its own PR — it needs real AMI IDs per region.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)