### PR TITLE
feat(allocator): add an errors-only filter to the log pages

### DIFF
--- a/docs/api-endpoints.md
+++ b/docs/api-endpoints.md
@@ -480,7 +480,21 @@ These endpoints require HTTP Basic Authentication and are intended for administr
 **URL Parameters:**
 
 - `hostname` (string, required): The hostname of the VM.
-  **Request Body:** None
+
+**Query Parameters:**
+
+- `errors_only` (boolean, optional, default `false`): When `true`, both
+  `cloud_init_logs` and `docker_logs` are reduced to their error lines —
+  lines carrying an uppercase level token (`ERROR`, `CRITICAL`, `FATAL`, plus
+  cloudflared's `ERR`/`FTL` and postgres' `PANIC`), together with any
+  traceback that follows them. Matching is case-sensitive so the client
+  startup script's `--retry-all-errors` and `status=error` lines are not
+  treated as errors, and a short denylist suppresses client reporting-path
+  failures that do not affect the VM's usability (GPU-health and
+  in-use-status report failures, and session-metrics push failures). A stream
+  with no error lines becomes `""`, not `null`.
+
+**Request Body:** None
 
 **Success Response:**
 
@@ -489,7 +503,9 @@ These endpoints require HTTP Basic Authentication and are intended for administr
   ```json
   {
     "hostname": "lablink-vm-prod-1",
-    "logs": "Starting cloud-init...\n..."
+    "cloud_init_logs": "Starting cloud-init...\n...",
+    "docker_logs": "[start] ALLOCATOR_HOST: ...\n...",
+    "logs": "Starting cloud-init...\n...\n[start] ALLOCATOR_HOST: ...\n..."
   }
   ```
 
@@ -508,6 +524,13 @@ These endpoints require HTTP Basic Authentication and are intended for administr
 **Authentication:** Admin HTTP Basic
 
 **URL Parameters:** None
+
+**Query Parameters:**
+
+- `errors_only` (boolean, optional, default `false`): As on
+  `GET /api/vm-logs/<hostname>` — reduces `docker_logs` to its error lines.
+  `error` still reports only a genuinely missing log file; a log with no
+  error lines returns `docker_logs: ""` with `error: null`.
 
 **Request Body:** None
 

--- a/packages/allocator/src/lablink_allocator_service/routes/allocator_logs.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/allocator_logs.py
@@ -7,9 +7,10 @@ therefore cannot run `docker logs` on itself.
 """
 import logging
 
-from flask import Blueprint, jsonify, render_template
+from flask import Blueprint, jsonify, render_template, request
 
 from lablink_allocator_service.auth import auth
+from lablink_allocator_service.utils.log_filter import filter_errors
 from lablink_allocator_service.utils.log_tail import read_allocator_log
 
 bp = Blueprint("allocator_logs", __name__)
@@ -33,11 +34,17 @@ def allocator_logs_api():
     container, and is deliberately out of scope.
     """
     logs = read_allocator_log()
+    # Capture missing-ness *before* filtering: a log with no error lines
+    # filters down to "", which is falsy, and would otherwise be reported
+    # as a missing log file.
+    missing = logs is None
+    if request.args.get("errors_only", "false").lower() == "true":
+        logs = filter_errors(logs)
     return jsonify(
         {
             "cloud_init_logs": None,
             "docker_logs": logs,
-            "error": None if logs else _MISSING_LOG_MSG,
+            "error": _MISSING_LOG_MSG if missing else None,
         }
     )
 

--- a/packages/allocator/src/lablink_allocator_service/routes/vm_telemetry.py
+++ b/packages/allocator/src/lablink_allocator_service/routes/vm_telemetry.py
@@ -14,6 +14,7 @@ from flask import Blueprint, jsonify, request
 
 from lablink_allocator_service.auth import auth, require_client_secret
 from lablink_allocator_service.utils.ansi import strip_ansi
+from lablink_allocator_service.utils.log_filter import filter_errors
 
 bp = Blueprint("vm_telemetry", __name__)
 logger = logging.getLogger(__name__)
@@ -201,6 +202,11 @@ def get_vm_logs_by_hostname(hostname):
 
         cloud_init_logs = (logs_data or {}).get("cloud_init_logs")
         docker_logs = (logs_data or {}).get("docker_logs")
+
+        # Same spelling as routes/metrics.py:122's include_logs flag.
+        if request.args.get("errors_only", "false").lower() == "true":
+            cloud_init_logs = filter_errors(cloud_init_logs)
+            docker_logs = filter_errors(docker_logs)
 
         return jsonify({
             "hostname": hostname,

--- a/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
+++ b/packages/allocator/src/lablink_allocator_service/templates/instance-logs.html
@@ -218,6 +218,9 @@
                 <button onclick="toggleAutoRefresh()" id="autoRefreshBtn">
                     <i class="bi bi-play me-1"></i>Start Auto Refresh
                 </button>
+                <button onclick="toggleErrorsOnly()" id="errorsOnlyBtn">
+                    <i class="bi bi-exclamation-triangle me-1"></i>Show errors only
+                </button>
                 <button class="btn-secondary" onclick="downloadLogs()">
                     <i class="bi bi-download me-1"></i>Download
                 </button>
@@ -293,6 +296,7 @@
         const hasCloudInit = {{ 'true' if has_cloud_init else 'false' }};
         let autoRefreshInterval = null;
         let isAutoRefreshing = false;
+        let errorsOnly = false;
 
         // Initialize page
         document.addEventListener('DOMContentLoaded', function() {
@@ -310,11 +314,19 @@
             try {
                 const shouldFollowTail = document.getElementById("followTail").checked;
 
-                const res = await fetch(logEndpoint, { credentials : 'include' });
+                const url = errorsOnly
+                    ? logEndpoint + "?errors_only=true"
+                    : logEndpoint;
+                const res = await fetch(url, { credentials : 'include' });
                 if (res.ok) {
                     const data = await res.json();
-                    const cloudInitLogs = data.cloud_init_logs || "No logs available.";
-                    const dockerLogs = data.docker_logs || data.error || "No logs available.";
+                    // A filtered stream that matched nothing comes back as
+                    // "" — that is "no errors", not "no logs".
+                    const emptyMsg = errorsOnly
+                        ? "No error lines in this log."
+                        : "No logs available.";
+                    const cloudInitLogs = data.cloud_init_logs || emptyMsg;
+                    const dockerLogs = data.docker_logs || data.error || emptyMsg;
 
                     setBoxText("cloudInitLogBox", cloudInitLogs);
                     setBoxText("dockerLogBox", dockerLogs);
@@ -366,16 +378,60 @@
             }
         }
 
-        function downloadLogs() {
-            const docker = document.getElementById("dockerLogBox").textContent;
+        function toggleErrorsOnly() {
+            // The filter is server-side (one rule, shared with the CLI's
+            // /api/vm-logs path), so flipping it means refetching.
+            errorsOnly = !errorsOnly;
+            const btn = document.getElementById("errorsOnlyBtn");
+            if (errorsOnly) {
+                btn.innerHTML = '<i class="bi bi-list-ul me-1"></i>Show all';
+                btn.className = 'btn-danger';
+            } else {
+                btn.innerHTML =
+                    '<i class="bi bi-exclamation-triangle me-1"></i>Show errors only';
+                btn.className = '';
+            }
+            refreshLogs();
+        }
+
+        async function downloadLogs() {
+            // Always export the complete log, even while the view is
+            // filtered: an admin attaching this to an issue needs the
+            // context, and a silently-filtered file is data loss.
+            let cloudInit = null;
+            let docker = null;
+            let note = "";
+            let fetched = false;
+            try {
+                const res = await fetch(logEndpoint, { credentials : 'include' });
+                if (res.ok) {
+                    const data = await res.json();
+                    cloudInit = data.cloud_init_logs;
+                    docker = data.docker_logs || data.error;
+                    fetched = true;
+                }
+            } catch (err) {
+                console.error("Error fetching full logs for download:", err);
+            }
+            if (!fetched) {
+                // Fetch failed — fall back to what is on screen, and say so
+                // in the file rather than passing it off as the full log.
+                note = "=== NOTE: could not fetch the full log; " +
+                       "this is the view as displayed ===\n\n";
+                docker = document.getElementById("dockerLogBox").textContent;
+                if (hasCloudInit) {
+                    cloudInit =
+                        document.getElementById("cloudInitLogBox").textContent;
+                }
+            }
             let logs;
             if (hasCloudInit) {
-                const cloudInit = document.getElementById("cloudInitLogBox").textContent;
-                logs = "=== Cloud Init Logs ===\n" + cloudInit + "\n\n=== Docker Logs ===\n" + docker;
+                logs = "=== Cloud Init Logs ===\n" + (cloudInit || "") +
+                       "\n\n=== Docker Logs ===\n" + (docker || "");
             } else {
-                logs = "=== Docker Logs ===\n" + docker;
+                logs = "=== Docker Logs ===\n" + (docker || "");
             }
-            const blob = new Blob([logs], { type: 'text/plain' });
+            const blob = new Blob([note + logs], { type: 'text/plain' });
             const url = window.URL.createObjectURL(blob);
             const a = document.createElement('a');
             a.href = url;

--- a/packages/allocator/src/lablink_allocator_service/utils/log_filter.py
+++ b/packages/allocator/src/lablink_allocator_service/utils/log_filter.py
@@ -1,0 +1,186 @@
+"""Errors-only filtering for the two admin log surfaces.
+
+Both streams are heterogeneous. A client VM's shipped output mixes Python
+records with KasmVNC/XFCE output and shell echoes; the allocator's own
+stream mixes its Flask records with cloudflared, postgres and gunicorn.
+(Not nginx: start.sh execs it, and its errors go to Debian's default
+/var/log/nginx/error.log rather than into allocator.log.)
+
+So the rule matches the level markers those producers actually emit --
+Python's uppercase `%(levelname)s` tokens, cloudflared's zerolog
+three-letter levels (`ERR`/`FTL`) and postgres' `PANIC`. It is a
+recall-first rule; what keeps it honest is being case-sensitive, plus a
+short denylist. See _ERROR_RE and BENIGN_ERROR_PATTERNS.
+
+Flask-free on purpose, like log_tail.py next door: the rule is the part
+worth testing, and keeping it out of the route modules lets it test
+against plain strings with no app fixture.
+"""
+
+import re
+
+# Case-sensitive on purpose. A case-insensitive `error` matches the client
+# startup script's happy path -- `--retry-all-errors` (start.sh:45,57,133)
+# and `send_status "error"` (89,173) -- which would fill the error view
+# with healthy lines. WARNING is deliberately excluded. The word
+# boundaries matter too: `\bERR\b` does not fire inside `STDERR`.
+_ERROR_RE = re.compile(r"\b(?:ERROR|CRITICAL|FATAL|ERR|FTL|PANIC)\b")
+
+_TRACEBACK_HEADER = "Traceback (most recent call last)"
+
+# What CPython prints between the two halves of a chained traceback. The
+# half that follows is the one naming the fault an admin needs (e.g. the
+# requests ConnectionError with its host and port, not the inner
+# ConnectionRefusedError), so both halves belong to the same kept block.
+_CHAIN_MARKERS = (
+    "During handling of the above exception, another exception occurred:",
+    "The above exception was the direct cause of the following exception:",
+)
+
+# Strips an optional leading RFC3339 timestamp and an optional `[tag] `
+# source prefix, capturing the tag for the continuation walk. Client lines
+# carry both by the time they reach the allocator: the log shipper prepends
+# the timestamp (log_shipper.py:284) and start.sh pipes every service
+# through `sed 's/^/[tag] /'`. Without this, a traceback's indented frames
+# do not start at column 0 and the continuation walk below would drop every
+# frame for every client VM.
+_PREFIX_RE = re.compile(
+    r"^(?:\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}:\d{2}\S*\s+)?(?:\[(?P<tag>[\w.-]+)\]\s?)?"
+)
+
+# ERROR-level lines from the client's reporting path: a report was lost
+# after its retries were exhausted, which does not affect the VM's own
+# usability -- the desktop is still serving and the student is unaffected.
+# Suppressed here rather than downgraded at the source because client code
+# ships inside a released Docker image, so a level change would only reach
+# VMs launched after the next client release; this reaches every
+# already-running VM on allocator restart. Substring-matched against the
+# whole line, so the `[tag] ` prefix and the f-string tails do not matter.
+# A real failure diagnosis never belongs here (see test_log_filter.py's
+# drift test, and the nvidia-smi entry this list used to carry).
+BENIGN_ERROR_PATTERNS: tuple[str, ...] = (
+    "Failed to report GPU health after",  # check_gpu.py:112
+    "Failed to update in-use status after",  # update_inuse_status.py:114
+    "Push failed; will retry next interval",  # monitoring/__main__.py:174
+)
+
+
+def _body(line: str) -> str:
+    """Return *line* with any timestamp / source-tag prefix removed."""
+    return _PREFIX_RE.sub("", line, count=1)
+
+
+def _tag(line: str) -> str | None:
+    """Return *line*'s `[tag]` source prefix, or None if it carries none."""
+    match = _PREFIX_RE.match(line)
+    return match.group("tag") if match else None
+
+
+def _traceback_indices(lines: list[str], start: int) -> list[int]:
+    """Indices of the traceback belonging to the error line at *start*.
+
+    The client's shipped stream interleaves by design: start.sh:14 dups
+    stdout to fd 5 and every service then writes its own
+    `... | sed -u 's/^/[tag] /' >&5 &` pipeline into it concurrently, so a
+    `[kasmvnc]` or `[xstartup]` line landing in the middle of an `[agent]`
+    traceback is the normal condition. When the error line carries a tag,
+    only lines with that same tag count as continuation and foreign lines
+    are stepped over. When it does not (the allocator's own stream, a bare
+    tee/rotatelogs pipeline that is not interleaved), any indented line
+    counts, as before.
+
+    ponytail: an *untagged* interleaved stream can still mis-associate, and
+    a tagged traceback whose terminal line somehow lost its tag loses that
+    line. Neither shipped stream can produce either -- one service's lines
+    all pass through one sed -- and the frame-count guard below keeps the
+    damage to a dropped line rather than a foreign line presented as the
+    exception. Tag every producer if that ever stops being true.
+
+    Args:
+        lines: Every line of the log, in stream order.
+        start: Index of the kept error line whose traceback to collect.
+
+    Returns:
+        The indices to keep, ascending. Empty when no traceback follows.
+    """
+    tag = _tag(lines[start])
+    claimed: list[int] = []
+    i = start + 1
+    while i < len(lines) and _body(lines[i]).startswith(_TRACEBACK_HEADER):
+        claimed.append(i)
+        i += 1
+        frames = 0
+        while i < len(lines):
+            if tag is not None and _tag(lines[i]) != tag:
+                i += 1  # interleaved foreign line; not ours, not the end
+                continue
+            if not _body(lines[i])[:1].isspace():
+                break
+            claimed.append(i)  # a stack frame
+            frames += 1
+            i += 1
+        # The terminal `SomeError: msg`, but only once a frame has actually
+        # been consumed -- that guard is what stops an unrelated line from
+        # being presented as the exception when the tag logic cannot help.
+        if frames and i < len(lines):
+            claimed.append(i)
+            i += 1
+        # A chained traceback continues after a blank line and a marker.
+        # Hold that filler until a header really follows, so a plain
+        # trailing blank line is not swept into the output.
+        j = i
+        filler: list[int] = []
+        while j < len(lines):
+            if tag is not None and _tag(lines[j]) != tag:
+                j += 1
+                continue
+            body = _body(lines[j]).strip()
+            if body and body not in _CHAIN_MARKERS:
+                break
+            filler.append(j)
+            j += 1
+        if j < len(lines) and _body(lines[j]).startswith(_TRACEBACK_HEADER):
+            claimed.extend(filler)
+            i = j
+        else:
+            break
+    return claimed
+
+
+def is_error_line(line: str) -> bool:
+    """True if *line* carries an uppercase error level and is not benign."""
+    if not _ERROR_RE.search(line):
+        return False
+    return not any(p in line for p in BENIGN_ERROR_PATTERNS)
+
+
+def filter_errors(text: str | None) -> str | None:
+    """Keep only the error lines of *text*, with their tracebacks attached.
+
+    Returns None for None -- there is no log at all -- and "" when the log
+    had lines but none were errors. Callers render those two cases
+    differently.
+
+    Args:
+        text: The raw log blob, or None when no log exists.
+
+    Returns:
+        The kept lines joined by newlines, "" if none matched, or None.
+    """
+    if text is None:
+        return None
+
+    lines = text.splitlines()
+    # Indices rather than a running output list: a foreign line stepped
+    # over inside a traceback walk stays eligible here, so an interleaved
+    # `[kasmvnc] ERROR ...` is still kept on its own account instead of
+    # being swallowed by the walk it interrupted.
+    keep: set[int] = set()
+    for i, line in enumerate(lines):
+        if i in keep or not is_error_line(line):
+            continue
+        keep.add(i)
+        # A logger.exception record puts its traceback on the lines that
+        # follow, none of which carry a level token of their own.
+        keep.update(_traceback_indices(lines, i))
+    return "\n".join(lines[i] for i in sorted(keep))

--- a/packages/allocator/tests/test_allocator_logs.py
+++ b/packages/allocator/tests/test_allocator_logs.py
@@ -54,3 +54,38 @@ def test_page_has_no_close_button(client, admin_headers):
 def test_admin_dashboard_links_to_the_page(client, admin_headers):
     html = client.get("/admin", headers=admin_headers).data.decode()
     assert "/admin/allocator-logs" in html
+
+
+def test_api_errors_only_filters_the_tail(client, admin_headers, monkeypatch):
+    monkeypatch.setattr(
+        "lablink_allocator_service.routes.allocator_logs.read_allocator_log",
+        lambda: "INFO serving on :5000\nERROR - could not reach postgres",
+    )
+    body = client.get(
+        "/api/allocator-logs?errors_only=true", headers=admin_headers
+    ).get_json()
+    assert body["docker_logs"] == "ERROR - could not reach postgres"
+    assert body["error"] is None
+
+
+def test_api_errors_only_with_no_errors_is_not_a_missing_file(
+    client, admin_headers, monkeypatch
+):
+    """An empty filtered result must not claim the log file is absent --
+    the page distinguishes "no errors" from "no log"."""
+    monkeypatch.setattr(
+        "lablink_allocator_service.routes.allocator_logs.read_allocator_log",
+        lambda: "INFO serving on :5000",
+    )
+    body = client.get(
+        "/api/allocator-logs?errors_only=true", headers=admin_headers
+    ).get_json()
+    assert body["docker_logs"] == ""
+    assert body["error"] is None
+
+
+def test_page_has_an_errors_only_toggle(client, admin_headers):
+    """The allocator page shares the template, so it gets the toggle too."""
+    html = client.get("/admin/allocator-logs", headers=admin_headers).data.decode()
+    assert 'id="errorsOnlyBtn"' in html
+    assert "errors_only=true" in html

--- a/packages/allocator/tests/test_api_calls.py
+++ b/packages/allocator/tests/test_api_calls.py
@@ -1900,3 +1900,59 @@ def test_vm_metrics_bumps_last_seen(client, monkeypatch):
 
     assert resp.status_code == 200
     fake_db.touch_last_seen.assert_called_once_with(hostname="vm-1")
+
+
+def test_get_vm_logs_errors_only_filters_both_streams(
+    client, admin_headers, monkeypatch
+):
+    """?errors_only=true keeps error lines and drops the benign ones."""
+    fake_db = MagicMock()
+    fake_db.vm_exists.return_value = True
+    fake_db.get_status_by_hostname.return_value = "running"
+    fake_db.get_vm_logs.return_value = {
+        "cloud_init_logs": "INFO booting\nERROR cloud-init exploded",
+        "docker_logs": (
+            "INFO healthy\n"
+            "ERROR check_gpu: Failed to report GPU health after 3 attempts\n"
+            "ERROR agent: real problem"
+        ),
+    }
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.get(
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1?errors_only=true",
+        headers=admin_headers,
+    )
+
+    assert resp.status_code == 200
+    result = resp.get_json()
+    assert result["cloud_init_logs"] == "ERROR cloud-init exploded"
+    assert result["docker_logs"] == "ERROR agent: real problem"
+    # The combined key is built from the filtered halves.
+    assert result["logs"] == (
+        "ERROR cloud-init exploded\nERROR agent: real problem"
+    )
+
+
+def test_get_vm_logs_is_unfiltered_by_default(client, admin_headers, monkeypatch):
+    """Omitting the param must not change the existing response."""
+    fake_db = MagicMock()
+    fake_db.vm_exists.return_value = True
+    fake_db.get_status_by_hostname.return_value = "running"
+    fake_db.get_vm_logs.return_value = {
+        "cloud_init_logs": "INFO booting",
+        "docker_logs": "INFO healthy",
+    }
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.database", fake_db, raising=False
+    )
+
+    resp = client.get(
+        f"{VM_LOGS_ENDPOINT}/lablink-vm-test-1", headers=admin_headers
+    )
+
+    result = resp.get_json()
+    assert result["cloud_init_logs"] == "INFO booting"
+    assert result["docker_logs"] == "INFO healthy"

--- a/packages/allocator/tests/test_log_filter.py
+++ b/packages/allocator/tests/test_log_filter.py
@@ -1,0 +1,254 @@
+"""Errors-only filtering of the log streams."""
+
+from pathlib import Path
+
+import pytest
+
+from lablink_allocator_service.utils.log_filter import (
+    BENIGN_ERROR_PATTERNS,
+    filter_errors,
+    is_error_line,
+)
+
+# tests -> allocator -> packages. Verified, not assumed: parents[3] is the
+# repo root, where there is no `client/`, so the skipif below would have
+# skipped this file's drift test forever.
+CLIENT_SRC = Path(__file__).parents[2] / "client" / "src"
+
+
+def test_keeps_error_lines_and_drops_the_rest():
+    text = "\n".join([
+        "2026-08-14 12:00:00 - app - INFO - serving on :5000",
+        "2026-08-14 12:00:01 - app - ERROR - database is on fire",
+        "2026-08-14 12:00:02 - app - DEBUG - tick",
+    ])
+    assert filter_errors(text) == (
+        "2026-08-14 12:00:01 - app - ERROR - database is on fire"
+    )
+
+
+def test_keeps_critical_and_fatal():
+    text = "CRITICAL disk full\nFATAL cannot bind\nINFO fine"
+    assert filter_errors(text) == "CRITICAL disk full\nFATAL cannot bind"
+
+
+def test_excludes_warning():
+    text = "2026-08-14 12:00:00 WARNING nvidia-smi not found\nINFO fine"
+    assert filter_errors(text) == ""
+
+
+def test_is_case_sensitive_so_the_startup_scripts_happy_path_is_excluded():
+    """start.sh says `--retry-all-errors` and `status=error` on success
+    paths; a case-insensitive rule would show them as errors."""
+    assert not is_error_line("[start] curl --retry-all-errors ...")
+    assert not is_error_line('[start] send_status "error" || echo ...')
+    assert not is_error_line("[start] >> WARNING: failed to report status=error")
+
+
+def test_drops_every_benign_retry_error():
+    text = "\n".join([
+        "2026-08-14T12:00:00Z [check_gpu] 12:00 ERROR check_gpu: "
+        "Failed to report GPU health after 3 attempts",
+        "2026-08-14T12:00:01Z [update_inuse_status] 12:00 ERROR u: "
+        "Failed to update in-use status after 3 attempts",
+        "2026-08-14T12:00:03Z [monitoring] 12:00 ERROR m: "
+        "Push failed; will retry next interval",
+        "2026-08-14T12:00:04Z [agent] 12:00 ERROR a: real problem",
+    ])
+    assert filter_errors(text) == (
+        "2026-08-14T12:00:04Z [agent] 12:00 ERROR a: real problem"
+    )
+
+
+@pytest.mark.parametrize("pattern", BENIGN_ERROR_PATTERNS)
+def test_every_benign_pattern_is_suppressed(pattern):
+    """Covers a newly added pattern automatically, unlike a count check."""
+    assert filter_errors(f"12:00 ERROR svc: {pattern} tail") == ""
+
+
+@pytest.mark.skipif(not CLIENT_SRC.exists(), reason="client package not in checkout")
+@pytest.mark.parametrize("pattern", BENIGN_ERROR_PATTERNS)
+def test_benign_pattern_still_exists_in_client_source(pattern):
+    """A renamed client log message must fail here, not drift silently."""
+    hits = [p for p in CLIENT_SRC.rglob("*.py") if pattern in p.read_text()]
+    assert hits, f"{pattern!r} no longer appears in the client source"
+
+
+def test_a_real_gpu_failure_is_not_suppressed():
+    """check_gpu.py's `nvidia-smi failed:` branch is the one that sets
+    status=Unhealthy, and its body carries nvidia-smi's own stderr -- the
+    diagnosis an admin opens the errors-only view to find. The
+    drivers-not-installed cases log at WARNING instead, so they are already
+    excluded without a denylist entry."""
+    assert is_error_line(
+        "[check_gpu] 12:00 ERROR check_gpu: nvidia-smi failed: no devices found"
+    )
+
+
+def test_keeps_traceback_frames_and_the_terminal_line():
+    text = "\n".join([
+        "2026-08-14 12:00:00 - app - ERROR - boom",
+        "Traceback (most recent call last):",
+        '  File "/app/x.py", line 3, in go',
+        "    raise ValueError('nope')",
+        "ValueError: nope",
+        "2026-08-14 12:00:01 - app - INFO - carrying on",
+    ])
+    assert filter_errors(text) == "\n".join([
+        "2026-08-14 12:00:00 - app - ERROR - boom",
+        "Traceback (most recent call last):",
+        '  File "/app/x.py", line 3, in go',
+        "    raise ValueError('nope')",
+        "ValueError: nope",
+    ])
+
+
+def test_keeps_traceback_frames_behind_shipper_prefixes():
+    """Client lines arrive as `<ts> [tag] ...` (log_shipper.py:284 plus
+    start.sh's sed tags), so frames do not start at column 0."""
+    text = "\n".join([
+        "2026-08-14T12:00:00Z [agent] 12:00 ERROR a: boom",
+        "2026-08-14T12:00:00Z [agent] Traceback (most recent call last):",
+        '2026-08-14T12:00:00Z [agent]   File "/app/x.py", line 3, in go',
+        "2026-08-14T12:00:00Z [agent] ValueError: nope",
+        "2026-08-14T12:00:01Z [agent] 12:00 INFO a: carrying on",
+    ])
+    assert filter_errors(text) == "\n".join([
+        "2026-08-14T12:00:00Z [agent] 12:00 ERROR a: boom",
+        "2026-08-14T12:00:00Z [agent] Traceback (most recent call last):",
+        '2026-08-14T12:00:00Z [agent]   File "/app/x.py", line 3, in go',
+        "2026-08-14T12:00:00Z [agent] ValueError: nope",
+    ])
+
+
+def test_drops_the_traceback_of_a_benign_error():
+    text = "\n".join([
+        "12:00 ERROR m: Push failed; will retry next interval",
+        "Traceback (most recent call last):",
+        '  File "/app/p.py", line 9, in push',
+        "ConnectionError: refused",
+        "12:00 INFO m: next tick",
+    ])
+    assert filter_errors(text) == ""
+
+
+def test_none_passes_through():
+    """None means there is no log at all; the caller renders that
+    differently from a log with no errors in it."""
+    assert filter_errors(None) is None
+
+
+def test_no_errors_yields_empty_string():
+    assert filter_errors("INFO all good\nDEBUG tick") == ""
+
+
+def test_interleaved_foreign_line_does_not_end_the_traceback():
+    """start.sh:14 dups stdout to fd 5 and every service then pipes through
+    its own `sed 's/^/[tag] /' >&5 &`, so a [kasmvnc] line landing inside an
+    [agent] traceback is the normal condition, not a corner case."""
+    text = "\n".join([
+        "[agent] 12:00 ERROR a: boom",
+        "[agent] Traceback (most recent call last):",
+        "[kasmvnc] Framebuffer resize to 1920x1080",
+        '[agent]   File "/app/x.py", line 3, in go',
+        "[agent] ValueError: nope",
+        "[agent] 12:00 INFO a: carrying on",
+    ])
+    out = filter_errors(text)
+    assert out == "\n".join([
+        "[agent] 12:00 ERROR a: boom",
+        "[agent] Traceback (most recent call last):",
+        '[agent]   File "/app/x.py", line 3, in go',
+        "[agent] ValueError: nope",
+    ])
+    # The bug this guards: the resize was presented AS the exception.
+    assert "[kasmvnc]" not in out
+
+
+def test_an_interleaved_foreign_error_is_still_kept_on_its_own_account():
+    """Stepping over a foreign line inside a traceback walk must not
+    swallow it when it is itself an error."""
+    text = "\n".join([
+        "[agent] 12:00 ERROR a: boom",
+        "[agent] Traceback (most recent call last):",
+        "[kasmvnc] 12:00 ERROR kasm: no framebuffer",
+        '[agent]   File "/app/x.py", line 3, in go',
+        "[agent] ValueError: nope",
+    ])
+    assert filter_errors(text) == text
+
+
+def test_a_foreign_line_is_never_presented_as_the_exception():
+    """With no frame consumed there is nothing to attach, so the frame-count
+    guard must leave the next line alone even when the tag cannot resolve
+    it (here: an untagged stream, where any indented line is a frame)."""
+    text = "\n".join([
+        "12:00 ERROR a: boom",
+        "Traceback (most recent call last):",
+        "Framebuffer resize to 1920x1080",
+    ])
+    assert filter_errors(text) == "\n".join([
+        "12:00 ERROR a: boom",
+        "Traceback (most recent call last):",
+    ])
+
+
+def test_chained_traceback_keeps_the_outer_exception():
+    """requests re-raises inside an `except`, so every logger.exception
+    around an HTTP call chains. The second half's final line is the useful
+    one -- it names the host and port."""
+    text = "\n".join([
+        "12:00 ERROR h: heartbeat failed",
+        "Traceback (most recent call last):",
+        '  File "/app/h.py", line 5, in send',
+        "ConnectionRefusedError: [Errno 111] Connection refused",
+        "",
+        "During handling of the above exception, another exception occurred:",
+        "",
+        "Traceback (most recent call last):",
+        '  File "/app/h.py", line 9, in beat',
+        "requests.exceptions.ConnectionError: HTTPSConnectionPool(host='a')",
+        "12:00 INFO h: next tick",
+    ])
+    assert filter_errors(text) == "\n".join(text.splitlines()[:-1])
+
+
+def test_chained_traceback_survives_an_interleaved_line_in_the_gap():
+    """The direct-cause marker, behind shipper tags, with a foreign line in
+    the two-line gap between the halves."""
+    text = "\n".join([
+        "[agent] 12:00 ERROR a: rotation failed",
+        "[agent] Traceback (most recent call last):",
+        '[agent]   File "/app/k.py", line 2, in rotate',
+        "[agent] KeyError: 'pw'",
+        "[agent] ",
+        "[xstartup] xfce4-session: starting",
+        "[agent] The above exception was the direct cause of the following "
+        "exception:",
+        "[agent] ",
+        "[agent] Traceback (most recent call last):",
+        '[agent]   File "/app/k.py", line 9, in start',
+        "[agent] RuntimeError: could not rotate the session password",
+    ])
+    out = filter_errors(text)
+    assert out.endswith("[agent] RuntimeError: could not rotate the session password")
+    assert "[xstartup]" not in out
+
+
+def test_keeps_cloudflared_and_postgres_levels():
+    """cloudflared runs in the allocator container with its output teed into
+    the same allocator.log (start.sh:153) and uses zerolog's three-letter
+    levels; postgres says PANIC."""
+    text = "\n".join([
+        "2026-08-14T12:00:00Z ERR Failed to serve quic connection",
+        "2026-08-14T12:00:01Z FTL Register tunnel error: dial tcp: refused",
+        "2026-08-14 12:00:02 UTC [42] PANIC: could not write to file",
+        "2026-08-14T12:00:03Z INF Connection established",
+    ])
+    assert filter_errors(text) == "\n".join(text.splitlines()[:-1])
+
+
+def test_stderr_substring_alone_is_not_an_error():
+    """`\\bERR\\b` must not fire inside STDERR -- no word boundary there."""
+    assert not is_error_line("[start] redirecting STDERR through the tagger")
+    assert not is_error_line("2026-08-14T12:00:00Z INF wrote 2 lines to STDERR")

--- a/packages/allocator/tests/test_pages.py
+++ b/packages/allocator/tests/test_pages.py
@@ -518,3 +518,20 @@ def test_instances_shows_clear_unhealthy_only_for_unhealthy_rows(
     # Connect must still be offered on the unhealthy row — a successful
     # Admin Connect is the other, automatic way the flag gets cleared.
     assert "/admin/instances/vm-unhealthy/connect" in html
+
+
+def test_log_page_has_an_errors_only_toggle(client, admin_headers, monkeypatch):
+    """The toggle and the query param it sends must both render."""
+    fake_db = MagicMock()
+    fake_db.vm_exists.return_value = True
+    monkeypatch.setattr("lablink_allocator_service.main.database", fake_db)
+    monkeypatch.setattr(
+        "lablink_allocator_service.main.cfg",
+        SimpleNamespace(provider="aws"),
+    )
+
+    html = client.get("/admin/logs/vm-1", headers=admin_headers).data.decode()
+    assert 'id="errorsOnlyBtn"' in html
+    assert "Show errors only" in html
+    assert "errors_only=true" in html
+    assert "No error lines in this log." in html


### PR DESCRIPTION
## Summary

Adds a **"Show errors only"** toggle to both admin log pages, backed by a single server-side filtering rule, and stops a small set of known-benign client ERROR lines from polluting that view.

`templates/instance-logs.html` is rendered by both `routes/admin_pages.py` (VM logs) and `routes/allocator_logs.py` (the allocator's own logs), so one template edit covers both pages.

## Why server-side

The `lablink` CLI fetches client-VM logs from the same `GET /api/vm-logs/<hostname>` endpoint the web page uses, so putting the rule behind a query param means one implementation serves both surfaces. A browser-side rule would have to be duplicated in Python for the CLI to ever use it. Cost: toggling costs one refetch instead of being instant.

## What's in it

| Area | Change |
|---|---|
| `utils/log_filter.py` (new) | The match rule, the traceback walk, and the benign-error denylist. Flask-free, like `log_tail.py` next door. |
| `routes/vm_telemetry.py`, `routes/allocator_logs.py` | `?errors_only=true` on both GET log endpoints. Response shape unchanged; behavior with the param absent is identical to before. |
| `templates/instance-logs.html` | The toggle, plus empty-state copy and a download that always exports the full log. |
| `docs/api-endpoints.md` | The new query parameter on both endpoint sections. |

## Three details worth reviewing closely

**The rule is case-sensitive on purpose.** A case-insensitive `error` matches the client startup script's happy path — `--retry-all-errors` (`start.sh:45,57,133`) and `status=error` (`89,173`) — and would fill the errors view with healthy lines. It matches `ERROR|CRITICAL|FATAL` for Python levelnames plus `ERR|FTL` for cloudflared's zerolog levels and postgres `PANIC`, since cloudflared's output is teed into the same `allocator.log` the page reads.

**Tracebacks travel with their error line, and prefixes are stripped first.** Client lines arrive as `<RFC3339 ts> [tag] message` — the log shipper prepends the timestamp and `start.sh` pipes every service through `sed 's/^/[tag] /'`. A naive "starts with whitespace" continuation test would drop every frame from every client VM. The client stream also interleaves by design (six-plus services writing to the same fd concurrently), so continuation is matched by source tag and chained tracebacks are followed through their `During handling of the above exception` markers.

**`""` and `None` mean different things.** `filter_errors` returns `""` for "the log had lines but none were errors" and `None` for "there is no log at all". The allocator route captures missing-ness *before* filtering, so an empty filtered result is not reported as a missing log file, and the page renders "No error lines in this log." rather than "No logs available."

## Deliberately not in scope

- **Client log levels are unchanged.** Client code ships inside a released Docker image, so a level change would only reach VMs launched after the next client release; the allocator-side denylist reaches every already-running VM on restart.
- No `lablink logs --errors` flag — the endpoint gains the capability, the CLI is untouched.
- The CLI's *allocator* log path reads over SSH / local `docker logs`, bypassing the API, so it does not get filtering.
- No `localStorage` persistence of the toggle across reloads, and no `filtered / total` counts.

## Known ceiling

A foreign line landing between an error line and its `Traceback` header still detaches that traceback. This is pre-existing behavior in the sense that the walk never handled it, and closing it means applying the same source-tag skip at the header search.

## Testing

- 24 new tests in `tests/test_log_filter.py`, including regression guards for the interleaved-traceback, chained-traceback, and cloudflared/postgres-level cases.
- Route tests on both endpoints, including one pinning that a filtered-empty allocator log is not reported as a missing file.
- Page tests asserting the toggle, the query param, and the empty-state copy render on both pages.
- One test asserts each denylist pattern still exists in the client source, so a renamed client log message fails loudly instead of drifting silently.
- Full allocator suite: **952 passed, 20 skipped** (baseline 939). `ruff check src tests` clean. `log_filter.py` at 99% statement coverage.

The template's JavaScript has no automated coverage (no Node in this repo's test path); it was verified with `node --check` on the extracted script block. A manual pass over the page is still worth doing, ideally against a stream containing an interleaved traceback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
