### PR TITLE
feat(cli): surface the admin page URL in deploy and status output

### DIFF
--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -916,6 +916,18 @@ def _print_summary(
             "  Allocator URL (LAN):   (no LAN IP detected — pass the "
             "operator host's reachable address manually)"
         )
+    # Where the operator administers from. public_url and lan_direct
+    # connectivity are mutually exclusive (see the preflight above), so this
+    # chain already encodes "LAN IP for a LAN deployment, public URL
+    # otherwise" without re-reading cfg.manual.connectivity. local_url is the
+    # last resort for a host whose LAN IP we couldn't detect.
+    admin_url = public_url or lan_url or local_url
+    # soft_wrap: a real Funnel URL plus the column prefix overruns 80 cols.
+    console.print(
+        f"  Admin URL:             {admin_url}/admin",
+        soft_wrap=True,
+        highlight=False,
+    )
     console.print(f"  Admin user:            {cfg.app.admin_user}")
     if register_token:
         console.print(f"  Register token:        {register_token}")

--- a/packages/cli/src/lablink_cli/commands/deploy_compose.py
+++ b/packages/cli/src/lablink_cli/commands/deploy_compose.py
@@ -916,11 +916,8 @@ def _print_summary(
             "  Allocator URL (LAN):   (no LAN IP detected — pass the "
             "operator host's reachable address manually)"
         )
-    # Where the operator administers from. public_url and lan_direct
-    # connectivity are mutually exclusive (see the preflight above), so this
-    # chain already encodes "LAN IP for a LAN deployment, public URL
-    # otherwise" without re-reading cfg.manual.connectivity. local_url is the
-    # last resort for a host whose LAN IP we couldn't detect.
+    # public_url and lan_direct are mutually exclusive (preflight above), so
+    # this chain encodes the connectivity rule without re-reading it.
     admin_url = public_url or lan_url or local_url
     # soft_wrap: a real Funnel URL plus the column prefix overruns 80 cols.
     console.print(

--- a/packages/cli/src/lablink_cli/commands/status.py
+++ b/packages/cli/src/lablink_cli/commands/status.py
@@ -457,13 +457,7 @@ def _build_health_url(cfg: Config, outputs: dict) -> str:
 
 
 def _print_admin_url(base_url: str) -> None:
-    """Print the admin page URL.
-
-    Printed regardless of health — the URL comes from config/state, not from
-    the service answering, and it's exactly what you want to keep retrying
-    while DNS or SSL is still propagating. Skipped only when there's no URL
-    to build one from (nothing deployed).
-    """
+    """Print the admin page URL, if we could build one."""
     if base_url:
         console.print(f"[bold]Admin URL:[/bold] {base_url.rstrip('/')}/admin")
 
@@ -835,8 +829,7 @@ def _run_status_manual(cfg: Config, *, docker: Docker | None = None) -> None:
                 f"{f' — {detail}' if detail else ''}[/yellow]"
             )
 
-    # Same precedence as the deploy summary's admin line, minus the LAN term
-    # — this path never detects a LAN IP, so it degrades to localhost.
+    # No LAN detection on this path — degrades to localhost.
     _print_admin_url(public_url or base_url)
 
     console.print()

--- a/packages/cli/src/lablink_cli/commands/status.py
+++ b/packages/cli/src/lablink_cli/commands/status.py
@@ -456,6 +456,18 @@ def _build_health_url(cfg: Config, outputs: dict) -> str:
     return ""
 
 
+def _print_admin_url(base_url: str) -> None:
+    """Print the admin page URL.
+
+    Printed regardless of health — the URL comes from config/state, not from
+    the service answering, and it's exactly what you want to keep retrying
+    while DNS or SSL is still propagating. Skipped only when there's no URL
+    to build one from (nothing deployed).
+    """
+    if base_url:
+        console.print(f"[bold]Admin URL:[/bold] {base_url.rstrip('/')}/admin")
+
+
 def _render_health_checks(cfg: Config, outputs: dict) -> None:
     """Run and display health checks."""
     domain = cfg.dns.domain if cfg.dns.enabled else ""
@@ -823,6 +835,10 @@ def _run_status_manual(cfg: Config, *, docker: Docker | None = None) -> None:
                 f"{f' — {detail}' if detail else ''}[/yellow]"
             )
 
+    # Same precedence as the deploy summary's admin line, minus the LAN term
+    # — this path never detects a LAN IP, so it degrades to localhost.
+    _print_admin_url(public_url or base_url)
+
     console.print()
     console.print("[bold]Registered Clients[/bold]")
     creds = _resolve_manual_admin_credentials(cfg, workdir)
@@ -920,5 +936,6 @@ def run_status(cfg: Config) -> None:
     outputs = _render_tofu_state(deploy_dir, aws_unavailable=aws_down)
     # DNS/HTTP/SSL checks need no AWS credentials, so they still run.
     _render_health_checks(cfg, outputs)
+    _print_admin_url(_build_health_url(cfg, outputs))
     _render_client_vms(cfg, aws_unavailable=aws_down)
     _render_cost_estimate(cfg, live_pricing=not aws_down)

--- a/packages/cli/tests/test_deploy_compose.py
+++ b/packages/cli/tests/test_deploy_compose.py
@@ -1674,6 +1674,45 @@ class TestPrintSummaryFunnel:
 
     @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
     @patch("lablink_cli.commands.deploy_compose._extract_register_token")
+    def test_admin_url_precedence(self, mock_extract, mock_lan, capsys):
+        """Admin URL is public > LAN > localhost.
+
+        The public-wins case is the one worth pinning: it's a deliberate
+        choice, not a fallback accident, and "keep admin off the public
+        exposure" is a plausible-sounding change someone makes later without
+        realising it was decided. Note there is no lan_direct case to test —
+        the preflight rejects participant_exposure != none with lan_direct,
+        so a public URL and LAN-direct connectivity can never coexist.
+        """
+        from lablink_cli.commands.deploy_compose import _print_summary
+
+        mock_extract.return_value = "tok"
+        funnel = "https://lablink-allocator-testlab-2.example.ts.net"
+
+        # Funnel up: public wins even though a LAN IP was detected.
+        mock_lan.return_value = "192.168.1.42"
+        _print_summary(
+            _manual_cfg(connectivity="mesh_overlay", overlay_tailnet="example.ts.net"),
+            funnel_active=True,
+            funnel_url=funnel,
+            docker=ComposeDocker(),
+        )
+        assert f"Admin URL:             {funnel}/admin" in capsys.readouterr().out
+
+        # No public exposure: the LAN IP, not localhost.
+        _print_summary(_manual_cfg(), docker=ComposeDocker())
+        out = capsys.readouterr().out
+        assert "Admin URL:             http://192.168.1.42/admin" in out
+
+        # No public exposure and LAN detection failed: localhost is the
+        # last resort, so the line always resolves to something clickable.
+        mock_lan.return_value = None
+        _print_summary(_manual_cfg(), docker=ComposeDocker())
+        out = capsys.readouterr().out
+        assert "Admin URL:             http://localhost/admin" in out
+
+    @patch("lablink_cli.commands.deploy_compose._detect_lan_ip")
+    @patch("lablink_cli.commands.deploy_compose._extract_register_token")
     def test_no_localhost_warning_when_funnel_substituted(
         self, mock_extract, mock_lan, capsys
     ):


### PR DESCRIPTION
## Summary

- `lablink deploy`, `lablink deploy-compose`, and `lablink status` now print an `Admin URL:` line pointing at `/admin`.
- Previously none of them printed it, so admins assembled the URL by hand from the allocator address.
- Chosen as **public > LAN > localhost**, printed regardless of health.

## Changes Made

- **`commands/deploy_compose.py`** — `Admin URL:` line above the existing `Admin user:` line, chain `public_url or lan_url or local_url`. `soft_wrap=True` because a real Funnel URL plus the column prefix overruns 80 columns.
- **`commands/status.py`** — new `_print_admin_url()` helper, called from both branches of `run_status`: the classic AWS path (via `_build_health_url`) and `_run_status_manual` (`public_url or base_url`).
- **`commands/deploy.py`** — untouched. It already ends with `run_status(cfg)`, so the deploy summary picks the line up for free.

## Testing

- New `test_admin_url_precedence` in `TestPrintSummary` pins all three rungs: public wins over a detected LAN IP, LAN wins over localhost, localhost is the last resort.
- Full CLI suite: **833 passed**. `ruff check packages/cli/src packages/cli/tests`: clean.
- No existing assertion broke — the label is `Admin URL:`, which does not collide with `test_no_public_url_line_when_funnel_inactive`'s `"Allocator URL (public)" not in out`.

## Design Decisions

**`cfg.manual.connectivity` is deliberately not read.** The preflight at `deploy_compose.py:419-432` already rejects `participant_exposure != "none"` together with `connectivity == "lan_direct"`, and `public_url` derives purely from `participant_exposure`. So the two are mutually exclusive by construction: LAN-direct always falls through to the LAN IP, and a public URL only exists when connectivity is not LAN-direct. A connectivity branch would be dead logic restating a guard that already ran. There is a comment at the insertion point so it doesn't get "fixed" later.

**Localhost is kept as the last rung.** It fires only when `_detect_lan_ip()` returns `None` — VPN/Tailscale-routed hosts, the case `deploy_compose.py:912-914` already warns about. Without it the line silently disappears in exactly that scenario, though the allocator is answering on `http://localhost/admin`. Mirrors the existing `register_url = lan_url or local_url` one line up.

**Printed regardless of health.** The URL comes from config and terraform/compose state, not from the service answering. Suppressing it on a failed health check would hide the link during slow SSL propagation, which is when it is most wanted.

**Its own line, not folded into the existing `Allocator URL` lines.** The bare allocator URL is the participant-facing entry point; collapsing the two invites pasting an admin link into a class.

**No `lablink admin` command, no `webbrowser` call, no credentials printed, no docs change.** A printed URL is clickable in any modern terminal, and `docs/reference/cli.md` documents commands and flags — no command, flag, or config key changes here.

## Known Gap

`mesh_overlay` connectivity with `participant_exposure: none` is legal, and in that configuration participants may reach the allocator by its **tailnet address** — which exists nowhere in the CLI's URL set (`_public_url` reads the Funnel URL only). That case currently falls through to LAN/localhost, which is correct for an operator administering from the host but not for one on the tailnet elsewhere. Adding a MagicDNS term would mean shelling `tailscale status --json` against the sidecar; deferred as a self-contained addition to the same chain if that workflow turns out to be real.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)